### PR TITLE
feat: TO 강사 배정(InstructorAssignment) 타입 및 API 서비스 구현 (#73)

### DIFF
--- a/src/services/to/index.ts
+++ b/src/services/to/index.ts
@@ -1,3 +1,4 @@
 export * from './programService';
 export * from './snapshotService';
 export * from './timeService';
+export * from './instructorAssignmentService';

--- a/src/services/to/instructorAssignmentService.ts
+++ b/src/services/to/instructorAssignmentService.ts
@@ -1,0 +1,81 @@
+/**
+ * TO(Tenant Operator) 강사 배정 관리 API 서비스
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type { InstructorAssignmentResponse } from '@/types/tu/instructorAssignment.types';
+import type {
+  AssignInstructorRequest,
+  UpdateInstructorRoleRequest,
+  ReplaceInstructorRequest,
+  CancelAssignmentRequest,
+  InstructorAssignmentFilterParams,
+} from '@/types/to/instructorAssignment.types';
+
+export const instructorAssignmentService = {
+  // ============================================
+  // 강사 배정 CRUD
+  // ============================================
+
+  /** 강사 배정 */
+  async assignInstructor(
+    timeId: number,
+    request: AssignInstructorRequest
+  ): Promise<InstructorAssignmentResponse> {
+    const { data } = await axiosInstance.post<{ data: InstructorAssignmentResponse }>(
+      API_ENDPOINTS.TIMES.INSTRUCTORS(timeId),
+      request
+    );
+    return data.data;
+  },
+
+  /** 차수별 강사 목록 조회 */
+  async getInstructors(
+    timeId: number,
+    params?: InstructorAssignmentFilterParams
+  ): Promise<InstructorAssignmentResponse[]> {
+    const { data } = await axiosInstance.get<{ data: InstructorAssignmentResponse[] }>(
+      API_ENDPOINTS.TIMES.INSTRUCTORS(timeId),
+      { params }
+    );
+    return data.data;
+  },
+
+  /** 강사 역할 변경 */
+  async updateRole(
+    timeId: number,
+    assignmentId: number,
+    request: UpdateInstructorRoleRequest
+  ): Promise<InstructorAssignmentResponse> {
+    const { data } = await axiosInstance.put<{ data: InstructorAssignmentResponse }>(
+      API_ENDPOINTS.TIMES.INSTRUCTOR_BY_ID(timeId, assignmentId),
+      request
+    );
+    return data.data;
+  },
+
+  /** 강사 교체 */
+  async replaceInstructor(
+    timeId: number,
+    assignmentId: number,
+    request: ReplaceInstructorRequest
+  ): Promise<InstructorAssignmentResponse> {
+    const { data } = await axiosInstance.post<{ data: InstructorAssignmentResponse }>(
+      API_ENDPOINTS.TIMES.INSTRUCTOR_REPLACE(timeId, assignmentId),
+      request
+    );
+    return data.data;
+  },
+
+  /** 배정 취소 */
+  async cancelAssignment(
+    timeId: number,
+    assignmentId: number,
+    request?: CancelAssignmentRequest
+  ): Promise<void> {
+    await axiosInstance.delete(
+      API_ENDPOINTS.TIMES.INSTRUCTOR_BY_ID(timeId, assignmentId),
+      { data: request }
+    );
+  },
+};

--- a/src/types/to/index.ts
+++ b/src/types/to/index.ts
@@ -2,3 +2,4 @@ export * from './content.types';
 export * from './course.types';
 export * from './snapshot.types';
 export * from './time.types';
+export * from './instructorAssignment.types';

--- a/src/types/to/instructorAssignment.types.ts
+++ b/src/types/to/instructorAssignment.types.ts
@@ -1,0 +1,54 @@
+/**
+ * TO(Tenant Operator) 강사 배정 관리 타입 정의
+ * 백엔드 IIS 모듈 API와 연동
+ */
+
+// ============================================
+// Re-export from TU (공통 타입)
+// ============================================
+
+export type {
+  InstructorRole,
+  AssignmentStatus,
+  InstructorAssignmentResponse,
+} from '@/types/tu/instructorAssignment.types';
+
+export {
+  INSTRUCTOR_ROLE_LABELS,
+  ASSIGNMENT_STATUS_LABELS,
+} from '@/types/tu/instructorAssignment.types';
+
+// ============================================
+// TO 전용 Request Types
+// ============================================
+
+/** 강사 배정 요청 */
+export interface AssignInstructorRequest {
+  userId: number;
+  role: import('@/types/tu/instructorAssignment.types').InstructorRole;
+  forceAssign?: boolean; // 일정 충돌 무시
+}
+
+/** 역할 변경 요청 */
+export interface UpdateInstructorRoleRequest {
+  role: import('@/types/tu/instructorAssignment.types').InstructorRole;
+}
+
+/** 강사 교체 요청 */
+export interface ReplaceInstructorRequest {
+  newUserId: number;
+}
+
+/** 배정 취소 요청 */
+export interface CancelAssignmentRequest {
+  reason?: string;
+}
+
+// ============================================
+// Filter Types
+// ============================================
+
+/** 강사 배정 목록 필터 */
+export interface InstructorAssignmentFilterParams {
+  status?: import('@/types/tu/instructorAssignment.types').AssignmentStatus;
+}


### PR DESCRIPTION
## Summary

TO(Tenant Operator) 역할에서 차수별 강사 배정을 관리하기 위한 타입 정의와 API 서비스를 구현합니다.

## Related Issue

- Closes #73

## Changes

- TU 타입 재사용 (`InstructorRole`, `AssignmentStatus`, `InstructorAssignmentResponse`)
- TO 전용 Request 타입 정의 (4개)
- `instructorAssignmentService` 구현 (5개 메서드)
- `src/types/to/index.ts` - export 추가
- `src/services/to/index.ts` - export 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A (UI 변경 없음)

## Additional Notes

- Phase 1 (#71)에서 정의한 `API_ENDPOINTS.TIMES.INSTRUCTORS` 엔드포인트 사용
- TU의 `InstructorRole`, `AssignmentStatus` 타입을 재사용하여 중복 방지
- `forceAssign` 옵션으로 일정 충돌 무시 배정 지원