### PR TITLE
feat: 랜딩페이지, 카탈로그 페이지 다국어(i18n) 지원 추가

### DIFF
--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -1,14 +1,15 @@
 import { useState, useEffect } from 'react';
 import { ChevronLeft, ChevronRight, Sparkles, Rocket, Zap } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from '@/store/common/languageStore';
 
-const slides = [
+const slideData = [
   {
     id: 1,
     title: 'Empower Your',
     highlight: 'Future',
-    subtitle: '클라우드 전문가로 성장하는\n가장 빠른 길',
-    description: 'MZC Learn과 함께 시작하세요.',
+    subtitleKey: 'slide1Subtitle' as const,
+    descKey: 'slide1Desc' as const,
     badge: 'MZC LEARN',
     icon: Sparkles,
     gradientClass: 'gradient-text',
@@ -17,8 +18,8 @@ const slides = [
     id: 2,
     title: 'Build Your',
     highlight: 'Career',
-    subtitle: '나만의 커리어 로드맵\n지금 설계하세요',
-    description: '초보자부터 전문가까지, 단계별 학습 가이드',
+    subtitleKey: 'slide2Subtitle' as const,
+    descKey: 'slide2Desc' as const,
     badge: 'ROADMAP',
     icon: Rocket,
     gradientClass: 'gradient-text-purple',
@@ -27,8 +28,8 @@ const slides = [
     id: 3,
     title: 'Master',
     highlight: 'Cloud',
-    subtitle: 'AWS, Azure, GCP\n클라우드 완전 정복',
-    description: '현직자가 알려주는 실무 클라우드 노하우',
+    subtitleKey: 'slide3Subtitle' as const,
+    descKey: 'slide3Desc' as const,
     badge: 'CLOUD',
     icon: Zap,
     gradientClass: 'gradient-text',
@@ -39,13 +40,14 @@ export function HeroSection() {
   const [currentSlide, setCurrentSlide] = useState(0);
   const [isAnimating, setIsAnimating] = useState(false);
   const [direction, setDirection] = useState<'left' | 'right'>('right');
+  const { t } = useTranslation();
 
   useEffect(() => {
     const timer = setInterval(() => {
       setDirection('right');
       setIsAnimating(true);
       setTimeout(() => {
-        setCurrentSlide((prev) => (prev + 1) % slides.length);
+        setCurrentSlide((prev) => (prev + 1) % slideData.length);
         setIsAnimating(false);
       }, 300);
     }, 5000);
@@ -67,7 +69,7 @@ export function HeroSection() {
     setDirection('left');
     setIsAnimating(true);
     setTimeout(() => {
-      setCurrentSlide((prev) => (prev - 1 + slides.length) % slides.length);
+      setCurrentSlide((prev) => (prev - 1 + slideData.length) % slideData.length);
       setIsAnimating(false);
     }, 300);
   };
@@ -77,12 +79,12 @@ export function HeroSection() {
     setDirection('right');
     setIsAnimating(true);
     setTimeout(() => {
-      setCurrentSlide((prev) => (prev + 1) % slides.length);
+      setCurrentSlide((prev) => (prev + 1) % slideData.length);
       setIsAnimating(false);
     }, 300);
   };
 
-  const slide = slides[currentSlide];
+  const slide = slideData[currentSlide];
   const IconComponent = slide.icon;
 
   return (
@@ -120,24 +122,24 @@ export function HeroSection() {
           </div>
 
           <p className="text-xl md:text-2xl font-medium text-gray-300 whitespace-pre-line leading-relaxed">
-            {slide.subtitle}
+            {t.hero[slide.subtitleKey]}
           </p>
 
-          <p className="text-base md:text-lg text-gray-500">{slide.description}</p>
+          <p className="text-base md:text-lg text-gray-500">{t.hero[slide.descKey]}</p>
 
           <div className="flex gap-4 pt-4">
             <Link
               to="/tu/catalog"
               className="landing-btn-primary px-8 py-4 rounded-full text-white font-bold text-base flex items-center gap-2"
             >
-              시작하기
+              {t.hero.getStarted}
               <ChevronRight className="w-5 h-5" />
             </Link>
             <Link
               to="/tu/learning"
               className="landing-btn-outline px-8 py-4 rounded-full text-white font-medium text-base"
             >
-              둘러보기
+              {t.hero.explore}
             </Link>
           </div>
         </div>
@@ -161,14 +163,14 @@ export function HeroSection() {
         <button
           onClick={prevSlide}
           className="absolute left-4 top-1/2 -translate-y-1/2 p-3 rounded-full glass hover:bg-white/20 transition-all"
-          aria-label="이전 슬라이드"
+          aria-label={t.hero.prevSlide}
         >
           <ChevronLeft className="w-6 h-6 text-white" />
         </button>
         <button
           onClick={nextSlide}
           className="absolute right-4 lg:right-[380px] top-1/2 -translate-y-1/2 p-3 rounded-full glass hover:bg-white/20 transition-all"
-          aria-label="다음 슬라이드"
+          aria-label={t.hero.nextSlide}
         >
           <ChevronRight className="w-6 h-6 text-white" />
         </button>
@@ -176,11 +178,11 @@ export function HeroSection() {
 
       {/* Dots */}
       <div className="absolute bottom-8 left-1/2 -translate-x-1/2 flex gap-3">
-        {slides.map((_, index) => (
+        {slideData.map((_, index) => (
           <button
             key={index}
             onClick={() => goToSlide(index)}
-            aria-label={`슬라이드 ${index + 1}로 이동`}
+            aria-label={`${t.hero.goToSlide} ${index + 1}`}
             className={`h-2 rounded-full transition-all duration-300 ${
               index === currentSlide
                 ? 'w-8 bg-gradient-to-r from-[#6778ff] to-[#a855f7]'

--- a/src/components/landing/LandingCourseCard.tsx
+++ b/src/components/landing/LandingCourseCard.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Star } from 'lucide-react';
+import { useTranslation } from '@/store/common/languageStore';
 
 interface LandingCourseCardProps {
   id: number;
@@ -23,6 +24,22 @@ export function LandingCourseCard({
   image,
   tags,
 }: LandingCourseCardProps) {
+  const { t, language } = useTranslation();
+
+  // 태그 번역 매핑
+  const getTagLabel = (tag: string) => {
+    if (tag === 'NEW') return t.landing.tagNew;
+    if (tag === '베스트') return t.landing.tagBest;
+    if (tag === '할인중') return t.landing.tagSale;
+    return tag;
+  };
+
+  // 수강생 수 포맷
+  const formatStudentCount = (count: number) => {
+    const displayCount = count > 100 ? '100+' : count.toString();
+    return language === 'ko' ? `+${displayCount}명` : `${displayCount}+ students`;
+  };
+
   return (
     <Link to={`/tu/catalog/${id}`} className="group block h-full">
       <div className="h-full card-hover rounded-xl overflow-hidden landing-card-bg border landing-card-border">
@@ -47,7 +64,7 @@ export function LandingCourseCard({
                         : 'bg-gradient-to-r from-[#ff7867] to-[#ff9a5a]'
                   }`}
                 >
-                  {tag}
+                  {getTagLabel(tag)}
                 </span>
               ))}
             </div>
@@ -79,7 +96,7 @@ export function LandingCourseCard({
             <span className="font-bold text-[#6778ff] text-lg">{price}</span>
             <div className="flex gap-1.5">
               <span className="landing-badge-bg landing-text-muted text-[10px] px-2 py-1 rounded-full">
-                +{reviewCount > 100 ? '100' : reviewCount}명
+                {formatStudentCount(reviewCount)}
               </span>
             </div>
           </div>

--- a/src/components/landing/LandingFooter.tsx
+++ b/src/components/landing/LandingFooter.tsx
@@ -1,6 +1,9 @@
 import { Youtube, Instagram } from 'lucide-react';
+import { useTranslation } from '@/store/common/languageStore';
 
 export function LandingFooter() {
+  const { t } = useTranslation();
+
   return (
     <footer className="landing-footer-wrapper landing-text-secondary text-sm py-16">
       <div className="w-full px-4 md:px-8 lg:px-16">
@@ -12,10 +15,10 @@ export function LandingFooter() {
                 <span className="text-2xl font-bold gradient-text">MEGAZONECLOUD</span>
               </div>
               <div className="text-[12px] landing-text-muted leading-relaxed space-y-1">
-                <p>메가존클라우드(주) | 대표이사: 이주완, 조원우</p>
-                <p>사업자등록번호: 232-88-00982</p>
-                <p>서울시 강남구 논현로85길 46 메가존빌딩</p>
-                <p>대표전화: 1644-2243 | Email: cloud@megazone.com</p>
+                <p>{t.footer.company} | {t.footer.ceo}</p>
+                <p>{t.footer.businessNo}</p>
+                <p>{t.footer.address}</p>
+                <p>{t.footer.phone}</p>
               </div>
             </div>
 
@@ -70,13 +73,13 @@ export function LandingFooter() {
         <div className="landing-border-top pt-6 flex flex-col md:flex-row justify-between items-center gap-4">
           <div className="flex flex-wrap gap-6 text-[12px] landing-text-muted">
             <a href="#" className="landing-link-hover transition-colors">
-              개인정보처리방침
+              {t.footer.privacyPolicy}
             </a>
             <a href="#" className="landing-link-hover transition-colors">
-              이용약관
+              {t.footer.terms}
             </a>
             <a href="#" className="landing-link-hover transition-colors">
-              이메일무단수집거부
+              {t.footer.emailPolicy}
             </a>
           </div>
           <p className="text-[12px] landing-text-muted">

--- a/src/pages/tu/catalog/CatalogDetailPage.tsx
+++ b/src/pages/tu/catalog/CatalogDetailPage.tsx
@@ -23,13 +23,8 @@ import {
   Skeleton,
 } from '@/components/common';
 import { useCatalogProgram, useCatalogCourseTimes, useEnroll } from '@/hooks/tu';
+import { useTranslation } from '@/store/common/languageStore';
 import type { CatalogCourseTime } from '@/services/tu/catalogService';
-
-const difficultyLabels: Record<string, string> = {
-  BEGINNER: '입문',
-  INTERMEDIATE: '중급',
-  ADVANCED: '고급',
-};
 
 const difficultyColors: Record<string, 'green' | 'blue' | 'orange'> = {
   BEGINNER: 'green',
@@ -49,10 +44,12 @@ function CourseTimeCard({
   courseTime,
   onEnroll,
   isEnrolling,
+  t,
 }: {
   courseTime: CatalogCourseTime;
   onEnroll: (id: number) => void;
   isEnrolling: boolean;
+  t: ReturnType<typeof useTranslation>['t'];
 }) {
   const isFull = courseTime.capacity && courseTime.currentEnrollment
     ? courseTime.currentEnrollment >= courseTime.capacity
@@ -90,10 +87,10 @@ function CourseTimeCard({
               <div className="flex items-center gap-2 text-sm" style={{ color: designTokens.text.secondary }}>
                 <Users className="w-4 h-4" />
                 <span>
-                  {courseTime.currentEnrollment || 0} / {courseTime.capacity}명
+                  {courseTime.currentEnrollment || 0} / {courseTime.capacity}
                 </span>
                 {isFull && (
-                  <Badge variant="red" className="text-xs">마감</Badge>
+                  <Badge variant="red" className="text-xs">{t.catalog.closed}</Badge>
                 )}
               </div>
             )}
@@ -101,7 +98,7 @@ function CourseTimeCard({
             {/* 수강 신청 기간 */}
             {courseTime.enrollmentStartDate && courseTime.enrollmentEndDate && (
               <p className="mt-2 text-xs" style={{ color: designTokens.text.placeholder }}>
-                신청기간: {formatDate(courseTime.enrollmentStartDate)} ~ {formatDate(courseTime.enrollmentEndDate)}
+                {t.catalog.enrollmentPeriod}: {formatDate(courseTime.enrollmentStartDate)} ~ {formatDate(courseTime.enrollmentEndDate)}
               </p>
             )}
           </div>
@@ -116,14 +113,14 @@ function CourseTimeCard({
               {isEnrolling ? (
                 <>
                   <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                  처리 중...
+                  {t.catalog.processing}
                 </>
               ) : isFull ? (
-                '마감됨'
+                t.catalog.closedStatus
               ) : !courseTime.isEnrollable ? (
-                '신청 불가'
+                t.catalog.notAvailable
               ) : (
-                '수강신청'
+                t.catalog.enroll
               )}
             </Button>
           </div>
@@ -136,7 +133,14 @@ function CourseTimeCard({
 export function CatalogDetailPage() {
   const { programId } = useParams<{ programId: string }>();
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const id = Number(programId);
+
+  const difficultyLabels: Record<string, string> = {
+    BEGINNER: t.catalog.beginner,
+    INTERMEDIATE: t.catalog.intermediate,
+    ADVANCED: t.catalog.advanced,
+  };
 
   const { data: program, isLoading: isProgramLoading, isError: isProgramError } = useCatalogProgram(id);
   const { data: courseTimes, isLoading: isTimesLoading } = useCatalogCourseTimes(id);
@@ -149,9 +153,9 @@ export function CatalogDetailPage() {
   const handleEnroll = async (courseTimeId: number) => {
     try {
       await enrollMutation.mutateAsync(courseTimeId);
-      alert('수강신청이 완료되었습니다.');
+      alert(t.catalog.enrollSuccess);
     } catch {
-      alert('수강신청에 실패했습니다. 다시 시도해주세요.');
+      alert(t.catalog.enrollFail);
     }
   };
 
@@ -189,16 +193,16 @@ export function CatalogDetailPage() {
         <div style={{ maxWidth: '1000px', margin: '0 auto' }}>
           <Button variant="ghost" onClick={handleBack} className="mb-6 gap-2">
             <ArrowLeft className="w-5 h-5" />
-            카탈로그로 돌아가기
+            {t.catalog.backToCatalog}
           </Button>
 
           <div className="text-center py-20">
             <AlertCircle className="w-16 h-16 mx-auto mb-4" style={{ color: designTokens.status.error_text }} />
             <h3 className="text-lg font-medium mb-2" style={{ color: designTokens.text.primary }}>
-              강의를 찾을 수 없습니다
+              {t.catalog.courseNotFound}
             </h3>
             <p style={{ color: designTokens.text.secondary }}>
-              요청하신 강의가 존재하지 않거나 접근할 수 없습니다.
+              {t.catalog.courseNotFoundDesc}
             </p>
           </div>
         </div>
@@ -218,7 +222,7 @@ export function CatalogDetailPage() {
         {/* Back Button */}
         <Button variant="ghost" onClick={handleBack} className="mb-6 gap-2">
           <ArrowLeft className="w-5 h-5" />
-          카탈로그로 돌아가기
+          {t.catalog.backToCatalog}
         </Button>
 
         {/* Hero Section */}
@@ -273,13 +277,13 @@ export function CatalogDetailPage() {
               {program.duration && (
                 <div className="flex items-center gap-2">
                   <Clock className="w-5 h-5" />
-                  <span>{Math.floor(program.duration / 60)}시간 {program.duration % 60}분</span>
+                  <span>{Math.floor(program.duration / 60)}{t.catalog.hours} {program.duration % 60}{t.catalog.minutes}</span>
                 </div>
               )}
               {program.enrollmentCount !== undefined && (
                 <div className="flex items-center gap-2">
                   <Users className="w-5 h-5" />
-                  <span>{program.enrollmentCount.toLocaleString()}명 수강</span>
+                  <span>{program.enrollmentCount.toLocaleString()} {t.catalog.enrolled}</span>
                 </div>
               )}
               {program.rating !== undefined && (
@@ -296,7 +300,7 @@ export function CatalogDetailPage() {
         {program.description && (
           <Card className="mb-8" style={{ backgroundColor: designTokens.bg.default }}>
             <CardHeader>
-              <CardTitle className="text-lg">강의 소개</CardTitle>
+              <CardTitle className="text-lg">{t.catalog.courseIntro}</CardTitle>
             </CardHeader>
             <CardContent>
               <p
@@ -314,7 +318,7 @@ export function CatalogDetailPage() {
           <CardHeader>
             <CardTitle className="text-lg flex items-center gap-2">
               <Calendar className="w-5 h-5" />
-              수강 가능한 차수
+              {t.catalog.availableSessions}
             </CardTitle>
           </CardHeader>
           <CardContent>
@@ -331,6 +335,7 @@ export function CatalogDetailPage() {
                     courseTime={courseTime}
                     onEnroll={handleEnroll}
                     isEnrolling={enrollMutation.isPending}
+                    t={t}
                   />
                 ))}
               </div>
@@ -343,7 +348,7 @@ export function CatalogDetailPage() {
               >
                 <AlertCircle className="w-5 h-5" style={{ color: designTokens.status.warning_text }} />
                 <AlertDescription style={{ color: designTokens.status.warning_text }}>
-                  현재 수강 가능한 차수가 없습니다.
+                  {t.catalog.noAvailableSessions}
                 </AlertDescription>
               </Alert>
             )}

--- a/src/pages/tu/catalog/CatalogPage.tsx
+++ b/src/pages/tu/catalog/CatalogPage.tsx
@@ -28,16 +28,11 @@ import {
   PaginationPrevious,
 } from '@/components/common';
 import { useCatalogPrograms } from '@/hooks/tu';
+import { useTranslation } from '@/store/common/languageStore';
 import type { CatalogFilterParams, CatalogProgram } from '@/services/tu/catalogService';
 
 type ViewMode = 'grid' | 'list';
 type Difficulty = 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED' | 'all';
-
-const difficultyLabels: Record<string, string> = {
-  BEGINNER: '입문',
-  INTERMEDIATE: '중급',
-  ADVANCED: '고급',
-};
 
 const difficultyColors: Record<string, 'green' | 'blue' | 'orange'> = {
   BEGINNER: 'green',
@@ -45,7 +40,13 @@ const difficultyColors: Record<string, 'green' | 'blue' | 'orange'> = {
   ADVANCED: 'orange',
 };
 
-function ProgramCard({ program, onClick }: { program: CatalogProgram; onClick: () => void }) {
+function ProgramCard({ program, onClick, t }: { program: CatalogProgram; onClick: () => void; t: ReturnType<typeof useTranslation>['t'] }) {
+  const difficultyLabels: Record<string, string> = {
+    BEGINNER: t.catalog.beginner,
+    INTERMEDIATE: t.catalog.intermediate,
+    ADVANCED: t.catalog.advanced,
+  };
+
   return (
     <Card
       className="cursor-pointer transition-all hover:shadow-md"
@@ -113,13 +114,13 @@ function ProgramCard({ program, onClick }: { program: CatalogProgram; onClick: (
           {program.duration && (
             <span className="flex items-center gap-1">
               <Clock className="w-3.5 h-3.5" />
-              {Math.floor(program.duration / 60)}시간 {program.duration % 60}분
+              {Math.floor(program.duration / 60)}{t.catalog.hours} {program.duration % 60}{t.catalog.minutes}
             </span>
           )}
           {program.enrollmentCount !== undefined && (
             <span className="flex items-center gap-1">
               <Users className="w-3.5 h-3.5" />
-              {program.enrollmentCount.toLocaleString()}명
+              {program.enrollmentCount.toLocaleString()}{t.catalog.students}
             </span>
           )}
           {program.rating !== undefined && (
@@ -134,7 +135,13 @@ function ProgramCard({ program, onClick }: { program: CatalogProgram; onClick: (
   );
 }
 
-function ProgramListItem({ program, onClick }: { program: CatalogProgram; onClick: () => void }) {
+function ProgramListItem({ program, onClick, t }: { program: CatalogProgram; onClick: () => void; t: ReturnType<typeof useTranslation>['t'] }) {
+  const difficultyLabels: Record<string, string> = {
+    BEGINNER: t.catalog.beginner,
+    INTERMEDIATE: t.catalog.intermediate,
+    ADVANCED: t.catalog.advanced,
+  };
+
   return (
     <div
       className="flex gap-4 p-4 rounded-lg cursor-pointer transition-all hover:bg-opacity-80"
@@ -201,13 +208,13 @@ function ProgramListItem({ program, onClick }: { program: CatalogProgram; onClic
           {program.duration && (
             <span className="flex items-center gap-1">
               <Clock className="w-3.5 h-3.5" />
-              {Math.floor(program.duration / 60)}시간 {program.duration % 60}분
+              {Math.floor(program.duration / 60)}{t.catalog.hours} {program.duration % 60}{t.catalog.minutes}
             </span>
           )}
           {program.enrollmentCount !== undefined && (
             <span className="flex items-center gap-1">
               <Users className="w-3.5 h-3.5" />
-              {program.enrollmentCount.toLocaleString()}명
+              {program.enrollmentCount.toLocaleString()}{t.catalog.students}
             </span>
           )}
           {program.rating !== undefined && (
@@ -223,6 +230,13 @@ function ProgramListItem({ program, onClick }: { program: CatalogProgram; onClic
 }
 
 export function CatalogPage() {
+  const { t } = useTranslation();
+
+  const difficultyLabels: Record<string, string> = {
+    BEGINNER: t.catalog.beginner,
+    INTERMEDIATE: t.catalog.intermediate,
+    ADVANCED: t.catalog.advanced,
+  };
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState('');
   const [difficultyFilter, setDifficultyFilter] = useState<Difficulty>('all');
@@ -270,10 +284,10 @@ export function CatalogPage() {
               marginBottom: '8px',
             }}
           >
-            강의 카탈로그
+            {t.catalog.title}
           </h1>
           <p style={{ color: designTokens.text.secondary, fontSize: '14px' }}>
-            수강 가능한 강의를 탐색하고 수강신청하세요
+            {t.catalog.description}
           </p>
         </div>
 
@@ -288,7 +302,7 @@ export function CatalogPage() {
               />
               <Input
                 type="text"
-                placeholder="강의 검색..."
+                placeholder={t.catalog.searchPlaceholder}
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 className="pl-10"
@@ -303,7 +317,7 @@ export function CatalogPage() {
             className="gap-2"
           >
             <Filter className="w-4 h-4" />
-            필터
+            {t.catalog.filter}
             <ChevronDown className={`w-4 h-4 transition-transform ${showFilters ? 'rotate-180' : ''}`} />
           </Button>
 
@@ -342,7 +356,7 @@ export function CatalogPage() {
                   className="block text-sm font-medium mb-2"
                   style={{ color: designTokens.text.secondary }}
                 >
-                  난이도
+                  {t.catalog.difficulty}
                 </label>
                 <div className="flex gap-2">
                   {(['all', 'BEGINNER', 'INTERMEDIATE', 'ADVANCED'] as Difficulty[]).map((level) => (
@@ -355,7 +369,7 @@ export function CatalogPage() {
                         setPage(0);
                       }}
                     >
-                      {level === 'all' ? '전체' : difficultyLabels[level]}
+                      {level === 'all' ? t.landing.all : difficultyLabels[level]}
                     </Button>
                   ))}
                 </div>
@@ -367,7 +381,7 @@ export function CatalogPage() {
         {/* Results Count */}
         {data && (
           <p className="mb-4 text-sm" style={{ color: designTokens.text.secondary }}>
-            총 <span style={{ color: designTokens.text.primary, fontWeight: 600 }}>{data.totalElements}</span>개의 강의
+            {t.catalog.totalCourses} <span style={{ color: designTokens.text.primary, fontWeight: 600 }}>{data.totalElements}</span> {t.catalog.courses}
           </p>
         )}
 
@@ -382,7 +396,7 @@ export function CatalogPage() {
         {isError && (
           <div className="text-center py-20">
             <p style={{ color: designTokens.status.error_text }}>
-              데이터를 불러오는 중 오류가 발생했습니다.
+              {t.catalog.loadError}
             </p>
           </div>
         )}
@@ -395,10 +409,10 @@ export function CatalogPage() {
               className="text-lg font-medium mb-2"
               style={{ color: designTokens.text.primary }}
             >
-              강의가 없습니다
+              {t.catalog.noCourses}
             </h3>
             <p style={{ color: designTokens.text.secondary }}>
-              검색 조건을 변경해 보세요
+              {t.catalog.changeFilter}
             </p>
           </div>
         )}
@@ -413,6 +427,7 @@ export function CatalogPage() {
                     key={program.id}
                     program={program}
                     onClick={() => handleProgramClick(program.id)}
+                    t={t}
                   />
                 ))}
               </div>
@@ -423,6 +438,7 @@ export function CatalogPage() {
                     key={program.id}
                     program={program}
                     onClick={() => handleProgramClick(program.id)}
+                    t={t}
                   />
                 ))}
               </div>

--- a/src/pages/tu/main/LandingPage.tsx
+++ b/src/pages/tu/main/LandingPage.tsx
@@ -7,17 +7,10 @@ import {
   LandingFooter,
 } from '@/components/landing';
 import { useThemeStore } from '@/store/common/themeStore';
+import { useTranslation } from '@/store/common/languageStore';
 
-// 정적 데이터
-const categories = [
-  { id: 'all', label: '전체' },
-  { id: 'cloud', label: '클라우드' },
-  { id: 'dev', label: '개발' },
-  { id: 'ai', label: 'AI' },
-  { id: 'data', label: '데이터' },
-  { id: 'security', label: '보안' },
-  { id: 'devops', label: 'DevOps' },
-];
+// 카테고리 ID 목록
+const categoryIds = ['all', 'cloud', 'dev', 'ai', 'data', 'security', 'devops'] as const;
 
 const courses = [
   {
@@ -138,7 +131,13 @@ const courses = [
 export function LandingPage() {
   const [activeCategory, setActiveCategory] = useState('all');
   const { theme } = useThemeStore();
+  const { t } = useTranslation();
   const isDark = theme === 'dark';
+
+  // 카테고리 레이블을 번역으로 가져오기
+  const getCategoryLabel = (id: string) => {
+    return t.landing[id as keyof typeof t.landing] as string;
+  };
 
   const filteredCourses =
     activeCategory === 'all'
@@ -160,19 +159,19 @@ export function LandingPage() {
         <div className="w-full px-4 md:px-8 lg:px-16 py-12">
           {/* Quick Category Chips */}
           <div className="flex flex-wrap items-center gap-3">
-            {categories.map((cat) => (
+            {categoryIds.map((catId) => (
               <button
-                key={cat.id}
-                onClick={() => setActiveCategory(cat.id)}
+                key={catId}
+                onClick={() => setActiveCategory(catId)}
                 className={`px-5 py-2.5 rounded-full text-sm font-medium transition-all duration-300
                   ${
-                    activeCategory === cat.id
+                    activeCategory === catId
                       ? 'landing-btn-primary shadow-lg'
                       : 'landing-chip-inactive'
                   }
                 `}
               >
-                {cat.label}
+                {getCategoryLabel(catId)}
               </button>
             ))}
           </div>
@@ -184,16 +183,16 @@ export function LandingPage() {
             <div>
               <h2 className="text-2xl md:text-3xl font-bold landing-text-primary">
                 {activeCategory === 'all'
-                  ? '지금 주목해야 할 강의'
-                  : `${categories.find((c) => c.id === activeCategory)?.label} 관련 강의`}
+                  ? t.landing.featuredCourses
+                  : `${getCategoryLabel(activeCategory)} ${t.landing.relatedCourses}`}
               </h2>
-              <p className="landing-text-muted text-sm mt-2">성장을 위한 최고의 선택</p>
+              <p className="landing-text-muted text-sm mt-2">{t.landing.featuredCoursesDesc}</p>
             </div>
             <a
               href="/tu/catalog"
               className="text-sm landing-text-secondary hover:opacity-80 flex items-center gap-1 transition-colors"
             >
-              전체보기 <ChevronRight className="w-4 h-4" />
+              {t.landing.viewAll} <ChevronRight className="w-4 h-4" />
             </a>
           </div>
 
@@ -202,7 +201,7 @@ export function LandingPage() {
               filteredCourses.map((course) => <LandingCourseCard key={course.id} {...course} />)
             ) : (
               <p className="col-span-5 text-center landing-text-muted py-10">
-                해당 카테고리에 강의가 없습니다.
+                {t.landing.noCoursesInCategory}
               </p>
             )}
           </div>
@@ -213,14 +212,14 @@ export function LandingPage() {
           <div className="w-full px-4 md:px-8 lg:px-16">
             <div className="flex items-center justify-between mb-8">
               <div>
-                <h2 className="text-2xl md:text-3xl font-bold landing-text-primary">따끈따끈 신규 강의</h2>
-                <p className="landing-text-muted text-sm mt-2">매일 업데이트되는 새로운 배움</p>
+                <h2 className="text-2xl md:text-3xl font-bold landing-text-primary">{t.landing.newCourses}</h2>
+                <p className="landing-text-muted text-sm mt-2">{t.landing.newCoursesDesc}</p>
               </div>
               <a
                 href="/tu/catalog"
                 className="text-sm landing-text-secondary hover:opacity-80 flex items-center gap-1 transition-colors"
               >
-                전체보기 <ChevronRight className="w-4 h-4" />
+                {t.landing.viewAll} <ChevronRight className="w-4 h-4" />
               </a>
             </div>
 
@@ -236,14 +235,14 @@ export function LandingPage() {
         <section className="w-full px-4 md:px-8 lg:px-16 py-20">
           <div className="flex items-center justify-between mb-8">
             <div>
-              <h2 className="text-2xl md:text-3xl font-bold landing-text-primary">왕초보도 할 수 있어요</h2>
-              <p className="landing-text-muted text-sm mt-2">시작이 반! 기초부터 탄탄하게</p>
+              <h2 className="text-2xl md:text-3xl font-bold landing-text-primary">{t.landing.beginnerCourses}</h2>
+              <p className="landing-text-muted text-sm mt-2">{t.landing.beginnerCoursesDesc}</p>
             </div>
             <a
               href="/tu/catalog"
               className="text-sm landing-text-secondary hover:opacity-80 flex items-center gap-1 transition-colors"
             >
-              전체보기 <ChevronRight className="w-4 h-4" />
+              {t.landing.viewAll} <ChevronRight className="w-4 h-4" />
             </a>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6">

--- a/src/pages/tu/settings/SettingsLanguagePage.tsx
+++ b/src/pages/tu/settings/SettingsLanguagePage.tsx
@@ -1,169 +1,90 @@
-import { useState } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
-import { ArrowLeft, Globe, Clock } from 'lucide-react';
-import { designTokens } from '@/styles/admin-design-tokens';
+import { Globe, Check } from 'lucide-react';
+import { useThemeStore } from '@/store/common/themeStore';
+import { useLanguageStore, useTranslation, type Language } from '@/store/common/languageStore';
 import {
-  Button,
   Card,
   CardHeader,
   CardTitle,
   CardContent,
-  Label,
-  NativeSelect,
-  RadioOptionCard,
 } from '@/components/common';
-import { useUIStore } from '@/store/common/uiStore';
+
+const languages: { value: Language; label: string; flag: string }[] = [
+  { value: 'ko', label: '한국어', flag: '🇰🇷' },
+  { value: 'en', label: 'English', flag: '🇺🇸' },
+];
 
 export function SettingsLanguagePage() {
-  const navigate = useNavigate();
-  const location = useLocation();
+  const { theme } = useThemeStore();
+  const { language, setLanguage } = useLanguageStore();
+  const { t } = useTranslation();
+  const isDark = theme === 'dark';
 
-  const { language, setLanguage } = useUIStore();
-  const [timezone, setTimezone] = useState('Asia/Seoul');
-  const [dateFormat, setDateFormat] = useState('YYYY-MM-DD');
-
-  const basePath = location.pathname.split('/settings')[0];
-
-  const handleBack = () => {
-    navigate(`${basePath}/settings`);
-  };
-
-  const timezones = [
-    { value: 'Asia/Seoul', label: '서울 (UTC+9)' },
-    { value: 'America/New_York', label: '뉴욕 (UTC-5)' },
-    { value: 'America/Los_Angeles', label: '로스앤젤레스 (UTC-8)' },
-    { value: 'Europe/London', label: '런던 (UTC+0)' },
-    { value: 'Europe/Paris', label: '파리 (UTC+1)' },
-    { value: 'Asia/Tokyo', label: '도쿄 (UTC+9)' },
-    { value: 'Asia/Shanghai', label: '상하이 (UTC+8)' },
-    { value: 'Australia/Sydney', label: '시드니 (UTC+10)' },
-  ];
-
-  const dateFormats = [
-    { value: 'YYYY-MM-DD', label: '2024-12-23', description: '연-월-일' },
-    { value: 'MM/DD/YYYY', label: '12/23/2024', description: '월/일/연' },
-    { value: 'DD/MM/YYYY', label: '23/12/2024', description: '일/월/연' },
-    { value: 'YYYY년 MM월 DD일', label: '2024년 12월 23일', description: '한국어 형식' },
-  ];
-
-  const handleSave = () => {
-    alert('언어 및 지역 설정이 저장되었습니다.');
-  };
+  const cardClass = isDark
+    ? 'bg-white/5 border-white/10'
+    : 'bg-white border-gray-200 shadow-sm';
 
   return (
-    <div
-      style={{
-        padding: '40px',
-        backgroundColor: designTokens.bg.app_default,
-        minHeight: '100%',
-        overflowY: 'auto',
-      }}
-    >
-      <div style={{ maxWidth: '800px', margin: '0 auto' }}>
-        {/* Header with Back Button */}
-        <Button
-          variant="ghost"
-          onClick={handleBack}
-          className="mb-6 gap-2 text-muted-foreground hover:text-foreground"
-        >
-          <ArrowLeft className="w-5 h-5" />
-          <span>설정으로 돌아가기</span>
-        </Button>
-
-        <h1
-          style={{
-            color: designTokens.text.primary,
-            fontSize: '24px',
-            fontWeight: 600,
-            marginBottom: '8px',
-          }}
-        >
-          언어 및 지역
-        </h1>
-        <p style={{ color: designTokens.text.secondary, marginBottom: '32px' }}>
-          언어, 시간대 및 날짜 형식을 설정하세요
-        </p>
-
-        {/* Language Section */}
-        <Card className="mb-6">
-          <CardHeader className="border-b px-6 py-4">
-            <div className="flex items-center gap-3">
-              <Globe className="w-5 h-5" style={{ color: designTokens.text.secondary }} />
-              <CardTitle className="text-lg font-medium">언어 설정</CardTitle>
-            </div>
-          </CardHeader>
-          <CardContent className="px-6 pb-6">
-            <div>
-              <Label className="mb-3 text-muted-foreground text-sm">표시 언어</Label>
-              <div className="flex gap-3 mt-3 flex-wrap">
-                <Button
-                  variant={language === 'ko' ? 'default' : 'outline'}
-                  onClick={() => setLanguage('ko')}
-                  className="min-w-[120px]"
-                >
-                  한국어
-                </Button>
-                <Button
-                  variant={language === 'en' ? 'default' : 'outline'}
-                  onClick={() => setLanguage('en')}
-                  className="min-w-[120px]"
-                >
-                  English
-                </Button>
-              </div>
-              <p className="text-xs text-muted-foreground mt-3">
-                인터페이스 언어가 즉시 변경됩니다.
-              </p>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Timezone Section */}
-        <Card className="mb-6">
-          <CardHeader className="border-b px-6 py-4">
-            <div className="flex items-center gap-3">
-              <Clock className="w-5 h-5" style={{ color: designTokens.text.secondary }} />
-              <CardTitle className="text-lg font-medium">시간대 설정</CardTitle>
-            </div>
-          </CardHeader>
-          <CardContent className="px-6 pb-6">
-            <div className="mb-6">
-              <NativeSelect
-                label="시간대"
-                value={timezone}
-                onChange={(e) => setTimezone(e.target.value)}
-                options={timezones}
-              />
-              <p className="text-xs text-muted-foreground mt-2">
-                강의 일정과 알림 시간에 적용됩니다.
-              </p>
-            </div>
-
-            <div>
-              <Label className="mb-3 text-muted-foreground text-sm">날짜 형식</Label>
-              <div className="flex flex-col gap-2 mt-3">
-                {dateFormats.map((format) => (
-                  <RadioOptionCard
-                    key={format.value}
-                    name="dateFormat"
-                    value={format.value}
-                    label={format.label}
-                    description={format.description}
-                    isSelected={dateFormat === format.value}
-                    onChange={setDateFormat}
-                  />
-                ))}
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Save Button */}
-        <div className="flex justify-end pt-4">
-          <Button onClick={handleSave}>
-            저장
-          </Button>
+    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#0a0a14]' : 'bg-gray-50'}`}>
+      <div className="max-w-3xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            {t.mypage.languageRegion}
+          </h1>
+          <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
+            {t.settings.languageDesc}
+          </p>
         </div>
+
+        {/* Language Selection Card */}
+        <Card className={cardClass}>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <Globe className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+              <CardTitle className={isDark ? 'text-white' : 'text-gray-900'}>
+                {t.settings.selectLanguage}
+              </CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {languages.map((lang) => (
+                <button
+                  key={lang.value}
+                  onClick={() => setLanguage(lang.value)}
+                  className={`w-full flex items-center justify-between p-4 rounded-xl transition-all ${
+                    language === lang.value
+                      ? isDark
+                        ? 'bg-gradient-to-r from-[#6778ff]/20 to-[#a855f7]/20 border border-[#6778ff]/50'
+                        : 'bg-blue-50 border border-blue-300'
+                      : isDark
+                      ? 'bg-white/5 border border-white/10 hover:bg-white/10'
+                      : 'bg-gray-50 border border-gray-200 hover:bg-gray-100'
+                  }`}
+                >
+                  <div className="flex items-center gap-4">
+                    <span className="text-2xl">{lang.flag}</span>
+                    <span className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                      {lang.label}
+                    </span>
+                  </div>
+                  {language === lang.value && (
+                    <div className={`w-6 h-6 rounded-full flex items-center justify-center ${
+                      isDark ? 'bg-[#6778ff]' : 'bg-blue-600'
+                    }`}>
+                      <Check className="w-4 h-4 text-white" />
+                    </div>
+                  )}
+                </button>
+              ))}
+            </div>
+            <p className="text-sm mt-4 text-gray-500">
+              {language === 'ko'
+                ? '언어 변경 시 모든 페이지에 즉시 적용됩니다.'
+                : 'Language changes will be applied immediately to all pages.'}
+            </p>
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/src/store/common/index.ts
+++ b/src/store/common/index.ts
@@ -1,2 +1,5 @@
 export { useUIStore } from './uiStore';
 export { useAuthStore } from './authStore';
+export { useThemeStore } from './themeStore';
+export { useLanguageStore, useTranslation, getTranslation } from './languageStore';
+export type { Language } from './languageStore';

--- a/src/store/common/languageStore.ts
+++ b/src/store/common/languageStore.ts
@@ -1,0 +1,770 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type Language = 'ko' | 'en';
+
+interface LanguageState {
+  language: Language;
+  setLanguage: (language: Language) => void;
+  toggleLanguage: () => void;
+}
+
+export const useLanguageStore = create<LanguageState>()(
+  persist(
+    (set, get) => ({
+      language: 'ko', // 기본값: 한국어
+      setLanguage: (language) => set({ language }),
+      toggleLanguage: () => {
+        const newLang = get().language === 'ko' ? 'en' : 'ko';
+        set({ language: newLang });
+      },
+    }),
+    {
+      name: 'language-storage',
+    }
+  )
+);
+
+// 번역 타입
+type TranslationKeys = {
+  // 공통
+  common: {
+    save: string;
+    cancel: string;
+    confirm: string;
+    delete: string;
+    edit: string;
+    view: string;
+    search: string;
+    loading: string;
+    noData: string;
+    error: string;
+    success: string;
+    warning: string;
+    info: string;
+    logout: string;
+    login: string;
+    signup: string;
+    darkMode: string;
+    lightMode: string;
+  };
+  // 마이페이지
+  mypage: {
+    title: string;
+    profile: string;
+    profileAndSecurity: string;
+    profileDescription: string;
+    learningStatus: string;
+    inProgress: string;
+    completed: string;
+    pending: string;
+    total: string;
+    recentLearning: string;
+    viewAll: string;
+    quickMenu: string;
+    myLearning: string;
+    myLearningDesc: string;
+    certificates: string;
+    certificatesDesc: string;
+    profileSecurityDesc: string;
+    notifications: string;
+    notificationsDesc: string;
+    languageRegion: string;
+    languageRegionDesc: string;
+    learningProgress: string;
+    learningProgressDesc: string;
+    noEnrolledCourses: string;
+    noEnrolledCoursesDesc: string;
+    browseCourses: string;
+    editProfile: string;
+    hello: string;
+    generalMember: string;
+  };
+  // 내 강의 관리
+  teaching: {
+    title: string;
+    description: string;
+    createCourse: string;
+    newCourse: string;
+    noCourses: string;
+    noCoursesDesc: string;
+    courseNotice: string;
+    courseNoticeDesc: string;
+    grantPermission: string;
+    grantPermissionDesc: string;
+    grantPermissionConfirm: string;
+    grantPermissionWarning: string;
+    granting: string;
+    designer: string;
+    draft: string;
+    pendingApproval: string;
+    approved: string;
+    rejected: string;
+    students: string;
+    lastModified: string;
+  };
+  // 프로필 및 보안
+  profileSecurity: {
+    title: string;
+    description: string;
+    profileInfo: string;
+    profileImage: string;
+    imageGuide: string;
+    imageClickGuide: string;
+    name: string;
+    email: string;
+    joinDate: string;
+    passwordChange: string;
+    currentPassword: string;
+    newPassword: string;
+    confirmPassword: string;
+    passwordMinLength: string;
+    changePassword: string;
+    coursePermission: string;
+    currentPermissionStatus: string;
+    generalUser: string;
+    courseCreationEnabled: string;
+    fullAccess: string;
+    permissionRequestDesc: string;
+    requestPermission: string;
+    permissionEnabled: string;
+    accountManagement: string;
+    accountDeleteWarning: string;
+    withdraw: string;
+    withdrawTitle: string;
+    withdrawDesc: string;
+    withdrawConfirm: string;
+    processing: string;
+  };
+  // 설정
+  settings: {
+    title: string;
+    language: string;
+    languageDesc: string;
+    selectLanguage: string;
+    korean: string;
+    english: string;
+  };
+  // 랜딩 페이지
+  landing: {
+    banner: string;
+    closeBanner: string;
+    searchPlaceholder: string;
+    switchToDark: string;
+    switchToLight: string;
+    openMenu: string;
+    mypage: string;
+    createCourse: string;
+    settings: string;
+    profileSecurity: string;
+    notifications: string;
+    languageRegion: string;
+    // 카테고리
+    all: string;
+    cloud: string;
+    dev: string;
+    ai: string;
+    data: string;
+    security: string;
+    devops: string;
+    // 섹션 타이틀
+    featuredCourses: string;
+    featuredCoursesDesc: string;
+    newCourses: string;
+    newCoursesDesc: string;
+    beginnerCourses: string;
+    beginnerCoursesDesc: string;
+    viewAll: string;
+    noCoursesInCategory: string;
+    relatedCourses: string;
+    // 태그
+    tagNew: string;
+    tagBest: string;
+    tagSale: string;
+  };
+  // 히어로 섹션
+  hero: {
+    getStarted: string;
+    explore: string;
+    prevSlide: string;
+    nextSlide: string;
+    goToSlide: string;
+    // 슬라이드 1
+    slide1Subtitle: string;
+    slide1Desc: string;
+    // 슬라이드 2
+    slide2Subtitle: string;
+    slide2Desc: string;
+    // 슬라이드 3
+    slide3Subtitle: string;
+    slide3Desc: string;
+  };
+  // 푸터
+  footer: {
+    company: string;
+    ceo: string;
+    businessNo: string;
+    address: string;
+    phone: string;
+    privacyPolicy: string;
+    terms: string;
+    emailPolicy: string;
+    copyright: string;
+  };
+  // 카탈로그
+  catalog: {
+    title: string;
+    description: string;
+    searchPlaceholder: string;
+    filter: string;
+    difficulty: string;
+    beginner: string;
+    intermediate: string;
+    advanced: string;
+    totalCourses: string;
+    courses: string;
+    loadError: string;
+    noCourses: string;
+    changeFilter: string;
+    hours: string;
+    minutes: string;
+    students: string;
+    enrolled: string;
+    backToCatalog: string;
+    courseNotFound: string;
+    courseNotFoundDesc: string;
+    courseIntro: string;
+    availableSessions: string;
+    closed: string;
+    enrollmentPeriod: string;
+    processing: string;
+    closedStatus: string;
+    notAvailable: string;
+    enroll: string;
+    noAvailableSessions: string;
+    enrollSuccess: string;
+    enrollFail: string;
+  };
+  // 학습
+  learning: {
+    title: string;
+    description: string;
+    searchPlaceholder: string;
+    filter: string;
+    enrollmentStatus: string;
+    statusPending: string;
+    statusApproved: string;
+    statusRejected: string;
+    statusCancelled: string;
+    statusCompleted: string;
+    progress: string;
+    continueLearning: string;
+    totalEnrollments: string;
+    enrollments: string;
+    loadError: string;
+    noEnrollments: string;
+    noEnrollmentsDesc: string;
+    browseCourses: string;
+    backToLearning: string;
+    enrollmentNotFound: string;
+    learningProgress: string;
+    completed: string;
+    curriculum: string;
+    cancelEnrollment: string;
+    cancelConfirmTitle: string;
+    cancelConfirmDesc: string;
+    minutes: string;
+    enrollmentPeriod: string;
+    enrolledDate: string;
+  };
+};
+
+// 한국어 번역
+const ko: TranslationKeys = {
+  common: {
+    save: '저장',
+    cancel: '취소',
+    confirm: '확인',
+    delete: '삭제',
+    edit: '수정',
+    view: '보기',
+    search: '검색',
+    loading: '로딩 중...',
+    noData: '데이터가 없습니다',
+    error: '오류가 발생했습니다',
+    success: '성공',
+    warning: '경고',
+    info: '정보',
+    logout: '로그아웃',
+    login: '로그인',
+    signup: '회원가입',
+    darkMode: '다크 모드',
+    lightMode: '라이트 모드',
+  },
+  mypage: {
+    title: '마이페이지',
+    profile: '프로필',
+    profileAndSecurity: '프로필 및 보안',
+    profileDescription: '프로필 정보를 수정하고 프로필 이미지를 변경하세요',
+    learningStatus: '학습 현황',
+    inProgress: '수강 중',
+    completed: '완료',
+    pending: '승인 대기',
+    total: '전체',
+    recentLearning: '최근 학습',
+    viewAll: '전체보기',
+    quickMenu: '빠른 메뉴',
+    myLearning: '내 학습',
+    myLearningDesc: '수강 중인 강의를 확인하세요',
+    certificates: '인증서',
+    certificatesDesc: '취득한 인증서를 확인하세요',
+    profileSecurityDesc: '프로필 정보 및 보안 설정',
+    notifications: '알림 설정',
+    notificationsDesc: '알림 설정을 관리하세요',
+    languageRegion: '언어 및 지역',
+    languageRegionDesc: '언어 및 지역 설정을 변경하세요',
+    learningProgress: '학습 진도',
+    learningProgressDesc: '전체 학습 진도를 확인하세요',
+    noEnrolledCourses: '수강 중인 강의가 없습니다',
+    noEnrolledCoursesDesc: '새로운 강의를 찾아 학습을 시작해보세요',
+    browseCourses: '강의 둘러보기',
+    editProfile: '프로필 수정',
+    hello: '님, 안녕하세요!',
+    generalMember: '일반 회원',
+  },
+  teaching: {
+    title: '내 강의 관리',
+    description: '개설한 강의를 관리하고 새 강의를 만들어보세요',
+    createCourse: '강의 개설하기',
+    newCourse: '새 강의 개설',
+    noCourses: '개설한 강의가 없습니다',
+    noCoursesDesc: '아직 개설한 강의가 없습니다. 새로운 강의를 만들어 학습자들과 지식을 나눠보세요.',
+    courseNotice: '강의 개설 안내',
+    courseNoticeDesc: '강의 개설 정보와 강의 내용의 적합성은 운영진의 판단하에 강의 개설 승인이 이루어집니다. 승인까지 영업일 기준 3~5일이 소요될 수 있습니다.',
+    grantPermission: '강의 개설 권한 부여',
+    grantPermissionDesc: '강의를 개설하려면 강의 설계자(Designer) 권한이 필요합니다.',
+    grantPermissionConfirm: '"확인"을 누르시면 자동으로 권한이 부여되며, 강의 개설 페이지로 이동합니다.',
+    grantPermissionWarning: '주의사항: 강의 개설 정보와 강의 내용의 적합성은 운영진의 판단하에 강의 개설 승인이 이루어집니다. 부적절한 내용의 강의는 승인이 거부될 수 있습니다.',
+    granting: '권한 부여 중...',
+    designer: '강의 설계자(Designer)',
+    draft: '임시저장',
+    pendingApproval: '승인 대기',
+    approved: '승인됨',
+    rejected: '반려됨',
+    students: '수강생',
+    lastModified: '최종 수정',
+  },
+  profileSecurity: {
+    title: '프로필 및 보안',
+    description: '프로필 정보와 보안 설정을 관리하세요',
+    profileInfo: '프로필 정보',
+    profileImage: '프로필 이미지',
+    imageGuide: 'JPG, PNG, GIF (최대 5MB)',
+    imageClickGuide: '이미지를 클릭하여 변경하세요',
+    name: '이름',
+    email: '이메일',
+    joinDate: '가입일',
+    passwordChange: '비밀번호 변경',
+    currentPassword: '현재 비밀번호',
+    newPassword: '새 비밀번호',
+    confirmPassword: '새 비밀번호 확인',
+    passwordMinLength: '최소 8자 이상 입력해주세요',
+    changePassword: '비밀번호 변경',
+    coursePermission: '강의 개설 권한',
+    currentPermissionStatus: '현재 권한 상태',
+    generalUser: '일반 사용자',
+    courseCreationEnabled: '강의 개설 가능',
+    fullAccess: '전체 권한',
+    permissionRequestDesc: '강의를 개설하고 콘텐츠를 등록하려면 권한을 요청해주세요.',
+    requestPermission: '강의 개설 권한 요청',
+    permissionEnabled: '강의 개설 및 콘텐츠 등록 권한이 활성화되었습니다.',
+    accountManagement: '계정 관리',
+    accountDeleteWarning: '계정을 삭제하면 모든 데이터가 영구적으로 삭제되며 복구할 수 없습니다.',
+    withdraw: '회원 탈퇴',
+    withdrawTitle: '회원 탈퇴',
+    withdrawDesc: '정말로 계정을 삭제하시겠습니까? 이 작업은 되돌릴 수 없으며, 모든 데이터가 영구적으로 삭제됩니다.',
+    withdrawConfirm: '탈퇴하기',
+    processing: '처리 중...',
+  },
+  settings: {
+    title: '설정',
+    language: '언어',
+    languageDesc: '사용할 언어를 선택하세요',
+    selectLanguage: '언어 선택',
+    korean: '한국어',
+    english: 'English',
+  },
+  landing: {
+    banner: 'MZC Learn Platform - 클라우드 교육의 새로운 시작',
+    closeBanner: '배너 닫기',
+    searchPlaceholder: '배우고 싶은 지식을 입력해보세요.',
+    switchToDark: '다크 모드로 전환',
+    switchToLight: '라이트 모드로 전환',
+    openMenu: '메뉴 열기',
+    mypage: '마이페이지',
+    createCourse: '강의 개설하기',
+    settings: '설정',
+    profileSecurity: '프로필 및 보안',
+    notifications: '알림',
+    languageRegion: '언어 및 지역',
+    all: '전체',
+    cloud: '클라우드',
+    dev: '개발',
+    ai: 'AI',
+    data: '데이터',
+    security: '보안',
+    devops: 'DevOps',
+    featuredCourses: '지금 주목해야 할 강의',
+    featuredCoursesDesc: '성장을 위한 최고의 선택',
+    newCourses: '따끈따끈 신규 강의',
+    newCoursesDesc: '매일 업데이트되는 새로운 배움',
+    beginnerCourses: '왕초보도 할 수 있어요',
+    beginnerCoursesDesc: '시작이 반! 기초부터 탄탄하게',
+    viewAll: '전체보기',
+    noCoursesInCategory: '해당 카테고리에 강의가 없습니다.',
+    relatedCourses: '관련 강의',
+    tagNew: 'NEW',
+    tagBest: '베스트',
+    tagSale: '할인중',
+  },
+  hero: {
+    getStarted: '시작하기',
+    explore: '둘러보기',
+    prevSlide: '이전 슬라이드',
+    nextSlide: '다음 슬라이드',
+    goToSlide: '슬라이드로 이동',
+    slide1Subtitle: '클라우드 전문가로 성장하는\n가장 빠른 길',
+    slide1Desc: 'MZC Learn과 함께 시작하세요.',
+    slide2Subtitle: '나만의 커리어 로드맵\n지금 설계하세요',
+    slide2Desc: '초보자부터 전문가까지, 단계별 학습 가이드',
+    slide3Subtitle: 'AWS, Azure, GCP\n클라우드 완전 정복',
+    slide3Desc: '현직자가 알려주는 실무 클라우드 노하우',
+  },
+  footer: {
+    company: '메가존클라우드(주)',
+    ceo: '대표이사: 이주완, 조원우',
+    businessNo: '사업자등록번호: 232-88-00982',
+    address: '서울시 강남구 논현로85길 46 메가존빌딩',
+    phone: '대표전화: 1644-2243 | Email: cloud@megazone.com',
+    privacyPolicy: '개인정보처리방침',
+    terms: '이용약관',
+    emailPolicy: '이메일무단수집거부',
+    copyright: 'MEGAZONECLOUD Corp. All rights reserved.',
+  },
+  catalog: {
+    title: '강의 카탈로그',
+    description: '수강 가능한 강의를 탐색하고 수강신청하세요',
+    searchPlaceholder: '강의 검색...',
+    filter: '필터',
+    difficulty: '난이도',
+    beginner: '입문',
+    intermediate: '중급',
+    advanced: '고급',
+    totalCourses: '총',
+    courses: '개의 강의',
+    loadError: '데이터를 불러오는 중 오류가 발생했습니다.',
+    noCourses: '강의가 없습니다',
+    changeFilter: '검색 조건을 변경해 보세요',
+    hours: '시간',
+    minutes: '분',
+    students: '명',
+    enrolled: '명 수강',
+    backToCatalog: '카탈로그로 돌아가기',
+    courseNotFound: '강의를 찾을 수 없습니다',
+    courseNotFoundDesc: '요청하신 강의가 존재하지 않거나 접근할 수 없습니다.',
+    courseIntro: '강의 소개',
+    availableSessions: '수강 가능한 차수',
+    closed: '마감',
+    enrollmentPeriod: '신청기간',
+    processing: '처리 중...',
+    closedStatus: '마감됨',
+    notAvailable: '신청 불가',
+    enroll: '수강신청',
+    noAvailableSessions: '현재 수강 가능한 차수가 없습니다.',
+    enrollSuccess: '수강신청이 완료되었습니다.',
+    enrollFail: '수강신청에 실패했습니다. 다시 시도해주세요.',
+  },
+  learning: {
+    title: '내 학습',
+    description: '수강 중인 강의를 관리하고 학습을 이어가세요',
+    searchPlaceholder: '강의명 검색...',
+    filter: '필터',
+    enrollmentStatus: '수강 상태',
+    statusPending: '승인 대기',
+    statusApproved: '수강 중',
+    statusRejected: '반려됨',
+    statusCancelled: '취소됨',
+    statusCompleted: '완료',
+    progress: '진도율',
+    continueLearning: '학습 이어하기',
+    totalEnrollments: '총',
+    enrollments: '개의 수강',
+    loadError: '데이터를 불러오는 중 오류가 발생했습니다.',
+    noEnrollments: '수강 중인 강의가 없습니다',
+    noEnrollmentsDesc: '강의 카탈로그에서 원하는 강의를 찾아 수강신청하세요',
+    browseCourses: '강의 둘러보기',
+    backToLearning: '내 학습으로 돌아가기',
+    enrollmentNotFound: '수강 정보를 찾을 수 없습니다',
+    learningProgress: '학습 진도',
+    completed: '완료',
+    curriculum: '커리큘럼',
+    cancelEnrollment: '수강 취소',
+    cancelConfirmTitle: '수강을 취소하시겠습니까?',
+    cancelConfirmDesc: '수강을 취소하면 학습 진도가 모두 초기화됩니다. 이 작업은 되돌릴 수 없습니다.',
+    minutes: '분',
+    enrollmentPeriod: '수강 기간',
+    enrolledDate: '신청일',
+  },
+};
+
+// 영어 번역
+const en: TranslationKeys = {
+  common: {
+    save: 'Save',
+    cancel: 'Cancel',
+    confirm: 'Confirm',
+    delete: 'Delete',
+    edit: 'Edit',
+    view: 'View',
+    search: 'Search',
+    loading: 'Loading...',
+    noData: 'No data available',
+    error: 'An error occurred',
+    success: 'Success',
+    warning: 'Warning',
+    info: 'Info',
+    logout: 'Logout',
+    login: 'Login',
+    signup: 'Sign up',
+    darkMode: 'Dark Mode',
+    lightMode: 'Light Mode',
+  },
+  mypage: {
+    title: 'My Page',
+    profile: 'Profile',
+    profileAndSecurity: 'Profile & Security',
+    profileDescription: 'Edit your profile information and change your profile image',
+    learningStatus: 'Learning Status',
+    inProgress: 'In Progress',
+    completed: 'Completed',
+    pending: 'Pending',
+    total: 'Total',
+    recentLearning: 'Recent Learning',
+    viewAll: 'View All',
+    quickMenu: 'Quick Menu',
+    myLearning: 'My Learning',
+    myLearningDesc: 'Check your enrolled courses',
+    certificates: 'Certificates',
+    certificatesDesc: 'View your earned certificates',
+    profileSecurityDesc: 'Profile and security settings',
+    notifications: 'Notifications',
+    notificationsDesc: 'Manage your notification settings',
+    languageRegion: 'Language & Region',
+    languageRegionDesc: 'Change language and region settings',
+    learningProgress: 'Learning Progress',
+    learningProgressDesc: 'Check your overall learning progress',
+    noEnrolledCourses: 'No enrolled courses',
+    noEnrolledCoursesDesc: 'Find new courses and start learning',
+    browseCourses: 'Browse Courses',
+    editProfile: 'Edit Profile',
+    hello: ', Welcome!',
+    generalMember: 'Member',
+  },
+  teaching: {
+    title: 'My Courses',
+    description: 'Manage your courses and create new ones',
+    createCourse: 'Create Course',
+    newCourse: 'New Course',
+    noCourses: 'No courses created',
+    noCoursesDesc: 'You haven\'t created any courses yet. Create a new course to share your knowledge with learners.',
+    courseNotice: 'Course Creation Notice',
+    courseNoticeDesc: 'Course creation approval is based on the appropriateness of course information and content as judged by the administrators. Approval may take 3-5 business days.',
+    grantPermission: 'Grant Course Creation Permission',
+    grantPermissionDesc: 'You need Designer permission to create courses.',
+    grantPermissionConfirm: 'Click "Confirm" to automatically grant permission and navigate to the course creation page.',
+    grantPermissionWarning: 'Note: Course creation approval is based on the appropriateness of course information and content. Courses with inappropriate content may be rejected.',
+    granting: 'Granting permission...',
+    designer: 'Designer',
+    draft: 'Draft',
+    pendingApproval: 'Pending',
+    approved: 'Approved',
+    rejected: 'Rejected',
+    students: 'Students',
+    lastModified: 'Last Modified',
+  },
+  profileSecurity: {
+    title: 'Profile & Security',
+    description: 'Manage your profile and security settings',
+    profileInfo: 'Profile Information',
+    profileImage: 'Profile Image',
+    imageGuide: 'JPG, PNG, GIF (max 5MB)',
+    imageClickGuide: 'Click to change image',
+    name: 'Name',
+    email: 'Email',
+    joinDate: 'Join Date',
+    passwordChange: 'Change Password',
+    currentPassword: 'Current Password',
+    newPassword: 'New Password',
+    confirmPassword: 'Confirm New Password',
+    passwordMinLength: 'Minimum 8 characters required',
+    changePassword: 'Change Password',
+    coursePermission: 'Course Creation Permission',
+    currentPermissionStatus: 'Current Permission Status',
+    generalUser: 'General User',
+    courseCreationEnabled: 'Course Creation Enabled',
+    fullAccess: 'Full Access',
+    permissionRequestDesc: 'Request permission to create courses and register content.',
+    requestPermission: 'Request Permission',
+    permissionEnabled: 'Course creation and content registration permission is enabled.',
+    accountManagement: 'Account Management',
+    accountDeleteWarning: 'Deleting your account will permanently remove all data and cannot be recovered.',
+    withdraw: 'Delete Account',
+    withdrawTitle: 'Delete Account',
+    withdrawDesc: 'Are you sure you want to delete your account? This action cannot be undone and all data will be permanently deleted.',
+    withdrawConfirm: 'Delete',
+    processing: 'Processing...',
+  },
+  settings: {
+    title: 'Settings',
+    language: 'Language',
+    languageDesc: 'Select your preferred language',
+    selectLanguage: 'Select Language',
+    korean: '한국어',
+    english: 'English',
+  },
+  landing: {
+    banner: 'MZC Learn Platform - A New Beginning in Cloud Education',
+    closeBanner: 'Close banner',
+    searchPlaceholder: 'Search for knowledge you want to learn.',
+    switchToDark: 'Switch to dark mode',
+    switchToLight: 'Switch to light mode',
+    openMenu: 'Open menu',
+    mypage: 'My Page',
+    createCourse: 'Create Course',
+    settings: 'Settings',
+    profileSecurity: 'Profile & Security',
+    notifications: 'Notifications',
+    languageRegion: 'Language & Region',
+    all: 'All',
+    cloud: 'Cloud',
+    dev: 'Development',
+    ai: 'AI',
+    data: 'Data',
+    security: 'Security',
+    devops: 'DevOps',
+    featuredCourses: 'Featured Courses',
+    featuredCoursesDesc: 'The best choice for your growth',
+    newCourses: 'New Courses',
+    newCoursesDesc: 'Fresh learning updated daily',
+    beginnerCourses: 'Perfect for Beginners',
+    beginnerCoursesDesc: 'Start strong with solid fundamentals',
+    viewAll: 'View All',
+    noCoursesInCategory: 'No courses in this category.',
+    relatedCourses: 'Related Courses',
+    tagNew: 'NEW',
+    tagBest: 'BEST',
+    tagSale: 'SALE',
+  },
+  hero: {
+    getStarted: 'Get Started',
+    explore: 'Explore',
+    prevSlide: 'Previous slide',
+    nextSlide: 'Next slide',
+    goToSlide: 'Go to slide',
+    slide1Subtitle: 'The fastest path to becoming\na cloud expert',
+    slide1Desc: 'Start with MZC Learn.',
+    slide2Subtitle: 'Design your own\ncareer roadmap',
+    slide2Desc: 'Step-by-step learning guide from beginner to expert',
+    slide3Subtitle: 'AWS, Azure, GCP\nMaster the Cloud',
+    slide3Desc: 'Real-world cloud expertise from industry professionals',
+  },
+  footer: {
+    company: 'MEGAZONECLOUD Co., Ltd.',
+    ceo: 'CEO: Lee Joo-wan, Cho Won-woo',
+    businessNo: 'Business No: 232-88-00982',
+    address: '46, Nonhyeon-ro 85-gil, Gangnam-gu, Seoul',
+    phone: 'Tel: 1644-2243 | Email: cloud@megazone.com',
+    privacyPolicy: 'Privacy Policy',
+    terms: 'Terms of Service',
+    emailPolicy: 'Email Collection Policy',
+    copyright: 'MEGAZONECLOUD Corp. All rights reserved.',
+  },
+  catalog: {
+    title: 'Course Catalog',
+    description: 'Browse and enroll in available courses',
+    searchPlaceholder: 'Search courses...',
+    filter: 'Filter',
+    difficulty: 'Difficulty',
+    beginner: 'Beginner',
+    intermediate: 'Intermediate',
+    advanced: 'Advanced',
+    totalCourses: 'Total',
+    courses: 'courses',
+    loadError: 'An error occurred while loading data.',
+    noCourses: 'No courses found',
+    changeFilter: 'Try changing your search criteria',
+    hours: 'hr',
+    minutes: 'min',
+    students: '',
+    enrolled: 'enrolled',
+    backToCatalog: 'Back to Catalog',
+    courseNotFound: 'Course not found',
+    courseNotFoundDesc: 'The requested course does not exist or is not accessible.',
+    courseIntro: 'Course Overview',
+    availableSessions: 'Available Sessions',
+    closed: 'Closed',
+    enrollmentPeriod: 'Enrollment Period',
+    processing: 'Processing...',
+    closedStatus: 'Closed',
+    notAvailable: 'Not Available',
+    enroll: 'Enroll',
+    noAvailableSessions: 'No available sessions at this time.',
+    enrollSuccess: 'Successfully enrolled!',
+    enrollFail: 'Enrollment failed. Please try again.',
+  },
+  learning: {
+    title: 'My Learning',
+    description: 'Manage your enrolled courses and continue learning',
+    searchPlaceholder: 'Search courses...',
+    filter: 'Filter',
+    enrollmentStatus: 'Enrollment Status',
+    statusPending: 'Pending',
+    statusApproved: 'In Progress',
+    statusRejected: 'Rejected',
+    statusCancelled: 'Cancelled',
+    statusCompleted: 'Completed',
+    progress: 'Progress',
+    continueLearning: 'Continue Learning',
+    totalEnrollments: 'Total',
+    enrollments: 'enrollments',
+    loadError: 'An error occurred while loading data.',
+    noEnrollments: 'No enrolled courses',
+    noEnrollmentsDesc: 'Browse the course catalog to find courses you want to take',
+    browseCourses: 'Browse Courses',
+    backToLearning: 'Back to My Learning',
+    enrollmentNotFound: 'Enrollment not found',
+    learningProgress: 'Learning Progress',
+    completed: 'completed',
+    curriculum: 'Curriculum',
+    cancelEnrollment: 'Cancel Enrollment',
+    cancelConfirmTitle: 'Cancel this enrollment?',
+    cancelConfirmDesc: 'Cancelling will reset all your progress. This action cannot be undone.',
+    minutes: 'min',
+    enrollmentPeriod: 'Enrollment Period',
+    enrolledDate: 'Enrolled Date',
+  },
+};
+
+const translations: Record<Language, TranslationKeys> = { ko, en };
+
+// 번역 함수
+export function useTranslation() {
+  const { language } = useLanguageStore();
+  const t = translations[language];
+  return { t, language };
+}
+
+// 직접 번역 가져오기 (컴포넌트 외부에서 사용)
+export function getTranslation(language: Language) {
+  return translations[language];
+}


### PR DESCRIPTION
## Summary

랜딩페이지 및 카탈로그 페이지에 다국어(한국어/영어) 지원을 추가했습니다.

## Related Issue

- Closes #76

## Changes

- HeroSection 컴포넌트 다국어 처리
- LandingCourseCard 컴포넌트 다국어 처리
- LandingFooter 컴포넌트 다국어 처리
- LandingPage 다국어 처리
- CatalogPage, CatalogDetailPage 다국어 처리
- SettingsLanguagePage 언어 설정 UI 다국어 처리

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)
<img width="2856" height="1492" alt="image" src="https://github.com/user-attachments/assets/1d80c2cd-aee2-48e5-840a-aae16ece0be7" />

## Additional Notes

7개 파일 변경