### PR TITLE
feat: TO 강사 배정(InstructorAssignment) React Query 훅 구현 (#74)

### DIFF
--- a/src/hooks/to/index.ts
+++ b/src/hooks/to/index.ts
@@ -1,1 +1,2 @@
 export * from './useTimeQueries';
+export * from './useInstructorAssignmentQueries';

--- a/src/hooks/to/useInstructorAssignmentQueries.ts
+++ b/src/hooks/to/useInstructorAssignmentQueries.ts
@@ -1,0 +1,142 @@
+/**
+ * TO(Tenant Operator) 강사 배정(InstructorAssignment) React Query Hooks
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { instructorAssignmentService } from '@/services/to';
+import { timeKeys } from './useTimeQueries';
+import type {
+  AssignInstructorRequest,
+  UpdateInstructorRoleRequest,
+  ReplaceInstructorRequest,
+  CancelAssignmentRequest,
+  InstructorAssignmentFilterParams,
+} from '@/types/to';
+
+// ============================================
+// Query Keys
+// ============================================
+
+export const instructorAssignmentKeys = {
+  all: ['instructorAssignments'] as const,
+  byTime: (timeId: number) => [...instructorAssignmentKeys.all, 'time', timeId] as const,
+  list: (timeId: number, params?: InstructorAssignmentFilterParams) =>
+    [...instructorAssignmentKeys.byTime(timeId), params] as const,
+};
+
+// ============================================
+// Query Hooks
+// ============================================
+
+/** 차수별 강사 목록 조회 */
+export const useTimeInstructors = (
+  timeId: number,
+  params?: InstructorAssignmentFilterParams
+) => {
+  return useQuery({
+    queryKey: instructorAssignmentKeys.list(timeId, params),
+    queryFn: () => instructorAssignmentService.getInstructors(timeId, params),
+    enabled: !!timeId,
+  });
+};
+
+// ============================================
+// Mutation Hooks
+// ============================================
+
+/** 강사 배정 */
+export const useAssignInstructor = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      timeId,
+      request,
+    }: {
+      timeId: number;
+      request: AssignInstructorRequest;
+    }) => instructorAssignmentService.assignInstructor(timeId, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: instructorAssignmentKeys.byTime(variables.timeId),
+      });
+      // CourseTimeDetailResponse.instructors 필드 갱신
+      queryClient.invalidateQueries({
+        queryKey: timeKeys.detail(variables.timeId),
+      });
+    },
+  });
+};
+
+/** 강사 역할 변경 */
+export const useUpdateInstructorRole = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      timeId,
+      assignmentId,
+      request,
+    }: {
+      timeId: number;
+      assignmentId: number;
+      request: UpdateInstructorRoleRequest;
+    }) => instructorAssignmentService.updateRole(timeId, assignmentId, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: instructorAssignmentKeys.byTime(variables.timeId),
+      });
+    },
+  });
+};
+
+/** 강사 교체 */
+export const useReplaceInstructor = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      timeId,
+      assignmentId,
+      request,
+    }: {
+      timeId: number;
+      assignmentId: number;
+      request: ReplaceInstructorRequest;
+    }) => instructorAssignmentService.replaceInstructor(timeId, assignmentId, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: instructorAssignmentKeys.byTime(variables.timeId),
+      });
+      // CourseTimeDetailResponse.instructors 필드 갱신
+      queryClient.invalidateQueries({
+        queryKey: timeKeys.detail(variables.timeId),
+      });
+    },
+  });
+};
+
+/** 배정 취소 */
+export const useCancelAssignment = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      timeId,
+      assignmentId,
+      request,
+    }: {
+      timeId: number;
+      assignmentId: number;
+      request?: CancelAssignmentRequest;
+    }) => instructorAssignmentService.cancelAssignment(timeId, assignmentId, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: instructorAssignmentKeys.byTime(variables.timeId),
+      });
+      // CourseTimeDetailResponse.instructors 필드 갱신
+      queryClient.invalidateQueries({
+        queryKey: timeKeys.detail(variables.timeId),
+      });
+    },
+  });
+};


### PR DESCRIPTION
## Summary

TO(Tenant Operator) 역할에서 강사 배정을 관리하기 위한 React Query 훅을 구현합니다.

## Related Issue

- Closes #74

## Changes

- `instructorAssignmentKeys` 쿼리 키 정의 (3개 키)
- Query Hooks 구현: `useTimeInstructors`
- Mutation Hooks 구현: `useAssignInstructor`, `useUpdateInstructorRole`, `useReplaceInstructor`, `useCancelAssignment`
- 교차 캐시 무효화: `instructorAssignmentKeys.byTime` + `timeKeys.detail` 동시 무효화
- `src/hooks/to/index.ts` - export 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A (UI 변경 없음)

## Additional Notes

- Phase 3 (#73)의 `instructorAssignmentService`를 기반으로 구현
- `CourseTimeDetailResponse.instructors` 필드 갱신을 위해 `timeKeys.detail` 캐시도 함께 무효화
- 기존 `useTimeQueries.ts` 패턴을 따라 구현