### PR TITLE
feat: Program 도메인 타입 및 API 서비스 추가

### DIFF
--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -71,6 +71,18 @@ export const API_ENDPOINTS = {
     MOVE: (id: number) => `/content-folders/${id}/move`,
   },
 
+  // Programs (TO)
+  PROGRAMS: {
+    BASE: '/programs',
+    BY_ID: (id: number) => `/programs/${id}`,
+    SUBMIT: (id: number) => `/programs/${id}/submit`,
+    PENDING: '/programs/pending',
+    APPROVE: (id: number) => `/programs/${id}/approve`,
+    REJECT: (id: number) => `/programs/${id}/reject`,
+    CLOSE: (id: number) => `/programs/${id}/close`,
+    SNAPSHOT: (id: number) => `/programs/${id}/snapshot`,
+  },
+
   // Snapshots (TO)
   SNAPSHOTS: {
     BASE: '/snapshots',

--- a/src/services/to/index.ts
+++ b/src/services/to/index.ts
@@ -1,1 +1,2 @@
+export * from './programService';
 export * from './snapshotService';

--- a/src/services/to/programService.ts
+++ b/src/services/to/programService.ts
@@ -1,0 +1,157 @@
+/**
+ * Program API 서비스 (TO - Tenant Operator)
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type {
+  ProgramStatus,
+  ProgramResponse,
+  ProgramDetailResponse,
+  PendingProgramResponse,
+  CreateProgramRequest,
+  UpdateProgramRequest,
+  ApproveRequest,
+  RejectRequest,
+} from '@/types/common';
+
+// Spring Page 응답 타입
+interface PageResponse<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+}
+
+// 프로그램 필터 파라미터
+export interface ProgramFilterParams {
+  status?: ProgramStatus;
+  creatorId?: number;
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+export const programService = {
+  // ============================================
+  // Program CRUD
+  // ============================================
+
+  /** 프로그램 생성 */
+  async createProgram(
+    request: CreateProgramRequest
+  ): Promise<ProgramResponse> {
+    const { data } = await axiosInstance.post<ProgramResponse>(
+      API_ENDPOINTS.PROGRAMS.BASE,
+      request
+    );
+    return data;
+  },
+
+  /** 프로그램 목록 조회 */
+  async getPrograms(
+    params?: ProgramFilterParams
+  ): Promise<PageResponse<ProgramResponse>> {
+    const { data } = await axiosInstance.get<PageResponse<ProgramResponse>>(
+      API_ENDPOINTS.PROGRAMS.BASE,
+      { params }
+    );
+    return data;
+  },
+
+  /** 프로그램 상세 조회 */
+  async getProgram(id: number): Promise<ProgramDetailResponse> {
+    const { data } = await axiosInstance.get<ProgramDetailResponse>(
+      API_ENDPOINTS.PROGRAMS.BY_ID(id)
+    );
+    return data;
+  },
+
+  /** 프로그램 수정 */
+  async updateProgram(
+    id: number,
+    request: UpdateProgramRequest
+  ): Promise<ProgramResponse> {
+    const { data } = await axiosInstance.put<ProgramResponse>(
+      API_ENDPOINTS.PROGRAMS.BY_ID(id),
+      request
+    );
+    return data;
+  },
+
+  /** 프로그램 삭제 */
+  async deleteProgram(id: number): Promise<void> {
+    await axiosInstance.delete(API_ENDPOINTS.PROGRAMS.BY_ID(id));
+  },
+
+  // ============================================
+  // Program 워크플로우 (상태 전이)
+  // ============================================
+
+  /** 프로그램 개설 신청 (DRAFT/REJECTED → PENDING) */
+  async submitProgram(id: number): Promise<ProgramResponse> {
+    const { data } = await axiosInstance.post<ProgramResponse>(
+      API_ENDPOINTS.PROGRAMS.SUBMIT(id)
+    );
+    return data;
+  },
+
+  /** 검토 대기 프로그램 목록 조회 (OPERATOR용) */
+  async getPendingPrograms(
+    params?: Pick<ProgramFilterParams, 'page' | 'size' | 'sort'>
+  ): Promise<PageResponse<PendingProgramResponse>> {
+    const { data } = await axiosInstance.get<
+      PageResponse<PendingProgramResponse>
+    >(API_ENDPOINTS.PROGRAMS.PENDING, { params });
+    return data;
+  },
+
+  /** 프로그램 승인 (PENDING → APPROVED) */
+  async approveProgram(
+    id: number,
+    request?: ApproveRequest
+  ): Promise<ProgramDetailResponse> {
+    const { data } = await axiosInstance.post<ProgramDetailResponse>(
+      API_ENDPOINTS.PROGRAMS.APPROVE(id),
+      request
+    );
+    return data;
+  },
+
+  /** 프로그램 반려 (PENDING → REJECTED) */
+  async rejectProgram(
+    id: number,
+    request: RejectRequest
+  ): Promise<ProgramDetailResponse> {
+    const { data } = await axiosInstance.post<ProgramDetailResponse>(
+      API_ENDPOINTS.PROGRAMS.REJECT(id),
+      request
+    );
+    return data;
+  },
+
+  /** 프로그램 종료 (APPROVED/DRAFT → CLOSED) */
+  async closeProgram(id: number): Promise<ProgramResponse> {
+    const { data } = await axiosInstance.post<ProgramResponse>(
+      API_ENDPOINTS.PROGRAMS.CLOSE(id)
+    );
+    return data;
+  },
+
+  // ============================================
+  // Program 스냅샷 연결
+  // ============================================
+
+  /** 스냅샷 연결 */
+  async linkSnapshot(
+    programId: number,
+    snapshotId: number
+  ): Promise<ProgramResponse> {
+    const { data } = await axiosInstance.post<ProgramResponse>(
+      API_ENDPOINTS.PROGRAMS.SNAPSHOT(programId),
+      null,
+      { params: { snapshotId } }
+    );
+    return data;
+  },
+};

--- a/src/types/common/index.ts
+++ b/src/types/common/index.ts
@@ -1,5 +1,6 @@
 export * from './api.types';
 export * from './auth.types';
 export * from './course.types';
+export * from './program.types';
 export * from './sidebar.types';
 export * from './snapshot.types';

--- a/src/types/common/program.types.ts
+++ b/src/types/common/program.types.ts
@@ -1,0 +1,160 @@
+/**
+ * Program 도메인 타입 정의
+ * 백엔드 엔티티 구조에 맞춘 타입들
+ */
+
+// ============================================
+// Enums (Union Types)
+// ============================================
+
+/** 프로그램 상태 */
+export type ProgramStatus =
+  | 'DRAFT' // 작성 중
+  | 'PENDING' // 검토 대기
+  | 'APPROVED' // 승인됨 (운영 가능)
+  | 'REJECTED' // 반려됨
+  | 'CLOSED'; // 종료됨
+
+/** 프로그램 레벨 */
+export type ProgramLevel =
+  | 'BEGINNER' // 입문
+  | 'INTERMEDIATE' // 중급
+  | 'ADVANCED'; // 고급
+
+/** 프로그램 타입 */
+export type ProgramType =
+  | 'ONLINE' // 온라인 (비대면)
+  | 'OFFLINE' // 오프라인 (대면)
+  | 'BLENDED'; // 블렌디드 (혼합)
+
+// ============================================
+// Response Types
+// ============================================
+
+/** 프로그램 목록 조회 응답 */
+export interface ProgramResponse {
+  id: number;
+  title: string;
+  description: string | null;
+  thumbnailUrl: string | null;
+  level: ProgramLevel | null;
+  type: ProgramType | null;
+  estimatedHours: number | null;
+  status: ProgramStatus;
+  creatorId: number;
+  snapshotId: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** 프로그램 상세 조회 응답 */
+export interface ProgramDetailResponse {
+  id: number;
+  title: string;
+  description: string | null;
+  thumbnailUrl: string | null;
+  level: ProgramLevel | null;
+  type: ProgramType | null;
+  estimatedHours: number | null;
+  status: ProgramStatus;
+  creatorId: number;
+  snapshotId: number | null;
+  snapshotName: string | null;
+  // 승인 정보
+  approvedBy: number | null;
+  approvedAt: string | null;
+  approvalComment: string | null;
+  // 반려 정보
+  rejectionReason: string | null;
+  rejectedAt: string | null;
+  // 제출 정보
+  submittedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** 검토 대기 프로그램 응답 (OPERATOR용) */
+export interface PendingProgramResponse {
+  id: number;
+  title: string;
+  thumbnailUrl: string | null;
+  level: ProgramLevel | null;
+  type: ProgramType | null;
+  creatorId: number;
+  submittedAt: string;
+  snapshotId: number | null;
+}
+
+// ============================================
+// Request Types
+// ============================================
+
+/** 프로그램 생성 요청 */
+export interface CreateProgramRequest {
+  title: string;
+  description?: string;
+  thumbnailUrl?: string;
+  level?: ProgramLevel;
+  type?: ProgramType;
+  estimatedHours?: number;
+  snapshotId?: number;
+}
+
+/** 프로그램 수정 요청 */
+export interface UpdateProgramRequest {
+  title?: string;
+  description?: string;
+  thumbnailUrl?: string;
+  level?: ProgramLevel;
+  type?: ProgramType;
+  estimatedHours?: number;
+}
+
+/** 프로그램 승인 요청 */
+export interface ApproveRequest {
+  comment?: string;
+}
+
+/** 프로그램 반려 요청 */
+export interface RejectRequest {
+  reason: string;
+}
+
+// ============================================
+// Utility Types & Constants
+// ============================================
+
+/** ProgramStatus 라벨 맵 */
+export const PROGRAM_STATUS_LABELS: Record<ProgramStatus, string> = {
+  DRAFT: '작성 중',
+  PENDING: '검토 대기',
+  APPROVED: '승인됨',
+  REJECTED: '반려됨',
+  CLOSED: '종료됨',
+};
+
+/** ProgramStatus 색상 맵 (UI용) */
+export const PROGRAM_STATUS_COLORS: Record<
+  ProgramStatus,
+  { bg: string; text: string }
+> = {
+  DRAFT: { bg: 'bg-gray-100', text: 'text-gray-700' },
+  PENDING: { bg: 'bg-yellow-100', text: 'text-yellow-700' },
+  APPROVED: { bg: 'bg-green-100', text: 'text-green-700' },
+  REJECTED: { bg: 'bg-red-100', text: 'text-red-700' },
+  CLOSED: { bg: 'bg-slate-100', text: 'text-slate-700' },
+};
+
+/** ProgramLevel 라벨 맵 */
+export const PROGRAM_LEVEL_LABELS: Record<ProgramLevel, string> = {
+  BEGINNER: '입문',
+  INTERMEDIATE: '중급',
+  ADVANCED: '고급',
+};
+
+/** ProgramType 라벨 맵 */
+export const PROGRAM_TYPE_LABELS: Record<ProgramType, string> = {
+  ONLINE: '온라인',
+  OFFLINE: '오프라인',
+  BLENDED: '블렌디드',
+};


### PR DESCRIPTION
## Summary

- Program 도메인 타입 정의 추가 (`program.types.ts`)
- Program API 서비스 구현 (`programService.ts`)
- FRONTEND_TYPE_CHECKLIST.md Phase 3 완료

## 변경 내용

### 타입 정의 (`src/types/common/program.types.ts`)

**Enums:**
- `ProgramStatus`: DRAFT, PENDING, APPROVED, REJECTED, CLOSED
- `ProgramLevel`: BEGINNER, INTERMEDIATE, ADVANCED
- `ProgramType`: ONLINE, OFFLINE, BLENDED

**Response Types:**
- `ProgramResponse` - 목록 조회용
- `ProgramDetailResponse` - 상세 조회용 (승인/반려 정보 포함)
- `PendingProgramResponse` - 검토 대기 목록용

**Request Types:**
- `CreateProgramRequest`, `UpdateProgramRequest`
- `ApproveRequest`, `RejectRequest` (워크플로우)

### API 서비스 (`src/services/to/programService.ts`)

| 메서드 | 엔드포인트 | 설명 |
|--------|-----------|------|
| createProgram | POST /api/programs | 프로그램 생성 |
| getPrograms | GET /api/programs | 목록 조회 |
| getProgram | GET /api/programs/{id} | 상세 조회 |
| updateProgram | PUT /api/programs/{id} | 수정 |
| deleteProgram | DELETE /api/programs/{id} | 삭제 |
| submitProgram | POST /api/programs/{id}/submit | 개설 신청 |
| getPendingPrograms | GET /api/programs/pending | 검토 대기 목록 |
| approveProgram | POST /api/programs/{id}/approve | 승인 |
| rejectProgram | POST /api/programs/{id}/reject | 반려 |
| closeProgram | POST /api/programs/{id}/close | 종료 |
| linkSnapshot | POST /api/programs/{id}/snapshot | 스냅샷 연결 |

## Test plan

- [ ] TypeScript 컴파일 오류 없음 확인
- [ ] 타입 import 정상 동작 확인
- [ ] API 서비스 함수 호출 테스트 (백엔드 연동 시)

Closes #35