### PR TITLE
fix: 콘텐츠 업로드 메타데이터 및 다운로드 개선 (#53)

### DIFF
--- a/src/components/domain/tu/content/ContentCard.tsx
+++ b/src/components/domain/tu/content/ContentCard.tsx
@@ -82,6 +82,11 @@ export const ContentCard = ({
   const IconComponent = contentTypeIcon[content.contentType];
   const isArchived = content.status === 'ARCHIVED';
 
+  // 썸네일 URL 결정: prop > customThumbnailPath > thumbnailPath
+  const resolvedThumbnailUrl = thumbnailUrl
+    || (content.customThumbnailPath ? `${import.meta.env.VITE_API_BASE_URL || ''}${content.customThumbnailPath}` : null)
+    || (content.thumbnailPath ? `${import.meta.env.VITE_API_BASE_URL || ''}${content.thumbnailPath}` : null);
+
   return (
     <div
       className={cn(
@@ -92,11 +97,14 @@ export const ContentCard = ({
     >
       {/* Thumbnail */}
       <div className="relative aspect-video bg-bg-secondary">
-        {thumbnailUrl ? (
+        {resolvedThumbnailUrl ? (
           <img
-            src={thumbnailUrl}
+            src={resolvedThumbnailUrl}
             alt={content.originalFileName}
             className="w-full h-full object-cover"
+            onError={(e) => {
+              e.currentTarget.style.display = 'none';
+            }}
           />
         ) : (
           <div className="w-full h-full flex items-center justify-center">

--- a/src/hooks/tu/useContentQueries.ts
+++ b/src/hooks/tu/useContentQueries.ts
@@ -80,8 +80,8 @@ export const useUploadContent = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ file, folderId }: { file: File; folderId?: number }) =>
-      contentService.uploadFile(file, folderId),
+    mutationFn: ({ file, folderId, originalFileName }: { file: File; folderId?: number; originalFileName?: string }) =>
+      contentService.uploadFile(file, folderId, originalFileName),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: contentKeys.lists() });
       queryClient.invalidateQueries({ queryKey: contentKeys.myLists() });

--- a/src/hooks/tu/useContentQueries.ts
+++ b/src/hooks/tu/useContentQueries.ts
@@ -75,13 +75,23 @@ export const useContentVersion = (id: number, versionNumber: number) => {
   });
 };
 
+// 파일 업로드 파라미터
+interface UploadContentParams {
+  file: File;
+  folderId?: number;
+  originalFileName?: string;
+  description?: string;
+  tags?: string;
+  thumbnail?: File;
+}
+
 // 파일 업로드
 export const useUploadContent = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ file, folderId, originalFileName }: { file: File; folderId?: number; originalFileName?: string }) =>
-      contentService.uploadFile(file, folderId, originalFileName),
+    mutationFn: ({ file, folderId, originalFileName, description, tags, thumbnail }: UploadContentParams) =>
+      contentService.uploadFile(file, { folderId, originalFileName, description, tags, thumbnail }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: contentKeys.lists() });
       queryClient.invalidateQueries({ queryKey: contentKeys.myLists() });

--- a/src/pages/tu/teaching/content/ContentCreatePage.tsx
+++ b/src/pages/tu/teaching/content/ContentCreatePage.tsx
@@ -21,10 +21,13 @@ export function ContentCreatePage() {
           name: data.title, // 콘텐츠 제목을 name으로 사용
         });
       } else if (data.uploadedFile) {
-        // 파일 업로드 (제목이 있으면 originalFileName으로 전달)
+        // 파일 업로드 (제목, 설명, 태그, 썸네일 전달)
         await uploadContent.mutateAsync({
           file: data.uploadedFile,
           originalFileName: data.title && data.title !== data.uploadedFile.name ? data.title : undefined,
+          description: data.description || undefined,
+          tags: data.tags.length > 0 ? data.tags.join(',') : undefined,
+          thumbnail: data.thumbnailImage,
         });
       }
 

--- a/src/pages/tu/teaching/content/ContentCreatePage.tsx
+++ b/src/pages/tu/teaching/content/ContentCreatePage.tsx
@@ -21,9 +21,10 @@ export function ContentCreatePage() {
           name: data.title, // 콘텐츠 제목을 name으로 사용
         });
       } else if (data.uploadedFile) {
-        // 파일 업로드
+        // 파일 업로드 (제목이 있으면 originalFileName으로 전달)
         await uploadContent.mutateAsync({
           file: data.uploadedFile,
+          originalFileName: data.title && data.title !== data.uploadedFile.name ? data.title : undefined,
         });
       }
 

--- a/src/pages/tu/teaching/content/ContentDetailPage.tsx
+++ b/src/pages/tu/teaching/content/ContentDetailPage.tsx
@@ -117,6 +117,10 @@ const t = {
   inCourse: { ko: '과정에 포함됨', en: 'In Course' },
   yes: { ko: '예', en: 'Yes' },
   no: { ko: '아니오', en: 'No' },
+  description: { ko: '설명', en: 'Description' },
+  tags: { ko: '태그', en: 'Tags' },
+  noDescription: { ko: '설명 없음', en: 'No description' },
+  noTags: { ko: '태그 없음', en: 'No tags' },
 };
 
 // 파일 크기 포맷팅
@@ -628,6 +632,34 @@ export function ContentDetailPage({ language = 'ko' }: Readonly<ContentDetailPag
                   {formatDate(content.updatedAt)}
                 </p>
               </div>
+
+              {/* Description (설명) */}
+              <div className="md:col-span-2">
+                <label className="block text-sm text-text-secondary mb-1">{getText('description')}</label>
+                <p className="text-text-primary">
+                  {content.description || <span className="text-text-placeholder">{getText('noDescription')}</span>}
+                </p>
+              </div>
+
+              {/* Tags (태그) */}
+              <div className="md:col-span-2">
+                <label className="block text-sm text-text-secondary mb-1">{getText('tags')}</label>
+                {content.tags ? (
+                  <div className="flex flex-wrap gap-2">
+                    {content.tags.split(',').map((tag, index) => (
+                      <span
+                        key={index}
+                        className="inline-flex items-center px-2 py-1 bg-bg-secondary border border-border rounded-full text-sm text-text-primary"
+                      >
+                        {tag.trim()}
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-text-placeholder">{getText('noTags')}</p>
+                )}
+              </div>
+
             </div>
           </div>
 

--- a/src/pages/tu/teaching/content/ContentDetailPage.tsx
+++ b/src/pages/tu/teaching/content/ContentDetailPage.tsx
@@ -283,9 +283,14 @@ export function ContentDetailPage({ language = 'ko' }: Readonly<ContentDetailPag
   };
 
   // 다운로드
-  const handleDownload = () => {
-    const downloadUrl = contentService.getDownloadUrl(contentId);
-    window.open(downloadUrl, '_blank');
+  const handleDownload = async () => {
+    if (!content) return;
+    try {
+      await contentService.downloadFile(contentId, content.originalFileName);
+    } catch (err) {
+      console.error('Download failed:', err);
+      alert('다운로드에 실패했습니다.');
+    }
   };
 
   // 버전 복원

--- a/src/services/tu/contentService.ts
+++ b/src/services/tu/contentService.ts
@@ -169,7 +169,9 @@ export const contentService = {
       { responseType: 'blob' }
     );
 
-    const blob = new Blob([response.data]);
+    // 응답의 Content-Type을 사용하여 Blob 생성
+    const contentType = response.headers['content-type'] || 'application/octet-stream';
+    const blob = new Blob([response.data], { type: contentType });
     const url = window.URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;

--- a/src/services/tu/contentService.ts
+++ b/src/services/tu/contentService.ts
@@ -22,16 +22,35 @@ interface PageResponse<T> {
   number: number;
 }
 
+// 파일 업로드 옵션
+interface UploadFileOptions {
+  folderId?: number;
+  originalFileName?: string;
+  description?: string;
+  tags?: string;
+  thumbnail?: File;
+}
+
 export const contentService = {
   // 파일 업로드
-  async uploadFile(file: File, folderId?: number, originalFileName?: string): Promise<ContentResponse> {
+  async uploadFile(file: File, options?: UploadFileOptions): Promise<ContentResponse> {
     const formData = new FormData();
     formData.append('file', file);
-    if (folderId) {
-      formData.append('folderId', String(folderId));
+
+    if (options?.folderId) {
+      formData.append('folderId', String(options.folderId));
     }
-    if (originalFileName) {
-      formData.append('originalFileName', originalFileName);
+    if (options?.originalFileName) {
+      formData.append('originalFileName', options.originalFileName);
+    }
+    if (options?.description) {
+      formData.append('description', options.description);
+    }
+    if (options?.tags) {
+      formData.append('tags', options.tags);
+    }
+    if (options?.thumbnail) {
+      formData.append('thumbnail', options.thumbnail);
     }
 
     const { data } = await axiosInstance.post<{ data: ContentResponse }>(

--- a/src/services/tu/contentService.ts
+++ b/src/services/tu/contentService.ts
@@ -24,14 +24,17 @@ interface PageResponse<T> {
 
 export const contentService = {
   // 파일 업로드
-  async uploadFile(file: File, folderId?: number): Promise<ContentResponse> {
+  async uploadFile(file: File, folderId?: number, originalFileName?: string): Promise<ContentResponse> {
     const formData = new FormData();
     formData.append('file', file);
     if (folderId) {
       formData.append('folderId', String(folderId));
     }
+    if (originalFileName) {
+      formData.append('originalFileName', originalFileName);
+    }
 
-    const { data } = await axiosInstance.post<ContentResponse>(
+    const { data } = await axiosInstance.post<{ data: ContentResponse }>(
       API_ENDPOINTS.CONTENTS.UPLOAD,
       formData,
       {
@@ -40,16 +43,16 @@ export const contentService = {
         },
       }
     );
-    return data;
+    return data.data;
   },
 
   // 외부 링크 생성
   async createExternalLink(request: CreateExternalLinkRequest): Promise<ContentResponse> {
-    const { data } = await axiosInstance.post<ContentResponse>(
+    const { data } = await axiosInstance.post<{ data: ContentResponse }>(
       API_ENDPOINTS.CONTENTS.EXTERNAL_LINK,
       request
     );
-    return data;
+    return data.data;
   },
 
   // 콘텐츠 목록 조회
@@ -138,6 +141,24 @@ export const contentService = {
   getDownloadUrl(id: number): string {
     const baseUrl = import.meta.env.VITE_API_BASE_URL || '/api';
     return `${baseUrl}${API_ENDPOINTS.CONTENTS.DOWNLOAD(id)}`;
+  },
+
+  // 파일 다운로드 (Blob 방식 - 인증 토큰 포함)
+  async downloadFile(id: number, fileName: string): Promise<void> {
+    const response = await axiosInstance.get(
+      API_ENDPOINTS.CONTENTS.DOWNLOAD(id),
+      { responseType: 'blob' }
+    );
+
+    const blob = new Blob([response.data]);
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
   },
 
   // 미리보기 URL 반환

--- a/src/types/tu/content.types.ts
+++ b/src/types/tu/content.types.ts
@@ -27,6 +27,9 @@ export interface ContentResponse {
   externalUrl: string | null;
   filePath: string;
   thumbnailPath: string | null;
+  customThumbnailPath: string | null;
+  description: string | null;
+  tags: string | null;
   createdBy: number;
   currentVersion: number;
   inCourse: boolean;
@@ -42,9 +45,13 @@ export interface ContentListResponse {
   status: ContentStatus;
   fileSize: number;
   duration: number | null;
+  resolution: string | null;
   thumbnailPath: string | null;
-  createdBy: number;
+  customThumbnailPath: string | null;
+  description: string | null;
+  tags: string | null;
   currentVersion: number;
+  inCourse: boolean | null;
   createdAt: string;
 }
 


### PR DESCRIPTION
Closes #53

## Summary
- 콘텐츠 업로드 시 설명, 태그, 커스텀 썸네일 전송 기능 추가
- content.types.ts에 customThumbnailPath, description, tags 필드 추가
- ContentDetailPage에 설명, 태그 표시 섹션 추가
- ContentCard에서 커스텀 썸네일 URL 우선 적용
- 다운로드 시 서버 응답 Content-Type 사용하도록 개선

## Test plan
- [x] 콘텐츠 등록 시 설명, 태그 입력 후 저장 확인
- [x] 콘텐츠 상세 페이지에서 설명, 태그 표시 확인
- [x] 파일 다운로드 시 올바른 형식으로 저장 확인
- [ ] 콘텐츠 카드에 커스텀 썸네일 표시 확인 (추후 확인)