### PR TITLE
[Feat] TU 내 강의 배정 Phase 1: 타입 및 API 서비스 구현 (#62)

### DIFF
--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -111,6 +111,12 @@ export const API_ENDPOINTS = {
     SNAPSHOT: (id: number) => `/programs/${id}/snapshot`,
   },
 
+  // Instructor Assignments (TU - 내 배정)
+  INSTRUCTOR_ASSIGNMENTS: {
+    MY: '/users/me/instructor-assignments',
+    MY_STATISTICS: '/users/me/instructor-statistics',
+  },
+
   // Snapshots (TO)
   SNAPSHOTS: {
     BASE: '/snapshots',

--- a/src/services/tu/index.ts
+++ b/src/services/tu/index.ts
@@ -1,3 +1,4 @@
 export { contentService } from './contentService';
 export { learningObjectService } from './learningObjectService';
 export { contentFolderService } from './contentFolderService';
+export { myAssignmentService } from './myAssignmentService';

--- a/src/services/tu/myAssignmentService.ts
+++ b/src/services/tu/myAssignmentService.ts
@@ -1,0 +1,41 @@
+/**
+ * 내 강의 배정 API 서비스 (TU - 강사 본인용)
+ */
+import { axiosInstance } from '../common/api';
+import { API_ENDPOINTS } from '../common/api/endpoints';
+import type {
+  InstructorAssignmentResponse,
+  InstructorDetailStatResponse,
+} from '@/types/tu';
+
+export const myAssignmentService = {
+  /**
+   * 내 배정 목록 조회
+   * GET /api/users/me/instructor-assignments
+   */
+  getMyAssignments: async (): Promise<InstructorAssignmentResponse[]> => {
+    const response = await axiosInstance.get(API_ENDPOINTS.INSTRUCTOR_ASSIGNMENTS.MY);
+    return response.data.data;
+  },
+
+  /**
+   * 내 강사 통계 조회
+   * GET /api/users/me/instructor-statistics
+   * @param startDate - 시작일 (선택, YYYY-MM-DD)
+   * @param endDate - 종료일 (선택, YYYY-MM-DD)
+   */
+  getMyStatistics: async (
+    startDate?: string,
+    endDate?: string
+  ): Promise<InstructorDetailStatResponse> => {
+    const params: Record<string, string> = {};
+    if (startDate) params.startDate = startDate;
+    if (endDate) params.endDate = endDate;
+
+    const response = await axiosInstance.get(
+      API_ENDPOINTS.INSTRUCTOR_ASSIGNMENTS.MY_STATISTICS,
+      { params }
+    );
+    return response.data.data;
+  },
+};

--- a/src/types/tu/index.ts
+++ b/src/types/tu/index.ts
@@ -30,3 +30,17 @@ export type {
   UpdateContentFolderRequest,
   MoveContentFolderRequest,
 } from './contentFolder.types';
+
+// Instructor Assignment (IIS - 내 배정)
+export type {
+  InstructorRole,
+  AssignmentStatus,
+  InstructorAssignmentResponse,
+  CourseTimeStatResponse,
+  InstructorDetailStatResponse,
+} from './instructorAssignment.types';
+
+export {
+  INSTRUCTOR_ROLE_LABELS,
+  ASSIGNMENT_STATUS_LABELS,
+} from './instructorAssignment.types';

--- a/src/types/tu/instructorAssignment.types.ts
+++ b/src/types/tu/instructorAssignment.types.ts
@@ -1,0 +1,79 @@
+/**
+ * 강사 배정 관련 타입 정의 (TU - 강사 본인용)
+ */
+
+// ========== 상수 타입 ==========
+
+/**
+ * 강사 역할
+ */
+export type InstructorRole = 'MAIN' | 'SUB' | 'ASSISTANT';
+
+/**
+ * 배정 상태
+ */
+export type AssignmentStatus = 'ACTIVE' | 'REPLACED' | 'CANCELLED';
+
+// ========== 응답 타입 ==========
+
+/**
+ * 강사 배정 응답
+ */
+export interface InstructorAssignmentResponse {
+  id: number;
+  userId: number;
+  userName: string | null;
+  userEmail: string | null;
+  timeId: number;
+  role: InstructorRole;
+  status: AssignmentStatus;
+  assignedAt: string;
+  replacedAt: string | null;
+  assignedBy: number;
+  createdAt: string;
+}
+
+/**
+ * 차수별 강사 통계 응답
+ */
+export interface CourseTimeStatResponse {
+  timeKey: number;
+  courseName: string;
+  timeName: string;
+  role: InstructorRole;
+  totalStudents: number | null;
+  completedStudents: number | null;
+  completionRate: number | null;
+}
+
+/**
+ * 강사 상세 통계 응답 (내 통계용)
+ */
+export interface InstructorDetailStatResponse {
+  userId: number;
+  userName: string;
+  totalCount: number;
+  mainCount: number;
+  subCount: number;
+  courseTimeStats: CourseTimeStatResponse[];
+}
+
+// ========== 라벨 매핑 ==========
+
+/**
+ * 강사 역할 라벨
+ */
+export const INSTRUCTOR_ROLE_LABELS: Record<InstructorRole, { ko: string; en: string }> = {
+  MAIN: { ko: '주강사', en: 'Main Instructor' },
+  SUB: { ko: '보조강사', en: 'Sub Instructor' },
+  ASSISTANT: { ko: '조교', en: 'Assistant' },
+};
+
+/**
+ * 배정 상태 라벨
+ */
+export const ASSIGNMENT_STATUS_LABELS: Record<AssignmentStatus, { ko: string; en: string }> = {
+  ACTIVE: { ko: '활동 중', en: 'Active' },
+  REPLACED: { ko: '교체됨', en: 'Replaced' },
+  CANCELLED: { ko: '취소됨', en: 'Cancelled' },
+};


### PR DESCRIPTION
## Summary

TU(강사) 역할의 "내 배정 관리" 기능 Phase 1 구현

강사가 자신에게 배정된 강의를 조회하고 통계를 확인할 수 있는 기능의 타입 정의 및 API 서비스를 구현했습니다.

## Related Issue

- Closes #62

## Changes

### 타입 정의 (`src/types/tu/`)
- `InstructorRole` 타입 추가 (MAIN, SUB, ASSISTANT)
- `AssignmentStatus` 타입 추가 (ACTIVE, REPLACED, CANCELLED)
- `InstructorAssignmentResponse` 인터페이스 추가
- `CourseTimeStatResponse` 인터페이스 추가
- `InstructorDetailStatResponse` 인터페이스 추가
- 다국어 라벨 매핑 상수 추가 (INSTRUCTOR_ROLE_LABELS, ASSIGNMENT_STATUS_LABELS)

### API 엔드포인트 (`src/services/common/api/endpoints.ts`)
- `INSTRUCTOR_ASSIGNMENTS.MY` 추가 (`/users/me/instructor-assignments`)
- `INSTRUCTOR_ASSIGNMENTS.MY_STATISTICS` 추가 (`/users/me/instructor-statistics`)

### API 서비스 (`src/services/tu/`)
- `myAssignmentService` 신규 생성
  - `getMyAssignments()`: 내 배정 목록 조회
  - `getMyStatistics()`: 내 강사 통계 조회 (날짜 필터 지원)

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (Optional)

N/A (타입 및 서비스 레이어만 구현, UI 없음)

## Additional Notes

- 백엔드 IIS 도메인의 `/api/users/me/instructor-assignments`, `/api/users/me/instructor-statistics` API와 연동
- Phase 2 (React Query Hooks), Phase 3 (Page 구현)에서 이 서비스를 활용할 예정
- 기존 프로젝트 컨벤션(Types → Service → Hook → Component)을 따름