### PR TITLE
feat: Course 도메인 타입 백엔드 정렬

### DIFF
--- a/src/types/common/course.types.ts
+++ b/src/types/common/course.types.ts
@@ -1,0 +1,104 @@
+/**
+ * Course 도메인 타입 정의
+ * 백엔드 엔티티 구조에 맞춘 타입들
+ */
+
+// ============================================
+// Enums (Union Types)
+// ============================================
+
+/** 강의 난이도 */
+export type CourseLevel = 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED';
+
+/** 강의 유형 */
+export type CourseType = 'ONLINE' | 'OFFLINE' | 'BLENDED';
+
+// ============================================
+// Response Types
+// ============================================
+
+/** 강의 목록 조회 응답 */
+export interface CourseResponse {
+  courseId: number;
+  title: string;
+  description: string | null;
+  thumbnailUrl: string | null;
+  level: CourseLevel | null;
+  type: CourseType | null;
+  estimatedHours: number | null;
+  categoryId: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** 강의 아이템 응답 (CourseDetailResponse에서 사용) */
+export interface CourseItemResponse {
+  itemId: number;
+  itemName: string;
+  depth: number;
+  parentId: number | null;
+  learningObjectId: number | null;
+  isFolder: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** 강의 상세 조회 응답 */
+export interface CourseDetailResponse {
+  courseId: number;
+  title: string;
+  description: string | null;
+  thumbnailUrl: string | null;
+  level: CourseLevel | null;
+  type: CourseType | null;
+  estimatedHours: number | null;
+  categoryId: number | null;
+  items: CourseItemResponse[];
+  itemCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ============================================
+// Request Types
+// ============================================
+
+/** 강의 생성 요청 */
+export interface CreateCourseRequest {
+  title: string;
+  description?: string;
+  level?: CourseLevel;
+  type?: CourseType;
+  estimatedHours?: number;
+  categoryId?: number;
+  thumbnailUrl?: string;
+}
+
+/** 강의 수정 요청 */
+export interface UpdateCourseRequest {
+  title?: string;
+  description?: string;
+  level?: CourseLevel;
+  type?: CourseType;
+  estimatedHours?: number;
+  categoryId?: number;
+  thumbnailUrl?: string;
+}
+
+// ============================================
+// Utility Types
+// ============================================
+
+/** CourseLevel 라벨 맵 */
+export const COURSE_LEVEL_LABELS: Record<CourseLevel, string> = {
+  BEGINNER: '초급',
+  INTERMEDIATE: '중급',
+  ADVANCED: '고급',
+};
+
+/** CourseType 라벨 맵 */
+export const COURSE_TYPE_LABELS: Record<CourseType, string> = {
+  ONLINE: '온라인',
+  OFFLINE: '오프라인',
+  BLENDED: '블렌디드',
+};

--- a/src/types/common/index.ts
+++ b/src/types/common/index.ts
@@ -1,3 +1,4 @@
 export * from './api.types';
 export * from './auth.types';
+export * from './course.types';
 export * from './sidebar.types';

--- a/src/types/to/course.types.ts
+++ b/src/types/to/course.types.ts
@@ -1,8 +1,33 @@
 /**
- * Course 관련 타입 정의
+ * Course 관련 타입 정의 (Tenant Operator)
+ *
+ * 백엔드 정렬 타입은 common/course.types.ts 에서 관리됩니다.
+ * 아래는 UI/폼 전용 타입들입니다.
  */
 
-// 콘텐츠 첨부 타입
+// ============================================
+// Re-export from common (백엔드 정렬 타입)
+// ============================================
+export type {
+  CourseLevel,
+  CourseType,
+  CourseResponse,
+  CourseDetailResponse,
+  CourseItemResponse,
+  CreateCourseRequest,
+  UpdateCourseRequest,
+} from '../common/course.types';
+
+export {
+  COURSE_LEVEL_LABELS,
+  COURSE_TYPE_LABELS,
+} from '../common/course.types';
+
+// ============================================
+// UI/Form Types (프론트엔드 전용)
+// ============================================
+
+/** 콘텐츠 첨부 타입 */
 export interface ContentAttachment {
   id: string;
   type: 'upload' | 'link';
@@ -10,7 +35,7 @@ export interface ContentAttachment {
   url: string;
 }
 
-// 회차(레슨) 데이터 타입
+/** 회차(레슨) 데이터 타입 */
 export interface LessonData {
   id: string;
   order: number;
@@ -19,13 +44,16 @@ export interface LessonData {
   contents: ContentAttachment[];
 }
 
-// 강의 난이도
+/**
+ * 강의 난이도 (UI 전용)
+ * @deprecated common/course.types.ts의 CourseLevel 사용 권장
+ */
 export type CourseDifficulty = 'beginner' | 'elementary' | 'intermediate' | 'advanced' | '';
 
-// 강의 상태
+/** 강의 상태 (UI 전용) */
 export type CourseStatus = 'active' | 'completed' | 'draft';
 
-// 다국어 버전 타입
+/** 다국어 버전 타입 */
 export interface LanguageVersion {
   code: string;
   name: string;
@@ -33,13 +61,16 @@ export interface LanguageVersion {
   courseDescription: string;
 }
 
-// 다국어 설정 타입
+/** 다국어 설정 타입 */
 export interface MultiLanguageSettings {
   enabled: boolean;
   languages: LanguageVersion[];
 }
 
-// 강의 폼 데이터
+/**
+ * 강의 폼 데이터 (UI 전용)
+ * @deprecated CreateCourseRequest 사용 권장
+ */
 export interface CourseFormData {
   courseName: string;
   courseDescription: string;
@@ -54,7 +85,10 @@ export interface CourseFormData {
   multiLanguage: MultiLanguageSettings;
 }
 
-// 강의 목록 아이템
+/**
+ * 강의 목록 아이템 (UI 전용)
+ * @deprecated CourseResponse 사용 권장
+ */
 export interface Course {
   id: string;
   title: string;
@@ -70,11 +104,15 @@ export interface Course {
   status?: CourseStatus;
 }
 
-// 카테고리 색상 타입
+// ============================================
+// UI Utility Types
+// ============================================
+
+/** 카테고리 색상 타입 */
 export interface CategoryColor {
   bg: string;
   text: string;
 }
 
-// 카테고리 색상 맵
+/** 카테고리 색상 맵 */
 export type CategoryColorsMap = Record<string, CategoryColor>;


### PR DESCRIPTION
## Summary
- Course 도메인 타입을 백엔드 엔티티 구조에 맞춰 정렬
- `types/common/course.types.ts` 신규 생성하여 공통 타입으로 분리
- 기존 `types/to/course.types.ts`에서 common 타입 re-export

## Changes
### 신규 타입 (common/course.types.ts)
| 타입 | 설명 |
|------|------|
| `CourseLevel` | `'BEGINNER' \| 'INTERMEDIATE' \| 'ADVANCED'` |
| `CourseType` | `'ONLINE' \| 'OFFLINE' \| 'BLENDED'` |
| `CourseResponse` | 강의 목록 조회 응답 |
| `CourseDetailResponse` | 강의 상세 조회 응답 |
| `CourseItemResponse` | 강의 아이템 응답 |
| `CreateCourseRequest` | 강의 생성 요청 |
| `UpdateCourseRequest` | 강의 수정 요청 |

### Deprecated 타입 (to/course.types.ts)
- `CourseDifficulty` → `CourseLevel` 사용 권장
- `CourseFormData` → `CreateCourseRequest` 사용 권장
- `Course` → `CourseResponse` 사용 권장

## Test plan
- [ ] TypeScript 컴파일 오류 없음 확인
- [ ] 기존 코드에서 import 경로 변경 없이 동작 확인

Closes #27