### PR TITLE
feat: TO 차수(CourseTime) 타입 및 API 서비스 구현(#71)

### DIFF
--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -143,11 +143,28 @@ export const API_ENDPOINTS = {
       `/snapshots/${snapshotId}/relations/${relationId}`,
   },
 
-  // Course Times (차수) - TU Catalog
+  // Course Times (차수) - TO 관리 + TU Catalog
   TIMES: {
     BASE: '/times',
     BY_ID: (id: number) => `/times/${id}`,
+    // CRUD
+    CLONE: (id: number) => `/times/${id}/clone`,
+    // 상태 전이
+    OPEN: (id: number) => `/times/${id}/open`,
+    START: (id: number) => `/times/${id}/start`,
+    CLOSE: (id: number) => `/times/${id}/close`,
+    ARCHIVE: (id: number) => `/times/${id}/archive`,
+    // 조회
+    CAPACITY: (id: number) => `/times/${id}/capacity`,
+    PRICE: (id: number) => `/times/${id}/price`,
+    // 수강신청 (TU)
     ENROLLMENTS: (id: number) => `/times/${id}/enrollments`,
+    // 강사 배정 (TO)
+    INSTRUCTORS: (timeId: number) => `/times/${timeId}/instructors`,
+    INSTRUCTOR_BY_ID: (timeId: number, assignmentId: number) =>
+      `/times/${timeId}/instructors/${assignmentId}`,
+    INSTRUCTOR_REPLACE: (timeId: number, assignmentId: number) =>
+      `/times/${timeId}/instructors/${assignmentId}/replace`,
   },
 
   // Enrollments (수강 신청) - TU

--- a/src/services/to/index.ts
+++ b/src/services/to/index.ts
@@ -1,2 +1,3 @@
 export * from './programService';
 export * from './snapshotService';
+export * from './timeService';

--- a/src/services/to/timeService.ts
+++ b/src/services/to/timeService.ts
@@ -1,0 +1,135 @@
+/**
+ * TO(Tenant Operator) 차수(CourseTime) 관리 API 서비스
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type {
+  CourseTimeResponse,
+  CourseTimeDetailResponse,
+  CreateCourseTimeRequest,
+  UpdateCourseTimeRequest,
+  CloneCourseTimeRequest,
+  CourseTimeFilterParams,
+  CapacityResponse,
+  PriceResponse,
+} from '@/types/to/time.types';
+
+// Spring Page 응답 타입
+interface PageResponse<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+}
+
+export const timeService = {
+  // ============================================
+  // CourseTime CRUD
+  // ============================================
+
+  /** 차수 생성 */
+  async createTime(request: CreateCourseTimeRequest): Promise<CourseTimeResponse> {
+    const { data } = await axiosInstance.post<{ data: CourseTimeResponse }>(
+      API_ENDPOINTS.TIMES.BASE,
+      request
+    );
+    return data.data;
+  },
+
+  /** 차수 목록 조회 */
+  async getTimes(params?: CourseTimeFilterParams): Promise<PageResponse<CourseTimeResponse>> {
+    const { data } = await axiosInstance.get<{ data: PageResponse<CourseTimeResponse> }>(
+      API_ENDPOINTS.TIMES.BASE,
+      { params }
+    );
+    return data.data;
+  },
+
+  /** 차수 상세 조회 */
+  async getTime(id: number): Promise<CourseTimeDetailResponse> {
+    const { data } = await axiosInstance.get<{ data: CourseTimeDetailResponse }>(
+      API_ENDPOINTS.TIMES.BY_ID(id)
+    );
+    return data.data;
+  },
+
+  /** 차수 수정 */
+  async updateTime(id: number, request: UpdateCourseTimeRequest): Promise<CourseTimeResponse> {
+    const { data } = await axiosInstance.patch<{ data: CourseTimeResponse }>(
+      API_ENDPOINTS.TIMES.BY_ID(id),
+      request
+    );
+    return data.data;
+  },
+
+  /** 차수 삭제 */
+  async deleteTime(id: number): Promise<void> {
+    await axiosInstance.delete(API_ENDPOINTS.TIMES.BY_ID(id));
+  },
+
+  /** 차수 복제 */
+  async cloneTime(id: number, request: CloneCourseTimeRequest): Promise<CourseTimeResponse> {
+    const { data } = await axiosInstance.post<{ data: CourseTimeResponse }>(
+      API_ENDPOINTS.TIMES.CLONE(id),
+      request
+    );
+    return data.data;
+  },
+
+  // ============================================
+  // 상태 전이 워크플로우
+  // ============================================
+
+  /** 모집 개시 (DRAFT → RECRUITING) */
+  async openTime(id: number): Promise<CourseTimeResponse> {
+    const { data } = await axiosInstance.post<{ data: CourseTimeResponse }>(
+      API_ENDPOINTS.TIMES.OPEN(id)
+    );
+    return data.data;
+  },
+
+  /** 수업 시작 (RECRUITING → ONGOING) */
+  async startTime(id: number): Promise<CourseTimeResponse> {
+    const { data } = await axiosInstance.post<{ data: CourseTimeResponse }>(
+      API_ENDPOINTS.TIMES.START(id)
+    );
+    return data.data;
+  },
+
+  /** 수업 종료 (ONGOING → CLOSED) */
+  async closeTime(id: number): Promise<CourseTimeResponse> {
+    const { data } = await axiosInstance.post<{ data: CourseTimeResponse }>(
+      API_ENDPOINTS.TIMES.CLOSE(id)
+    );
+    return data.data;
+  },
+
+  /** 보관 처리 (CLOSED → ARCHIVED) */
+  async archiveTime(id: number): Promise<CourseTimeResponse> {
+    const { data } = await axiosInstance.post<{ data: CourseTimeResponse }>(
+      API_ENDPOINTS.TIMES.ARCHIVE(id)
+    );
+    return data.data;
+  },
+
+  // ============================================
+  // 조회
+  // ============================================
+
+  /** 정원 정보 조회 */
+  async getCapacity(id: number): Promise<CapacityResponse> {
+    const { data } = await axiosInstance.get<{ data: CapacityResponse }>(
+      API_ENDPOINTS.TIMES.CAPACITY(id)
+    );
+    return data.data;
+  },
+
+  /** 가격 정보 조회 */
+  async getPrice(id: number): Promise<PriceResponse> {
+    const { data } = await axiosInstance.get<{ data: PriceResponse }>(
+      API_ENDPOINTS.TIMES.PRICE(id)
+    );
+    return data.data;
+  },
+};

--- a/src/types/to/index.ts
+++ b/src/types/to/index.ts
@@ -1,3 +1,4 @@
 export * from './content.types';
 export * from './course.types';
 export * from './snapshot.types';
+export * from './time.types';

--- a/src/types/to/time.types.ts
+++ b/src/types/to/time.types.ts
@@ -1,0 +1,201 @@
+/**
+ * TO(Tenant Operator) 차수(CourseTime) 관리 타입 정의
+ * 백엔드 TS 모듈 API와 연동
+ */
+
+// ============================================
+// Enums (Union Types)
+// ============================================
+
+/** 차수 상태 */
+export type CourseTimeStatus =
+  | 'DRAFT' // 작성 중
+  | 'RECRUITING' // 모집 중
+  | 'ONGOING' // 진행 중
+  | 'CLOSED' // 종료됨
+  | 'ARCHIVED'; // 보관됨
+
+/** 진행 방식 */
+export type DeliveryType =
+  | 'ONLINE' // 온라인
+  | 'OFFLINE' // 오프라인
+  | 'BLENDED' // 블렌디드
+  | 'LIVE'; // 실시간
+
+/** 수강 신청 방식 */
+export type EnrollmentMethod =
+  | 'FIRST_COME' // 선착순
+  | 'APPROVAL' // 승인제
+  | 'INVITE_ONLY'; // 초대 전용
+
+// ============================================
+// Response Types
+// ============================================
+
+/** 차수 목록 조회 응답 */
+export interface CourseTimeResponse {
+  id: number;
+  programId: number;
+  cmCourseId: number;
+  title: string;
+  status: CourseTimeStatus;
+  deliveryType: DeliveryType;
+  enrollmentMethod: EnrollmentMethod;
+  enrollmentStartDate: string;
+  enrollmentEndDate: string;
+  startDate: string;
+  endDate: string;
+  capacity: number | null; // null = 무제한
+  currentEnrollment: number;
+  availableSeats: number | null; // null = 무제한
+  price: number | null; // null = 무료
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** 강사 정보 (상세 조회용) */
+export interface CourseTimeInstructor {
+  id: number;
+  userId: number;
+  userName: string;
+  userEmail: string;
+  role: 'MAIN' | 'SUB' | 'ASSISTANT';
+  status: 'ACTIVE' | 'REPLACED' | 'CANCELLED';
+}
+
+/** 차수 상세 조회 응답 */
+export interface CourseTimeDetailResponse extends CourseTimeResponse {
+  description: string | null;
+  location: string | null;
+  programTitle: string | null;
+  cmCourseTitle: string | null;
+  instructors: CourseTimeInstructor[];
+}
+
+/** 정원 조회 응답 */
+export interface CapacityResponse {
+  courseTimeId: number;
+  capacity: number | null;
+  currentEnrollment: number;
+  availableSeats: number | null;
+  unlimited: boolean;
+}
+
+/** 가격 조회 응답 */
+export interface PriceResponse {
+  courseTimeId: number;
+  price: number | null;
+  free: boolean;
+}
+
+// ============================================
+// Request Types
+// ============================================
+
+/** 차수 생성 요청 */
+export interface CreateCourseTimeRequest {
+  programId: number;
+  cmCourseId: number;
+  title: string;
+  deliveryType: DeliveryType;
+  enrollmentMethod: EnrollmentMethod;
+  enrollmentStartDate: string;
+  enrollmentEndDate: string;
+  startDate: string;
+  endDate: string;
+  capacity?: number | null;
+  price?: number | null;
+  description?: string;
+  location?: string;
+}
+
+/** 차수 수정 요청 */
+export interface UpdateCourseTimeRequest {
+  cmCourseId?: number;
+  title?: string;
+  deliveryType?: DeliveryType;
+  enrollmentMethod?: EnrollmentMethod;
+  enrollmentStartDate?: string;
+  enrollmentEndDate?: string;
+  startDate?: string;
+  endDate?: string;
+  capacity?: number | null;
+  price?: number | null;
+  description?: string;
+  location?: string;
+}
+
+/** 차수 복제 요청 */
+export interface CloneCourseTimeRequest {
+  title: string;
+  enrollmentStartDate: string;
+  enrollmentEndDate: string;
+  startDate: string;
+  endDate: string;
+}
+
+// ============================================
+// Filter Types
+// ============================================
+
+/** 차수 목록 조회 필터 */
+export interface CourseTimeFilterParams {
+  programId?: number;
+  cmCourseId?: number;
+  status?: CourseTimeStatus;
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+// ============================================
+// Utility Types & Constants
+// ============================================
+
+/** CourseTimeStatus 라벨 맵 */
+export const COURSE_TIME_STATUS_LABELS: Record<CourseTimeStatus, string> = {
+  DRAFT: '작성 중',
+  RECRUITING: '모집 중',
+  ONGOING: '진행 중',
+  CLOSED: '종료됨',
+  ARCHIVED: '보관됨',
+};
+
+/** CourseTimeStatus 색상 맵 (UI용) */
+export const COURSE_TIME_STATUS_COLORS: Record<
+  CourseTimeStatus,
+  { bg: string; text: string }
+> = {
+  DRAFT: { bg: 'bg-gray-100', text: 'text-gray-700' },
+  RECRUITING: { bg: 'bg-blue-100', text: 'text-blue-700' },
+  ONGOING: { bg: 'bg-green-100', text: 'text-green-700' },
+  CLOSED: { bg: 'bg-slate-100', text: 'text-slate-700' },
+  ARCHIVED: { bg: 'bg-purple-100', text: 'text-purple-700' },
+};
+
+/** DeliveryType 라벨 맵 */
+export const DELIVERY_TYPE_LABELS: Record<DeliveryType, string> = {
+  ONLINE: '온라인',
+  OFFLINE: '오프라인',
+  BLENDED: '블렌디드',
+  LIVE: '실시간',
+};
+
+/** EnrollmentMethod 라벨 맵 */
+export const ENROLLMENT_METHOD_LABELS: Record<EnrollmentMethod, string> = {
+  FIRST_COME: '선착순',
+  APPROVAL: '승인제',
+  INVITE_ONLY: '초대 전용',
+};
+
+/** 상태 전이 가능 여부 */
+export const COURSE_TIME_STATUS_TRANSITIONS: Record<
+  CourseTimeStatus,
+  CourseTimeStatus | null
+> = {
+  DRAFT: 'RECRUITING', // open
+  RECRUITING: 'ONGOING', // start
+  ONGOING: 'CLOSED', // close
+  CLOSED: 'ARCHIVED', // archive
+  ARCHIVED: null, // 최종 상태
+};


### PR DESCRIPTION
## Summary

TO(Tenant Operator) 역할에서 차수(CourseTime)를 관리하기 위한 타입 정의와 API 서비스를 구현했습니다.

## Related Issue

- Closes #71

## Changes

- `src/types/to/time.types.ts` 신규 생성
  - CourseTimeStatus, DeliveryType, EnrollmentMethod 타입
  - CourseTimeResponse, CourseTimeDetailResponse 응답 타입
  - CreateCourseTimeRequest, UpdateCourseTimeRequest, CloneCourseTimeRequest 요청 타입
  - CapacityResponse, PriceResponse 조회 응답 타입
  - STATUS_LABELS, STATUS_COLORS 등 UI 매핑 상수
- `src/services/common/api/endpoints.ts` TIMES 엔드포인트 확장
  - CLONE, OPEN, START, CLOSE, ARCHIVE (상태 전이)
  - CAPACITY, PRICE (조회)
  - INSTRUCTORS, INSTRUCTOR_BY_ID, INSTRUCTOR_REPLACE (강사 배정)
- `src/services/to/timeService.ts` 신규 생성
  - CRUD: createTime, getTimes, getTime, updateTime, deleteTime, cloneTime
  - 상태 전이: openTime, startTime, closeTime, archiveTime
  - 조회: getCapacity, getPrice
- `src/types/to/index.ts`, `src/services/to/index.ts` export 추가

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A (타입 및 서비스 레이어만 구현, UI 없음)

## Additional Notes

- 백엔드 TS 모듈의 12개 차수 API와 연동
- Phase 2 (React Query Hooks #72)에서 이 서비스를 활용할 예정