### PR TITLE
feat: Snapshot 도메인 타입 및 API 서비스 추가

### DIFF
--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -70,4 +70,30 @@ export const API_ENDPOINTS = {
     CHILDREN: (id: number) => `/content-folders/${id}/children`,
     MOVE: (id: number) => `/content-folders/${id}/move`,
   },
+
+  // Snapshots (TO)
+  SNAPSHOTS: {
+    BASE: '/snapshots',
+    BY_ID: (id: number) => `/snapshots/${id}`,
+    PUBLISH: (id: number) => `/snapshots/${id}/publish`,
+    COMPLETE: (id: number) => `/snapshots/${id}/complete`,
+    ARCHIVE: (id: number) => `/snapshots/${id}/archive`,
+    // Course에서 스냅샷 생성/조회
+    FROM_COURSE: (courseId: number) => `/courses/${courseId}/snapshots`,
+    // Items
+    ITEMS: (snapshotId: number) => `/snapshots/${snapshotId}/items`,
+    ITEMS_FLAT: (snapshotId: number) => `/snapshots/${snapshotId}/items/flat`,
+    ITEM_BY_ID: (snapshotId: number, itemId: number) =>
+      `/snapshots/${snapshotId}/items/${itemId}`,
+    ITEM_MOVE: (snapshotId: number, itemId: number) =>
+      `/snapshots/${snapshotId}/items/${itemId}/move`,
+    // Relations
+    RELATIONS: (snapshotId: number) => `/snapshots/${snapshotId}/relations`,
+    RELATIONS_ORDERED: (snapshotId: number) =>
+      `/snapshots/${snapshotId}/relations/ordered`,
+    RELATIONS_START: (snapshotId: number) =>
+      `/snapshots/${snapshotId}/relations/start`,
+    RELATION_BY_ID: (snapshotId: number, relationId: number) =>
+      `/snapshots/${snapshotId}/relations/${relationId}`,
+  },
 } as const;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,8 +1,8 @@
 // Common services
 export * from './common';
 
-// Role-specific services will be exported here as they are created
+// Role-specific services
 // export * from './sa';
 // export * from './ta';
-// export * from './to';
-// export * from './tu';
+export * from './to';
+export * from './tu';

--- a/src/services/to/index.ts
+++ b/src/services/to/index.ts
@@ -1,0 +1,1 @@
+export * from './snapshotService';

--- a/src/services/to/snapshotService.ts
+++ b/src/services/to/snapshotService.ts
@@ -1,0 +1,259 @@
+/**
+ * Snapshot API 서비스 (TO - Tenant Operator)
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type {
+  SnapshotStatus,
+  SnapshotResponse,
+  SnapshotDetailResponse,
+  SnapshotItemResponse,
+  SnapshotRelationResponse,
+  SnapshotRelationsResponse,
+  CreateSnapshotRequest,
+  UpdateSnapshotRequest,
+  CreateSnapshotItemRequest,
+  UpdateSnapshotItemRequest,
+  MoveSnapshotItemRequest,
+  CreateSnapshotRelationRequest,
+  SetStartSnapshotItemRequest,
+} from '@/types/to';
+
+// Spring Page 응답 타입
+interface PageResponse<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+}
+
+// 스냅샷 필터 파라미터
+export interface SnapshotFilterParams {
+  status?: SnapshotStatus;
+  keyword?: string;
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+export const snapshotService = {
+  // ============================================
+  // Snapshot CRUD
+  // ============================================
+
+  /** 스냅샷 목록 조회 */
+  async getSnapshots(
+    params?: SnapshotFilterParams
+  ): Promise<PageResponse<SnapshotResponse>> {
+    const { data } = await axiosInstance.get<PageResponse<SnapshotResponse>>(
+      API_ENDPOINTS.SNAPSHOTS.BASE,
+      { params }
+    );
+    return data;
+  },
+
+  /** 스냅샷 상세 조회 */
+  async getSnapshot(id: number): Promise<SnapshotDetailResponse> {
+    const { data } = await axiosInstance.get<SnapshotDetailResponse>(
+      API_ENDPOINTS.SNAPSHOTS.BY_ID(id)
+    );
+    return data;
+  },
+
+  /** 스냅샷 생성 (빈 스냅샷) */
+  async create(request: CreateSnapshotRequest): Promise<SnapshotResponse> {
+    const { data } = await axiosInstance.post<SnapshotResponse>(
+      API_ENDPOINTS.SNAPSHOTS.BASE,
+      request
+    );
+    return data;
+  },
+
+  /** 코스에서 스냅샷 생성 */
+  async createFromCourse(
+    courseId: number,
+    request: CreateSnapshotRequest
+  ): Promise<SnapshotResponse> {
+    const { data } = await axiosInstance.post<SnapshotResponse>(
+      API_ENDPOINTS.SNAPSHOTS.FROM_COURSE(courseId),
+      request
+    );
+    return data;
+  },
+
+  /** 코스의 스냅샷 목록 조회 */
+  async getSnapshotsByCourse(
+    courseId: number,
+    params?: SnapshotFilterParams
+  ): Promise<PageResponse<SnapshotResponse>> {
+    const { data } = await axiosInstance.get<PageResponse<SnapshotResponse>>(
+      API_ENDPOINTS.SNAPSHOTS.FROM_COURSE(courseId),
+      { params }
+    );
+    return data;
+  },
+
+  /** 스냅샷 수정 */
+  async update(
+    id: number,
+    request: UpdateSnapshotRequest
+  ): Promise<SnapshotResponse> {
+    const { data } = await axiosInstance.put<SnapshotResponse>(
+      API_ENDPOINTS.SNAPSHOTS.BY_ID(id),
+      request
+    );
+    return data;
+  },
+
+  /** 스냅샷 삭제 */
+  async delete(id: number): Promise<void> {
+    await axiosInstance.delete(API_ENDPOINTS.SNAPSHOTS.BY_ID(id));
+  },
+
+  // ============================================
+  // Snapshot 상태 전이
+  // ============================================
+
+  /** 스냅샷 발행 (DRAFT → ACTIVE) */
+  async publish(id: number): Promise<SnapshotResponse> {
+    const { data } = await axiosInstance.post<SnapshotResponse>(
+      API_ENDPOINTS.SNAPSHOTS.PUBLISH(id)
+    );
+    return data;
+  },
+
+  /** 스냅샷 완료 (ACTIVE → COMPLETED) */
+  async complete(id: number): Promise<SnapshotResponse> {
+    const { data } = await axiosInstance.post<SnapshotResponse>(
+      API_ENDPOINTS.SNAPSHOTS.COMPLETE(id)
+    );
+    return data;
+  },
+
+  /** 스냅샷 보관 (COMPLETED → ARCHIVED) */
+  async archive(id: number): Promise<SnapshotResponse> {
+    const { data } = await axiosInstance.post<SnapshotResponse>(
+      API_ENDPOINTS.SNAPSHOTS.ARCHIVE(id)
+    );
+    return data;
+  },
+
+  // ============================================
+  // Snapshot Items
+  // ============================================
+
+  /** 스냅샷 아이템 계층 구조 조회 */
+  async getItems(snapshotId: number): Promise<SnapshotItemResponse[]> {
+    const { data } = await axiosInstance.get<SnapshotItemResponse[]>(
+      API_ENDPOINTS.SNAPSHOTS.ITEMS(snapshotId)
+    );
+    return data;
+  },
+
+  /** 스냅샷 아이템 평면 목록 조회 */
+  async getItemsFlat(snapshotId: number): Promise<SnapshotItemResponse[]> {
+    const { data } = await axiosInstance.get<SnapshotItemResponse[]>(
+      API_ENDPOINTS.SNAPSHOTS.ITEMS_FLAT(snapshotId)
+    );
+    return data;
+  },
+
+  /** 스냅샷 아이템 추가 */
+  async addItem(
+    snapshotId: number,
+    request: CreateSnapshotItemRequest
+  ): Promise<SnapshotItemResponse> {
+    const { data } = await axiosInstance.post<SnapshotItemResponse>(
+      API_ENDPOINTS.SNAPSHOTS.ITEMS(snapshotId),
+      request
+    );
+    return data;
+  },
+
+  /** 스냅샷 아이템 이름 수정 */
+  async updateItem(
+    snapshotId: number,
+    itemId: number,
+    request: UpdateSnapshotItemRequest
+  ): Promise<SnapshotItemResponse> {
+    const { data } = await axiosInstance.put<SnapshotItemResponse>(
+      API_ENDPOINTS.SNAPSHOTS.ITEM_BY_ID(snapshotId, itemId),
+      request
+    );
+    return data;
+  },
+
+  /** 스냅샷 아이템 이동 */
+  async moveItem(
+    snapshotId: number,
+    itemId: number,
+    request: MoveSnapshotItemRequest
+  ): Promise<SnapshotItemResponse> {
+    const { data } = await axiosInstance.put<SnapshotItemResponse>(
+      API_ENDPOINTS.SNAPSHOTS.ITEM_MOVE(snapshotId, itemId),
+      request
+    );
+    return data;
+  },
+
+  /** 스냅샷 아이템 삭제 */
+  async deleteItem(snapshotId: number, itemId: number): Promise<void> {
+    await axiosInstance.delete(
+      API_ENDPOINTS.SNAPSHOTS.ITEM_BY_ID(snapshotId, itemId)
+    );
+  },
+
+  // ============================================
+  // Snapshot Relations (학습 순서)
+  // ============================================
+
+  /** 스냅샷 관계 목록 조회 */
+  async getRelations(snapshotId: number): Promise<SnapshotRelationResponse[]> {
+    const { data } = await axiosInstance.get<SnapshotRelationResponse[]>(
+      API_ENDPOINTS.SNAPSHOTS.RELATIONS(snapshotId)
+    );
+    return data;
+  },
+
+  /** 스냅샷 관계 순서대로 조회 */
+  async getRelationsOrdered(
+    snapshotId: number
+  ): Promise<SnapshotRelationsResponse> {
+    const { data } = await axiosInstance.get<SnapshotRelationsResponse>(
+      API_ENDPOINTS.SNAPSHOTS.RELATIONS_ORDERED(snapshotId)
+    );
+    return data;
+  },
+
+  /** 스냅샷 관계 생성 */
+  async createRelation(
+    snapshotId: number,
+    request: CreateSnapshotRelationRequest
+  ): Promise<SnapshotRelationResponse> {
+    const { data } = await axiosInstance.post<SnapshotRelationResponse>(
+      API_ENDPOINTS.SNAPSHOTS.RELATIONS(snapshotId),
+      request
+    );
+    return data;
+  },
+
+  /** 스냅샷 시작점 설정 */
+  async setStartItem(
+    snapshotId: number,
+    request: SetStartSnapshotItemRequest
+  ): Promise<SnapshotRelationResponse> {
+    const { data } = await axiosInstance.put<SnapshotRelationResponse>(
+      API_ENDPOINTS.SNAPSHOTS.RELATIONS_START(snapshotId),
+      request
+    );
+    return data;
+  },
+
+  /** 스냅샷 관계 삭제 */
+  async deleteRelation(snapshotId: number, relationId: number): Promise<void> {
+    await axiosInstance.delete(
+      API_ENDPOINTS.SNAPSHOTS.RELATION_BY_ID(snapshotId, relationId)
+    );
+  },
+};

--- a/src/types/common/index.ts
+++ b/src/types/common/index.ts
@@ -2,3 +2,4 @@ export * from './api.types';
 export * from './auth.types';
 export * from './course.types';
 export * from './sidebar.types';
+export * from './snapshot.types';

--- a/src/types/common/snapshot.types.ts
+++ b/src/types/common/snapshot.types.ts
@@ -1,0 +1,173 @@
+/**
+ * Snapshot 도메인 타입 정의
+ * 백엔드 엔티티 구조에 맞춘 타입들
+ */
+
+// ============================================
+// Enums (Union Types)
+// ============================================
+
+/** 스냅샷 상태 */
+export type SnapshotStatus = 'DRAFT' | 'ACTIVE' | 'COMPLETED' | 'ARCHIVED';
+
+// ============================================
+// Response Types
+// ============================================
+
+/** 스냅샷 Learning Object 응답 */
+export interface SnapshotLearningObjectResponse {
+  snapshotLoId: number;
+  sourceLoId: number | null;
+  contentId: number;
+  displayName: string;
+  duration: number | null;
+  thumbnailUrl: string | null;
+  resolution: string | null;
+  isCustomized: boolean;
+}
+
+/** 스냅샷 아이템 응답 */
+export interface SnapshotItemResponse {
+  itemId: number;
+  snapshotId: number;
+  itemName: string;
+  parentId: number | null;
+  depth: number;
+  isFolder: boolean;
+  itemType: string | null;
+  snapshotLearningObject: SnapshotLearningObjectResponse | null;
+  children: SnapshotItemResponse[] | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** 스냅샷 목록 조회 응답 */
+export interface SnapshotResponse {
+  snapshotId: number;
+  snapshotName: string;
+  description: string | null;
+  hashtags: string | null;
+  sourceCourseId: number | null;
+  sourceCourseName: string | null;
+  createdBy: number;
+  status: SnapshotStatus;
+  version: number;
+  tenantId: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** 스냅샷 상세 조회 응답 */
+export interface SnapshotDetailResponse {
+  snapshotId: number;
+  snapshotName: string;
+  description: string | null;
+  hashtags: string | null;
+  sourceCourseId: number | null;
+  sourceCourseName: string | null;
+  createdBy: number;
+  status: SnapshotStatus;
+  version: number;
+  tenantId: number;
+  items: SnapshotItemResponse[];
+  itemCount: number;
+  totalDuration: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** 스냅샷 관계 응답 */
+export interface SnapshotRelationResponse {
+  relationId: number;
+  snapshotId: number;
+  fromItemId: number | null;
+  fromItemName: string | null;
+  toItemId: number;
+  toItemName: string;
+  isStartPoint: boolean;
+  createdAt: string;
+}
+
+/** 순서 아이템 (관계 조회용) */
+export interface SnapshotOrderedItem {
+  itemId: number;
+  itemName: string;
+  seq: number;
+}
+
+/** 스냅샷 관계 목록 응답 */
+export interface SnapshotRelationsResponse {
+  snapshotId: number;
+  orderedItems: SnapshotOrderedItem[];
+  relations: SnapshotRelationResponse[];
+}
+
+// ============================================
+// Request Types
+// ============================================
+
+/** 스냅샷 생성 요청 */
+export interface CreateSnapshotRequest {
+  snapshotName: string;
+  description?: string;
+  hashtags?: string;
+}
+
+/** 스냅샷 수정 요청 */
+export interface UpdateSnapshotRequest {
+  snapshotName?: string;
+  description?: string;
+  hashtags?: string;
+}
+
+/** 스냅샷 아이템 생성 요청 */
+export interface CreateSnapshotItemRequest {
+  itemName: string;
+  parentId?: number | null;
+  learningObjectId?: number | null;
+  itemType?: string;
+}
+
+/** 스냅샷 아이템 수정 요청 */
+export interface UpdateSnapshotItemRequest {
+  itemName: string;
+}
+
+/** 스냅샷 아이템 이동 요청 */
+export interface MoveSnapshotItemRequest {
+  newParentId?: number | null;
+}
+
+/** 스냅샷 관계 생성 요청 */
+export interface CreateSnapshotRelationRequest {
+  fromItemId?: number | null;
+  toItemId: number;
+}
+
+/** 스냅샷 시작점 설정 요청 */
+export interface SetStartSnapshotItemRequest {
+  itemId: number;
+}
+
+// ============================================
+// Utility Types & Constants
+// ============================================
+
+/** SnapshotStatus 라벨 맵 */
+export const SNAPSHOT_STATUS_LABELS: Record<SnapshotStatus, string> = {
+  DRAFT: '초안',
+  ACTIVE: '활성',
+  COMPLETED: '완료',
+  ARCHIVED: '보관됨',
+};
+
+/** SnapshotStatus 색상 맵 (UI용) */
+export const SNAPSHOT_STATUS_COLORS: Record<
+  SnapshotStatus,
+  { bg: string; text: string }
+> = {
+  DRAFT: { bg: 'bg-gray-100', text: 'text-gray-700' },
+  ACTIVE: { bg: 'bg-green-100', text: 'text-green-700' },
+  COMPLETED: { bg: 'bg-blue-100', text: 'text-blue-700' },
+  ARCHIVED: { bg: 'bg-yellow-100', text: 'text-yellow-700' },
+};

--- a/src/types/to/index.ts
+++ b/src/types/to/index.ts
@@ -1,2 +1,3 @@
 export * from './content.types';
 export * from './course.types';
+export * from './snapshot.types';

--- a/src/types/to/snapshot.types.ts
+++ b/src/types/to/snapshot.types.ts
@@ -1,0 +1,32 @@
+/**
+ * Snapshot 관련 타입 정의 (Tenant Operator)
+ *
+ * 백엔드 정렬 타입은 common/snapshot.types.ts 에서 관리됩니다.
+ * 아래는 re-export 및 UI/폼 전용 타입들입니다.
+ */
+
+// ============================================
+// Re-export from common (백엔드 정렬 타입)
+// ============================================
+export type {
+  SnapshotStatus,
+  SnapshotResponse,
+  SnapshotDetailResponse,
+  SnapshotItemResponse,
+  SnapshotLearningObjectResponse,
+  SnapshotRelationResponse,
+  SnapshotOrderedItem,
+  SnapshotRelationsResponse,
+  CreateSnapshotRequest,
+  UpdateSnapshotRequest,
+  CreateSnapshotItemRequest,
+  UpdateSnapshotItemRequest,
+  MoveSnapshotItemRequest,
+  CreateSnapshotRelationRequest,
+  SetStartSnapshotItemRequest,
+} from '../common/snapshot.types';
+
+export {
+  SNAPSHOT_STATUS_LABELS,
+  SNAPSHOT_STATUS_COLORS,
+} from '../common/snapshot.types';


### PR DESCRIPTION
## Summary

- Snapshot 도메인 타입 정의 완료 (백엔드 엔티티 구조 정렬)
- Snapshot API 서비스 구현 완료
- FRONTEND_TYPE_CHECKLIST.md Phase 2 완료

## 변경 사항

### 타입 정의 (`src/types/common/snapshot.types.ts`)
- `SnapshotStatus` enum: DRAFT, ACTIVE, COMPLETED, ARCHIVED
- Response 타입: SnapshotResponse, SnapshotDetailResponse, SnapshotItemResponse, SnapshotLearningObjectResponse, SnapshotRelationResponse, SnapshotRelationsResponse
- Request 타입: CreateSnapshotRequest, UpdateSnapshotRequest, CreateSnapshotItemRequest, UpdateSnapshotItemRequest, MoveSnapshotItemRequest, CreateSnapshotRelationRequest, SetStartSnapshotItemRequest
- 유틸리티: SNAPSHOT_STATUS_LABELS, SNAPSHOT_STATUS_COLORS

### API 서비스 (`src/services/to/snapshotService.ts`)
- 스냅샷 CRUD: getSnapshots, getSnapshot, create, createFromCourse, update, delete
- 상태 전이: publish, complete, archive
- 아이템 관리: getItems, getItemsFlat, addItem, updateItem, moveItem, deleteItem
- 학습 순서: getRelations, getRelationsOrdered, createRelation, setStartItem, deleteRelation

### API 엔드포인트 (`src/services/common/api/endpoints.ts`)
- SNAPSHOTS 엔드포인트 상수 추가

## Test plan

- [x] TypeScript 타입 체크 통과 (`npx tsc --noEmit`)
- [ ] 실제 API 연동 테스트 (백엔드 배포 후)

Closes #33