### PR TITLE
feat: CourseItem 도메인 타입 추가

### DIFF
--- a/src/types/common/course.types.ts
+++ b/src/types/common/course.types.ts
@@ -43,6 +43,16 @@ export interface CourseItemResponse {
   updatedAt: string;
 }
 
+/** 강의 아이템 계층 구조 응답 (트리 조회용) */
+export interface CourseItemHierarchyResponse {
+  itemId: number;
+  itemName: string;
+  depth: number;
+  learningObjectId: number | null;
+  isFolder: boolean;
+  children: CourseItemHierarchyResponse[];
+}
+
 /** 강의 상세 조회 응답 */
 export interface CourseDetailResponse {
   courseId: number;
@@ -83,6 +93,40 @@ export interface UpdateCourseRequest {
   estimatedHours?: number;
   categoryId?: number;
   thumbnailUrl?: string;
+}
+
+// ============================================
+// CourseItem Request Types
+// ============================================
+
+/** 차시 생성 요청 */
+export interface CreateItemRequest {
+  itemName: string;
+  parentId?: number | null;
+  learningObjectId: number;
+}
+
+/** 폴더 생성 요청 */
+export interface CreateFolderRequest {
+  folderName: string;
+  parentId?: number | null;
+}
+
+/** 항목 이동 요청 */
+export interface MoveItemRequest {
+  itemId: number;
+  targetParentId?: number | null;
+  targetIndex?: number;
+}
+
+/** 항목 이름 변경 요청 */
+export interface UpdateItemNameRequest {
+  itemName: string;
+}
+
+/** 학습 객체 변경 요청 */
+export interface UpdateLearningObjectRequest {
+  learningObjectId: number;
 }
 
 // ============================================


### PR DESCRIPTION
## Summary

- 백엔드 CourseItem 도메인에 맞춰 프론트엔드 타입 추가
- `CourseItemHierarchyResponse` - 트리 구조 조회용 (children 재귀)
- Request 타입들: `CreateItemRequest`, `CreateFolderRequest`, `MoveItemRequest`, `UpdateItemNameRequest`, `UpdateLearningObjectRequest`

## Changes

| 타입 | 설명 |
|------|------|
| `CourseItemHierarchyResponse` | 트리 구조 조회 응답 |
| `CreateItemRequest` | 차시 생성 요청 |
| `CreateFolderRequest` | 폴더 생성 요청 |
| `MoveItemRequest` | 항목 이동 요청 |
| `UpdateItemNameRequest` | 이름 변경 요청 |
| `UpdateLearningObjectRequest` | LO 변경 요청 |

## Test plan

- [x] TypeScript 빌드 확인 (`npx tsc --noEmit`)
- [ ] 실제 API 연동 시 타입 검증

## Related

- Closes #29
- Phase 1 완료 (Course + CourseItem 타입 정렬)