### PR TITLE
[Feat] 설정 페이지 구현 및 UI 설정 기능 연결

### DIFF
--- a/src/components/common/RadioOptionCard/RadioOptionCard.tsx
+++ b/src/components/common/RadioOptionCard/RadioOptionCard.tsx
@@ -1,0 +1,80 @@
+import type { LucideIcon } from 'lucide-react';
+import { designTokens } from '@/styles/admin-design-tokens';
+import { cn } from '@/utils/cn';
+
+interface RadioOptionCardProps {
+  name: string;
+  value: string;
+  label: string;
+  description?: string;
+  isSelected: boolean;
+  onChange: (value: string) => void;
+  icon?: LucideIcon;
+  iconBg?: string;
+  iconColor?: string;
+  className?: string;
+}
+
+export function RadioOptionCard({
+  name,
+  value,
+  label,
+  description,
+  isSelected,
+  onChange,
+  icon: Icon,
+  iconBg,
+  iconColor,
+  className,
+}: RadioOptionCardProps) {
+  return (
+    <label
+      className={cn(
+        'flex items-center p-4 rounded-xl cursor-pointer transition-all hover:bg-muted/50',
+        className
+      )}
+      style={{
+        border: `1px solid ${isSelected ? designTokens.text.secondary : designTokens.bg.border}`,
+        backgroundColor: isSelected ? designTokens.bg.secondary : 'transparent',
+      }}
+    >
+      <input
+        type="radio"
+        name={name}
+        value={value}
+        checked={isSelected}
+        onChange={() => onChange(value)}
+        className="hidden"
+      />
+      {Icon && (
+        <div
+          className="w-12 h-12 rounded-xl flex items-center justify-center mr-4"
+          style={{ backgroundColor: iconBg }}
+        >
+          <Icon className="w-6 h-6" style={{ color: iconColor }} />
+        </div>
+      )}
+      <div className="flex-1">
+        <div style={{ color: designTokens.text.primary, fontSize: '14px', marginBottom: description ? '4px' : 0 }}>
+          {label}
+        </div>
+        {description && (
+          <div style={{ color: designTokens.text.secondary, fontSize: '12px' }}>
+            {description}
+          </div>
+        )}
+      </div>
+      {isSelected && (
+        <div
+          className="w-5 h-5 rounded-full flex items-center justify-center ml-3"
+          style={{ backgroundColor: designTokens.text.secondary }}
+        >
+          <div
+            className="w-2 h-2 rounded-full"
+            style={{ backgroundColor: designTokens.bg.default }}
+          />
+        </div>
+      )}
+    </label>
+  );
+}

--- a/src/components/common/RadioOptionCard/index.ts
+++ b/src/components/common/RadioOptionCard/index.ts
@@ -1,0 +1,1 @@
+export { RadioOptionCard } from './RadioOptionCard';

--- a/src/components/common/SettingsCard.tsx
+++ b/src/components/common/SettingsCard.tsx
@@ -1,0 +1,91 @@
+import { LucideIcon } from 'lucide-react';
+import { designTokens } from '@/styles/admin-design-tokens';
+
+type BadgeColor = 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'indigo' | 'purple' | 'gray';
+
+// 카드 색상 자동 순환 (새 카드 추가 시 color 지정 불필요)
+const CARD_COLORS: BadgeColor[] = ['indigo', 'orange', 'green', 'blue', 'purple', 'red'];
+
+interface SettingsCardProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  onClick: () => void;
+  color?: BadgeColor; // optional - 없으면 index 기반 자동 할당
+  index?: number; // 자동 색상 할당용 index
+}
+
+export function SettingsCard({
+  icon: Icon,
+  title,
+  description,
+  onClick,
+  color,
+  index = 0,
+}: SettingsCardProps) {
+  const colorKey = color ?? CARD_COLORS[index % CARD_COLORS.length];
+  const badgeColor = designTokens.badge[colorKey];
+
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        backgroundColor: designTokens.bg.default,
+        border: `1px solid ${designTokens.bg.border}`,
+        borderRadius: '12px',
+        padding: '24px',
+        textAlign: 'left',
+        cursor: 'pointer',
+        transition: 'all 0.2s',
+        boxShadow: '0 1px 3px rgba(0, 0, 0, 0.08)',
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.borderColor = badgeColor.text;
+        e.currentTarget.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.12)';
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.borderColor = designTokens.bg.border;
+        e.currentTarget.style.boxShadow = '0 1px 3px rgba(0, 0, 0, 0.08)';
+      }}
+    >
+      {/* Icon Container */}
+      <div
+        style={{
+          width: '48px',
+          height: '48px',
+          borderRadius: '12px',
+          backgroundColor: badgeColor.bg,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginBottom: '16px',
+        }}
+      >
+        <Icon style={{ width: '24px', height: '24px', color: badgeColor.text }} />
+      </div>
+
+      {/* Title */}
+      <h3
+        style={{
+          color: designTokens.text.primary,
+          fontSize: '16px',
+          fontWeight: 500,
+          marginBottom: '8px',
+        }}
+      >
+        {title}
+      </h3>
+
+      {/* Description */}
+      <p
+        style={{
+          color: designTokens.text.secondary,
+          fontSize: '14px',
+          lineHeight: 1.5,
+        }}
+      >
+        {description}
+      </p>
+    </button>
+  );
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -300,6 +300,7 @@ export { EmptyState } from './EmptyState';
 export { FileUpload } from './FileUpload';
 export { KanbanBoard, KanbanColumnComponent, KanbanCard } from './Kanban';
 export type { KanbanColumn } from './Kanban';
+export { SettingsCard } from './SettingsCard';
 export { StatsCard } from './StatsCard';
 export { Stepper } from './Stepper';
 export type { Step } from './Stepper';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -300,6 +300,7 @@ export { EmptyState } from './EmptyState';
 export { FileUpload } from './FileUpload';
 export { KanbanBoard, KanbanColumnComponent, KanbanCard } from './Kanban';
 export type { KanbanColumn } from './Kanban';
+export { RadioOptionCard } from './RadioOptionCard';
 export { SettingsCard } from './SettingsCard';
 export { StatsCard } from './StatsCard';
 export { Stepper } from './Stepper';

--- a/src/components/layout/common/AdminLayout.tsx
+++ b/src/components/layout/common/AdminLayout.tsx
@@ -1,7 +1,8 @@
-import { useState, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { BaseSidebar } from './BaseSidebar';
 import type { MenuItem } from '@/types';
 import { designTokens } from '@/styles/admin-design-tokens';
+import { useUIStore } from '@/store/common/uiStore';
 
 interface AdminLayoutProps {
   children: ReactNode;
@@ -16,9 +17,7 @@ export function AdminLayout({
   roleLabel,
   onMenuItemClick,
 }: AdminLayoutProps) {
-  const [isSidebarExpanded, setIsSidebarExpanded] = useState(true);
-  const [isDarkMode, setIsDarkMode] = useState(true);
-  const [language, setLanguage] = useState<'ko' | 'en'>('ko');
+  const { isSidebarExpanded, isDarkMode, language, toggleSidebar } = useUIStore();
 
   return (
     <div
@@ -27,12 +26,10 @@ export function AdminLayout({
     >
       <BaseSidebar
         isExpanded={isSidebarExpanded}
-        onToggle={() => setIsSidebarExpanded(!isSidebarExpanded)}
+        onToggle={toggleSidebar}
         onMenuItemClick={onMenuItemClick}
         isDarkMode={isDarkMode}
-        onThemeToggle={() => setIsDarkMode(!isDarkMode)}
         language={language}
-        onLanguageChange={setLanguage}
         menuData={menuData}
         roleLabel={roleLabel}
       />

--- a/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
+++ b/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
@@ -4,9 +4,6 @@ import {
   ChevronRight,
   PanelLeftClose,
   PanelLeft,
-  Languages,
-  Moon,
-  Sun,
   GraduationCap,
 } from 'lucide-react';
 import type { BaseSidebarProps, SidebarColors } from '@/types';
@@ -18,21 +15,12 @@ export function BaseSidebar({
   onToggle,
   onMenuItemClick,
   isDarkMode = true,
-  onThemeToggle,
   language = 'ko',
-  onLanguageChange,
   menuData,
   roleLabel,
 }: BaseSidebarProps) {
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
   const [activeItem, setActiveItem] = useState<string>('dashboard');
-
-  const toggleLanguage = () => {
-    const newLanguage = language === 'ko' ? 'en' : 'ko';
-    if (onLanguageChange) {
-      onLanguageChange(newLanguage);
-    }
-  };
 
   // Color tokens - Dynamic based on theme
   const colors: SidebarColors = isDarkMode
@@ -357,81 +345,6 @@ export function BaseSidebar({
 
       {/* Divider */}
       <div className="border-t" style={{ borderColor: colors.border }} />
-
-      {/* Language Toggle */}
-      <div className="p-3 border-b" style={{ borderColor: colors.border }}>
-        <button
-          onClick={toggleLanguage}
-          className={cn(
-            'w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all duration-200',
-            !isExpanded && 'justify-center'
-          )}
-          style={{ color: colors.textPrimary }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.backgroundColor = colors.hover;
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.backgroundColor = 'transparent';
-          }}
-          title={language === 'ko' ? '한국어 / English' : 'Korean / English'}
-        >
-          <Languages
-            className="w-5 h-5"
-            style={{ color: colors.textSecondary }}
-          />
-          {isExpanded && (
-            <span className="flex-1 text-left text-sm">
-              {language === 'ko' ? '한국어' : 'English'}
-            </span>
-          )}
-        </button>
-      </div>
-
-      {/* Theme Toggle */}
-      {onThemeToggle && (
-        <div className="p-3 border-b" style={{ borderColor: colors.border }}>
-          <button
-            onClick={onThemeToggle}
-            className={cn(
-              'w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all duration-200',
-              !isExpanded && 'justify-center'
-            )}
-            style={{ color: colors.textPrimary }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.backgroundColor = colors.hover;
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.backgroundColor = 'transparent';
-            }}
-            title={
-              isDarkMode
-                ? language === 'ko'
-                  ? '라이트 모드'
-                  : 'Light Mode'
-                : language === 'ko'
-                  ? '다크 모드'
-                  : 'Dark Mode'
-            }
-          >
-            {isDarkMode ? (
-              <Sun className="w-5 h-5" style={{ color: colors.textSecondary }} />
-            ) : (
-              <Moon className="w-5 h-5" style={{ color: colors.textSecondary }} />
-            )}
-            {isExpanded && (
-              <span className="flex-1 text-left text-sm">
-                {isDarkMode
-                  ? language === 'ko'
-                    ? '라이트 모드'
-                    : 'Light Mode'
-                  : language === 'ko'
-                    ? '다크 모드'
-                    : 'Dark Mode'}
-              </span>
-            )}
-          </button>
-        </div>
-      )}
 
       {/* Collapse Toggle */}
       <div className="p-3">

--- a/src/components/layout/sa/SuperAdminLayout.tsx
+++ b/src/components/layout/sa/SuperAdminLayout.tsx
@@ -1,8 +1,9 @@
-import { useState, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { SuperAdminSidebar } from './SuperAdminSidebar';
 import { designTokens } from '@/styles/admin-design-tokens';
 import { superAdminMenuData } from '@/config/sidebar-menus';
+import { useUIStore } from '@/store/common/uiStore';
 
 interface SuperAdminLayoutProps {
   children: ReactNode;
@@ -10,9 +11,7 @@ interface SuperAdminLayoutProps {
 
 export function SuperAdminLayout({ children }: SuperAdminLayoutProps) {
   const navigate = useNavigate();
-  const [isSidebarExpanded, setIsSidebarExpanded] = useState(true);
-  const [isDarkMode, setIsDarkMode] = useState(true);
-  const [language, setLanguage] = useState<'ko' | 'en'>('ko');
+  const { isSidebarExpanded, isDarkMode, language, toggleSidebar } = useUIStore();
 
   const handleMenuItemClick = (itemId: string) => {
     // Check top-level menu items
@@ -39,12 +38,10 @@ export function SuperAdminLayout({ children }: SuperAdminLayoutProps) {
     >
       <SuperAdminSidebar
         isExpanded={isSidebarExpanded}
-        onToggle={() => setIsSidebarExpanded(!isSidebarExpanded)}
+        onToggle={toggleSidebar}
         onMenuItemClick={handleMenuItemClick}
         isDarkMode={isDarkMode}
-        onThemeToggle={() => setIsDarkMode(!isDarkMode)}
         language={language}
-        onLanguageChange={setLanguage}
       />
 
       <main className="flex-1 overflow-auto">{children}</main>

--- a/src/components/layout/sa/SuperAdminSidebar/SuperAdminSidebar.tsx
+++ b/src/components/layout/sa/SuperAdminSidebar/SuperAdminSidebar.tsx
@@ -6,9 +6,7 @@ interface SuperAdminSidebarProps {
   onToggle: () => void;
   onMenuItemClick?: (itemId: string) => void;
   isDarkMode?: boolean;
-  onThemeToggle?: () => void;
   language?: 'ko' | 'en';
-  onLanguageChange?: (language: 'ko' | 'en') => void;
 }
 
 export function SuperAdminSidebar(props: SuperAdminSidebarProps) {

--- a/src/components/layout/ta/TenantAdminLayout.tsx
+++ b/src/components/layout/ta/TenantAdminLayout.tsx
@@ -1,8 +1,9 @@
-import { useState, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TenantAdminSidebar } from './TenantAdminSidebar';
 import { designTokens } from '@/styles/admin-design-tokens';
 import { tenantAdminMenuData } from '@/config/sidebar-menus';
+import { useUIStore } from '@/store/common/uiStore';
 
 interface TenantAdminLayoutProps {
   children: ReactNode;
@@ -10,9 +11,7 @@ interface TenantAdminLayoutProps {
 
 export function TenantAdminLayout({ children }: TenantAdminLayoutProps) {
   const navigate = useNavigate();
-  const [isSidebarExpanded, setIsSidebarExpanded] = useState(true);
-  const [isDarkMode, setIsDarkMode] = useState(true);
-  const [language, setLanguage] = useState<'ko' | 'en'>('ko');
+  const { isSidebarExpanded, isDarkMode, language, toggleSidebar } = useUIStore();
 
   const handleMenuItemClick = (itemId: string) => {
     // Check top-level menu items
@@ -39,12 +38,10 @@ export function TenantAdminLayout({ children }: TenantAdminLayoutProps) {
     >
       <TenantAdminSidebar
         isExpanded={isSidebarExpanded}
-        onToggle={() => setIsSidebarExpanded(!isSidebarExpanded)}
+        onToggle={toggleSidebar}
         onMenuItemClick={handleMenuItemClick}
         isDarkMode={isDarkMode}
-        onThemeToggle={() => setIsDarkMode(!isDarkMode)}
         language={language}
-        onLanguageChange={setLanguage}
       />
 
       <main className="flex-1 overflow-auto">{children}</main>

--- a/src/components/layout/ta/TenantAdminSidebar/TenantAdminSidebar.tsx
+++ b/src/components/layout/ta/TenantAdminSidebar/TenantAdminSidebar.tsx
@@ -6,9 +6,7 @@ interface TenantAdminSidebarProps {
   onToggle: () => void;
   onMenuItemClick?: (itemId: string) => void;
   isDarkMode?: boolean;
-  onThemeToggle?: () => void;
   language?: 'ko' | 'en';
-  onLanguageChange?: (language: 'ko' | 'en') => void;
 }
 
 export function TenantAdminSidebar(props: TenantAdminSidebarProps) {

--- a/src/components/layout/to/TenantOperatorLayout.tsx
+++ b/src/components/layout/to/TenantOperatorLayout.tsx
@@ -1,8 +1,9 @@
-import { useState, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TenantOperatorSidebar } from './TenantOperatorSidebar';
 import { designTokens } from '@/styles/admin-design-tokens';
 import { tenantOperatorMenuData } from '@/config/sidebar-menus';
+import { useUIStore } from '@/store/common/uiStore';
 
 interface TenantOperatorLayoutProps {
   children: ReactNode;
@@ -12,9 +13,7 @@ export function TenantOperatorLayout({
   children,
 }: TenantOperatorLayoutProps) {
   const navigate = useNavigate();
-  const [isSidebarExpanded, setIsSidebarExpanded] = useState(true);
-  const [isDarkMode, setIsDarkMode] = useState(true);
-  const [language, setLanguage] = useState<'ko' | 'en'>('ko');
+  const { isSidebarExpanded, isDarkMode, language, toggleSidebar } = useUIStore();
 
   const handleMenuItemClick = (itemId: string) => {
     // Check top-level menu items
@@ -41,12 +40,10 @@ export function TenantOperatorLayout({
     >
       <TenantOperatorSidebar
         isExpanded={isSidebarExpanded}
-        onToggle={() => setIsSidebarExpanded(!isSidebarExpanded)}
+        onToggle={toggleSidebar}
         onMenuItemClick={handleMenuItemClick}
         isDarkMode={isDarkMode}
-        onThemeToggle={() => setIsDarkMode(!isDarkMode)}
         language={language}
-        onLanguageChange={setLanguage}
       />
 
       <main className="flex-1 overflow-auto">{children}</main>

--- a/src/components/layout/to/TenantOperatorSidebar/TenantOperatorSidebar.tsx
+++ b/src/components/layout/to/TenantOperatorSidebar/TenantOperatorSidebar.tsx
@@ -6,9 +6,7 @@ interface TenantOperatorSidebarProps {
   onToggle: () => void;
   onMenuItemClick?: (itemId: string) => void;
   isDarkMode?: boolean;
-  onThemeToggle?: () => void;
   language?: 'ko' | 'en';
-  onLanguageChange?: (language: 'ko' | 'en') => void;
 }
 
 export function TenantOperatorSidebar(props: TenantOperatorSidebarProps) {

--- a/src/components/layout/tu/TenantUserLayout.tsx
+++ b/src/components/layout/tu/TenantUserLayout.tsx
@@ -1,8 +1,9 @@
-import { useState, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TenantUserSidebar } from './TenantUserSidebar';
 import { designTokens } from '@/styles/admin-design-tokens';
 import { tenantUserMenuData } from '@/config/sidebar-menus';
+import { useUIStore } from '@/store/common/uiStore';
 
 interface TenantUserLayoutProps {
   children: ReactNode;
@@ -10,9 +11,7 @@ interface TenantUserLayoutProps {
 
 export function TenantUserLayout({ children }: TenantUserLayoutProps) {
   const navigate = useNavigate();
-  const [isSidebarExpanded, setIsSidebarExpanded] = useState(true);
-  const [isDarkMode, setIsDarkMode] = useState(true);
-  const [language, setLanguage] = useState<'ko' | 'en'>('ko');
+  const { isSidebarExpanded, isDarkMode, language, toggleSidebar } = useUIStore();
 
   const handleMenuItemClick = (itemId: string) => {
     // Check top-level menu items
@@ -39,12 +38,10 @@ export function TenantUserLayout({ children }: TenantUserLayoutProps) {
     >
       <TenantUserSidebar
         isExpanded={isSidebarExpanded}
-        onToggle={() => setIsSidebarExpanded(!isSidebarExpanded)}
+        onToggle={toggleSidebar}
         onMenuItemClick={handleMenuItemClick}
         isDarkMode={isDarkMode}
-        onThemeToggle={() => setIsDarkMode(!isDarkMode)}
         language={language}
-        onLanguageChange={setLanguage}
       />
 
       <main className="flex-1 overflow-auto">{children}</main>

--- a/src/components/layout/tu/TenantUserSidebar/TenantUserSidebar.tsx
+++ b/src/components/layout/tu/TenantUserSidebar/TenantUserSidebar.tsx
@@ -6,9 +6,7 @@ interface TenantUserSidebarProps {
   onToggle: () => void;
   onMenuItemClick?: (itemId: string) => void;
   isDarkMode?: boolean;
-  onThemeToggle?: () => void;
   language?: 'ko' | 'en';
-  onLanguageChange?: (language: 'ko' | 'en') => void;
 }
 
 export function TenantUserSidebar(props: TenantUserSidebarProps) {

--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -24,7 +24,6 @@ import {
   Activity,
   FileText,
   Shield,
-  Bell,
   Server,
   Layout,
   Paintbrush,
@@ -104,10 +103,7 @@ export const superAdminMenuData: MenuItem[] = [
     id: 'settings',
     label: { ko: '설정', en: 'Settings' },
     icon: Settings,
-    subItems: [
-      { id: 'account-security', label: { ko: '계정 및 보안', en: 'Account & Security' }, icon: Shield, path: '/sa/settings/security' },
-      { id: 'notification-settings', label: { ko: '알림', en: 'Notifications' }, icon: Bell, path: '/sa/settings/notifications' },
-    ],
+    path: '/sa/settings',
   },
 ];
 
@@ -164,10 +160,7 @@ export const tenantAdminMenuData: MenuItem[] = [
     id: 'settings',
     label: { ko: '설정', en: 'Settings' },
     icon: Settings,
-    subItems: [
-      { id: 'account-security', label: { ko: '계정 및 보안', en: 'Account & Security' }, icon: Shield, path: '/ta/settings/security' },
-      { id: 'notification-settings', label: { ko: '알림', en: 'Notifications' }, icon: Bell, path: '/ta/settings/notifications' },
-    ],
+    path: '/ta/settings',
   },
 ];
 
@@ -221,10 +214,7 @@ export const tenantOperatorMenuData: MenuItem[] = [
     id: 'settings',
     label: { ko: '설정', en: 'Settings' },
     icon: Settings,
-    subItems: [
-      { id: 'account-security', label: { ko: '계정 및 보안', en: 'Account & Security' }, icon: Shield, path: '/to/settings/security' },
-      { id: 'notification-settings', label: { ko: '알림', en: 'Notifications' }, icon: Bell, path: '/to/settings/notifications' },
-    ],
+    path: '/to/settings',
   },
 ];
 
@@ -270,10 +260,7 @@ export const tenantUserMenuData: MenuItem[] = [
     id: 'settings',
     label: { ko: '설정', en: 'Settings' },
     icon: Settings,
-    subItems: [
-      { id: 'account-security', label: { ko: '계정 및 보안', en: 'Account & Security' }, icon: Shield, path: '/tu/settings/security' },
-      { id: 'notification-settings', label: { ko: '알림', en: 'Notifications' }, icon: Bell, path: '/tu/settings/notifications' },
-    ],
+    path: '/tu/settings',
   },
 ];
 

--- a/src/pages/common/index.ts
+++ b/src/pages/common/index.ts
@@ -1,0 +1,6 @@
+export {
+  SettingsPage,
+  SettingsSecurityPage,
+  SettingsNotificationsPage,
+  SettingsAppearancePage,
+} from './settings';

--- a/src/pages/common/settings/SettingsAppearancePage.tsx
+++ b/src/pages/common/settings/SettingsAppearancePage.tsx
@@ -10,7 +10,15 @@ import {
   Maximize2,
   Minimize2,
 } from 'lucide-react';
-import { designTokens } from '@/styles/design-tokens';
+import { designTokens } from '@/styles/admin-design-tokens';
+import {
+  Button,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  Label,
+} from '@/components/common';
 
 export function SettingsAppearancePage() {
   const navigate = useNavigate();
@@ -29,6 +37,33 @@ export function SettingsAppearancePage() {
     alert('외관 설정이 저장되었습니다.');
   };
 
+  const themeOptions = [
+    {
+      value: 'light' as const,
+      icon: Sun,
+      label: '라이트 모드',
+      description: '밝은 배경과 어두운 텍스트',
+      iconBg: designTokens.badge.yellow.bg,
+      iconColor: designTokens.badge.yellow.text,
+    },
+    {
+      value: 'dark' as const,
+      icon: Moon,
+      label: '다크 모드',
+      description: '어두운 배경과 밝은 텍스트',
+      iconBg: designTokens.badge.blue.bg,
+      iconColor: designTokens.badge.blue.text,
+    },
+    {
+      value: 'system' as const,
+      icon: Laptop,
+      label: '시스템 설정 따라가기',
+      description: '운영체제 테마 설정을 따릅니다',
+      iconBg: designTokens.badge.purple.bg,
+      iconColor: designTokens.badge.purple.text,
+    },
+  ];
+
   return (
     <div
       style={{
@@ -40,26 +75,14 @@ export function SettingsAppearancePage() {
     >
       <div style={{ maxWidth: '800px', margin: '0 auto' }}>
         {/* Header with Back Button */}
-        <button
+        <Button
+          variant="ghost"
           onClick={handleBack}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px',
-            padding: '8px 12px',
-            marginBottom: '24px',
-            backgroundColor: 'transparent',
-            border: 'none',
-            color: designTokens.text.secondary,
-            cursor: 'pointer',
-            transition: 'color 0.2s',
-          }}
-          onMouseEnter={(e) => (e.currentTarget.style.color = designTokens.text.primary)}
-          onMouseLeave={(e) => (e.currentTarget.style.color = designTokens.text.secondary)}
+          className="mb-6 gap-2 text-muted-foreground hover:text-foreground"
         >
-          <ArrowLeft style={{ width: '20px', height: '20px' }} />
+          <ArrowLeft className="w-5 h-5" />
           <span>설정으로 돌아가기</span>
-        </button>
+        </Button>
 
         <h1
           style={{
@@ -76,446 +99,108 @@ export function SettingsAppearancePage() {
         </p>
 
         {/* Theme Mode Section */}
-        <section
-          style={{
-            backgroundColor: designTokens.bg.default,
-            border: `1px solid ${designTokens.bg.border}`,
-            borderRadius: '12px',
-            padding: '24px',
-            marginBottom: '24px',
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '12px',
-              marginBottom: '24px',
-              paddingBottom: '16px',
-              borderBottom: `1px solid ${designTokens.bg.border}`,
-            }}
-          >
-            <Palette style={{ width: '20px', height: '20px', color: '#4C2D9A' }} />
-            <h2 style={{ color: designTokens.text.primary, fontSize: '18px', fontWeight: 500 }}>
-              테마 모드
-            </h2>
-          </div>
-
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-            {/* Light Mode */}
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                padding: '16px',
-                border: `2px solid ${themeMode === 'light' ? '#4C2D9A' : designTokens.bg.border}`,
-                borderRadius: '12px',
-                cursor: 'pointer',
-                backgroundColor: themeMode === 'light' ? '#F8F5FC' : 'transparent',
-                transition: 'all 0.2s',
-              }}
-              onMouseEnter={(e) => {
-                if (themeMode !== 'light') {
-                  e.currentTarget.style.backgroundColor = '#FAFAFA';
-                }
-              }}
-              onMouseLeave={(e) => {
-                if (themeMode !== 'light') {
-                  e.currentTarget.style.backgroundColor = 'transparent';
-                }
-              }}
-            >
-              <input
-                type="radio"
-                name="themeMode"
-                value="light"
-                checked={themeMode === 'light'}
-                onChange={() => setThemeMode('light')}
-                style={{ display: 'none' }}
-              />
-              <div
-                style={{
-                  width: '48px',
-                  height: '48px',
-                  borderRadius: '12px',
-                  backgroundColor: '#FFF9E6',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  marginRight: '16px',
-                }}
-              >
-                <Sun style={{ width: '24px', height: '24px', color: '#FFB74D' }} />
-              </div>
-              <div style={{ flex: 1 }}>
-                <div
-                  style={{
-                    color: designTokens.text.primary,
-                    fontSize: '16px',
-                    marginBottom: '4px',
-                  }}
-                >
-                  라이트 모드
-                </div>
-                <div
-                  style={{
-                    color: designTokens.text.secondary,
-                    fontSize: '13px',
-                  }}
-                >
-                  밝은 배경과 어두운 텍스트
-                </div>
-              </div>
-              {themeMode === 'light' && (
-                <div
-                  style={{
-                    width: '20px',
-                    height: '20px',
-                    borderRadius: '50%',
-                    backgroundColor: '#4C2D9A',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <div
+        <Card className="mb-6">
+          <CardHeader className="border-b px-6 py-4">
+            <div className="flex items-center gap-3">
+              <Palette className="w-5 h-5" style={{ color: designTokens.text.secondary }} />
+              <CardTitle className="text-lg font-medium">테마 모드</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent className="pt-6 px-6 pb-6">
+            <div className="flex flex-col gap-3">
+              {themeOptions.map((option) => {
+                const Icon = option.icon;
+                const isSelected = themeMode === option.value;
+                return (
+                  <label
+                    key={option.value}
+                    className="flex items-center p-4 rounded-xl cursor-pointer transition-all hover:bg-muted/50"
                     style={{
-                      width: '8px',
-                      height: '8px',
-                      borderRadius: '50%',
-                      backgroundColor: 'white',
+                      border: `2px solid ${isSelected ? designTokens.action.primary_default : designTokens.bg.border}`,
+                      backgroundColor: isSelected ? designTokens.bg.secondary : 'transparent',
                     }}
-                  />
-                </div>
-              )}
-            </label>
-
-            {/* Dark Mode */}
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                padding: '16px',
-                border: `2px solid ${themeMode === 'dark' ? '#4C2D9A' : designTokens.bg.border}`,
-                borderRadius: '12px',
-                cursor: 'pointer',
-                backgroundColor: themeMode === 'dark' ? '#F8F5FC' : 'transparent',
-                transition: 'all 0.2s',
-              }}
-              onMouseEnter={(e) => {
-                if (themeMode !== 'dark') {
-                  e.currentTarget.style.backgroundColor = '#FAFAFA';
-                }
-              }}
-              onMouseLeave={(e) => {
-                if (themeMode !== 'dark') {
-                  e.currentTarget.style.backgroundColor = 'transparent';
-                }
-              }}
-            >
-              <input
-                type="radio"
-                name="themeMode"
-                value="dark"
-                checked={themeMode === 'dark'}
-                onChange={() => setThemeMode('dark')}
-                style={{ display: 'none' }}
-              />
-              <div
-                style={{
-                  width: '48px',
-                  height: '48px',
-                  borderRadius: '12px',
-                  backgroundColor: '#E3F2FD',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  marginRight: '16px',
-                }}
-              >
-                <Moon style={{ width: '24px', height: '24px', color: '#5C6BC0' }} />
-              </div>
-              <div style={{ flex: 1 }}>
-                <div
-                  style={{
-                    color: designTokens.text.primary,
-                    fontSize: '16px',
-                    marginBottom: '4px',
-                  }}
-                >
-                  다크 모드
-                </div>
-                <div
-                  style={{
-                    color: designTokens.text.secondary,
-                    fontSize: '13px',
-                  }}
-                >
-                  어두운 배경과 밝은 텍스트
-                </div>
-              </div>
-              {themeMode === 'dark' && (
-                <div
-                  style={{
-                    width: '20px',
-                    height: '20px',
-                    borderRadius: '50%',
-                    backgroundColor: '#4C2D9A',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <div
-                    style={{
-                      width: '8px',
-                      height: '8px',
-                      borderRadius: '50%',
-                      backgroundColor: 'white',
-                    }}
-                  />
-                </div>
-              )}
-            </label>
-
-            {/* System Mode */}
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                padding: '16px',
-                border: `2px solid ${themeMode === 'system' ? '#4C2D9A' : designTokens.bg.border}`,
-                borderRadius: '12px',
-                cursor: 'pointer',
-                backgroundColor: themeMode === 'system' ? '#F8F5FC' : 'transparent',
-                transition: 'all 0.2s',
-              }}
-              onMouseEnter={(e) => {
-                if (themeMode !== 'system') {
-                  e.currentTarget.style.backgroundColor = '#FAFAFA';
-                }
-              }}
-              onMouseLeave={(e) => {
-                if (themeMode !== 'system') {
-                  e.currentTarget.style.backgroundColor = 'transparent';
-                }
-              }}
-            >
-              <input
-                type="radio"
-                name="themeMode"
-                value="system"
-                checked={themeMode === 'system'}
-                onChange={() => setThemeMode('system')}
-                style={{ display: 'none' }}
-              />
-              <div
-                style={{
-                  width: '48px',
-                  height: '48px',
-                  borderRadius: '12px',
-                  backgroundColor: '#F3E5F5',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  marginRight: '16px',
-                }}
-              >
-                <Laptop style={{ width: '24px', height: '24px', color: '#9C27B0' }} />
-              </div>
-              <div style={{ flex: 1 }}>
-                <div
-                  style={{
-                    color: designTokens.text.primary,
-                    fontSize: '16px',
-                    marginBottom: '4px',
-                  }}
-                >
-                  시스템 설정 따라가기
-                </div>
-                <div
-                  style={{
-                    color: designTokens.text.secondary,
-                    fontSize: '13px',
-                  }}
-                >
-                  운영체제 테마 설정을 따릅니다
-                </div>
-              </div>
-              {themeMode === 'system' && (
-                <div
-                  style={{
-                    width: '20px',
-                    height: '20px',
-                    borderRadius: '50%',
-                    backgroundColor: '#4C2D9A',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <div
-                    style={{
-                      width: '8px',
-                      height: '8px',
-                      borderRadius: '50%',
-                      backgroundColor: 'white',
-                    }}
-                  />
-                </div>
-              )}
-            </label>
-          </div>
-        </section>
+                  >
+                    <input
+                      type="radio"
+                      name="themeMode"
+                      value={option.value}
+                      checked={isSelected}
+                      onChange={() => setThemeMode(option.value)}
+                      className="hidden"
+                    />
+                    <div
+                      className="w-12 h-12 rounded-xl flex items-center justify-center mr-4"
+                      style={{ backgroundColor: option.iconBg }}
+                    >
+                      <Icon className="w-6 h-6" style={{ color: option.iconColor }} />
+                    </div>
+                    <div className="flex-1">
+                      <div style={{ color: designTokens.text.primary, fontSize: '16px', marginBottom: '4px' }}>
+                        {option.label}
+                      </div>
+                      <div style={{ color: designTokens.text.secondary, fontSize: '13px' }}>
+                        {option.description}
+                      </div>
+                    </div>
+                    {isSelected && (
+                      <div
+                        className="w-5 h-5 rounded-full flex items-center justify-center"
+                        style={{ backgroundColor: designTokens.action.primary_default }}
+                      >
+                        <div
+                          className="w-2 h-2 rounded-full"
+                          style={{ backgroundColor: designTokens.bg.default }}
+                        />
+                      </div>
+                    )}
+                  </label>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
 
         {/* Sidebar Settings Section */}
-        <section
-          style={{
-            backgroundColor: designTokens.bg.default,
-            border: `1px solid ${designTokens.bg.border}`,
-            borderRadius: '12px',
-            padding: '24px',
-            marginBottom: '24px',
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '12px',
-              marginBottom: '24px',
-              paddingBottom: '16px',
-              borderBottom: `1px solid ${designTokens.bg.border}`,
-            }}
-          >
-            <Monitor style={{ width: '20px', height: '20px', color: '#4C2D9A' }} />
-            <h2 style={{ color: designTokens.text.primary, fontSize: '18px', fontWeight: 500 }}>
-              사이드바 설정
-            </h2>
-          </div>
-
-          <div>
-            <label
-              style={{
-                display: 'block',
-                color: designTokens.text.secondary,
-                fontSize: '14px',
-                marginBottom: '12px',
-              }}
-            >
-              사이드바 기본 상태
-            </label>
-            <div style={{ display: 'flex', gap: '12px' }}>
-              <button
-                onClick={() => setSidebarDefault('expanded')}
-                style={{
-                  flex: 1,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: '8px',
-                  padding: '16px',
-                  backgroundColor:
-                    sidebarDefault === 'expanded'
-                      ? designTokens.button.brand_default
-                      : designTokens.bg.default,
-                  color: sidebarDefault === 'expanded' ? 'white' : designTokens.text.primary,
-                  border: `1px solid ${sidebarDefault === 'expanded' ? designTokens.button.brand_default : designTokens.bg.border}`,
-                  borderRadius: '8px',
-                  cursor: 'pointer',
-                  fontSize: '14px',
-                  transition: 'all 0.2s',
-                }}
-                onMouseEnter={(e) => {
-                  if (sidebarDefault !== 'expanded') {
-                    e.currentTarget.style.borderColor = '#4C2D9A';
-                    e.currentTarget.style.backgroundColor = '#F8F5FC';
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  if (sidebarDefault !== 'expanded') {
-                    e.currentTarget.style.borderColor = designTokens.bg.border;
-                    e.currentTarget.style.backgroundColor = designTokens.bg.default;
-                  }
-                }}
-              >
-                <Maximize2 style={{ width: '18px', height: '18px' }} />
-                확장
-              </button>
-              <button
-                onClick={() => setSidebarDefault('collapsed')}
-                style={{
-                  flex: 1,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: '8px',
-                  padding: '16px',
-                  backgroundColor:
-                    sidebarDefault === 'collapsed'
-                      ? designTokens.button.brand_default
-                      : designTokens.bg.default,
-                  color: sidebarDefault === 'collapsed' ? 'white' : designTokens.text.primary,
-                  border: `1px solid ${sidebarDefault === 'collapsed' ? designTokens.button.brand_default : designTokens.bg.border}`,
-                  borderRadius: '8px',
-                  cursor: 'pointer',
-                  fontSize: '14px',
-                  transition: 'all 0.2s',
-                }}
-                onMouseEnter={(e) => {
-                  if (sidebarDefault !== 'collapsed') {
-                    e.currentTarget.style.borderColor = '#4C2D9A';
-                    e.currentTarget.style.backgroundColor = '#F8F5FC';
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  if (sidebarDefault !== 'collapsed') {
-                    e.currentTarget.style.borderColor = designTokens.bg.border;
-                    e.currentTarget.style.backgroundColor = designTokens.bg.default;
-                  }
-                }}
-              >
-                <Minimize2 style={{ width: '18px', height: '18px' }} />
-                축소
-              </button>
+        <Card className="mb-6">
+          <CardHeader className="border-b px-6 py-4">
+            <div className="flex items-center gap-3">
+              <Monitor className="w-5 h-5" style={{ color: designTokens.text.secondary }} />
+              <CardTitle className="text-lg font-medium">사이드바 설정</CardTitle>
             </div>
-            <p
-              style={{
-                fontSize: '12px',
-                color: designTokens.text.secondary,
-                marginTop: '12px',
-              }}
-            >
-              로그인 시 사이드바의 기본 상태를 설정합니다.
-            </p>
-          </div>
-        </section>
+          </CardHeader>
+          <CardContent className="pt-6 px-6 pb-6">
+            <div>
+              <Label className="mb-3 text-muted-foreground text-sm">사이드바 기본 상태</Label>
+              <div className="flex gap-3 mt-3">
+                <Button
+                  variant={sidebarDefault === 'expanded' ? 'default' : 'outline'}
+                  onClick={() => setSidebarDefault('expanded')}
+                  className="flex-1 gap-2"
+                >
+                  <Maximize2 className="w-4 h-4" />
+                  확장
+                </Button>
+                <Button
+                  variant={sidebarDefault === 'collapsed' ? 'default' : 'outline'}
+                  onClick={() => setSidebarDefault('collapsed')}
+                  className="flex-1 gap-2"
+                >
+                  <Minimize2 className="w-4 h-4" />
+                  축소
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground mt-3">
+                로그인 시 사이드바의 기본 상태를 설정합니다.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
 
         {/* Save Button */}
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'flex-end',
-            paddingTop: '16px',
-          }}
-        >
-          <button
-            onClick={handleSave}
-            style={{
-              padding: '10px 24px',
-              backgroundColor: designTokens.button.brand_default,
-              color: 'white',
-              border: 'none',
-              borderRadius: '8px',
-              cursor: 'pointer',
-              fontSize: '14px',
-              transition: 'opacity 0.2s',
-            }}
-            onMouseEnter={(e) => (e.currentTarget.style.opacity = '0.9')}
-            onMouseLeave={(e) => (e.currentTarget.style.opacity = '1')}
-          >
+        <div className="flex justify-end pt-4">
+          <Button onClick={handleSave}>
             저장
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/pages/common/settings/SettingsAppearancePage.tsx
+++ b/src/pages/common/settings/SettingsAppearancePage.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
   ArrowLeft,
@@ -19,13 +18,15 @@ import {
   Label,
   RadioOptionCard,
 } from '@/components/common';
+import { useUIStore } from '@/store/common/uiStore';
 
 export function SettingsAppearancePage() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const [themeMode, setThemeMode] = useState<'light' | 'dark'>('light');
-  const [sidebarDefault, setSidebarDefault] = useState<'expanded' | 'collapsed'>('expanded');
+  const { isDarkMode, setDarkMode, isSidebarExpanded, setSidebarExpanded } = useUIStore();
+  const themeMode = isDarkMode ? 'dark' : 'light';
+  const sidebarDefault = isSidebarExpanded ? 'expanded' : 'collapsed';
 
   const basePath = location.pathname.split('/settings')[0];
 
@@ -108,7 +109,7 @@ export function SettingsAppearancePage() {
                   label={option.label}
                   description={option.description}
                   isSelected={themeMode === option.value}
-                  onChange={(v) => setThemeMode(v as 'light' | 'dark')}
+                  onChange={(v) => setDarkMode(v === 'dark')}
                   icon={option.icon}
                   iconBg={option.iconBg}
                   iconColor={option.iconColor}
@@ -132,7 +133,7 @@ export function SettingsAppearancePage() {
               <div className="flex gap-3 mt-3">
                 <Button
                   variant={sidebarDefault === 'expanded' ? 'default' : 'outline'}
-                  onClick={() => setSidebarDefault('expanded')}
+                  onClick={() => setSidebarExpanded(true)}
                   className="flex-1 gap-2"
                 >
                   <Maximize2 className="w-4 h-4" />
@@ -140,7 +141,7 @@ export function SettingsAppearancePage() {
                 </Button>
                 <Button
                   variant={sidebarDefault === 'collapsed' ? 'default' : 'outline'}
-                  onClick={() => setSidebarDefault('collapsed')}
+                  onClick={() => setSidebarExpanded(false)}
                   className="flex-1 gap-2"
                 >
                   <Minimize2 className="w-4 h-4" />

--- a/src/pages/common/settings/SettingsAppearancePage.tsx
+++ b/src/pages/common/settings/SettingsAppearancePage.tsx
@@ -1,0 +1,523 @@
+import { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import {
+  ArrowLeft,
+  Palette,
+  Monitor,
+  Sun,
+  Moon,
+  Laptop,
+  Maximize2,
+  Minimize2,
+} from 'lucide-react';
+import { designTokens } from '@/styles/design-tokens';
+
+export function SettingsAppearancePage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const [themeMode, setThemeMode] = useState<'light' | 'dark' | 'system'>('light');
+  const [sidebarDefault, setSidebarDefault] = useState<'expanded' | 'collapsed'>('expanded');
+
+  const basePath = location.pathname.split('/settings')[0];
+
+  const handleBack = () => {
+    navigate(`${basePath}/settings`);
+  };
+
+  const handleSave = () => {
+    alert('외관 설정이 저장되었습니다.');
+  };
+
+  return (
+    <div
+      style={{
+        padding: '40px',
+        backgroundColor: designTokens.bg.app_default,
+        minHeight: '100%',
+        overflowY: 'auto',
+      }}
+    >
+      <div style={{ maxWidth: '800px', margin: '0 auto' }}>
+        {/* Header with Back Button */}
+        <button
+          onClick={handleBack}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            padding: '8px 12px',
+            marginBottom: '24px',
+            backgroundColor: 'transparent',
+            border: 'none',
+            color: designTokens.text.secondary,
+            cursor: 'pointer',
+            transition: 'color 0.2s',
+          }}
+          onMouseEnter={(e) => (e.currentTarget.style.color = designTokens.text.primary)}
+          onMouseLeave={(e) => (e.currentTarget.style.color = designTokens.text.secondary)}
+        >
+          <ArrowLeft style={{ width: '20px', height: '20px' }} />
+          <span>설정으로 돌아가기</span>
+        </button>
+
+        <h1
+          style={{
+            color: designTokens.text.primary,
+            fontSize: '24px',
+            fontWeight: 600,
+            marginBottom: '8px',
+          }}
+        >
+          외관
+        </h1>
+        <p style={{ color: designTokens.text.secondary, marginBottom: '32px' }}>
+          테마, 사이드바 및 표시 옵션을 설정하세요
+        </p>
+
+        {/* Theme Mode Section */}
+        <section
+          style={{
+            backgroundColor: designTokens.bg.default,
+            border: `1px solid ${designTokens.bg.border}`,
+            borderRadius: '12px',
+            padding: '24px',
+            marginBottom: '24px',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px',
+              marginBottom: '24px',
+              paddingBottom: '16px',
+              borderBottom: `1px solid ${designTokens.bg.border}`,
+            }}
+          >
+            <Palette style={{ width: '20px', height: '20px', color: '#4C2D9A' }} />
+            <h2 style={{ color: designTokens.text.primary, fontSize: '18px', fontWeight: 500 }}>
+              테마 모드
+            </h2>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+            {/* Light Mode */}
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                padding: '16px',
+                border: `2px solid ${themeMode === 'light' ? '#4C2D9A' : designTokens.bg.border}`,
+                borderRadius: '12px',
+                cursor: 'pointer',
+                backgroundColor: themeMode === 'light' ? '#F8F5FC' : 'transparent',
+                transition: 'all 0.2s',
+              }}
+              onMouseEnter={(e) => {
+                if (themeMode !== 'light') {
+                  e.currentTarget.style.backgroundColor = '#FAFAFA';
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (themeMode !== 'light') {
+                  e.currentTarget.style.backgroundColor = 'transparent';
+                }
+              }}
+            >
+              <input
+                type="radio"
+                name="themeMode"
+                value="light"
+                checked={themeMode === 'light'}
+                onChange={() => setThemeMode('light')}
+                style={{ display: 'none' }}
+              />
+              <div
+                style={{
+                  width: '48px',
+                  height: '48px',
+                  borderRadius: '12px',
+                  backgroundColor: '#FFF9E6',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  marginRight: '16px',
+                }}
+              >
+                <Sun style={{ width: '24px', height: '24px', color: '#FFB74D' }} />
+              </div>
+              <div style={{ flex: 1 }}>
+                <div
+                  style={{
+                    color: designTokens.text.primary,
+                    fontSize: '16px',
+                    marginBottom: '4px',
+                  }}
+                >
+                  라이트 모드
+                </div>
+                <div
+                  style={{
+                    color: designTokens.text.secondary,
+                    fontSize: '13px',
+                  }}
+                >
+                  밝은 배경과 어두운 텍스트
+                </div>
+              </div>
+              {themeMode === 'light' && (
+                <div
+                  style={{
+                    width: '20px',
+                    height: '20px',
+                    borderRadius: '50%',
+                    backgroundColor: '#4C2D9A',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: '8px',
+                      height: '8px',
+                      borderRadius: '50%',
+                      backgroundColor: 'white',
+                    }}
+                  />
+                </div>
+              )}
+            </label>
+
+            {/* Dark Mode */}
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                padding: '16px',
+                border: `2px solid ${themeMode === 'dark' ? '#4C2D9A' : designTokens.bg.border}`,
+                borderRadius: '12px',
+                cursor: 'pointer',
+                backgroundColor: themeMode === 'dark' ? '#F8F5FC' : 'transparent',
+                transition: 'all 0.2s',
+              }}
+              onMouseEnter={(e) => {
+                if (themeMode !== 'dark') {
+                  e.currentTarget.style.backgroundColor = '#FAFAFA';
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (themeMode !== 'dark') {
+                  e.currentTarget.style.backgroundColor = 'transparent';
+                }
+              }}
+            >
+              <input
+                type="radio"
+                name="themeMode"
+                value="dark"
+                checked={themeMode === 'dark'}
+                onChange={() => setThemeMode('dark')}
+                style={{ display: 'none' }}
+              />
+              <div
+                style={{
+                  width: '48px',
+                  height: '48px',
+                  borderRadius: '12px',
+                  backgroundColor: '#E3F2FD',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  marginRight: '16px',
+                }}
+              >
+                <Moon style={{ width: '24px', height: '24px', color: '#5C6BC0' }} />
+              </div>
+              <div style={{ flex: 1 }}>
+                <div
+                  style={{
+                    color: designTokens.text.primary,
+                    fontSize: '16px',
+                    marginBottom: '4px',
+                  }}
+                >
+                  다크 모드
+                </div>
+                <div
+                  style={{
+                    color: designTokens.text.secondary,
+                    fontSize: '13px',
+                  }}
+                >
+                  어두운 배경과 밝은 텍스트
+                </div>
+              </div>
+              {themeMode === 'dark' && (
+                <div
+                  style={{
+                    width: '20px',
+                    height: '20px',
+                    borderRadius: '50%',
+                    backgroundColor: '#4C2D9A',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: '8px',
+                      height: '8px',
+                      borderRadius: '50%',
+                      backgroundColor: 'white',
+                    }}
+                  />
+                </div>
+              )}
+            </label>
+
+            {/* System Mode */}
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                padding: '16px',
+                border: `2px solid ${themeMode === 'system' ? '#4C2D9A' : designTokens.bg.border}`,
+                borderRadius: '12px',
+                cursor: 'pointer',
+                backgroundColor: themeMode === 'system' ? '#F8F5FC' : 'transparent',
+                transition: 'all 0.2s',
+              }}
+              onMouseEnter={(e) => {
+                if (themeMode !== 'system') {
+                  e.currentTarget.style.backgroundColor = '#FAFAFA';
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (themeMode !== 'system') {
+                  e.currentTarget.style.backgroundColor = 'transparent';
+                }
+              }}
+            >
+              <input
+                type="radio"
+                name="themeMode"
+                value="system"
+                checked={themeMode === 'system'}
+                onChange={() => setThemeMode('system')}
+                style={{ display: 'none' }}
+              />
+              <div
+                style={{
+                  width: '48px',
+                  height: '48px',
+                  borderRadius: '12px',
+                  backgroundColor: '#F3E5F5',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  marginRight: '16px',
+                }}
+              >
+                <Laptop style={{ width: '24px', height: '24px', color: '#9C27B0' }} />
+              </div>
+              <div style={{ flex: 1 }}>
+                <div
+                  style={{
+                    color: designTokens.text.primary,
+                    fontSize: '16px',
+                    marginBottom: '4px',
+                  }}
+                >
+                  시스템 설정 따라가기
+                </div>
+                <div
+                  style={{
+                    color: designTokens.text.secondary,
+                    fontSize: '13px',
+                  }}
+                >
+                  운영체제 테마 설정을 따릅니다
+                </div>
+              </div>
+              {themeMode === 'system' && (
+                <div
+                  style={{
+                    width: '20px',
+                    height: '20px',
+                    borderRadius: '50%',
+                    backgroundColor: '#4C2D9A',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: '8px',
+                      height: '8px',
+                      borderRadius: '50%',
+                      backgroundColor: 'white',
+                    }}
+                  />
+                </div>
+              )}
+            </label>
+          </div>
+        </section>
+
+        {/* Sidebar Settings Section */}
+        <section
+          style={{
+            backgroundColor: designTokens.bg.default,
+            border: `1px solid ${designTokens.bg.border}`,
+            borderRadius: '12px',
+            padding: '24px',
+            marginBottom: '24px',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px',
+              marginBottom: '24px',
+              paddingBottom: '16px',
+              borderBottom: `1px solid ${designTokens.bg.border}`,
+            }}
+          >
+            <Monitor style={{ width: '20px', height: '20px', color: '#4C2D9A' }} />
+            <h2 style={{ color: designTokens.text.primary, fontSize: '18px', fontWeight: 500 }}>
+              사이드바 설정
+            </h2>
+          </div>
+
+          <div>
+            <label
+              style={{
+                display: 'block',
+                color: designTokens.text.secondary,
+                fontSize: '14px',
+                marginBottom: '12px',
+              }}
+            >
+              사이드바 기본 상태
+            </label>
+            <div style={{ display: 'flex', gap: '12px' }}>
+              <button
+                onClick={() => setSidebarDefault('expanded')}
+                style={{
+                  flex: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: '8px',
+                  padding: '16px',
+                  backgroundColor:
+                    sidebarDefault === 'expanded'
+                      ? designTokens.button.brand_default
+                      : designTokens.bg.default,
+                  color: sidebarDefault === 'expanded' ? 'white' : designTokens.text.primary,
+                  border: `1px solid ${sidebarDefault === 'expanded' ? designTokens.button.brand_default : designTokens.bg.border}`,
+                  borderRadius: '8px',
+                  cursor: 'pointer',
+                  fontSize: '14px',
+                  transition: 'all 0.2s',
+                }}
+                onMouseEnter={(e) => {
+                  if (sidebarDefault !== 'expanded') {
+                    e.currentTarget.style.borderColor = '#4C2D9A';
+                    e.currentTarget.style.backgroundColor = '#F8F5FC';
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (sidebarDefault !== 'expanded') {
+                    e.currentTarget.style.borderColor = designTokens.bg.border;
+                    e.currentTarget.style.backgroundColor = designTokens.bg.default;
+                  }
+                }}
+              >
+                <Maximize2 style={{ width: '18px', height: '18px' }} />
+                확장
+              </button>
+              <button
+                onClick={() => setSidebarDefault('collapsed')}
+                style={{
+                  flex: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: '8px',
+                  padding: '16px',
+                  backgroundColor:
+                    sidebarDefault === 'collapsed'
+                      ? designTokens.button.brand_default
+                      : designTokens.bg.default,
+                  color: sidebarDefault === 'collapsed' ? 'white' : designTokens.text.primary,
+                  border: `1px solid ${sidebarDefault === 'collapsed' ? designTokens.button.brand_default : designTokens.bg.border}`,
+                  borderRadius: '8px',
+                  cursor: 'pointer',
+                  fontSize: '14px',
+                  transition: 'all 0.2s',
+                }}
+                onMouseEnter={(e) => {
+                  if (sidebarDefault !== 'collapsed') {
+                    e.currentTarget.style.borderColor = '#4C2D9A';
+                    e.currentTarget.style.backgroundColor = '#F8F5FC';
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (sidebarDefault !== 'collapsed') {
+                    e.currentTarget.style.borderColor = designTokens.bg.border;
+                    e.currentTarget.style.backgroundColor = designTokens.bg.default;
+                  }
+                }}
+              >
+                <Minimize2 style={{ width: '18px', height: '18px' }} />
+                축소
+              </button>
+            </div>
+            <p
+              style={{
+                fontSize: '12px',
+                color: designTokens.text.secondary,
+                marginTop: '12px',
+              }}
+            >
+              로그인 시 사이드바의 기본 상태를 설정합니다.
+            </p>
+          </div>
+        </section>
+
+        {/* Save Button */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            paddingTop: '16px',
+          }}
+        >
+          <button
+            onClick={handleSave}
+            style={{
+              padding: '10px 24px',
+              backgroundColor: designTokens.button.brand_default,
+              color: 'white',
+              border: 'none',
+              borderRadius: '8px',
+              cursor: 'pointer',
+              fontSize: '14px',
+              transition: 'opacity 0.2s',
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.opacity = '0.9')}
+            onMouseLeave={(e) => (e.currentTarget.style.opacity = '1')}
+          >
+            저장
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/common/settings/SettingsAppearancePage.tsx
+++ b/src/pages/common/settings/SettingsAppearancePage.tsx
@@ -6,7 +6,6 @@ import {
   Monitor,
   Sun,
   Moon,
-  Laptop,
   Maximize2,
   Minimize2,
 } from 'lucide-react';
@@ -18,13 +17,14 @@ import {
   CardTitle,
   CardContent,
   Label,
+  RadioOptionCard,
 } from '@/components/common';
 
 export function SettingsAppearancePage() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const [themeMode, setThemeMode] = useState<'light' | 'dark' | 'system'>('light');
+  const [themeMode, setThemeMode] = useState<'light' | 'dark'>('light');
   const [sidebarDefault, setSidebarDefault] = useState<'expanded' | 'collapsed'>('expanded');
 
   const basePath = location.pathname.split('/settings')[0];
@@ -53,14 +53,6 @@ export function SettingsAppearancePage() {
       description: '어두운 배경과 밝은 텍스트',
       iconBg: designTokens.badge.blue.bg,
       iconColor: designTokens.badge.blue.text,
-    },
-    {
-      value: 'system' as const,
-      icon: Laptop,
-      label: '시스템 설정 따라가기',
-      description: '운영체제 테마 설정을 따릅니다',
-      iconBg: designTokens.badge.purple.bg,
-      iconColor: designTokens.badge.purple.text,
     },
   ];
 
@@ -106,56 +98,22 @@ export function SettingsAppearancePage() {
               <CardTitle className="text-lg font-medium">테마 모드</CardTitle>
             </div>
           </CardHeader>
-          <CardContent className="pt-6 px-6 pb-6">
+          <CardContent className="px-6 pb-6">
             <div className="flex flex-col gap-3">
-              {themeOptions.map((option) => {
-                const Icon = option.icon;
-                const isSelected = themeMode === option.value;
-                return (
-                  <label
-                    key={option.value}
-                    className="flex items-center p-4 rounded-xl cursor-pointer transition-all hover:bg-muted/50"
-                    style={{
-                      border: `2px solid ${isSelected ? designTokens.action.primary_default : designTokens.bg.border}`,
-                      backgroundColor: isSelected ? designTokens.bg.secondary : 'transparent',
-                    }}
-                  >
-                    <input
-                      type="radio"
-                      name="themeMode"
-                      value={option.value}
-                      checked={isSelected}
-                      onChange={() => setThemeMode(option.value)}
-                      className="hidden"
-                    />
-                    <div
-                      className="w-12 h-12 rounded-xl flex items-center justify-center mr-4"
-                      style={{ backgroundColor: option.iconBg }}
-                    >
-                      <Icon className="w-6 h-6" style={{ color: option.iconColor }} />
-                    </div>
-                    <div className="flex-1">
-                      <div style={{ color: designTokens.text.primary, fontSize: '16px', marginBottom: '4px' }}>
-                        {option.label}
-                      </div>
-                      <div style={{ color: designTokens.text.secondary, fontSize: '13px' }}>
-                        {option.description}
-                      </div>
-                    </div>
-                    {isSelected && (
-                      <div
-                        className="w-5 h-5 rounded-full flex items-center justify-center"
-                        style={{ backgroundColor: designTokens.action.primary_default }}
-                      >
-                        <div
-                          className="w-2 h-2 rounded-full"
-                          style={{ backgroundColor: designTokens.bg.default }}
-                        />
-                      </div>
-                    )}
-                  </label>
-                );
-              })}
+              {themeOptions.map((option) => (
+                <RadioOptionCard
+                  key={option.value}
+                  name="themeMode"
+                  value={option.value}
+                  label={option.label}
+                  description={option.description}
+                  isSelected={themeMode === option.value}
+                  onChange={(v) => setThemeMode(v as 'light' | 'dark')}
+                  icon={option.icon}
+                  iconBg={option.iconBg}
+                  iconColor={option.iconColor}
+                />
+              ))}
             </div>
           </CardContent>
         </Card>
@@ -168,7 +126,7 @@ export function SettingsAppearancePage() {
               <CardTitle className="text-lg font-medium">사이드바 설정</CardTitle>
             </div>
           </CardHeader>
-          <CardContent className="pt-6 px-6 pb-6">
+          <CardContent className="px-6 pb-6">
             <div>
               <Label className="mb-3 text-muted-foreground text-sm">사이드바 기본 상태</Label>
               <div className="flex gap-3 mt-3">

--- a/src/pages/common/settings/SettingsNotificationsPage.tsx
+++ b/src/pages/common/settings/SettingsNotificationsPage.tsx
@@ -1,11 +1,7 @@
 import { useNavigate, useLocation } from 'react-router-dom';
 import { ArrowLeft, Construction } from 'lucide-react';
 import { designTokens } from '@/styles/admin-design-tokens';
-import {
-  Button,
-  Card,
-  CardContent,
-} from '@/components/common';
+import { Button, EmptyState } from '@/components/common';
 
 export function SettingsNotificationsPage() {
   const navigate = useNavigate();
@@ -51,70 +47,12 @@ export function SettingsNotificationsPage() {
         </p>
 
         {/* Under Development Placeholder */}
-        <Card className="border-dashed border-2">
-          <CardContent className="py-12 px-6 text-center">
-            <div
-              className="w-20 h-20 mx-auto mb-6 rounded-full flex items-center justify-center"
-              style={{ backgroundColor: designTokens.status.warning_background }}
-            >
-              <Construction
-                className="w-10 h-10"
-                style={{ color: designTokens.status.warning_text }}
-              />
-            </div>
-
-            <h2
-              style={{
-                color: designTokens.text.primary,
-                marginBottom: '12px',
-                fontSize: '20px',
-                fontWeight: 500,
-              }}
-            >
-              개발 예정
-            </h2>
-
-            <p
-              style={{
-                color: designTokens.text.secondary,
-                fontSize: '14px',
-                lineHeight: '1.6',
-                maxWidth: '400px',
-                margin: '0 auto',
-              }}
-            >
-              알림 설정 기능은 현재 개발 중입니다. 곧 다양한 알림 옵션을 제공할 예정입니다.
-            </p>
-
-            <div
-              className="mt-8 p-4 rounded-lg text-left"
-              style={{ backgroundColor: designTokens.bg.secondary }}
-            >
-              <p
-                style={{
-                  fontSize: '12px',
-                  color: designTokens.text.secondary,
-                  marginBottom: '8px',
-                }}
-              >
-                예정된 기능:
-              </p>
-              <ul
-                style={{
-                  fontSize: '12px',
-                  color: designTokens.text.secondary,
-                  paddingLeft: '20px',
-                  margin: 0,
-                }}
-              >
-                <li>이메일 알림 설정</li>
-                <li>브라우저 푸시 알림</li>
-                <li>알림 시간 설정</li>
-                <li>카테고리별 알림 관리</li>
-              </ul>
-            </div>
-          </CardContent>
-        </Card>
+        <EmptyState
+          icon={Construction}
+          title="개발 예정"
+          description="알림 설정 기능은 현재 개발 중입니다. 곧 다양한 알림 옵션을 제공할 예정입니다."
+          className="border-2 border-dashed rounded-lg"
+        />
       </div>
     </div>
   );

--- a/src/pages/common/settings/SettingsNotificationsPage.tsx
+++ b/src/pages/common/settings/SettingsNotificationsPage.tsx
@@ -1,6 +1,11 @@
 import { useNavigate, useLocation } from 'react-router-dom';
 import { ArrowLeft, Construction } from 'lucide-react';
-import { designTokens } from '@/styles/design-tokens';
+import { designTokens } from '@/styles/admin-design-tokens';
+import {
+  Button,
+  Card,
+  CardContent,
+} from '@/components/common';
 
 export function SettingsNotificationsPage() {
   const navigate = useNavigate();
@@ -22,26 +27,14 @@ export function SettingsNotificationsPage() {
     >
       <div style={{ maxWidth: '800px', margin: '0 auto' }}>
         {/* Header with Back Button */}
-        <button
+        <Button
+          variant="ghost"
           onClick={handleBack}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px',
-            padding: '8px 12px',
-            marginBottom: '24px',
-            backgroundColor: 'transparent',
-            border: 'none',
-            color: designTokens.text.secondary,
-            cursor: 'pointer',
-            transition: 'color 0.2s',
-          }}
-          onMouseEnter={(e) => (e.currentTarget.style.color = designTokens.text.primary)}
-          onMouseLeave={(e) => (e.currentTarget.style.color = designTokens.text.secondary)}
+          className="mb-6 gap-2 text-muted-foreground hover:text-foreground"
         >
-          <ArrowLeft style={{ width: '20px', height: '20px' }} />
+          <ArrowLeft className="w-5 h-5" />
           <span>설정으로 돌아가기</span>
-        </button>
+        </Button>
 
         <h1
           style={{
@@ -58,92 +51,70 @@ export function SettingsNotificationsPage() {
         </p>
 
         {/* Under Development Placeholder */}
-        <div
-          style={{
-            backgroundColor: designTokens.bg.default,
-            border: `2px dashed ${designTokens.bg.border}`,
-            borderRadius: '12px',
-            padding: '48px 24px',
-            textAlign: 'center',
-          }}
-        >
-          <div
-            style={{
-              width: '80px',
-              height: '80px',
-              margin: '0 auto 24px',
-              backgroundColor: '#FFF3E0',
-              borderRadius: '50%',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <Construction
+        <Card className="border-dashed border-2">
+          <CardContent className="py-12 px-6 text-center">
+            <div
+              className="w-20 h-20 mx-auto mb-6 rounded-full flex items-center justify-center"
+              style={{ backgroundColor: designTokens.status.warning_background }}
+            >
+              <Construction
+                className="w-10 h-10"
+                style={{ color: designTokens.status.warning_text }}
+              />
+            </div>
+
+            <h2
               style={{
-                width: '40px',
-                height: '40px',
-                color: '#FF9800',
+                color: designTokens.text.primary,
+                marginBottom: '12px',
+                fontSize: '20px',
+                fontWeight: 500,
               }}
-            />
-          </div>
+            >
+              개발 예정
+            </h2>
 
-          <h2
-            style={{
-              color: designTokens.text.primary,
-              marginBottom: '12px',
-              fontSize: '20px',
-              fontWeight: 500,
-            }}
-          >
-            개발 예정
-          </h2>
-
-          <p
-            style={{
-              color: designTokens.text.secondary,
-              fontSize: '14px',
-              lineHeight: '1.6',
-              maxWidth: '400px',
-              margin: '0 auto',
-            }}
-          >
-            알림 설정 기능은 현재 개발 중입니다. 곧 다양한 알림 옵션을 제공할 예정입니다.
-          </p>
-
-          <div
-            style={{
-              marginTop: '32px',
-              padding: '16px',
-              backgroundColor: '#F4F4F4',
-              borderRadius: '8px',
-              textAlign: 'left',
-            }}
-          >
             <p
               style={{
-                fontSize: '12px',
                 color: designTokens.text.secondary,
-                marginBottom: '8px',
+                fontSize: '14px',
+                lineHeight: '1.6',
+                maxWidth: '400px',
+                margin: '0 auto',
               }}
             >
-              예정된 기능:
+              알림 설정 기능은 현재 개발 중입니다. 곧 다양한 알림 옵션을 제공할 예정입니다.
             </p>
-            <ul
-              style={{
-                fontSize: '12px',
-                color: designTokens.text.secondary,
-                paddingLeft: '20px',
-                margin: 0,
-              }}
+
+            <div
+              className="mt-8 p-4 rounded-lg text-left"
+              style={{ backgroundColor: designTokens.bg.secondary }}
             >
-              <li>이메일 알림 설정</li>
-              <li>브라우저 푸시 알림</li>
-              <li>알림 시간 설정</li>
-              <li>카테고리별 알림 관리</li>
-            </ul>
-          </div>
-        </div>
+              <p
+                style={{
+                  fontSize: '12px',
+                  color: designTokens.text.secondary,
+                  marginBottom: '8px',
+                }}
+              >
+                예정된 기능:
+              </p>
+              <ul
+                style={{
+                  fontSize: '12px',
+                  color: designTokens.text.secondary,
+                  paddingLeft: '20px',
+                  margin: 0,
+                }}
+              >
+                <li>이메일 알림 설정</li>
+                <li>브라우저 푸시 알림</li>
+                <li>알림 시간 설정</li>
+                <li>카테고리별 알림 관리</li>
+              </ul>
+            </div>
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/src/pages/common/settings/SettingsNotificationsPage.tsx
+++ b/src/pages/common/settings/SettingsNotificationsPage.tsx
@@ -1,0 +1,150 @@
+import { useNavigate, useLocation } from 'react-router-dom';
+import { ArrowLeft, Construction } from 'lucide-react';
+import { designTokens } from '@/styles/design-tokens';
+
+export function SettingsNotificationsPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const basePath = location.pathname.split('/settings')[0];
+
+  const handleBack = () => {
+    navigate(`${basePath}/settings`);
+  };
+
+  return (
+    <div
+      style={{
+        padding: '40px',
+        backgroundColor: designTokens.bg.app_default,
+        minHeight: '100%',
+      }}
+    >
+      <div style={{ maxWidth: '800px', margin: '0 auto' }}>
+        {/* Header with Back Button */}
+        <button
+          onClick={handleBack}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            padding: '8px 12px',
+            marginBottom: '24px',
+            backgroundColor: 'transparent',
+            border: 'none',
+            color: designTokens.text.secondary,
+            cursor: 'pointer',
+            transition: 'color 0.2s',
+          }}
+          onMouseEnter={(e) => (e.currentTarget.style.color = designTokens.text.primary)}
+          onMouseLeave={(e) => (e.currentTarget.style.color = designTokens.text.secondary)}
+        >
+          <ArrowLeft style={{ width: '20px', height: '20px' }} />
+          <span>설정으로 돌아가기</span>
+        </button>
+
+        <h1
+          style={{
+            color: designTokens.text.primary,
+            fontSize: '24px',
+            fontWeight: 600,
+            marginBottom: '8px',
+          }}
+        >
+          알림
+        </h1>
+        <p style={{ color: designTokens.text.secondary, marginBottom: '32px' }}>
+          알림 설정을 관리하세요
+        </p>
+
+        {/* Under Development Placeholder */}
+        <div
+          style={{
+            backgroundColor: designTokens.bg.default,
+            border: `2px dashed ${designTokens.bg.border}`,
+            borderRadius: '12px',
+            padding: '48px 24px',
+            textAlign: 'center',
+          }}
+        >
+          <div
+            style={{
+              width: '80px',
+              height: '80px',
+              margin: '0 auto 24px',
+              backgroundColor: '#FFF3E0',
+              borderRadius: '50%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Construction
+              style={{
+                width: '40px',
+                height: '40px',
+                color: '#FF9800',
+              }}
+            />
+          </div>
+
+          <h2
+            style={{
+              color: designTokens.text.primary,
+              marginBottom: '12px',
+              fontSize: '20px',
+              fontWeight: 500,
+            }}
+          >
+            개발 예정
+          </h2>
+
+          <p
+            style={{
+              color: designTokens.text.secondary,
+              fontSize: '14px',
+              lineHeight: '1.6',
+              maxWidth: '400px',
+              margin: '0 auto',
+            }}
+          >
+            알림 설정 기능은 현재 개발 중입니다. 곧 다양한 알림 옵션을 제공할 예정입니다.
+          </p>
+
+          <div
+            style={{
+              marginTop: '32px',
+              padding: '16px',
+              backgroundColor: '#F4F4F4',
+              borderRadius: '8px',
+              textAlign: 'left',
+            }}
+          >
+            <p
+              style={{
+                fontSize: '12px',
+                color: designTokens.text.secondary,
+                marginBottom: '8px',
+              }}
+            >
+              예정된 기능:
+            </p>
+            <ul
+              style={{
+                fontSize: '12px',
+                color: designTokens.text.secondary,
+                paddingLeft: '20px',
+                margin: 0,
+              }}
+            >
+              <li>이메일 알림 설정</li>
+              <li>브라우저 푸시 알림</li>
+              <li>알림 시간 설정</li>
+              <li>카테고리별 알림 관리</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/common/settings/SettingsPage.tsx
+++ b/src/pages/common/settings/SettingsPage.tsx
@@ -1,0 +1,254 @@
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Shield, Bell, Globe, Palette, Building2, Users, Database, FileText } from 'lucide-react';
+import { designTokens } from '@/styles/design-tokens';
+import { cardStyles } from '@/styles/card-styles';
+
+type UserRole = 'USER' | 'OPERATOR' | 'TENANT_ADMIN' | 'SUPER_ADMIN';
+
+interface SettingCard {
+  id: string;
+  icon: typeof Shield;
+  title: string;
+  description: string;
+  color: string;
+}
+
+interface SettingsPageProps {
+  userRole?: UserRole;
+}
+
+// 역할별 카드 설정
+const getSettingCards = (userRole: UserRole): SettingCard[] => {
+  // 공통 카드 (모든 역할)
+  const commonCards: SettingCard[] = [
+    {
+      id: 'security',
+      icon: Shield,
+      title: '계정 및 보안',
+      description: '프로필, 비밀번호, 계정 관리',
+      color: '#4C2D9A',
+    },
+    {
+      id: 'notifications',
+      icon: Bell,
+      title: '알림',
+      description: '알림 설정 및 환경 설정',
+      color: '#FF7043',
+    },
+    {
+      id: 'appearance',
+      icon: Palette,
+      title: '외관',
+      description: '테마, 사이드바 및 표시 옵션',
+      color: '#9C27B0',
+    },
+  ];
+
+  // USER 전용 카드
+  const userOnlyCards: SettingCard[] = [
+    {
+      id: 'language',
+      icon: Globe,
+      title: '언어 및 지역',
+      description: '언어, 시간대 및 날짜 형식',
+      color: '#4CAF50',
+    },
+    {
+      id: 'appearance',
+      icon: Palette,
+      title: '외관',
+      description: '테마, 사이드바 및 표시 옵션',
+      color: '#9C27B0',
+    },
+  ];
+
+  // OPERATOR 전용 카드
+  const operatorCards: SettingCard[] = [
+    {
+      id: 'content-defaults',
+      icon: FileText,
+      title: '콘텐츠 기본 설정',
+      description: '콘텐츠 업로드 및 관리 기본값',
+      color: '#2196F3',
+    },
+  ];
+
+  // TENANT_ADMIN 전용 카드
+  const tenantAdminCards: SettingCard[] = [
+    {
+      id: 'tenant-settings',
+      icon: Building2,
+      title: '테넌트 설정',
+      description: '조직 정보 및 브랜딩 설정',
+      color: '#009688',
+    },
+    {
+      id: 'user-management',
+      icon: Users,
+      title: '사용자 관리 설정',
+      description: '사용자 그룹 및 권한 기본값',
+      color: '#795548',
+    },
+  ];
+
+  // SUPER_ADMIN 전용 카드
+  const superAdminCards: SettingCard[] = [
+    {
+      id: 'system-settings',
+      icon: Database,
+      title: '시스템 설정',
+      description: '글로벌 시스템 구성 및 관리',
+      color: '#607D8B',
+    },
+    {
+      id: 'tenant-defaults',
+      icon: Building2,
+      title: '테넌트 기본값',
+      description: '신규 테넌트 생성 시 기본 설정',
+      color: '#009688',
+    },
+  ];
+
+  switch (userRole) {
+    case 'USER':
+      return [...commonCards, ...userOnlyCards];
+    case 'OPERATOR':
+      return [...commonCards, ...operatorCards];
+    case 'TENANT_ADMIN':
+      return [...commonCards, ...tenantAdminCards];
+    case 'SUPER_ADMIN':
+      return [...commonCards, ...superAdminCards];
+    default:
+      return commonCards;
+  }
+};
+
+// URL 경로에서 역할 추출
+const getRoleFromPath = (pathname: string): UserRole => {
+  if (pathname.startsWith('/sa')) return 'SUPER_ADMIN';
+  if (pathname.startsWith('/ta')) return 'TENANT_ADMIN';
+  if (pathname.startsWith('/to')) return 'OPERATOR';
+  return 'USER';
+};
+
+// 역할별 base path
+const getBasePath = (pathname: string): string => {
+  if (pathname.startsWith('/sa')) return '/sa';
+  if (pathname.startsWith('/ta')) return '/ta';
+  if (pathname.startsWith('/to')) return '/to';
+  return '/tu';
+};
+
+export function SettingsPage({ userRole }: SettingsPageProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const detectedRole = userRole || getRoleFromPath(location.pathname);
+  const basePath = getBasePath(location.pathname);
+  const settingCards = getSettingCards(detectedRole);
+
+  const handleCardClick = (cardId: string) => {
+    navigate(`${basePath}/settings/${cardId}`);
+  };
+
+  return (
+    <div
+      style={{
+        padding: '40px',
+        backgroundColor: designTokens.bg.app_default,
+        minHeight: '100%',
+      }}
+    >
+      <div style={{ maxWidth: '1200px', margin: '0 auto' }}>
+        {/* Header */}
+        <div style={{ marginBottom: '32px' }}>
+          <h1
+            style={{
+              color: designTokens.text.primary,
+              fontSize: '24px',
+              fontWeight: 600,
+              marginBottom: '8px',
+            }}
+          >
+            설정
+          </h1>
+          <p style={{ color: designTokens.text.secondary, fontSize: '14px' }}>
+            계정 설정 및 환경 설정을 관리하세요
+          </p>
+        </div>
+
+        {/* Settings Cards Grid */}
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
+            gap: '24px',
+          }}
+        >
+          {settingCards.map((card) => {
+            const Icon = card.icon;
+            return (
+              <button
+                key={card.id}
+                onClick={() => handleCardClick(card.id)}
+                style={{
+                  ...cardStyles.base,
+                  ...cardStyles.interactive,
+                  padding: cardStyles.padding.md,
+                  textAlign: 'left',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.borderColor = card.color;
+                  e.currentTarget.style.boxShadow = cardStyles.shadow.md;
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.borderColor = designTokens.bg.border;
+                  e.currentTarget.style.boxShadow = cardStyles.shadow.sm;
+                }}
+              >
+                {/* Icon Container */}
+                <div
+                  style={{
+                    width: '48px',
+                    height: '48px',
+                    borderRadius: '12px',
+                    backgroundColor: `${card.color}15`,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    marginBottom: '16px',
+                  }}
+                >
+                  <Icon style={{ width: '24px', height: '24px', color: card.color }} />
+                </div>
+
+                {/* Title */}
+                <h3
+                  style={{
+                    color: designTokens.text.primary,
+                    fontSize: '16px',
+                    fontWeight: 500,
+                    marginBottom: '8px',
+                  }}
+                >
+                  {card.title}
+                </h3>
+
+                {/* Description */}
+                <p
+                  style={{
+                    color: designTokens.text.secondary,
+                    fontSize: '14px',
+                    lineHeight: 1.5,
+                  }}
+                >
+                  {card.description}
+                </p>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/common/settings/SettingsPage.tsx
+++ b/src/pages/common/settings/SettingsPage.tsx
@@ -1,126 +1,62 @@
 import { useNavigate, useLocation } from 'react-router-dom';
-import { Shield, Bell, Globe, Palette, Building2, Users, Database, FileText } from 'lucide-react';
-import { designTokens } from '@/styles/design-tokens';
-import { cardStyles } from '@/styles/card-styles';
+import { Shield, Bell, Globe, Palette, LucideIcon } from 'lucide-react';
+import { designTokens } from '@/styles/admin-design-tokens';
+import { SettingsCard } from '@/components/common';
 
 type UserRole = 'USER' | 'OPERATOR' | 'TENANT_ADMIN' | 'SUPER_ADMIN';
 
-interface SettingCard {
+interface SettingCardData {
   id: string;
-  icon: typeof Shield;
+  icon: LucideIcon;
   title: string;
   description: string;
-  color: string;
 }
 
 interface SettingsPageProps {
   userRole?: UserRole;
 }
 
-// 역할별 카드 설정
-const getSettingCards = (userRole: UserRole): SettingCard[] => {
-  // 공통 카드 (모든 역할)
-  const commonCards: SettingCard[] = [
+// 역할별 카드 설정 (개인 설정만 - 관리 기능은 사이드바 메뉴에서 접근)
+// 새 카드 추가 시 색상은 자동으로 순환됨 (SettingsCard 컴포넌트에서 처리)
+const getSettingCards = (userRole: UserRole): SettingCardData[] => {
+  // 공통 카드 (모든 역할) - 개인 설정
+  const commonCards: SettingCardData[] = [
     {
       id: 'security',
       icon: Shield,
       title: '계정 및 보안',
       description: '프로필, 비밀번호, 계정 관리',
-      color: '#4C2D9A',
     },
     {
       id: 'notifications',
       icon: Bell,
       title: '알림',
       description: '알림 설정 및 환경 설정',
-      color: '#FF7043',
     },
     {
       id: 'appearance',
       icon: Palette,
       title: '외관',
       description: '테마, 사이드바 및 표시 옵션',
-      color: '#9C27B0',
     },
   ];
 
-  // USER 전용 카드
-  const userOnlyCards: SettingCard[] = [
+  // USER 전용 카드 (언어 및 지역 설정)
+  const userOnlyCards: SettingCardData[] = [
     {
       id: 'language',
       icon: Globe,
       title: '언어 및 지역',
       description: '언어, 시간대 및 날짜 형식',
-      color: '#4CAF50',
-    },
-    {
-      id: 'appearance',
-      icon: Palette,
-      title: '외관',
-      description: '테마, 사이드바 및 표시 옵션',
-      color: '#9C27B0',
     },
   ];
 
-  // OPERATOR 전용 카드
-  const operatorCards: SettingCard[] = [
-    {
-      id: 'content-defaults',
-      icon: FileText,
-      title: '콘텐츠 기본 설정',
-      description: '콘텐츠 업로드 및 관리 기본값',
-      color: '#2196F3',
-    },
-  ];
-
-  // TENANT_ADMIN 전용 카드
-  const tenantAdminCards: SettingCard[] = [
-    {
-      id: 'tenant-settings',
-      icon: Building2,
-      title: '테넌트 설정',
-      description: '조직 정보 및 브랜딩 설정',
-      color: '#009688',
-    },
-    {
-      id: 'user-management',
-      icon: Users,
-      title: '사용자 관리 설정',
-      description: '사용자 그룹 및 권한 기본값',
-      color: '#795548',
-    },
-  ];
-
-  // SUPER_ADMIN 전용 카드
-  const superAdminCards: SettingCard[] = [
-    {
-      id: 'system-settings',
-      icon: Database,
-      title: '시스템 설정',
-      description: '글로벌 시스템 구성 및 관리',
-      color: '#607D8B',
-    },
-    {
-      id: 'tenant-defaults',
-      icon: Building2,
-      title: '테넌트 기본값',
-      description: '신규 테넌트 생성 시 기본 설정',
-      color: '#009688',
-    },
-  ];
-
-  switch (userRole) {
-    case 'USER':
-      return [...commonCards, ...userOnlyCards];
-    case 'OPERATOR':
-      return [...commonCards, ...operatorCards];
-    case 'TENANT_ADMIN':
-      return [...commonCards, ...tenantAdminCards];
-    case 'SUPER_ADMIN':
-      return [...commonCards, ...superAdminCards];
-    default:
-      return commonCards;
+  // USER만 언어 설정 추가, 나머지 역할은 공통 카드만
+  if (userRole === 'USER') {
+    return [...commonCards, ...userOnlyCards];
   }
+
+  return commonCards;
 };
 
 // URL 경로에서 역할 추출
@@ -185,68 +121,16 @@ export function SettingsPage({ userRole }: SettingsPageProps) {
             gap: '24px',
           }}
         >
-          {settingCards.map((card) => {
-            const Icon = card.icon;
-            return (
-              <button
-                key={card.id}
-                onClick={() => handleCardClick(card.id)}
-                style={{
-                  ...cardStyles.base,
-                  ...cardStyles.interactive,
-                  padding: cardStyles.padding.md,
-                  textAlign: 'left',
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.borderColor = card.color;
-                  e.currentTarget.style.boxShadow = cardStyles.shadow.md;
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.borderColor = designTokens.bg.border;
-                  e.currentTarget.style.boxShadow = cardStyles.shadow.sm;
-                }}
-              >
-                {/* Icon Container */}
-                <div
-                  style={{
-                    width: '48px',
-                    height: '48px',
-                    borderRadius: '12px',
-                    backgroundColor: `${card.color}15`,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    marginBottom: '16px',
-                  }}
-                >
-                  <Icon style={{ width: '24px', height: '24px', color: card.color }} />
-                </div>
-
-                {/* Title */}
-                <h3
-                  style={{
-                    color: designTokens.text.primary,
-                    fontSize: '16px',
-                    fontWeight: 500,
-                    marginBottom: '8px',
-                  }}
-                >
-                  {card.title}
-                </h3>
-
-                {/* Description */}
-                <p
-                  style={{
-                    color: designTokens.text.secondary,
-                    fontSize: '14px',
-                    lineHeight: 1.5,
-                  }}
-                >
-                  {card.description}
-                </p>
-              </button>
-            );
-          })}
+          {settingCards.map((card, index) => (
+            <SettingsCard
+              key={card.id}
+              icon={card.icon}
+              title={card.title}
+              description={card.description}
+              onClick={() => handleCardClick(card.id)}
+              index={index}
+            />
+          ))}
         </div>
       </div>
     </div>

--- a/src/pages/common/settings/SettingsSecurityPage.tsx
+++ b/src/pages/common/settings/SettingsSecurityPage.tsx
@@ -1,0 +1,725 @@
+import { useState, useRef } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import {
+  ArrowLeft,
+  User,
+  Mail,
+  Calendar,
+  Lock,
+  AlertTriangle,
+  Shield,
+  CheckCircle,
+  Camera,
+} from 'lucide-react';
+import { designTokens } from '@/styles/design-tokens';
+
+export function SettingsSecurityPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const [profileData, setProfileData] = useState({
+    name: '김교수',
+    email: 'professor.kim@mzrun.edu',
+    joinDate: '2024-01-15',
+    profileImage: undefined as File | undefined,
+  });
+
+  const [passwordData, setPasswordData] = useState({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: '',
+  });
+
+  const [designAuthStatus, setDesignAuthStatus] = useState<'USER' | 'DESIGNER' | 'OWNER'>('USER');
+  const [isRequestPending, setIsRequestPending] = useState(false);
+  const [profileImagePreview, setProfileImagePreview] = useState<string | null>(null);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Get base path from current location
+  const basePath = location.pathname.split('/settings')[0];
+  const isUserRole = basePath === '/tu';
+
+  const handleBack = () => {
+    navigate(`${basePath}/settings`);
+  };
+
+  const handleProfileSave = () => {
+    alert('프로필 정보가 저장되었습니다.');
+  };
+
+  const handlePasswordChange = () => {
+    if (!passwordData.currentPassword || !passwordData.newPassword || !passwordData.confirmPassword) {
+      alert('모든 필드를 입력해주세요.');
+      return;
+    }
+    if (passwordData.newPassword !== passwordData.confirmPassword) {
+      alert('새 비밀번호가 일치하지 않습니다.');
+      return;
+    }
+    if (passwordData.newPassword.length < 8) {
+      alert('비밀번호는 최소 8자 이상이어야 합니다.');
+      return;
+    }
+
+    alert('비밀번호가 변경되었습니다.');
+    setPasswordData({ currentPassword: '', newPassword: '', confirmPassword: '' });
+  };
+
+  const handleRequestDesignAuth = () => {
+    if (confirm('강의 개설 권한을 요청하시겠습니까?')) {
+      setIsRequestPending(true);
+      setTimeout(() => {
+        setDesignAuthStatus('DESIGNER');
+        setIsRequestPending(false);
+        alert('권한이 승인되었습니다.');
+      }, 1500);
+    }
+  };
+
+  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      if (!file.type.startsWith('image/')) {
+        alert('이미지 파일만 업로드 가능합니다.');
+        return;
+      }
+      if (file.size > 5 * 1024 * 1024) {
+        alert('파일 크기는 5MB 이하여야 합니다.');
+        return;
+      }
+
+      setProfileData((prev) => ({ ...prev, profileImage: file }));
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setProfileImagePreview(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const getAuthBadgeColor = (status: 'USER' | 'DESIGNER' | 'OWNER') => {
+    switch (status) {
+      case 'USER':
+        return '#999999';
+      case 'DESIGNER':
+        return '#4C2D9A';
+      case 'OWNER':
+        return '#FF7043';
+      default:
+        return '#999999';
+    }
+  };
+
+  const getAuthLabel = (status: 'USER' | 'DESIGNER' | 'OWNER') => {
+    switch (status) {
+      case 'USER':
+        return '일반 사용자';
+      case 'DESIGNER':
+        return '강의 개설 가능';
+      case 'OWNER':
+        return '전체 권한';
+    }
+  };
+
+  return (
+    <div
+      style={{
+        padding: '40px',
+        backgroundColor: designTokens.bg.app_default,
+        minHeight: '100%',
+      }}
+    >
+      <div style={{ maxWidth: '800px', margin: '0 auto' }}>
+        {/* Header with Back Button */}
+        <button
+          onClick={handleBack}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            padding: '8px 12px',
+            marginBottom: '24px',
+            backgroundColor: 'transparent',
+            border: 'none',
+            color: designTokens.text.secondary,
+            cursor: 'pointer',
+            transition: 'color 0.2s',
+          }}
+          onMouseEnter={(e) => (e.currentTarget.style.color = designTokens.text.primary)}
+          onMouseLeave={(e) => (e.currentTarget.style.color = designTokens.text.secondary)}
+        >
+          <ArrowLeft style={{ width: '20px', height: '20px' }} />
+          <span>설정으로 돌아가기</span>
+        </button>
+
+        <h1
+          style={{
+            color: designTokens.text.primary,
+            fontSize: '24px',
+            fontWeight: 600,
+            marginBottom: '8px',
+          }}
+        >
+          계정 및 보안
+        </h1>
+        <p style={{ color: designTokens.text.secondary, marginBottom: '32px' }}>
+          계정 정보 및 보안 설정을 관리하세요
+        </p>
+
+        {/* Profile Information Section */}
+        <section
+          style={{
+            backgroundColor: designTokens.bg.default,
+            border: `1px solid ${designTokens.bg.border}`,
+            borderRadius: '12px',
+            padding: '24px',
+            marginBottom: '24px',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px',
+              marginBottom: '24px',
+              paddingBottom: '16px',
+              borderBottom: `1px solid ${designTokens.bg.border}`,
+            }}
+          >
+            <Shield style={{ width: '20px', height: '20px', color: '#4C2D9A' }} />
+            <h2 style={{ color: designTokens.text.primary, fontSize: '18px', fontWeight: 500 }}>
+              프로필 정보
+            </h2>
+          </div>
+
+          {/* Profile Image */}
+          <div style={{ marginBottom: '20px' }}>
+            <label
+              style={{
+                display: 'block',
+                color: designTokens.text.secondary,
+                fontSize: '14px',
+                marginBottom: '12px',
+              }}
+            >
+              프로필 이미지
+            </label>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+              <div
+                style={{
+                  width: '80px',
+                  height: '80px',
+                  borderRadius: '50%',
+                  backgroundColor: profileImagePreview ? 'transparent' : '#F4F4F4',
+                  border: `2px solid ${designTokens.bg.border}`,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  overflow: 'hidden',
+                }}
+              >
+                {profileImagePreview ? (
+                  <img
+                    src={profileImagePreview}
+                    alt="Profile"
+                    style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                  />
+                ) : (
+                  <User style={{ width: '32px', height: '32px', color: '#999999' }} />
+                )}
+              </div>
+              <div>
+                <button
+                  onClick={() => fileInputRef.current?.click()}
+                  style={{
+                    padding: '8px 16px',
+                    backgroundColor: designTokens.bg.default,
+                    border: `1px solid ${designTokens.bg.border}`,
+                    borderRadius: '8px',
+                    color: designTokens.text.primary,
+                    cursor: 'pointer',
+                    fontSize: '14px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                    transition: 'all 0.2s',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.borderColor = '#4C2D9A';
+                    e.currentTarget.style.backgroundColor = '#F8F5FC';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.borderColor = designTokens.bg.border;
+                    e.currentTarget.style.backgroundColor = designTokens.bg.default;
+                  }}
+                >
+                  <Camera style={{ width: '16px', height: '16px' }} />
+                  이미지 변경
+                </button>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={handleImageUpload}
+                  style={{ display: 'none' }}
+                />
+                <p
+                  style={{
+                    fontSize: '12px',
+                    color: designTokens.text.secondary,
+                    marginTop: '8px',
+                  }}
+                >
+                  JPG, PNG (최대 5MB)
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Name */}
+          <div style={{ marginBottom: '20px' }}>
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                color: designTokens.text.secondary,
+                fontSize: '14px',
+                marginBottom: '8px',
+              }}
+            >
+              <User style={{ width: '16px', height: '16px' }} />
+              이름
+            </label>
+            <input
+              type="text"
+              value={profileData.name}
+              onChange={(e) => setProfileData((prev) => ({ ...prev, name: e.target.value }))}
+              style={{
+                width: '100%',
+                padding: '10px 12px',
+                border: `1px solid ${designTokens.bg.border}`,
+                borderRadius: '8px',
+                fontSize: '14px',
+                color: designTokens.text.primary,
+                backgroundColor: designTokens.bg.default,
+                outline: 'none',
+              }}
+              onFocus={(e) => (e.currentTarget.style.borderColor = '#4C2D9A')}
+              onBlur={(e) => (e.currentTarget.style.borderColor = designTokens.bg.border)}
+            />
+          </div>
+
+          {/* Email (Read-only) */}
+          <div style={{ marginBottom: '20px' }}>
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                color: designTokens.text.secondary,
+                fontSize: '14px',
+                marginBottom: '8px',
+              }}
+            >
+              <Mail style={{ width: '16px', height: '16px' }} />
+              이메일
+            </label>
+            <input
+              type="email"
+              value={profileData.email}
+              readOnly
+              style={{
+                width: '100%',
+                padding: '10px 12px',
+                border: `1px solid ${designTokens.bg.border}`,
+                borderRadius: '8px',
+                fontSize: '14px',
+                color: designTokens.text.secondary,
+                backgroundColor: '#F8F8F8',
+                cursor: 'not-allowed',
+              }}
+            />
+          </div>
+
+          {/* Join Date (Read-only) */}
+          <div style={{ marginBottom: '24px' }}>
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                color: designTokens.text.secondary,
+                fontSize: '14px',
+                marginBottom: '8px',
+              }}
+            >
+              <Calendar style={{ width: '16px', height: '16px' }} />
+              가입일
+            </label>
+            <input
+              type="text"
+              value={profileData.joinDate}
+              readOnly
+              style={{
+                width: '100%',
+                padding: '10px 12px',
+                border: `1px solid ${designTokens.bg.border}`,
+                borderRadius: '8px',
+                fontSize: '14px',
+                color: designTokens.text.secondary,
+                backgroundColor: '#F8F8F8',
+                cursor: 'not-allowed',
+              }}
+            />
+          </div>
+
+          {/* Save Button */}
+          <button
+            onClick={handleProfileSave}
+            style={{
+              padding: '10px 24px',
+              backgroundColor: designTokens.button.brand_default,
+              color: 'white',
+              border: 'none',
+              borderRadius: '8px',
+              cursor: 'pointer',
+              fontSize: '14px',
+              transition: 'opacity 0.2s',
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.opacity = '0.9')}
+            onMouseLeave={(e) => (e.currentTarget.style.opacity = '1')}
+          >
+            저장
+          </button>
+        </section>
+
+        {/* Password Change Section */}
+        <section
+          style={{
+            backgroundColor: designTokens.bg.default,
+            border: `1px solid ${designTokens.bg.border}`,
+            borderRadius: '12px',
+            padding: '24px',
+            marginBottom: '24px',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px',
+              marginBottom: '24px',
+              paddingBottom: '16px',
+              borderBottom: `1px solid ${designTokens.bg.border}`,
+            }}
+          >
+            <Lock style={{ width: '20px', height: '20px', color: '#4C2D9A' }} />
+            <h2 style={{ color: designTokens.text.primary, fontSize: '18px', fontWeight: 500 }}>
+              비밀번호 변경
+            </h2>
+          </div>
+
+          <div style={{ marginBottom: '20px' }}>
+            <label
+              style={{
+                display: 'block',
+                color: designTokens.text.secondary,
+                fontSize: '14px',
+                marginBottom: '8px',
+              }}
+            >
+              현재 비밀번호
+            </label>
+            <input
+              type="password"
+              value={passwordData.currentPassword}
+              onChange={(e) =>
+                setPasswordData((prev) => ({ ...prev, currentPassword: e.target.value }))
+              }
+              style={{
+                width: '100%',
+                padding: '10px 12px',
+                border: `1px solid ${designTokens.bg.border}`,
+                borderRadius: '8px',
+                fontSize: '14px',
+                color: designTokens.text.primary,
+                backgroundColor: designTokens.bg.default,
+                outline: 'none',
+              }}
+              onFocus={(e) => (e.currentTarget.style.borderColor = '#4C2D9A')}
+              onBlur={(e) => (e.currentTarget.style.borderColor = designTokens.bg.border)}
+            />
+          </div>
+
+          <div style={{ marginBottom: '20px' }}>
+            <label
+              style={{
+                display: 'block',
+                color: designTokens.text.secondary,
+                fontSize: '14px',
+                marginBottom: '8px',
+              }}
+            >
+              새 비밀번호
+            </label>
+            <input
+              type="password"
+              value={passwordData.newPassword}
+              onChange={(e) =>
+                setPasswordData((prev) => ({ ...prev, newPassword: e.target.value }))
+              }
+              style={{
+                width: '100%',
+                padding: '10px 12px',
+                border: `1px solid ${designTokens.bg.border}`,
+                borderRadius: '8px',
+                fontSize: '14px',
+                color: designTokens.text.primary,
+                backgroundColor: designTokens.bg.default,
+                outline: 'none',
+              }}
+              onFocus={(e) => (e.currentTarget.style.borderColor = '#4C2D9A')}
+              onBlur={(e) => (e.currentTarget.style.borderColor = designTokens.bg.border)}
+            />
+          </div>
+
+          <div style={{ marginBottom: '24px' }}>
+            <label
+              style={{
+                display: 'block',
+                color: designTokens.text.secondary,
+                fontSize: '14px',
+                marginBottom: '8px',
+              }}
+            >
+              새 비밀번호 확인
+            </label>
+            <input
+              type="password"
+              value={passwordData.confirmPassword}
+              onChange={(e) =>
+                setPasswordData((prev) => ({ ...prev, confirmPassword: e.target.value }))
+              }
+              style={{
+                width: '100%',
+                padding: '10px 12px',
+                border: `1px solid ${designTokens.bg.border}`,
+                borderRadius: '8px',
+                fontSize: '14px',
+                color: designTokens.text.primary,
+                backgroundColor: designTokens.bg.default,
+                outline: 'none',
+              }}
+              onFocus={(e) => (e.currentTarget.style.borderColor = '#4C2D9A')}
+              onBlur={(e) => (e.currentTarget.style.borderColor = designTokens.bg.border)}
+            />
+          </div>
+
+          <button
+            onClick={handlePasswordChange}
+            style={{
+              padding: '10px 24px',
+              backgroundColor: designTokens.button.brand_default,
+              color: 'white',
+              border: 'none',
+              borderRadius: '8px',
+              cursor: 'pointer',
+              fontSize: '14px',
+              transition: 'opacity 0.2s',
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.opacity = '0.9')}
+            onMouseLeave={(e) => (e.currentTarget.style.opacity = '1')}
+          >
+            비밀번호 변경
+          </button>
+        </section>
+
+        {/* Design Authority Section (User Role Only) */}
+        {isUserRole && (
+          <section
+            style={{
+              backgroundColor: designTokens.bg.default,
+              border: `1px solid ${designTokens.bg.border}`,
+              borderRadius: '12px',
+              padding: '24px',
+              marginBottom: '24px',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '12px',
+                marginBottom: '24px',
+                paddingBottom: '16px',
+                borderBottom: `1px solid ${designTokens.bg.border}`,
+              }}
+            >
+              <CheckCircle style={{ width: '20px', height: '20px', color: '#4C2D9A' }} />
+              <h2 style={{ color: designTokens.text.primary, fontSize: '18px', fontWeight: 500 }}>
+                강의 개설 권한
+              </h2>
+            </div>
+
+            <div style={{ marginBottom: '20px' }}>
+              <label
+                style={{
+                  display: 'block',
+                  color: designTokens.text.secondary,
+                  fontSize: '14px',
+                  marginBottom: '12px',
+                }}
+              >
+                현재 권한 상태
+              </label>
+              <div
+                style={{
+                  display: 'inline-block',
+                  padding: '8px 16px',
+                  backgroundColor: `${getAuthBadgeColor(designAuthStatus)}15`,
+                  border: `1px solid ${getAuthBadgeColor(designAuthStatus)}`,
+                  borderRadius: '20px',
+                  fontSize: '14px',
+                  color: getAuthBadgeColor(designAuthStatus),
+                  fontWeight: 500,
+                }}
+              >
+                {getAuthLabel(designAuthStatus)}
+              </div>
+            </div>
+
+            {designAuthStatus === 'USER' && (
+              <div>
+                <p
+                  style={{
+                    fontSize: '14px',
+                    color: designTokens.text.secondary,
+                    marginBottom: '16px',
+                    lineHeight: '1.6',
+                  }}
+                >
+                  강의를 개설하고 콘텐츠를 등록하려면 권한을 요청해주세요.
+                </p>
+                <button
+                  onClick={handleRequestDesignAuth}
+                  disabled={isRequestPending}
+                  style={{
+                    padding: '10px 24px',
+                    backgroundColor: isRequestPending ? '#CCCCCC' : designTokens.button.brand_default,
+                    color: 'white',
+                    border: 'none',
+                    borderRadius: '8px',
+                    cursor: isRequestPending ? 'not-allowed' : 'pointer',
+                    fontSize: '14px',
+                    transition: 'opacity 0.2s',
+                  }}
+                  onMouseEnter={(e) =>
+                    !isRequestPending && (e.currentTarget.style.opacity = '0.9')
+                  }
+                  onMouseLeave={(e) =>
+                    !isRequestPending && (e.currentTarget.style.opacity = '1')
+                  }
+                >
+                  {isRequestPending ? '요청 중...' : '강의 개설 권한 요청'}
+                </button>
+              </div>
+            )}
+
+            {(designAuthStatus === 'DESIGNER' || designAuthStatus === 'OWNER') && (
+              <div
+                style={{
+                  padding: '12px 16px',
+                  backgroundColor: '#E8F5E9',
+                  border: '1px solid #4CAF50',
+                  borderRadius: '8px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '12px',
+                }}
+              >
+                <CheckCircle style={{ width: '20px', height: '20px', color: '#4CAF50' }} />
+                <p style={{ fontSize: '14px', color: '#2E7D32' }}>
+                  강의 개설 및 콘텐츠 등록 권한이 활성화되었습니다.
+                </p>
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* Account Management Section */}
+        <section
+          style={{
+            backgroundColor: designTokens.bg.default,
+            border: `1px solid ${designTokens.bg.border}`,
+            borderRadius: '12px',
+            padding: '24px',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px',
+              marginBottom: '16px',
+              paddingBottom: '16px',
+              borderBottom: `1px solid ${designTokens.bg.border}`,
+            }}
+          >
+            <AlertTriangle style={{ width: '20px', height: '20px', color: '#FF7043' }} />
+            <h2 style={{ color: designTokens.text.primary, fontSize: '18px', fontWeight: 500 }}>
+              계정 관리
+            </h2>
+          </div>
+
+          <div
+            style={{
+              padding: '16px',
+              backgroundColor: '#FFF3E0',
+              border: '1px solid #FFB74D',
+              borderRadius: '8px',
+              marginBottom: '16px',
+            }}
+          >
+            <p style={{ fontSize: '14px', color: '#E65100', lineHeight: '1.6' }}>
+              계정을 삭제하면 모든 데이터가 영구적으로 삭제되며 복구할 수 없습니다.
+            </p>
+          </div>
+
+          <button
+            onClick={() => {
+              if (
+                confirm(
+                  '정말로 계정을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.'
+                )
+              ) {
+                alert('계정 삭제가 요청되었습니다.');
+              }
+            }}
+            style={{
+              padding: '10px 24px',
+              backgroundColor: 'transparent',
+              color: '#D32F2F',
+              border: '1px solid #D32F2F',
+              borderRadius: '8px',
+              cursor: 'pointer',
+              fontSize: '14px',
+              transition: 'all 0.2s',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.backgroundColor = '#D32F2F';
+              e.currentTarget.style.color = 'white';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = 'transparent';
+              e.currentTarget.style.color = '#D32F2F';
+            }}
+          >
+            회원 탈퇴
+          </button>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/common/settings/SettingsSecurityPage.tsx
+++ b/src/pages/common/settings/SettingsSecurityPage.tsx
@@ -405,11 +405,12 @@ export function SettingsSecurityPage() {
                 color: designTokens.status.error_text,
                 borderColor: designTokens.status.error_text,
               }}
-              className="hover:bg-destructive"
               onMouseEnter={(e) => {
+                e.currentTarget.style.backgroundColor = designTokens.status.error_text;
                 e.currentTarget.style.color = designTokens.action.primary_text;
               }}
               onMouseLeave={(e) => {
+                e.currentTarget.style.backgroundColor = 'transparent';
                 e.currentTarget.style.color = designTokens.status.error_text;
               }}
             >

--- a/src/pages/common/settings/SettingsSecurityPage.tsx
+++ b/src/pages/common/settings/SettingsSecurityPage.tsx
@@ -178,7 +178,7 @@ export function SettingsSecurityPage() {
               <CardTitle className="text-lg font-medium">프로필 정보</CardTitle>
             </div>
           </CardHeader>
-          <CardContent className="pt-6 px-6 pb-6">
+          <CardContent className="px-6 pb-6">
             {/* Profile Image */}
             <div className="mb-5">
               <Label className="mb-3 text-muted-foreground text-sm">프로필 이미지</Label>
@@ -235,12 +235,7 @@ export function SettingsSecurityPage() {
                 type="email"
                 value={profileData.email}
                 readOnly
-                className="w-full px-3 py-2.5 rounded-md text-sm border cursor-not-allowed"
-                style={{
-                  backgroundColor: designTokens.bg.secondary,
-                  color: designTokens.text.secondary,
-                  borderColor: designTokens.bg.border,
-                }}
+                className="w-full px-3 py-2.5 rounded-md text-sm cursor-not-allowed bg-bg-secondary text-text-secondary border border-border outline-none hover:bg-bg-secondary focus:bg-bg-secondary"
               />
             </div>
 
@@ -254,12 +249,7 @@ export function SettingsSecurityPage() {
                 type="text"
                 value={profileData.joinDate}
                 readOnly
-                className="w-full px-3 py-2.5 rounded-md text-sm border cursor-not-allowed"
-                style={{
-                  backgroundColor: designTokens.bg.secondary,
-                  color: designTokens.text.secondary,
-                  borderColor: designTokens.bg.border,
-                }}
+                className="w-full px-3 py-2.5 rounded-md text-sm cursor-not-allowed bg-bg-secondary text-text-secondary border border-border outline-none hover:bg-bg-secondary focus:bg-bg-secondary"
               />
             </div>
 
@@ -278,7 +268,7 @@ export function SettingsSecurityPage() {
               <CardTitle className="text-lg font-medium">비밀번호 변경</CardTitle>
             </div>
           </CardHeader>
-          <CardContent className="pt-6 px-6 pb-6">
+          <CardContent className="px-6 pb-6">
             <div className="mb-5">
               <Input
                 label="현재 비밀번호"
@@ -327,7 +317,7 @@ export function SettingsSecurityPage() {
                 <CardTitle className="text-lg font-medium">강의 개설 권한</CardTitle>
               </div>
             </CardHeader>
-            <CardContent className="pt-6 px-6 pb-6">
+            <CardContent className="px-6 pb-6">
               <div className="mb-5">
                 <Label className="mb-3 text-muted-foreground text-sm">현재 권한 상태</Label>
                 <div className="mt-3">
@@ -377,7 +367,7 @@ export function SettingsSecurityPage() {
               <CardTitle className="text-lg font-medium">계정 관리</CardTitle>
             </div>
           </CardHeader>
-          <CardContent className="pt-6 px-6 pb-6">
+          <CardContent className="px-6 pb-6">
             <Alert
               className="mb-4"
               style={{

--- a/src/pages/common/settings/SettingsSecurityPage.tsx
+++ b/src/pages/common/settings/SettingsSecurityPage.tsx
@@ -11,7 +11,22 @@ import {
   CheckCircle,
   Camera,
 } from 'lucide-react';
-import { designTokens } from '@/styles/design-tokens';
+import { designTokens } from '@/styles/admin-design-tokens';
+import {
+  Button,
+  Input,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  Badge,
+  Alert,
+  AlertDescription,
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  Label,
+} from '@/components/common';
 
 export function SettingsSecurityPage() {
   const navigate = useNavigate();
@@ -98,16 +113,16 @@ export function SettingsSecurityPage() {
     }
   };
 
-  const getAuthBadgeColor = (status: 'USER' | 'DESIGNER' | 'OWNER') => {
+  const getAuthBadgeVariant = (status: 'USER' | 'DESIGNER' | 'OWNER') => {
     switch (status) {
       case 'USER':
-        return '#999999';
+        return 'gray' as const;
       case 'DESIGNER':
-        return '#4C2D9A';
+        return 'indigo' as const;
       case 'OWNER':
-        return '#FF7043';
+        return 'orange' as const;
       default:
-        return '#999999';
+        return 'gray' as const;
     }
   };
 
@@ -132,26 +147,14 @@ export function SettingsSecurityPage() {
     >
       <div style={{ maxWidth: '800px', margin: '0 auto' }}>
         {/* Header with Back Button */}
-        <button
+        <Button
+          variant="ghost"
           onClick={handleBack}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px',
-            padding: '8px 12px',
-            marginBottom: '24px',
-            backgroundColor: 'transparent',
-            border: 'none',
-            color: designTokens.text.secondary,
-            cursor: 'pointer',
-            transition: 'color 0.2s',
-          }}
-          onMouseEnter={(e) => (e.currentTarget.style.color = designTokens.text.primary)}
-          onMouseLeave={(e) => (e.currentTarget.style.color = designTokens.text.secondary)}
+          className="mb-6 gap-2 text-muted-foreground hover:text-foreground"
         >
-          <ArrowLeft style={{ width: '20px', height: '20px' }} />
+          <ArrowLeft className="w-5 h-5" />
           <span>설정으로 돌아가기</span>
-        </button>
+        </Button>
 
         <h1
           style={{
@@ -168,557 +171,252 @@ export function SettingsSecurityPage() {
         </p>
 
         {/* Profile Information Section */}
-        <section
-          style={{
-            backgroundColor: designTokens.bg.default,
-            border: `1px solid ${designTokens.bg.border}`,
-            borderRadius: '12px',
-            padding: '24px',
-            marginBottom: '24px',
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '12px',
-              marginBottom: '24px',
-              paddingBottom: '16px',
-              borderBottom: `1px solid ${designTokens.bg.border}`,
-            }}
-          >
-            <Shield style={{ width: '20px', height: '20px', color: '#4C2D9A' }} />
-            <h2 style={{ color: designTokens.text.primary, fontSize: '18px', fontWeight: 500 }}>
-              프로필 정보
-            </h2>
-          </div>
-
-          {/* Profile Image */}
-          <div style={{ marginBottom: '20px' }}>
-            <label
-              style={{
-                display: 'block',
-                color: designTokens.text.secondary,
-                fontSize: '14px',
-                marginBottom: '12px',
-              }}
-            >
-              프로필 이미지
-            </label>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
-              <div
-                style={{
-                  width: '80px',
-                  height: '80px',
-                  borderRadius: '50%',
-                  backgroundColor: profileImagePreview ? 'transparent' : '#F4F4F4',
-                  border: `2px solid ${designTokens.bg.border}`,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  overflow: 'hidden',
-                }}
-              >
-                {profileImagePreview ? (
-                  <img
-                    src={profileImagePreview}
-                    alt="Profile"
-                    style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+        <Card className="mb-6">
+          <CardHeader className="border-b px-6 py-4">
+            <div className="flex items-center gap-3">
+              <Shield className="w-5 h-5" style={{ color: designTokens.text.secondary }} />
+              <CardTitle className="text-lg font-medium">프로필 정보</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent className="pt-6 px-6 pb-6">
+            {/* Profile Image */}
+            <div className="mb-5">
+              <Label className="mb-3 text-muted-foreground text-sm">프로필 이미지</Label>
+              <div className="flex items-center gap-4 mt-3">
+                <Avatar className="w-20 h-20">
+                  {profileImagePreview ? (
+                    <AvatarImage src={profileImagePreview} alt="Profile" />
+                  ) : (
+                    <AvatarFallback>
+                      <User className="w-8 h-8" style={{ color: designTokens.text.placeholder }} />
+                    </AvatarFallback>
+                  )}
+                </Avatar>
+                <div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="gap-2"
+                  >
+                    <Camera className="w-4 h-4" />
+                    이미지 변경
+                  </Button>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    onChange={handleImageUpload}
+                    style={{ display: 'none' }}
                   />
-                ) : (
-                  <User style={{ width: '32px', height: '32px', color: '#999999' }} />
-                )}
-              </div>
-              <div>
-                <button
-                  onClick={() => fileInputRef.current?.click()}
-                  style={{
-                    padding: '8px 16px',
-                    backgroundColor: designTokens.bg.default,
-                    border: `1px solid ${designTokens.bg.border}`,
-                    borderRadius: '8px',
-                    color: designTokens.text.primary,
-                    cursor: 'pointer',
-                    fontSize: '14px',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '8px',
-                    transition: 'all 0.2s',
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.borderColor = '#4C2D9A';
-                    e.currentTarget.style.backgroundColor = '#F8F5FC';
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.borderColor = designTokens.bg.border;
-                    e.currentTarget.style.backgroundColor = designTokens.bg.default;
-                  }}
-                >
-                  <Camera style={{ width: '16px', height: '16px' }} />
-                  이미지 변경
-                </button>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept="image/*"
-                  onChange={handleImageUpload}
-                  style={{ display: 'none' }}
-                />
-                <p
-                  style={{
-                    fontSize: '12px',
-                    color: designTokens.text.secondary,
-                    marginTop: '8px',
-                  }}
-                >
-                  JPG, PNG (최대 5MB)
-                </p>
+                  <p className="text-xs text-muted-foreground mt-2">
+                    JPG, PNG (최대 5MB)
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
 
-          {/* Name */}
-          <div style={{ marginBottom: '20px' }}>
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '8px',
-                color: designTokens.text.secondary,
-                fontSize: '14px',
-                marginBottom: '8px',
-              }}
-            >
-              <User style={{ width: '16px', height: '16px' }} />
-              이름
-            </label>
-            <input
-              type="text"
-              value={profileData.name}
-              onChange={(e) => setProfileData((prev) => ({ ...prev, name: e.target.value }))}
-              style={{
-                width: '100%',
-                padding: '10px 12px',
-                border: `1px solid ${designTokens.bg.border}`,
-                borderRadius: '8px',
-                fontSize: '14px',
-                color: designTokens.text.primary,
-                backgroundColor: designTokens.bg.default,
-                outline: 'none',
-              }}
-              onFocus={(e) => (e.currentTarget.style.borderColor = '#4C2D9A')}
-              onBlur={(e) => (e.currentTarget.style.borderColor = designTokens.bg.border)}
-            />
-          </div>
+            {/* Name */}
+            <div className="mb-5">
+              <Input
+                label="이름"
+                value={profileData.name}
+                onChange={(e) => setProfileData((prev) => ({ ...prev, name: e.target.value }))}
+              />
+            </div>
 
-          {/* Email (Read-only) */}
-          <div style={{ marginBottom: '20px' }}>
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '8px',
-                color: designTokens.text.secondary,
-                fontSize: '14px',
-                marginBottom: '8px',
-              }}
-            >
-              <Mail style={{ width: '16px', height: '16px' }} />
-              이메일
-            </label>
-            <input
-              type="email"
-              value={profileData.email}
-              readOnly
-              style={{
-                width: '100%',
-                padding: '10px 12px',
-                border: `1px solid ${designTokens.bg.border}`,
-                borderRadius: '8px',
-                fontSize: '14px',
-                color: designTokens.text.secondary,
-                backgroundColor: '#F8F8F8',
-                cursor: 'not-allowed',
-              }}
-            />
-          </div>
+            {/* Email (Read-only) */}
+            <div className="mb-5">
+              <Label className="flex items-center gap-2 mb-2 text-muted-foreground text-sm">
+                <Mail className="w-4 h-4" />
+                이메일
+              </Label>
+              <input
+                type="email"
+                value={profileData.email}
+                readOnly
+                className="w-full px-3 py-2.5 rounded-md text-sm border cursor-not-allowed"
+                style={{
+                  backgroundColor: designTokens.bg.secondary,
+                  color: designTokens.text.secondary,
+                  borderColor: designTokens.bg.border,
+                }}
+              />
+            </div>
 
-          {/* Join Date (Read-only) */}
-          <div style={{ marginBottom: '24px' }}>
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '8px',
-                color: designTokens.text.secondary,
-                fontSize: '14px',
-                marginBottom: '8px',
-              }}
-            >
-              <Calendar style={{ width: '16px', height: '16px' }} />
-              가입일
-            </label>
-            <input
-              type="text"
-              value={profileData.joinDate}
-              readOnly
-              style={{
-                width: '100%',
-                padding: '10px 12px',
-                border: `1px solid ${designTokens.bg.border}`,
-                borderRadius: '8px',
-                fontSize: '14px',
-                color: designTokens.text.secondary,
-                backgroundColor: '#F8F8F8',
-                cursor: 'not-allowed',
-              }}
-            />
-          </div>
+            {/* Join Date (Read-only) */}
+            <div className="mb-6">
+              <Label className="flex items-center gap-2 mb-2 text-muted-foreground text-sm">
+                <Calendar className="w-4 h-4" />
+                가입일
+              </Label>
+              <input
+                type="text"
+                value={profileData.joinDate}
+                readOnly
+                className="w-full px-3 py-2.5 rounded-md text-sm border cursor-not-allowed"
+                style={{
+                  backgroundColor: designTokens.bg.secondary,
+                  color: designTokens.text.secondary,
+                  borderColor: designTokens.bg.border,
+                }}
+              />
+            </div>
 
-          {/* Save Button */}
-          <button
-            onClick={handleProfileSave}
-            style={{
-              padding: '10px 24px',
-              backgroundColor: designTokens.button.brand_default,
-              color: 'white',
-              border: 'none',
-              borderRadius: '8px',
-              cursor: 'pointer',
-              fontSize: '14px',
-              transition: 'opacity 0.2s',
-            }}
-            onMouseEnter={(e) => (e.currentTarget.style.opacity = '0.9')}
-            onMouseLeave={(e) => (e.currentTarget.style.opacity = '1')}
-          >
-            저장
-          </button>
-        </section>
+            {/* Save Button */}
+            <Button onClick={handleProfileSave}>
+              저장
+            </Button>
+          </CardContent>
+        </Card>
 
         {/* Password Change Section */}
-        <section
-          style={{
-            backgroundColor: designTokens.bg.default,
-            border: `1px solid ${designTokens.bg.border}`,
-            borderRadius: '12px',
-            padding: '24px',
-            marginBottom: '24px',
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '12px',
-              marginBottom: '24px',
-              paddingBottom: '16px',
-              borderBottom: `1px solid ${designTokens.bg.border}`,
-            }}
-          >
-            <Lock style={{ width: '20px', height: '20px', color: '#4C2D9A' }} />
-            <h2 style={{ color: designTokens.text.primary, fontSize: '18px', fontWeight: 500 }}>
+        <Card className="mb-6">
+          <CardHeader className="border-b px-6 py-4">
+            <div className="flex items-center gap-3">
+              <Lock className="w-5 h-5" style={{ color: designTokens.text.secondary }} />
+              <CardTitle className="text-lg font-medium">비밀번호 변경</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent className="pt-6 px-6 pb-6">
+            <div className="mb-5">
+              <Input
+                label="현재 비밀번호"
+                type="password"
+                value={passwordData.currentPassword}
+                onChange={(e) =>
+                  setPasswordData((prev) => ({ ...prev, currentPassword: e.target.value }))
+                }
+              />
+            </div>
+
+            <div className="mb-5">
+              <Input
+                label="새 비밀번호"
+                type="password"
+                value={passwordData.newPassword}
+                onChange={(e) =>
+                  setPasswordData((prev) => ({ ...prev, newPassword: e.target.value }))
+                }
+              />
+            </div>
+
+            <div className="mb-6">
+              <Input
+                label="새 비밀번호 확인"
+                type="password"
+                value={passwordData.confirmPassword}
+                onChange={(e) =>
+                  setPasswordData((prev) => ({ ...prev, confirmPassword: e.target.value }))
+                }
+              />
+            </div>
+
+            <Button onClick={handlePasswordChange}>
               비밀번호 변경
-            </h2>
-          </div>
-
-          <div style={{ marginBottom: '20px' }}>
-            <label
-              style={{
-                display: 'block',
-                color: designTokens.text.secondary,
-                fontSize: '14px',
-                marginBottom: '8px',
-              }}
-            >
-              현재 비밀번호
-            </label>
-            <input
-              type="password"
-              value={passwordData.currentPassword}
-              onChange={(e) =>
-                setPasswordData((prev) => ({ ...prev, currentPassword: e.target.value }))
-              }
-              style={{
-                width: '100%',
-                padding: '10px 12px',
-                border: `1px solid ${designTokens.bg.border}`,
-                borderRadius: '8px',
-                fontSize: '14px',
-                color: designTokens.text.primary,
-                backgroundColor: designTokens.bg.default,
-                outline: 'none',
-              }}
-              onFocus={(e) => (e.currentTarget.style.borderColor = '#4C2D9A')}
-              onBlur={(e) => (e.currentTarget.style.borderColor = designTokens.bg.border)}
-            />
-          </div>
-
-          <div style={{ marginBottom: '20px' }}>
-            <label
-              style={{
-                display: 'block',
-                color: designTokens.text.secondary,
-                fontSize: '14px',
-                marginBottom: '8px',
-              }}
-            >
-              새 비밀번호
-            </label>
-            <input
-              type="password"
-              value={passwordData.newPassword}
-              onChange={(e) =>
-                setPasswordData((prev) => ({ ...prev, newPassword: e.target.value }))
-              }
-              style={{
-                width: '100%',
-                padding: '10px 12px',
-                border: `1px solid ${designTokens.bg.border}`,
-                borderRadius: '8px',
-                fontSize: '14px',
-                color: designTokens.text.primary,
-                backgroundColor: designTokens.bg.default,
-                outline: 'none',
-              }}
-              onFocus={(e) => (e.currentTarget.style.borderColor = '#4C2D9A')}
-              onBlur={(e) => (e.currentTarget.style.borderColor = designTokens.bg.border)}
-            />
-          </div>
-
-          <div style={{ marginBottom: '24px' }}>
-            <label
-              style={{
-                display: 'block',
-                color: designTokens.text.secondary,
-                fontSize: '14px',
-                marginBottom: '8px',
-              }}
-            >
-              새 비밀번호 확인
-            </label>
-            <input
-              type="password"
-              value={passwordData.confirmPassword}
-              onChange={(e) =>
-                setPasswordData((prev) => ({ ...prev, confirmPassword: e.target.value }))
-              }
-              style={{
-                width: '100%',
-                padding: '10px 12px',
-                border: `1px solid ${designTokens.bg.border}`,
-                borderRadius: '8px',
-                fontSize: '14px',
-                color: designTokens.text.primary,
-                backgroundColor: designTokens.bg.default,
-                outline: 'none',
-              }}
-              onFocus={(e) => (e.currentTarget.style.borderColor = '#4C2D9A')}
-              onBlur={(e) => (e.currentTarget.style.borderColor = designTokens.bg.border)}
-            />
-          </div>
-
-          <button
-            onClick={handlePasswordChange}
-            style={{
-              padding: '10px 24px',
-              backgroundColor: designTokens.button.brand_default,
-              color: 'white',
-              border: 'none',
-              borderRadius: '8px',
-              cursor: 'pointer',
-              fontSize: '14px',
-              transition: 'opacity 0.2s',
-            }}
-            onMouseEnter={(e) => (e.currentTarget.style.opacity = '0.9')}
-            onMouseLeave={(e) => (e.currentTarget.style.opacity = '1')}
-          >
-            비밀번호 변경
-          </button>
-        </section>
+            </Button>
+          </CardContent>
+        </Card>
 
         {/* Design Authority Section (User Role Only) */}
         {isUserRole && (
-          <section
-            style={{
-              backgroundColor: designTokens.bg.default,
-              border: `1px solid ${designTokens.bg.border}`,
-              borderRadius: '12px',
-              padding: '24px',
-              marginBottom: '24px',
-            }}
-          >
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '12px',
-                marginBottom: '24px',
-                paddingBottom: '16px',
-                borderBottom: `1px solid ${designTokens.bg.border}`,
-              }}
-            >
-              <CheckCircle style={{ width: '20px', height: '20px', color: '#4C2D9A' }} />
-              <h2 style={{ color: designTokens.text.primary, fontSize: '18px', fontWeight: 500 }}>
-                강의 개설 권한
-              </h2>
-            </div>
-
-            <div style={{ marginBottom: '20px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  color: designTokens.text.secondary,
-                  fontSize: '14px',
-                  marginBottom: '12px',
-                }}
-              >
-                현재 권한 상태
-              </label>
-              <div
-                style={{
-                  display: 'inline-block',
-                  padding: '8px 16px',
-                  backgroundColor: `${getAuthBadgeColor(designAuthStatus)}15`,
-                  border: `1px solid ${getAuthBadgeColor(designAuthStatus)}`,
-                  borderRadius: '20px',
-                  fontSize: '14px',
-                  color: getAuthBadgeColor(designAuthStatus),
-                  fontWeight: 500,
-                }}
-              >
-                {getAuthLabel(designAuthStatus)}
+          <Card className="mb-6">
+            <CardHeader className="border-b px-6 py-4">
+              <div className="flex items-center gap-3">
+                <CheckCircle className="w-5 h-5" style={{ color: designTokens.text.secondary }} />
+                <CardTitle className="text-lg font-medium">강의 개설 권한</CardTitle>
               </div>
-            </div>
+            </CardHeader>
+            <CardContent className="pt-6 px-6 pb-6">
+              <div className="mb-5">
+                <Label className="mb-3 text-muted-foreground text-sm">현재 권한 상태</Label>
+                <div className="mt-3">
+                  <Badge variant={getAuthBadgeVariant(designAuthStatus)} className="px-4 py-2 text-sm">
+                    {getAuthLabel(designAuthStatus)}
+                  </Badge>
+                </div>
+              </div>
 
-            {designAuthStatus === 'USER' && (
-              <div>
-                <p
+              {designAuthStatus === 'USER' && (
+                <div>
+                  <p className="text-sm text-muted-foreground mb-4 leading-relaxed">
+                    강의를 개설하고 콘텐츠를 등록하려면 권한을 요청해주세요.
+                  </p>
+                  <Button
+                    onClick={handleRequestDesignAuth}
+                    disabled={isRequestPending}
+                  >
+                    {isRequestPending ? '요청 중...' : '강의 개설 권한 요청'}
+                  </Button>
+                </div>
+              )}
+
+              {(designAuthStatus === 'DESIGNER' || designAuthStatus === 'OWNER') && (
+                <Alert
+                  className="flex items-center gap-3"
                   style={{
-                    fontSize: '14px',
-                    color: designTokens.text.secondary,
-                    marginBottom: '16px',
-                    lineHeight: '1.6',
+                    backgroundColor: designTokens.status.success_background,
+                    borderColor: designTokens.status.success_text,
                   }}
                 >
-                  강의를 개설하고 콘텐츠를 등록하려면 권한을 요청해주세요.
-                </p>
-                <button
-                  onClick={handleRequestDesignAuth}
-                  disabled={isRequestPending}
-                  style={{
-                    padding: '10px 24px',
-                    backgroundColor: isRequestPending ? '#CCCCCC' : designTokens.button.brand_default,
-                    color: 'white',
-                    border: 'none',
-                    borderRadius: '8px',
-                    cursor: isRequestPending ? 'not-allowed' : 'pointer',
-                    fontSize: '14px',
-                    transition: 'opacity 0.2s',
-                  }}
-                  onMouseEnter={(e) =>
-                    !isRequestPending && (e.currentTarget.style.opacity = '0.9')
-                  }
-                  onMouseLeave={(e) =>
-                    !isRequestPending && (e.currentTarget.style.opacity = '1')
-                  }
-                >
-                  {isRequestPending ? '요청 중...' : '강의 개설 권한 요청'}
-                </button>
-              </div>
-            )}
-
-            {(designAuthStatus === 'DESIGNER' || designAuthStatus === 'OWNER') && (
-              <div
-                style={{
-                  padding: '12px 16px',
-                  backgroundColor: '#E8F5E9',
-                  border: '1px solid #4CAF50',
-                  borderRadius: '8px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '12px',
-                }}
-              >
-                <CheckCircle style={{ width: '20px', height: '20px', color: '#4CAF50' }} />
-                <p style={{ fontSize: '14px', color: '#2E7D32' }}>
-                  강의 개설 및 콘텐츠 등록 권한이 활성화되었습니다.
-                </p>
-              </div>
-            )}
-          </section>
+                  <CheckCircle className="w-5 h-5" style={{ color: designTokens.status.success_text }} />
+                  <AlertDescription style={{ color: designTokens.status.success_text }}>
+                    강의 개설 및 콘텐츠 등록 권한이 활성화되었습니다.
+                  </AlertDescription>
+                </Alert>
+              )}
+            </CardContent>
+          </Card>
         )}
 
         {/* Account Management Section */}
-        <section
-          style={{
-            backgroundColor: designTokens.bg.default,
-            border: `1px solid ${designTokens.bg.border}`,
-            borderRadius: '12px',
-            padding: '24px',
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '12px',
-              marginBottom: '16px',
-              paddingBottom: '16px',
-              borderBottom: `1px solid ${designTokens.bg.border}`,
-            }}
-          >
-            <AlertTriangle style={{ width: '20px', height: '20px', color: '#FF7043' }} />
-            <h2 style={{ color: designTokens.text.primary, fontSize: '18px', fontWeight: 500 }}>
-              계정 관리
-            </h2>
-          </div>
+        <Card>
+          <CardHeader className="border-b px-6 py-4">
+            <div className="flex items-center gap-3">
+              <AlertTriangle className="w-5 h-5" style={{ color: designTokens.badge.orange.text }} />
+              <CardTitle className="text-lg font-medium">계정 관리</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent className="pt-6 px-6 pb-6">
+            <Alert
+              className="mb-4"
+              style={{
+                backgroundColor: designTokens.status.warning_background,
+                borderColor: designTokens.status.warning_text,
+              }}
+            >
+              <AlertDescription style={{ color: designTokens.status.warning_text }}>
+                계정을 삭제하면 모든 데이터가 영구적으로 삭제되며 복구할 수 없습니다.
+              </AlertDescription>
+            </Alert>
 
-          <div
-            style={{
-              padding: '16px',
-              backgroundColor: '#FFF3E0',
-              border: '1px solid #FFB74D',
-              borderRadius: '8px',
-              marginBottom: '16px',
-            }}
-          >
-            <p style={{ fontSize: '14px', color: '#E65100', lineHeight: '1.6' }}>
-              계정을 삭제하면 모든 데이터가 영구적으로 삭제되며 복구할 수 없습니다.
-            </p>
-          </div>
-
-          <button
-            onClick={() => {
-              if (
-                confirm(
-                  '정말로 계정을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.'
-                )
-              ) {
-                alert('계정 삭제가 요청되었습니다.');
-              }
-            }}
-            style={{
-              padding: '10px 24px',
-              backgroundColor: 'transparent',
-              color: '#D32F2F',
-              border: '1px solid #D32F2F',
-              borderRadius: '8px',
-              cursor: 'pointer',
-              fontSize: '14px',
-              transition: 'all 0.2s',
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.backgroundColor = '#D32F2F';
-              e.currentTarget.style.color = 'white';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.backgroundColor = 'transparent';
-              e.currentTarget.style.color = '#D32F2F';
-            }}
-          >
-            회원 탈퇴
-          </button>
-        </section>
+            <Button
+              variant="outline"
+              onClick={() => {
+                if (
+                  confirm(
+                    '정말로 계정을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.'
+                  )
+                ) {
+                  alert('계정 삭제가 요청되었습니다.');
+                }
+              }}
+              style={{
+                color: designTokens.status.error_text,
+                borderColor: designTokens.status.error_text,
+              }}
+              className="hover:bg-destructive"
+              onMouseEnter={(e) => {
+                e.currentTarget.style.color = designTokens.action.primary_text;
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.color = designTokens.status.error_text;
+              }}
+            >
+              회원 탈퇴
+            </Button>
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/src/pages/common/settings/index.ts
+++ b/src/pages/common/settings/index.ts
@@ -1,0 +1,4 @@
+export { SettingsPage } from './SettingsPage';
+export { SettingsSecurityPage } from './SettingsSecurityPage';
+export { SettingsNotificationsPage } from './SettingsNotificationsPage';
+export { SettingsAppearancePage } from './SettingsAppearancePage';

--- a/src/pages/tu/index.ts
+++ b/src/pages/tu/index.ts
@@ -1,1 +1,2 @@
 export { MyCoursesPage, MyContentPage, CourseCreatePage, TuContentCreatePage, ContentDetailPage } from './teaching';
+export { SettingsLanguagePage } from './settings';

--- a/src/pages/tu/settings/SettingsLanguagePage.tsx
+++ b/src/pages/tu/settings/SettingsLanguagePage.tsx
@@ -1,7 +1,16 @@
 import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { ArrowLeft, Globe, Clock } from 'lucide-react';
-import { designTokens } from '@/styles/design-tokens';
+import { designTokens } from '@/styles/admin-design-tokens';
+import {
+  Button,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  Label,
+  NativeSelect,
+} from '@/components/common';
 
 export function SettingsLanguagePage() {
   const navigate = useNavigate();
@@ -50,26 +59,14 @@ export function SettingsLanguagePage() {
     >
       <div style={{ maxWidth: '800px', margin: '0 auto' }}>
         {/* Header with Back Button */}
-        <button
+        <Button
+          variant="ghost"
           onClick={handleBack}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px',
-            padding: '8px 12px',
-            marginBottom: '24px',
-            backgroundColor: 'transparent',
-            border: 'none',
-            color: designTokens.text.secondary,
-            cursor: 'pointer',
-            transition: 'color 0.2s',
-          }}
-          onMouseEnter={(e) => (e.currentTarget.style.color = designTokens.text.primary)}
-          onMouseLeave={(e) => (e.currentTarget.style.color = designTokens.text.secondary)}
+          className="mb-6 gap-2 text-muted-foreground hover:text-foreground"
         >
-          <ArrowLeft style={{ width: '20px', height: '20px' }} />
+          <ArrowLeft className="w-5 h-5" />
           <span>설정으로 돌아가기</span>
-        </button>
+        </Button>
 
         <h1
           style={{
@@ -86,282 +83,103 @@ export function SettingsLanguagePage() {
         </p>
 
         {/* Language Section */}
-        <section
-          style={{
-            backgroundColor: designTokens.bg.default,
-            border: `1px solid ${designTokens.bg.border}`,
-            borderRadius: '12px',
-            padding: '24px',
-            marginBottom: '24px',
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '12px',
-              marginBottom: '24px',
-              paddingBottom: '16px',
-              borderBottom: `1px solid ${designTokens.bg.border}`,
-            }}
-          >
-            <Globe style={{ width: '20px', height: '20px', color: '#4C2D9A' }} />
-            <h2 style={{ color: designTokens.text.primary, fontSize: '18px', fontWeight: 500 }}>
-              언어 설정
-            </h2>
-          </div>
-
-          <div>
-            <label
-              style={{
-                display: 'block',
-                color: designTokens.text.secondary,
-                fontSize: '14px',
-                marginBottom: '12px',
-              }}
-            >
-              표시 언어
-            </label>
-            <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
-              <button
-                onClick={() => setLanguage('ko')}
-                style={{
-                  padding: '12px 24px',
-                  backgroundColor:
-                    language === 'ko' ? designTokens.button.brand_default : designTokens.bg.default,
-                  color: language === 'ko' ? 'white' : designTokens.text.primary,
-                  border: `1px solid ${language === 'ko' ? designTokens.button.brand_default : designTokens.bg.border}`,
-                  borderRadius: '8px',
-                  cursor: 'pointer',
-                  fontSize: '14px',
-                  transition: 'all 0.2s',
-                  minWidth: '120px',
-                }}
-                onMouseEnter={(e) => {
-                  if (language !== 'ko') {
-                    e.currentTarget.style.borderColor = '#4C2D9A';
-                    e.currentTarget.style.backgroundColor = '#F8F5FC';
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  if (language !== 'ko') {
-                    e.currentTarget.style.borderColor = designTokens.bg.border;
-                    e.currentTarget.style.backgroundColor = designTokens.bg.default;
-                  }
-                }}
-              >
-                한국어
-              </button>
-              <button
-                onClick={() => setLanguage('en')}
-                style={{
-                  padding: '12px 24px',
-                  backgroundColor:
-                    language === 'en' ? designTokens.button.brand_default : designTokens.bg.default,
-                  color: language === 'en' ? 'white' : designTokens.text.primary,
-                  border: `1px solid ${language === 'en' ? designTokens.button.brand_default : designTokens.bg.border}`,
-                  borderRadius: '8px',
-                  cursor: 'pointer',
-                  fontSize: '14px',
-                  transition: 'all 0.2s',
-                  minWidth: '120px',
-                }}
-                onMouseEnter={(e) => {
-                  if (language !== 'en') {
-                    e.currentTarget.style.borderColor = '#4C2D9A';
-                    e.currentTarget.style.backgroundColor = '#F8F5FC';
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  if (language !== 'en') {
-                    e.currentTarget.style.borderColor = designTokens.bg.border;
-                    e.currentTarget.style.backgroundColor = designTokens.bg.default;
-                  }
-                }}
-              >
-                English
-              </button>
+        <Card className="mb-6">
+          <CardHeader className="border-b px-6 py-4">
+            <div className="flex items-center gap-3">
+              <Globe className="w-5 h-5" style={{ color: designTokens.text.secondary }} />
+              <CardTitle className="text-lg font-medium">언어 설정</CardTitle>
             </div>
-            <p
-              style={{
-                fontSize: '12px',
-                color: designTokens.text.secondary,
-                marginTop: '12px',
-              }}
-            >
-              인터페이스 언어가 즉시 변경됩니다.
-            </p>
-          </div>
-        </section>
+          </CardHeader>
+          <CardContent className="pt-6 px-6 pb-6">
+            <div>
+              <Label className="mb-3 text-muted-foreground text-sm">표시 언어</Label>
+              <div className="flex gap-3 mt-3 flex-wrap">
+                <Button
+                  variant={language === 'ko' ? 'default' : 'outline'}
+                  onClick={() => setLanguage('ko')}
+                  className="min-w-[120px]"
+                >
+                  한국어
+                </Button>
+                <Button
+                  variant={language === 'en' ? 'default' : 'outline'}
+                  onClick={() => setLanguage('en')}
+                  className="min-w-[120px]"
+                >
+                  English
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground mt-3">
+                인터페이스 언어가 즉시 변경됩니다.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
 
         {/* Timezone Section */}
-        <section
-          style={{
-            backgroundColor: designTokens.bg.default,
-            border: `1px solid ${designTokens.bg.border}`,
-            borderRadius: '12px',
-            padding: '24px',
-            marginBottom: '24px',
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '12px',
-              marginBottom: '24px',
-              paddingBottom: '16px',
-              borderBottom: `1px solid ${designTokens.bg.border}`,
-            }}
-          >
-            <Clock style={{ width: '20px', height: '20px', color: '#4C2D9A' }} />
-            <h2 style={{ color: designTokens.text.primary, fontSize: '18px', fontWeight: 500 }}>
-              시간대 설정
-            </h2>
-          </div>
-
-          <div style={{ marginBottom: '24px' }}>
-            <label
-              style={{
-                display: 'block',
-                color: designTokens.text.secondary,
-                fontSize: '14px',
-                marginBottom: '8px',
-              }}
-            >
-              시간대
-            </label>
-            <select
-              value={timezone}
-              onChange={(e) => setTimezone(e.target.value)}
-              style={{
-                width: '100%',
-                padding: '10px 12px',
-                border: `1px solid ${designTokens.bg.border}`,
-                borderRadius: '8px',
-                fontSize: '14px',
-                color: designTokens.text.primary,
-                backgroundColor: designTokens.bg.default,
-                cursor: 'pointer',
-                outline: 'none',
-              }}
-              onFocus={(e) => (e.currentTarget.style.borderColor = '#4C2D9A')}
-              onBlur={(e) => (e.currentTarget.style.borderColor = designTokens.bg.border)}
-            >
-              {timezones.map((tz) => (
-                <option key={tz.value} value={tz.value}>
-                  {tz.label}
-                </option>
-              ))}
-            </select>
-            <p
-              style={{
-                fontSize: '12px',
-                color: designTokens.text.secondary,
-                marginTop: '8px',
-              }}
-            >
-              강의 일정과 알림 시간에 적용됩니다.
-            </p>
-          </div>
-
-          <div>
-            <label
-              style={{
-                display: 'block',
-                color: designTokens.text.secondary,
-                fontSize: '14px',
-                marginBottom: '12px',
-              }}
-            >
-              날짜 형식
-            </label>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-              {dateFormats.map((format) => (
-                <label
-                  key={format.value}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    padding: '12px',
-                    border: `1px solid ${dateFormat === format.value ? '#4C2D9A' : designTokens.bg.border}`,
-                    borderRadius: '8px',
-                    cursor: 'pointer',
-                    backgroundColor: dateFormat === format.value ? '#F8F5FC' : 'transparent',
-                    transition: 'all 0.2s',
-                  }}
-                  onMouseEnter={(e) => {
-                    if (dateFormat !== format.value) {
-                      e.currentTarget.style.backgroundColor = '#FAFAFA';
-                    }
-                  }}
-                  onMouseLeave={(e) => {
-                    if (dateFormat !== format.value) {
-                      e.currentTarget.style.backgroundColor = 'transparent';
-                    }
-                  }}
-                >
-                  <input
-                    type="radio"
-                    name="dateFormat"
-                    value={format.value}
-                    checked={dateFormat === format.value}
-                    onChange={(e) => setDateFormat(e.target.value)}
-                    style={{
-                      marginRight: '12px',
-                      cursor: 'pointer',
-                    }}
-                  />
-                  <div style={{ flex: 1 }}>
-                    <div
-                      style={{
-                        color: designTokens.text.primary,
-                        fontSize: '14px',
-                        marginBottom: '4px',
-                      }}
-                    >
-                      {format.label}
-                    </div>
-                    <div
-                      style={{
-                        color: designTokens.text.secondary,
-                        fontSize: '12px',
-                      }}
-                    >
-                      {format.description}
-                    </div>
-                  </div>
-                </label>
-              ))}
+        <Card className="mb-6">
+          <CardHeader className="border-b px-6 py-4">
+            <div className="flex items-center gap-3">
+              <Clock className="w-5 h-5" style={{ color: designTokens.text.secondary }} />
+              <CardTitle className="text-lg font-medium">시간대 설정</CardTitle>
             </div>
-          </div>
-        </section>
+          </CardHeader>
+          <CardContent className="pt-6 px-6 pb-6">
+            <div className="mb-6">
+              <NativeSelect
+                label="시간대"
+                value={timezone}
+                onChange={(e) => setTimezone(e.target.value)}
+                options={timezones}
+              />
+              <p className="text-xs text-muted-foreground mt-2">
+                강의 일정과 알림 시간에 적용됩니다.
+              </p>
+            </div>
+
+            <div>
+              <Label className="mb-3 text-muted-foreground text-sm">날짜 형식</Label>
+              <div className="flex flex-col gap-2 mt-3">
+                {dateFormats.map((format) => {
+                  const isSelected = dateFormat === format.value;
+                  return (
+                    <label
+                      key={format.value}
+                      className="flex items-center p-3 rounded-lg cursor-pointer transition-all hover:bg-muted/50"
+                      style={{
+                        border: `1px solid ${isSelected ? designTokens.action.primary_default : designTokens.bg.border}`,
+                        backgroundColor: isSelected ? designTokens.bg.secondary : 'transparent',
+                      }}
+                    >
+                      <input
+                        type="radio"
+                        name="dateFormat"
+                        value={format.value}
+                        checked={isSelected}
+                        onChange={(e) => setDateFormat(e.target.value)}
+                        className="mr-3 cursor-pointer"
+                      />
+                      <div className="flex-1">
+                        <div style={{ color: designTokens.text.primary, fontSize: '14px', marginBottom: '4px' }}>
+                          {format.label}
+                        </div>
+                        <div style={{ color: designTokens.text.secondary, fontSize: '12px' }}>
+                          {format.description}
+                        </div>
+                      </div>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
 
         {/* Save Button */}
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'flex-end',
-            paddingTop: '16px',
-          }}
-        >
-          <button
-            onClick={handleSave}
-            style={{
-              padding: '10px 24px',
-              backgroundColor: designTokens.button.brand_default,
-              color: 'white',
-              border: 'none',
-              borderRadius: '8px',
-              cursor: 'pointer',
-              fontSize: '14px',
-              transition: 'opacity 0.2s',
-            }}
-            onMouseEnter={(e) => (e.currentTarget.style.opacity = '0.9')}
-            onMouseLeave={(e) => (e.currentTarget.style.opacity = '1')}
-          >
+        <div className="flex justify-end pt-4">
+          <Button onClick={handleSave}>
             저장
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/pages/tu/settings/SettingsLanguagePage.tsx
+++ b/src/pages/tu/settings/SettingsLanguagePage.tsx
@@ -10,6 +10,7 @@ import {
   CardContent,
   Label,
   NativeSelect,
+  RadioOptionCard,
 } from '@/components/common';
 
 export function SettingsLanguagePage() {
@@ -90,7 +91,7 @@ export function SettingsLanguagePage() {
               <CardTitle className="text-lg font-medium">언어 설정</CardTitle>
             </div>
           </CardHeader>
-          <CardContent className="pt-6 px-6 pb-6">
+          <CardContent className="px-6 pb-6">
             <div>
               <Label className="mb-3 text-muted-foreground text-sm">표시 언어</Label>
               <div className="flex gap-3 mt-3 flex-wrap">
@@ -124,7 +125,7 @@ export function SettingsLanguagePage() {
               <CardTitle className="text-lg font-medium">시간대 설정</CardTitle>
             </div>
           </CardHeader>
-          <CardContent className="pt-6 px-6 pb-6">
+          <CardContent className="px-6 pb-6">
             <div className="mb-6">
               <NativeSelect
                 label="시간대"
@@ -140,36 +141,17 @@ export function SettingsLanguagePage() {
             <div>
               <Label className="mb-3 text-muted-foreground text-sm">날짜 형식</Label>
               <div className="flex flex-col gap-2 mt-3">
-                {dateFormats.map((format) => {
-                  const isSelected = dateFormat === format.value;
-                  return (
-                    <label
-                      key={format.value}
-                      className="flex items-center p-3 rounded-lg cursor-pointer transition-all hover:bg-muted/50"
-                      style={{
-                        border: `1px solid ${isSelected ? designTokens.action.primary_default : designTokens.bg.border}`,
-                        backgroundColor: isSelected ? designTokens.bg.secondary : 'transparent',
-                      }}
-                    >
-                      <input
-                        type="radio"
-                        name="dateFormat"
-                        value={format.value}
-                        checked={isSelected}
-                        onChange={(e) => setDateFormat(e.target.value)}
-                        className="mr-3 cursor-pointer"
-                      />
-                      <div className="flex-1">
-                        <div style={{ color: designTokens.text.primary, fontSize: '14px', marginBottom: '4px' }}>
-                          {format.label}
-                        </div>
-                        <div style={{ color: designTokens.text.secondary, fontSize: '12px' }}>
-                          {format.description}
-                        </div>
-                      </div>
-                    </label>
-                  );
-                })}
+                {dateFormats.map((format) => (
+                  <RadioOptionCard
+                    key={format.value}
+                    name="dateFormat"
+                    value={format.value}
+                    label={format.label}
+                    description={format.description}
+                    isSelected={dateFormat === format.value}
+                    onChange={setDateFormat}
+                  />
+                ))}
               </div>
             </div>
           </CardContent>

--- a/src/pages/tu/settings/SettingsLanguagePage.tsx
+++ b/src/pages/tu/settings/SettingsLanguagePage.tsx
@@ -1,0 +1,369 @@
+import { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { ArrowLeft, Globe, Clock } from 'lucide-react';
+import { designTokens } from '@/styles/design-tokens';
+
+export function SettingsLanguagePage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const [language, setLanguage] = useState<'ko' | 'en'>('ko');
+  const [timezone, setTimezone] = useState('Asia/Seoul');
+  const [dateFormat, setDateFormat] = useState('YYYY-MM-DD');
+
+  const basePath = location.pathname.split('/settings')[0];
+
+  const handleBack = () => {
+    navigate(`${basePath}/settings`);
+  };
+
+  const timezones = [
+    { value: 'Asia/Seoul', label: '서울 (UTC+9)' },
+    { value: 'America/New_York', label: '뉴욕 (UTC-5)' },
+    { value: 'America/Los_Angeles', label: '로스앤젤레스 (UTC-8)' },
+    { value: 'Europe/London', label: '런던 (UTC+0)' },
+    { value: 'Europe/Paris', label: '파리 (UTC+1)' },
+    { value: 'Asia/Tokyo', label: '도쿄 (UTC+9)' },
+    { value: 'Asia/Shanghai', label: '상하이 (UTC+8)' },
+    { value: 'Australia/Sydney', label: '시드니 (UTC+10)' },
+  ];
+
+  const dateFormats = [
+    { value: 'YYYY-MM-DD', label: '2024-12-23', description: '연-월-일' },
+    { value: 'MM/DD/YYYY', label: '12/23/2024', description: '월/일/연' },
+    { value: 'DD/MM/YYYY', label: '23/12/2024', description: '일/월/연' },
+    { value: 'YYYY년 MM월 DD일', label: '2024년 12월 23일', description: '한국어 형식' },
+  ];
+
+  const handleSave = () => {
+    alert('언어 및 지역 설정이 저장되었습니다.');
+  };
+
+  return (
+    <div
+      style={{
+        padding: '40px',
+        backgroundColor: designTokens.bg.app_default,
+        minHeight: '100%',
+        overflowY: 'auto',
+      }}
+    >
+      <div style={{ maxWidth: '800px', margin: '0 auto' }}>
+        {/* Header with Back Button */}
+        <button
+          onClick={handleBack}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            padding: '8px 12px',
+            marginBottom: '24px',
+            backgroundColor: 'transparent',
+            border: 'none',
+            color: designTokens.text.secondary,
+            cursor: 'pointer',
+            transition: 'color 0.2s',
+          }}
+          onMouseEnter={(e) => (e.currentTarget.style.color = designTokens.text.primary)}
+          onMouseLeave={(e) => (e.currentTarget.style.color = designTokens.text.secondary)}
+        >
+          <ArrowLeft style={{ width: '20px', height: '20px' }} />
+          <span>설정으로 돌아가기</span>
+        </button>
+
+        <h1
+          style={{
+            color: designTokens.text.primary,
+            fontSize: '24px',
+            fontWeight: 600,
+            marginBottom: '8px',
+          }}
+        >
+          언어 및 지역
+        </h1>
+        <p style={{ color: designTokens.text.secondary, marginBottom: '32px' }}>
+          언어, 시간대 및 날짜 형식을 설정하세요
+        </p>
+
+        {/* Language Section */}
+        <section
+          style={{
+            backgroundColor: designTokens.bg.default,
+            border: `1px solid ${designTokens.bg.border}`,
+            borderRadius: '12px',
+            padding: '24px',
+            marginBottom: '24px',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px',
+              marginBottom: '24px',
+              paddingBottom: '16px',
+              borderBottom: `1px solid ${designTokens.bg.border}`,
+            }}
+          >
+            <Globe style={{ width: '20px', height: '20px', color: '#4C2D9A' }} />
+            <h2 style={{ color: designTokens.text.primary, fontSize: '18px', fontWeight: 500 }}>
+              언어 설정
+            </h2>
+          </div>
+
+          <div>
+            <label
+              style={{
+                display: 'block',
+                color: designTokens.text.secondary,
+                fontSize: '14px',
+                marginBottom: '12px',
+              }}
+            >
+              표시 언어
+            </label>
+            <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
+              <button
+                onClick={() => setLanguage('ko')}
+                style={{
+                  padding: '12px 24px',
+                  backgroundColor:
+                    language === 'ko' ? designTokens.button.brand_default : designTokens.bg.default,
+                  color: language === 'ko' ? 'white' : designTokens.text.primary,
+                  border: `1px solid ${language === 'ko' ? designTokens.button.brand_default : designTokens.bg.border}`,
+                  borderRadius: '8px',
+                  cursor: 'pointer',
+                  fontSize: '14px',
+                  transition: 'all 0.2s',
+                  minWidth: '120px',
+                }}
+                onMouseEnter={(e) => {
+                  if (language !== 'ko') {
+                    e.currentTarget.style.borderColor = '#4C2D9A';
+                    e.currentTarget.style.backgroundColor = '#F8F5FC';
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (language !== 'ko') {
+                    e.currentTarget.style.borderColor = designTokens.bg.border;
+                    e.currentTarget.style.backgroundColor = designTokens.bg.default;
+                  }
+                }}
+              >
+                한국어
+              </button>
+              <button
+                onClick={() => setLanguage('en')}
+                style={{
+                  padding: '12px 24px',
+                  backgroundColor:
+                    language === 'en' ? designTokens.button.brand_default : designTokens.bg.default,
+                  color: language === 'en' ? 'white' : designTokens.text.primary,
+                  border: `1px solid ${language === 'en' ? designTokens.button.brand_default : designTokens.bg.border}`,
+                  borderRadius: '8px',
+                  cursor: 'pointer',
+                  fontSize: '14px',
+                  transition: 'all 0.2s',
+                  minWidth: '120px',
+                }}
+                onMouseEnter={(e) => {
+                  if (language !== 'en') {
+                    e.currentTarget.style.borderColor = '#4C2D9A';
+                    e.currentTarget.style.backgroundColor = '#F8F5FC';
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (language !== 'en') {
+                    e.currentTarget.style.borderColor = designTokens.bg.border;
+                    e.currentTarget.style.backgroundColor = designTokens.bg.default;
+                  }
+                }}
+              >
+                English
+              </button>
+            </div>
+            <p
+              style={{
+                fontSize: '12px',
+                color: designTokens.text.secondary,
+                marginTop: '12px',
+              }}
+            >
+              인터페이스 언어가 즉시 변경됩니다.
+            </p>
+          </div>
+        </section>
+
+        {/* Timezone Section */}
+        <section
+          style={{
+            backgroundColor: designTokens.bg.default,
+            border: `1px solid ${designTokens.bg.border}`,
+            borderRadius: '12px',
+            padding: '24px',
+            marginBottom: '24px',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px',
+              marginBottom: '24px',
+              paddingBottom: '16px',
+              borderBottom: `1px solid ${designTokens.bg.border}`,
+            }}
+          >
+            <Clock style={{ width: '20px', height: '20px', color: '#4C2D9A' }} />
+            <h2 style={{ color: designTokens.text.primary, fontSize: '18px', fontWeight: 500 }}>
+              시간대 설정
+            </h2>
+          </div>
+
+          <div style={{ marginBottom: '24px' }}>
+            <label
+              style={{
+                display: 'block',
+                color: designTokens.text.secondary,
+                fontSize: '14px',
+                marginBottom: '8px',
+              }}
+            >
+              시간대
+            </label>
+            <select
+              value={timezone}
+              onChange={(e) => setTimezone(e.target.value)}
+              style={{
+                width: '100%',
+                padding: '10px 12px',
+                border: `1px solid ${designTokens.bg.border}`,
+                borderRadius: '8px',
+                fontSize: '14px',
+                color: designTokens.text.primary,
+                backgroundColor: designTokens.bg.default,
+                cursor: 'pointer',
+                outline: 'none',
+              }}
+              onFocus={(e) => (e.currentTarget.style.borderColor = '#4C2D9A')}
+              onBlur={(e) => (e.currentTarget.style.borderColor = designTokens.bg.border)}
+            >
+              {timezones.map((tz) => (
+                <option key={tz.value} value={tz.value}>
+                  {tz.label}
+                </option>
+              ))}
+            </select>
+            <p
+              style={{
+                fontSize: '12px',
+                color: designTokens.text.secondary,
+                marginTop: '8px',
+              }}
+            >
+              강의 일정과 알림 시간에 적용됩니다.
+            </p>
+          </div>
+
+          <div>
+            <label
+              style={{
+                display: 'block',
+                color: designTokens.text.secondary,
+                fontSize: '14px',
+                marginBottom: '12px',
+              }}
+            >
+              날짜 형식
+            </label>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+              {dateFormats.map((format) => (
+                <label
+                  key={format.value}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    padding: '12px',
+                    border: `1px solid ${dateFormat === format.value ? '#4C2D9A' : designTokens.bg.border}`,
+                    borderRadius: '8px',
+                    cursor: 'pointer',
+                    backgroundColor: dateFormat === format.value ? '#F8F5FC' : 'transparent',
+                    transition: 'all 0.2s',
+                  }}
+                  onMouseEnter={(e) => {
+                    if (dateFormat !== format.value) {
+                      e.currentTarget.style.backgroundColor = '#FAFAFA';
+                    }
+                  }}
+                  onMouseLeave={(e) => {
+                    if (dateFormat !== format.value) {
+                      e.currentTarget.style.backgroundColor = 'transparent';
+                    }
+                  }}
+                >
+                  <input
+                    type="radio"
+                    name="dateFormat"
+                    value={format.value}
+                    checked={dateFormat === format.value}
+                    onChange={(e) => setDateFormat(e.target.value)}
+                    style={{
+                      marginRight: '12px',
+                      cursor: 'pointer',
+                    }}
+                  />
+                  <div style={{ flex: 1 }}>
+                    <div
+                      style={{
+                        color: designTokens.text.primary,
+                        fontSize: '14px',
+                        marginBottom: '4px',
+                      }}
+                    >
+                      {format.label}
+                    </div>
+                    <div
+                      style={{
+                        color: designTokens.text.secondary,
+                        fontSize: '12px',
+                      }}
+                    >
+                      {format.description}
+                    </div>
+                  </div>
+                </label>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Save Button */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            paddingTop: '16px',
+          }}
+        >
+          <button
+            onClick={handleSave}
+            style={{
+              padding: '10px 24px',
+              backgroundColor: designTokens.button.brand_default,
+              color: 'white',
+              border: 'none',
+              borderRadius: '8px',
+              cursor: 'pointer',
+              fontSize: '14px',
+              transition: 'opacity 0.2s',
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.opacity = '0.9')}
+            onMouseLeave={(e) => (e.currentTarget.style.opacity = '1')}
+          >
+            저장
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/settings/SettingsLanguagePage.tsx
+++ b/src/pages/tu/settings/SettingsLanguagePage.tsx
@@ -12,12 +12,13 @@ import {
   NativeSelect,
   RadioOptionCard,
 } from '@/components/common';
+import { useUIStore } from '@/store/common/uiStore';
 
 export function SettingsLanguagePage() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const [language, setLanguage] = useState<'ko' | 'en'>('ko');
+  const { language, setLanguage } = useUIStore();
   const [timezone, setTimezone] = useState('Asia/Seoul');
   const [dateFormat, setDateFormat] = useState('YYYY-MM-DD');
 

--- a/src/pages/tu/settings/index.ts
+++ b/src/pages/tu/settings/index.ts
@@ -1,0 +1,1 @@
+export { SettingsLanguagePage } from './SettingsLanguagePage';

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,18 @@
 import { Routes, Route, Outlet } from 'react-router-dom';
-import { MyCoursesPage, MyContentPage, CourseCreatePage, TuContentCreatePage, ContentDetailPage } from '@/pages/tu';
+import {
+  MyCoursesPage,
+  MyContentPage,
+  CourseCreatePage,
+  TuContentCreatePage,
+  ContentDetailPage,
+  SettingsLanguagePage,
+} from '@/pages/tu';
+import {
+  SettingsPage,
+  SettingsSecurityPage,
+  SettingsNotificationsPage,
+  SettingsAppearancePage,
+} from '@/pages/common';
 import ComponentShowcase from '@/pages/ComponentShowcase';
 import {
   SuperAdminLayout,
@@ -66,9 +79,12 @@ export function AppRoutes() {
         <Route path="analytics/activity" element={<PlaceholderPage title="활동 분석" />} />
         <Route path="analytics/logs" element={<PlaceholderPage title="로그 관리" />} />
         {/* 설정 */}
-        <Route path="settings" element={<PlaceholderPage title="설정" />} />
-        <Route path="settings/security" element={<PlaceholderPage title="계정 및 보안" />} />
-        <Route path="settings/notifications" element={<PlaceholderPage title="알림 설정" />} />
+        <Route path="settings" element={<SettingsPage />} />
+        <Route path="settings/security" element={<SettingsSecurityPage />} />
+        <Route path="settings/notifications" element={<SettingsNotificationsPage />} />
+        <Route path="settings/appearance" element={<SettingsAppearancePage />} />
+        <Route path="settings/system-settings" element={<PlaceholderPage title="시스템 설정" />} />
+        <Route path="settings/tenant-defaults" element={<PlaceholderPage title="테넌트 기본값" />} />
       </Route>
 
       {/* Tenant Admin (TA) 라우트 */}
@@ -91,9 +107,12 @@ export function AppRoutes() {
         <Route path="analytics/export" element={<PlaceholderPage title="통계 조회 및 내보내기" />} />
         <Route path="analytics/logs" element={<PlaceholderPage title="이력 분석 및 로그 관리" />} />
         {/* 설정 */}
-        <Route path="settings" element={<PlaceholderPage title="설정" />} />
-        <Route path="settings/security" element={<PlaceholderPage title="계정 및 보안" />} />
-        <Route path="settings/notifications" element={<PlaceholderPage title="알림 설정" />} />
+        <Route path="settings" element={<SettingsPage />} />
+        <Route path="settings/security" element={<SettingsSecurityPage />} />
+        <Route path="settings/notifications" element={<SettingsNotificationsPage />} />
+        <Route path="settings/appearance" element={<SettingsAppearancePage />} />
+        <Route path="settings/tenant-settings" element={<PlaceholderPage title="테넌트 설정" />} />
+        <Route path="settings/user-management" element={<PlaceholderPage title="사용자 관리 설정" />} />
       </Route>
 
       {/* Tenant Operator (TO) 라우트 */}
@@ -115,9 +134,11 @@ export function AppRoutes() {
         <Route path="sis" element={<PlaceholderPage title="학생 수강 정보 확인" />} />
         <Route path="iis" element={<PlaceholderPage title="강사 배정 정보 확인" />} />
         {/* 설정 */}
-        <Route path="settings" element={<PlaceholderPage title="설정" />} />
-        <Route path="settings/security" element={<PlaceholderPage title="계정 및 보안" />} />
-        <Route path="settings/notifications" element={<PlaceholderPage title="알림 설정" />} />
+        <Route path="settings" element={<SettingsPage />} />
+        <Route path="settings/security" element={<SettingsSecurityPage />} />
+        <Route path="settings/notifications" element={<SettingsNotificationsPage />} />
+        <Route path="settings/appearance" element={<SettingsAppearancePage />} />
+        <Route path="settings/content-defaults" element={<PlaceholderPage title="콘텐츠 기본 설정" />} />
       </Route>
 
       {/* Tenant User (TU) 라우트 */}
@@ -138,9 +159,11 @@ export function AppRoutes() {
         <Route path="progress" element={<PlaceholderPage title="학습 진도" />} />
         <Route path="certifications" element={<PlaceholderPage title="인증서" />} />
         {/* 설정 */}
-        <Route path="settings" element={<PlaceholderPage title="설정" />} />
-        <Route path="settings/security" element={<PlaceholderPage title="계정 및 보안" />} />
-        <Route path="settings/notifications" element={<PlaceholderPage title="알림 설정" />} />
+        <Route path="settings" element={<SettingsPage />} />
+        <Route path="settings/security" element={<SettingsSecurityPage />} />
+        <Route path="settings/notifications" element={<SettingsNotificationsPage />} />
+        <Route path="settings/language" element={<SettingsLanguagePage />} />
+        <Route path="settings/appearance" element={<SettingsAppearancePage />} />
       </Route>
 
       {/* 기본 경로 - 랜딩 페이지 */}

--- a/src/store/common/uiStore.ts
+++ b/src/store/common/uiStore.ts
@@ -1,19 +1,31 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 interface UIState {
   isSidebarExpanded: boolean;
   isDarkMode: boolean;
   language: 'ko' | 'en';
   toggleSidebar: () => void;
+  setSidebarExpanded: (expanded: boolean) => void;
   toggleDarkMode: () => void;
+  setDarkMode: (isDark: boolean) => void;
   setLanguage: (lang: 'ko' | 'en') => void;
 }
 
-export const useUIStore = create<UIState>((set) => ({
-  isSidebarExpanded: true,
-  isDarkMode: true,
-  language: 'ko',
-  toggleSidebar: () => set((state) => ({ isSidebarExpanded: !state.isSidebarExpanded })),
-  toggleDarkMode: () => set((state) => ({ isDarkMode: !state.isDarkMode })),
-  setLanguage: (language) => set({ language }),
-}));
+export const useUIStore = create<UIState>()(
+  persist(
+    (set) => ({
+      isSidebarExpanded: true,
+      isDarkMode: false,
+      language: 'ko',
+      toggleSidebar: () => set((state) => ({ isSidebarExpanded: !state.isSidebarExpanded })),
+      setSidebarExpanded: (isSidebarExpanded) => set({ isSidebarExpanded }),
+      toggleDarkMode: () => set((state) => ({ isDarkMode: !state.isDarkMode })),
+      setDarkMode: (isDarkMode) => set({ isDarkMode }),
+      setLanguage: (language) => set({ language }),
+    }),
+    {
+      name: 'ui-settings',
+    }
+  )
+);

--- a/src/styles/admin-design-tokens.ts
+++ b/src/styles/admin-design-tokens.ts
@@ -59,6 +59,7 @@ export const designTokens = {
   },
 
   // --- Badge Colors (태그/카테고리용 - 뮤트 톤) ---
+  // 용도: 태그, 카테고리, 상태 표시, 설정 카드 아이콘 컨테이너 등
   badge: {
     red: { text: '#9E3A3A', bg: '#FAECEC' },
     orange: { text: '#B5663A', bg: '#FDF3EC' },

--- a/src/styles/card-styles.ts
+++ b/src/styles/card-styles.ts
@@ -1,4 +1,4 @@
-import { designTokens } from './design-tokens';
+import { designTokens } from './admin-design-tokens';
 
 /**
  * LMS Platform - Common Card Styles

--- a/src/styles/card-styles.ts
+++ b/src/styles/card-styles.ts
@@ -1,0 +1,56 @@
+import { designTokens } from './design-tokens';
+
+/**
+ * LMS Platform - Common Card Styles
+ * 모든 페이지에서 일관된 카드 스타일을 사용하기 위한 공통 상수
+ */
+export const cardStyles = {
+  // Base 카드 스타일
+  base: {
+    backgroundColor: designTokens.bg.default,
+    border: `1px solid ${designTokens.bg.border}`,
+    borderRadius: '12px',
+    transition: 'all 0.2s ease',
+  },
+
+  // 그림자 레벨 (Material Design 기반)
+  shadow: {
+    none: 'none',                                     // 정적 카드 (통계, 설정)
+    sm: '0 1px 3px rgba(0, 0, 0, 0.08)',              // 인터랙티브 카드 기본
+    md: '0 4px 12px rgba(0, 0, 0, 0.12)',             // 인터랙티브 카드 호버
+    lg: '0 8px 24px rgba(0, 0, 0, 0.08)',             // 모달/오버레이
+  },
+
+  // 패딩 크기
+  padding: {
+    sm: '16px',
+    md: '24px',
+    lg: '32px',
+  },
+
+  // 호버 효과 (인터랙티브 카드용)
+  hover: {
+    transform: 'translateY(-4px)',
+    shadowTransition: 'box-shadow 0.2s ease, transform 0.2s ease',
+  },
+
+  // 클릭 가능한 카드용 스타일
+  clickable: {
+    cursor: 'pointer',
+  },
+
+  // 정적 카드 (클릭 불가, 정보 표시용)
+  static: {
+    backgroundColor: designTokens.bg.card_static,  // #F0F0F0 연한 회색
+    boxShadow: 'none',  // 그림자 없음
+  },
+
+  // 인터랙티브 카드 (클릭 가능)
+  interactive: {
+    backgroundColor: designTokens.bg.default,  // #FFFFFF 순백
+    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.08)',
+    cursor: 'pointer',
+  },
+};
+
+export type CardStyles = typeof cardStyles;

--- a/src/types/common/sidebar.types.ts
+++ b/src/types/common/sidebar.types.ts
@@ -41,9 +41,7 @@ export interface BaseSidebarProps {
   onToggle: () => void;
   onMenuItemClick?: (itemId: string) => void;
   isDarkMode?: boolean;
-  onThemeToggle?: () => void;
   language?: 'ko' | 'en';
-  onLanguageChange?: (language: 'ko' | 'en') => void;
   menuData: MenuItem[];
   roleLabel: { ko: string; en: string };
 }


### PR DESCRIPTION
## Summary

- 공통 설정 페이지 컴포넌트 구현 (SettingsPage, Security, Notifications, Appearance)
- TU 전용 언어 설정 페이지 추가
- uiStore에 persist 미들웨어 적용으로 설정 localStorage 저장
- 사이드바 테마/언어 토글 버튼 제거 (설정 페이지에서 관리)

## Related Issue

- Closes #47

## Changes

- 공통 설정 페이지 4개 추가 (SettingsPage, SettingsSecurityPage, SettingsNotificationsPage, SettingsAppearancePage)
<img width="1202" height="752" alt="스크린샷 2025-12-24 오후 5 21 25" src="https://github.com/user-attachments/assets/dc6cd680-d79c-4587-83ae-fd1583c5e6d2" />

- TU 언어 설정 페이지 추가 (SettingsLanguagePage)
- RadioOptionCard, SettingsCard 공통 컴포넌트 추가
- uiStore에 zustand persist 미들웨어 적용
- 모든 Layout 컴포넌트에서 useUIStore 사용으로 통일

- BaseSidebar에서 테마/언어 토글 UI 제거
<img width="270" height="760" alt="스크린샷 2025-12-24 오후 5 20 57" src="https://github.com/user-attachments/assets/5fab77c7-8d71-47c6-a4e2-a3b1e53ffcbc" />

- 사이드바 메뉴에서 설정을 단일 메뉴로 변경 (서브메뉴 제거)


## Type of Change

- [x] Feat: 새로운 기능
- [x] Refactor: 리팩토링

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (mzc-lp-docs/docs/structure/frontend/pages.md)