### PR TITLE
[Refactor] Badge 컬러 팔레트 적용 및 디자인 토큰 정리

### DIFF
--- a/src/components/common/Badge/Badge.tsx
+++ b/src/components/common/Badge/Badge.tsx
@@ -1,17 +1,26 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/utils/cn';
-import type { BadgeProps, CategoryBadgeProps } from './Badge.types';
+import type { BadgeProps, CategoryBadgeProps, BadgeColor } from './Badge.types';
 
 const badgeVariants = cva(
   'inline-flex items-center px-3 py-1 rounded-md text-xs font-medium',
   {
     variants: {
       variant: {
+        // Status variants
         default: 'bg-bg-secondary text-text-secondary',
         success: 'bg-status-success-bg text-status-success',
         warning: 'bg-status-warning-bg text-status-warning',
         error: 'bg-status-error-bg text-status-error',
-        custom: '',
+        // Badge color variants (뮤트 톤)
+        red: 'bg-badge-red-bg text-badge-red',
+        orange: 'bg-badge-orange-bg text-badge-orange',
+        yellow: 'bg-badge-yellow-bg text-badge-yellow',
+        green: 'bg-badge-green-bg text-badge-green',
+        blue: 'bg-badge-blue-bg text-badge-blue',
+        indigo: 'bg-badge-indigo-bg text-badge-indigo',
+        purple: 'bg-badge-purple-bg text-badge-purple',
+        gray: 'bg-badge-gray-bg text-badge-gray',
       },
     },
     defaultVariants: {
@@ -24,40 +33,28 @@ export const Badge = ({
   children,
   variant,
   className,
-  customBg,
-  customText,
 }: BadgeProps & VariantProps<typeof badgeVariants>) => {
-  const customStyle =
-    variant === 'custom' && customBg && customText
-      ? { backgroundColor: customBg, color: customText }
-      : undefined;
-
   return (
-    <span className={cn(badgeVariants({ variant }), className)} style={customStyle}>
+    <span className={cn(badgeVariants({ variant }), className)}>
       {children}
     </span>
   );
 };
 
-// 카테고리별 색상 매핑
-const categoryColors: Record<string, { bg: string; text: string }> = {
-  프로그래밍: { bg: '#E3F2FD', text: '#1565C0' },
-  백엔드: { bg: '#E8F5E9', text: '#2E7D32' },
-  '개발 도구': { bg: '#FFF3E0', text: '#E65100' },
-  프론트엔드: { bg: '#F3E5F5', text: '#7B1FA2' },
-  데이터베이스: { bg: '#FFEBEE', text: '#C62828' },
-  default: { bg: '#F5F5F5', text: '#616161' },
-};
-
-const getCategoryColor = (category: string) => {
-  return categoryColors[category] || categoryColors.default;
+// 카테고리별 Badge 컬러 매핑
+const categoryColorMap: Record<string, BadgeColor> = {
+  프로그래밍: 'blue',
+  백엔드: 'green',
+  '개발 도구': 'orange',
+  프론트엔드: 'purple',
+  데이터베이스: 'red',
 };
 
 export const CategoryBadge = ({ category, className }: CategoryBadgeProps) => {
-  const colors = getCategoryColor(category);
+  const colorVariant = categoryColorMap[category] || 'gray';
 
   return (
-    <Badge variant="custom" customBg={colors.bg} customText={colors.text} className={className}>
+    <Badge variant={colorVariant} className={className}>
       {category}
     </Badge>
   );

--- a/src/components/common/Badge/Badge.types.ts
+++ b/src/components/common/Badge/Badge.types.ts
@@ -1,9 +1,9 @@
+export type BadgeColor = 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'indigo' | 'purple' | 'gray';
+
 export interface BadgeProps {
   children: React.ReactNode;
-  variant?: 'default' | 'success' | 'warning' | 'error' | 'custom';
+  variant?: 'default' | 'success' | 'warning' | 'error' | BadgeColor;
   className?: string;
-  customBg?: string;
-  customText?: string;
 }
 
 export interface CategoryBadgeProps {

--- a/src/index.css
+++ b/src/index.css
@@ -40,6 +40,24 @@
   --color-status-disabled: #666666;
   --color-status-disabled-bg: #E0E0E0;
 
+  /* === Badge Colors (태그/카테고리용 - 뮤트 톤) === */
+  --color-badge-red: #9E3A3A;
+  --color-badge-red-bg: #FAECEC;
+  --color-badge-orange: #B5663A;
+  --color-badge-orange-bg: #FDF3EC;
+  --color-badge-yellow: #8C7A35;
+  --color-badge-yellow-bg: #FBF8E8;
+  --color-badge-green: #3D7A4A;
+  --color-badge-green-bg: #EDF5EF;
+  --color-badge-blue: #3A6B9E;
+  --color-badge-blue-bg: #ECF3FA;
+  --color-badge-indigo: #4C2D9A;
+  --color-badge-indigo-bg: #EDE7F6;
+  --color-badge-purple: #7A4A8C;
+  --color-badge-purple-bg: #F5EDF8;
+  --color-badge-gray: #616161;
+  --color-badge-gray-bg: #F5F5F5;
+
   /* === Sidebar - Dark Mode === */
   --sidebar-dark-bg: #2A2A2A;
   --sidebar-dark-border: #3F3F3F;

--- a/src/pages/tu/teaching/content/MyContentPage.tsx
+++ b/src/pages/tu/teaching/content/MyContentPage.tsx
@@ -3,8 +3,16 @@ import { useNavigate } from 'react-router-dom';
 import { Plus, Search, Filter, Eye, Edit, Trash2, FileText, Calendar, ChevronDown, File } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button, Badge } from '@/components/common';
+import type { BadgeColor } from '@/components/common/Badge/Badge.types';
 
 type ContentType = 'assignment' | 'notice' | 'reference';
+
+// 콘텐츠 타입별 Badge 컬러 매핑
+const contentTypeBadgeColor: Record<ContentType, BadgeColor> = {
+  assignment: 'blue',
+  notice: 'orange',
+  reference: 'green',
+};
 
 interface Content {
   id: string;
@@ -45,13 +53,6 @@ const t = {
   view: { ko: '확인', en: 'View' },
   edit: { ko: '수정', en: 'Edit' },
   noResults: { ko: '검색 결과가 없습니다.', en: 'No results found.' },
-};
-
-// 콘텐츠 타입별 색상
-const typeColors: Record<ContentType, { bg: string; text: string }> = {
-  assignment: { bg: '#E3F2FD', text: '#1565C0' },
-  notice: { bg: '#FFF3E0', text: '#E65100' },
-  reference: { bg: '#E8F5E9', text: '#2E7D32' },
 };
 
 export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>) {
@@ -178,14 +179,12 @@ function StatCard({ label, value }: Readonly<{ label: string; value: number }>) 
 
 // 콘텐츠 카드 컴포넌트
 function ContentCard({ content, getText }: Readonly<{ content: Content; getText: (key: keyof typeof t) => string }>) {
-  const colors = typeColors[content.type];
-
   return (
     <div className="bg-bg-default border border-border rounded-lg p-5 transition-shadow hover:shadow-md cursor-pointer">
       {/* Content Header */}
       <div className="mb-3">
         <h3 className="text-text-primary mb-2 text-base leading-snug">{content.title}</h3>
-        <Badge variant="custom" customBg={colors.bg} customText={colors.text}>
+        <Badge variant={contentTypeBadgeColor[content.type]}>
           {getText(content.type)}
         </Badge>
       </div>

--- a/src/pages/tu/teaching/courses/CourseCreatePage.tsx
+++ b/src/pages/tu/teaching/courses/CourseCreatePage.tsx
@@ -455,7 +455,7 @@ function LessonCard({
           {/* 회차 제목 */}
           <div>
             <label className="block text-text-primary mb-1.5 text-sm font-medium">
-              {getText('lessonTitle')} <span className="text-orange-500">*</span>
+              {getText('lessonTitle')} <span className="text-status-error">*</span>
             </label>
             <input
               type="text"

--- a/src/styles/design-tokens.ts
+++ b/src/styles/design-tokens.ts
@@ -57,6 +57,18 @@ export const designTokens = {
     neutral_disabled_bg: '#E0E0E0',    // 진행 종료 등 비활성 배경
   },
 
+  // --- Badge Colors (태그/카테고리용 - 뮤트 톤) ---
+  badge: {
+    red: { text: '#9E3A3A', bg: '#FAECEC' },
+    orange: { text: '#B5663A', bg: '#FDF3EC' },
+    yellow: { text: '#8C7A35', bg: '#FBF8E8' },
+    green: { text: '#3D7A4A', bg: '#EDF5EF' },
+    blue: { text: '#3A6B9E', bg: '#ECF3FA' },
+    indigo: { text: '#4C2D9A', bg: '#EDE7F6' },
+    purple: { text: '#7A4A8C', bg: '#F5EDF8' },
+    gray: { text: '#616161', bg: '#F5F5F5' },
+  },
+
   // --- Dark Mode Sidebar (Preserved Original Values) ---
   darkMode: {
     bg: '#2A2A2A',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -38,6 +38,24 @@ export default {
         'status-disabled': 'var(--color-status-disabled)',
         'status-disabled-bg': 'var(--color-status-disabled-bg)',
 
+        // Badge (태그/카테고리용)
+        'badge-red': 'var(--color-badge-red)',
+        'badge-red-bg': 'var(--color-badge-red-bg)',
+        'badge-orange': 'var(--color-badge-orange)',
+        'badge-orange-bg': 'var(--color-badge-orange-bg)',
+        'badge-yellow': 'var(--color-badge-yellow)',
+        'badge-yellow-bg': 'var(--color-badge-yellow-bg)',
+        'badge-green': 'var(--color-badge-green)',
+        'badge-green-bg': 'var(--color-badge-green-bg)',
+        'badge-blue': 'var(--color-badge-blue)',
+        'badge-blue-bg': 'var(--color-badge-blue-bg)',
+        'badge-indigo': 'var(--color-badge-indigo)',
+        'badge-indigo-bg': 'var(--color-badge-indigo-bg)',
+        'badge-purple': 'var(--color-badge-purple)',
+        'badge-purple-bg': 'var(--color-badge-purple-bg)',
+        'badge-gray': 'var(--color-badge-gray)',
+        'badge-gray-bg': 'var(--color-badge-gray-bg)',
+
         // Sidebar - Dark Mode
         'sidebar-dark': {
           bg: 'var(--sidebar-dark-bg)',


### PR DESCRIPTION
## Summary

- Badge 컴포넌트에 8색 뮤트 톤 variant 추가 (red, orange, yellow, green, blue, indigo, purple, gray)
- CSS 변수, Tailwind 설정, TypeScript 토큰 동기화
- MyContentPage: 하드코딩 제거, Badge variant 사용
- CourseCreatePage: text-orange-500 → text-status-error 변경

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `src/index.css` | Badge CSS 변수 추가 |
| `tailwind.config.js` | Badge Tailwind 컬러 매핑 |
| `src/styles/design-tokens.ts` | Badge TypeScript 토큰 |
| `src/components/common/Badge/Badge.tsx` | 8색 variant 추가 |
| `src/components/common/Badge/Badge.types.ts` | BadgeColor 타입 정의 |
| `src/pages/tu/teaching/content/MyContentPage.tsx` | Badge variant 적용 |
| `src/pages/tu/teaching/courses/CourseCreatePage.tsx` | 디자인 토큰 적용 |

## Test plan

- [ ] Badge 8색 variant 렌더링 확인
- [ ] MyContentPage 콘텐츠 타입별 Badge 색상 확인
- [ ] CourseCreatePage 필수 입력 표시(*) 색상 확인