### PR TITLE
feat: TU 내 강의 배정(My Assignment) React Query 훅 구현

### DIFF
--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -66,3 +66,10 @@ export {
   useUpdateProgress,
   useMarkItemComplete,
 } from './useLearningPlayerQueries';
+
+// My Assignment Hooks
+export {
+  myAssignmentKeys,
+  useMyAssignments,
+  useMyInstructorStatistics,
+} from './useMyAssignmentQueries';

--- a/src/hooks/tu/useMyAssignmentQueries.ts
+++ b/src/hooks/tu/useMyAssignmentQueries.ts
@@ -1,0 +1,95 @@
+/**
+ * My Assignment React Query Hooks (TU - 강사 본인용)
+ */
+import { useQuery } from '@tanstack/react-query';
+import { useAuthStore } from '@/store/common/authStore';
+import { myAssignmentService } from '@/services/tu/myAssignmentService';
+
+// Query Keys
+export const myAssignmentKeys = {
+  all: ['my-assignments'] as const,
+  list: () => [...myAssignmentKeys.all, 'list'] as const,
+  statistics: (startDate?: string, endDate?: string) =>
+    [...myAssignmentKeys.all, 'statistics', { startDate, endDate }] as const,
+};
+
+/**
+ * 내 강사 배정 목록 조회 훅
+ *
+ * @description
+ * 현재 로그인한 사용자의 강사 배정 목록을 조회합니다.
+ * 인증된 사용자만 접근 가능합니다.
+ *
+ * @returns 강사 배정 목록
+ *
+ * @example
+ * ```tsx
+ * const { data: assignments, isLoading } = useMyAssignments();
+ *
+ * if (isLoading) return <div>로딩 중...</div>;
+ *
+ * return (
+ *   <div>
+ *     {assignments?.map(assignment => (
+ *       <div key={assignment.id}>
+ *         {assignment.userName} - {assignment.role}
+ *       </div>
+ *     ))}
+ *   </div>
+ * );
+ * ```
+ */
+export const useMyAssignments = () => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  return useQuery({
+    queryKey: myAssignmentKeys.list(),
+    queryFn: () => myAssignmentService.getMyAssignments(),
+    enabled: isAuthenticated,
+  });
+};
+
+/**
+ * 내 강사 통계 조회 훅
+ *
+ * @description
+ * 현재 로그인한 사용자의 강사 활동 통계를 조회합니다.
+ * 기간을 지정하지 않으면 전체 통계를 조회합니다.
+ *
+ * @param startDate - 시작일 (선택, YYYY-MM-DD)
+ * @param endDate - 종료일 (선택, YYYY-MM-DD)
+ * @returns 강사 통계 (총 배정 수, 역할별 배정 수, 차수별 통계)
+ *
+ * @example
+ * ```tsx
+ * // 전체 기간 통계
+ * const { data: stats } = useMyInstructorStatistics();
+ *
+ * // 특정 기간 통계
+ * const { data: stats } = useMyInstructorStatistics('2024-01-01', '2024-12-31');
+ *
+ * return (
+ *   <div>
+ *     <h2>총 배정: {stats?.totalCount}건</h2>
+ *     <p>주강사: {stats?.mainCount}건</p>
+ *     <p>보조강사: {stats?.subCount}건</p>
+ *     <ul>
+ *       {stats?.courseTimeStats.map(stat => (
+ *         <li key={stat.timeKey}>
+ *           {stat.courseName} - 수료율: {stat.completionRate}%
+ *         </li>
+ *       ))}
+ *     </ul>
+ *   </div>
+ * );
+ * ```
+ */
+export const useMyInstructorStatistics = (startDate?: string, endDate?: string) => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  return useQuery({
+    queryKey: myAssignmentKeys.statistics(startDate, endDate),
+    queryFn: () => myAssignmentService.getMyStatistics(startDate, endDate),
+    enabled: isAuthenticated,
+  });
+};


### PR DESCRIPTION
## Summary

내 강의 배정 데이터 조회를 위한 React Query 커스텀 훅을 구현했습니다.
Phase 1에서 구현한 API 서비스를 기반으로 강사 본인의 배정 목록 및 통계를 조회하는 Query 훅을 생성했습니다.

## Related Issue

- Closes #(이슈 번호)

## Changes

- `myAssignmentKeys` 쿼리 키 정의 (list, statistics)
- `useMyAssignments()` 훅 구현: 내 강사 배정 목록 조회
- `useMyInstructorStatistics(startDate?, endDate?)` 훅 구현: 강사 활동 통계 조회 (날짜 필터 지원)
- `src/hooks/tu/index.ts`에 export 추가
- JSDoc 주석 및 사용 예시 문서화 포함

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A (Query 훅만 구현, UI 변경 없음)

## Additional Notes

- Phase 1의 `myAssignmentService` 및 타입 정의와 연동되어 동작합니다
- 인증된 사용자만 접근 가능하도록 `isAuthenticated` 체크를 포함했습니다
- 통계 조회 시 날짜 파라미터를 통해 특정 기간의 통계를 조회할 수 있습니다
- React Query의 자동 캐싱 및 재검증 기능을 활용합니다