### PR TITLE
feat(tu): 내 배정 페이지 구현 (Phase 3)

### DIFF
--- a/src/components/domain/tu/assignment/AssignmentCard.tsx
+++ b/src/components/domain/tu/assignment/AssignmentCard.tsx
@@ -1,0 +1,62 @@
+/**
+ * 강사 배정 카드 컴포넌트
+ */
+import { Calendar, Clock } from 'lucide-react';
+import { InstructorRoleBadge } from './InstructorRoleBadge';
+import { AssignmentStatusBadge } from './AssignmentStatusBadge';
+import type { InstructorAssignmentResponse } from '@/types/tu';
+
+interface AssignmentCardProps {
+  assignment: InstructorAssignmentResponse;
+  language?: 'ko' | 'en';
+  onClick?: () => void;
+}
+
+const t = {
+  assignedAt: { ko: '배정일', en: 'Assigned' },
+  courseTime: { ko: '차수', en: 'Session' },
+};
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+}
+
+export function AssignmentCard({
+  assignment,
+  language = 'ko',
+  onClick,
+}: Readonly<AssignmentCardProps>) {
+  const getText = (key: keyof typeof t) => t[key][language];
+
+  return (
+    <div
+      onClick={onClick}
+      className="p-4 bg-bg-default border border-border rounded-lg hover:border-border-hover hover:shadow-sm transition-all cursor-pointer"
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <InstructorRoleBadge role={assignment.role} language={language} />
+          <AssignmentStatusBadge status={assignment.status} language={language} />
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 text-sm text-text-secondary">
+          <Clock size={14} />
+          <span>{getText('courseTime')} ID: {assignment.timeId}</span>
+        </div>
+        <div className="flex items-center gap-2 text-sm text-text-secondary">
+          <Calendar size={14} />
+          <span>{getText('assignedAt')}: {formatDate(assignment.assignedAt)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/domain/tu/assignment/AssignmentStatsCard.tsx
+++ b/src/components/domain/tu/assignment/AssignmentStatsCard.tsx
@@ -1,0 +1,47 @@
+/**
+ * 강사 배정 통계 카드 컴포넌트
+ */
+import { Users, UserCheck, UserMinus } from 'lucide-react';
+import { IconStatCard } from '@/components/common';
+
+interface AssignmentStatsCardProps {
+  totalCount: number;
+  mainCount: number;
+  subCount: number;
+  language?: 'ko' | 'en';
+}
+
+const t = {
+  totalAssignments: { ko: '총 배정', en: 'Total Assignments' },
+  mainInstructor: { ko: '주강사', en: 'Main Instructor' },
+  subInstructor: { ko: '보조강사', en: 'Sub Instructor' },
+};
+
+export function AssignmentStatsCard({
+  totalCount,
+  mainCount,
+  subCount,
+  language = 'ko',
+}: Readonly<AssignmentStatsCardProps>) {
+  const getText = (key: keyof typeof t) => t[key][language];
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <IconStatCard
+        icon={<Users size={20} />}
+        label={getText('totalAssignments')}
+        value={totalCount}
+      />
+      <IconStatCard
+        icon={<UserCheck size={20} />}
+        label={getText('mainInstructor')}
+        value={mainCount}
+      />
+      <IconStatCard
+        icon={<UserMinus size={20} />}
+        label={getText('subInstructor')}
+        value={subCount}
+      />
+    </div>
+  );
+}

--- a/src/components/domain/tu/assignment/AssignmentStatusBadge.tsx
+++ b/src/components/domain/tu/assignment/AssignmentStatusBadge.tsx
@@ -1,0 +1,33 @@
+/**
+ * 배정 상태 Badge 컴포넌트
+ */
+import { Badge } from '@/components/common';
+import type { AssignmentStatus } from '@/types/tu';
+import { ASSIGNMENT_STATUS_LABELS } from '@/types/tu';
+
+interface AssignmentStatusBadgeProps {
+  status: AssignmentStatus;
+  language?: 'ko' | 'en';
+  className?: string;
+}
+
+const statusVariantMap: Record<AssignmentStatus, 'success' | 'warning' | 'error'> = {
+  ACTIVE: 'success',
+  REPLACED: 'warning',
+  CANCELLED: 'error',
+};
+
+export function AssignmentStatusBadge({
+  status,
+  language = 'ko',
+  className,
+}: Readonly<AssignmentStatusBadgeProps>) {
+  const label = ASSIGNMENT_STATUS_LABELS[status][language];
+  const variant = statusVariantMap[status];
+
+  return (
+    <Badge variant={variant} className={className}>
+      {label}
+    </Badge>
+  );
+}

--- a/src/components/domain/tu/assignment/CourseTimeStatCard.tsx
+++ b/src/components/domain/tu/assignment/CourseTimeStatCard.tsx
@@ -1,0 +1,71 @@
+/**
+ * 차수별 통계 카드 컴포넌트
+ */
+import { Users, CheckCircle, TrendingUp } from 'lucide-react';
+import { InstructorRoleBadge } from './InstructorRoleBadge';
+import type { CourseTimeStatResponse } from '@/types/tu';
+
+interface CourseTimeStatCardProps {
+  stat: CourseTimeStatResponse;
+  language?: 'ko' | 'en';
+}
+
+const t = {
+  totalStudents: { ko: '총 수강생', en: 'Total Students' },
+  completedStudents: { ko: '수료', en: 'Completed' },
+  completionRate: { ko: '수료율', en: 'Completion Rate' },
+  noData: { ko: '데이터 없음', en: 'No data' },
+};
+
+export function CourseTimeStatCard({
+  stat,
+  language = 'ko',
+}: Readonly<CourseTimeStatCardProps>) {
+  const getText = (key: keyof typeof t) => t[key][language];
+
+  return (
+    <div className="p-4 bg-bg-default border border-border rounded-lg">
+      {/* Header */}
+      <div className="flex items-start justify-between mb-3">
+        <div>
+          <h4 className="text-sm font-medium text-text-primary mb-1">
+            {stat.courseName}
+          </h4>
+          <p className="text-xs text-text-secondary">{stat.timeName}</p>
+        </div>
+        <InstructorRoleBadge role={stat.role} language={language} />
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-2 mt-3 pt-3 border-t border-border">
+        <div className="text-center">
+          <div className="flex items-center justify-center gap-1 text-text-secondary mb-1">
+            <Users size={12} />
+          </div>
+          <p className="text-sm font-medium text-text-primary">
+            {stat.totalStudents ?? getText('noData')}
+          </p>
+          <p className="text-xs text-text-secondary">{getText('totalStudents')}</p>
+        </div>
+        <div className="text-center">
+          <div className="flex items-center justify-center gap-1 text-text-secondary mb-1">
+            <CheckCircle size={12} />
+          </div>
+          <p className="text-sm font-medium text-text-primary">
+            {stat.completedStudents ?? getText('noData')}
+          </p>
+          <p className="text-xs text-text-secondary">{getText('completedStudents')}</p>
+        </div>
+        <div className="text-center">
+          <div className="flex items-center justify-center gap-1 text-text-secondary mb-1">
+            <TrendingUp size={12} />
+          </div>
+          <p className="text-sm font-medium text-text-primary">
+            {stat.completionRate != null ? `${stat.completionRate}%` : getText('noData')}
+          </p>
+          <p className="text-xs text-text-secondary">{getText('completionRate')}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/domain/tu/assignment/InstructorRoleBadge.tsx
+++ b/src/components/domain/tu/assignment/InstructorRoleBadge.tsx
@@ -1,0 +1,33 @@
+/**
+ * 강사 역할 Badge 컴포넌트
+ */
+import { Badge } from '@/components/common';
+import type { InstructorRole } from '@/types/tu';
+import { INSTRUCTOR_ROLE_LABELS } from '@/types/tu';
+
+interface InstructorRoleBadgeProps {
+  role: InstructorRole;
+  language?: 'ko' | 'en';
+  className?: string;
+}
+
+const roleVariantMap: Record<InstructorRole, 'blue' | 'purple' | 'gray'> = {
+  MAIN: 'blue',
+  SUB: 'purple',
+  ASSISTANT: 'gray',
+};
+
+export function InstructorRoleBadge({
+  role,
+  language = 'ko',
+  className,
+}: Readonly<InstructorRoleBadgeProps>) {
+  const label = INSTRUCTOR_ROLE_LABELS[role][language];
+  const variant = roleVariantMap[role];
+
+  return (
+    <Badge variant={variant} className={className}>
+      {label}
+    </Badge>
+  );
+}

--- a/src/components/domain/tu/assignment/index.ts
+++ b/src/components/domain/tu/assignment/index.ts
@@ -1,0 +1,5 @@
+export { InstructorRoleBadge } from './InstructorRoleBadge';
+export { AssignmentStatusBadge } from './AssignmentStatusBadge';
+export { AssignmentStatsCard } from './AssignmentStatsCard';
+export { AssignmentCard } from './AssignmentCard';
+export { CourseTimeStatCard } from './CourseTimeStatCard';

--- a/src/pages/tu/index.ts
+++ b/src/pages/tu/index.ts
@@ -1,4 +1,4 @@
-export { MyCoursesPage, MyContentPage, CourseCreatePage, TuContentCreatePage, ContentDetailPage } from './teaching';
+export { MyCoursesPage, MyContentPage, CourseCreatePage, TuContentCreatePage, ContentDetailPage, MyAssignmentsPage } from './teaching';
 export { SettingsLanguagePage } from './settings';
 export { LandingPage, Page1, Page2, Page3 } from './main';
 export { CatalogPage, CatalogDetailPage } from './catalog';

--- a/src/pages/tu/teaching/assignments/MyAssignmentsPage.tsx
+++ b/src/pages/tu/teaching/assignments/MyAssignmentsPage.tsx
@@ -1,0 +1,178 @@
+/**
+ * 내 배정 페이지 (TU - 강사 본인용)
+ */
+import { useState } from 'react';
+import { Loader2, CalendarDays, FileText } from 'lucide-react';
+import { Button } from '@/components/common';
+import { useMyAssignments, useMyInstructorStatistics } from '@/hooks/tu';
+import {
+  AssignmentStatsCard,
+  AssignmentCard,
+  CourseTimeStatCard,
+} from '@/components/domain/tu/assignment';
+import type { AssignmentStatus } from '@/types/tu';
+
+// [DEV] 임시 로그인 버튼 - TODO: 실제 로그인 구현 후 삭제
+import { DevLoginButton } from '@/components/dev/DevLoginButton';
+
+interface MyAssignmentsPageProps {
+  language?: 'ko' | 'en';
+}
+
+const t = {
+  title: { ko: '내 배정', en: 'My Assignments' },
+  subtitle: { ko: '배정된 강의와 통계를 확인하세요.', en: 'View your assigned courses and statistics.' },
+  loading: { ko: '로딩 중...', en: 'Loading...' },
+  error: { ko: '오류가 발생했습니다.', en: 'An error occurred.' },
+  noAssignments: { ko: '배정된 강의가 없습니다.', en: 'No assignments found.' },
+  noAssignmentsDesc: { ko: '아직 배정된 강의가 없습니다.', en: 'You have no assigned courses yet.' },
+  myAssignments: { ko: '내 배정 목록', en: 'My Assignments' },
+  courseStats: { ko: '차수별 통계', en: 'Course Statistics' },
+  filterAll: { ko: '전체', en: 'All' },
+  filterActive: { ko: '활동 중', en: 'Active' },
+  filterReplaced: { ko: '교체됨', en: 'Replaced' },
+  filterCancelled: { ko: '취소됨', en: 'Cancelled' },
+  assignmentCount: { ko: '건', en: ' items' },
+};
+
+type StatusFilter = AssignmentStatus | 'all';
+
+export function MyAssignmentsPage({ language = 'ko' }: Readonly<MyAssignmentsPageProps>) {
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+
+  const getText = (key: keyof typeof t) => t[key][language];
+
+  // React Query hooks
+  const { data: assignments, isLoading: assignmentsLoading, error: assignmentsError } = useMyAssignments();
+  const { data: statistics, isLoading: statsLoading } = useMyInstructorStatistics();
+
+  const isLoading = assignmentsLoading || statsLoading;
+  const error = assignmentsError;
+
+  // 필터링된 배정 목록
+  const filteredAssignments = assignments?.filter((assignment) => {
+    if (statusFilter === 'all') return true;
+    return assignment.status === statusFilter;
+  }) ?? [];
+
+  // 에러 상태
+  if (error) {
+    return (
+      <div className="h-full flex items-center justify-center bg-bg-app">
+        <div className="text-center">
+          <FileText size={48} className="mx-auto mb-3 text-text-placeholder" />
+          <p className="text-text-secondary">{getText('error')}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col bg-bg-app">
+      {/* Header */}
+      <div className="sticky top-0 z-10 bg-bg-app">
+        <div className="p-6 px-8">
+          {/* [DEV] 임시 로그인 버튼 */}
+          <DevLoginButton />
+
+          <div className="mb-6">
+            <h1 className="text-text-primary mb-1">{getText('title')}</h1>
+            <p className="text-text-secondary text-sm m-0">{getText('subtitle')}</p>
+          </div>
+
+          {/* 통계 카드 */}
+          {!isLoading && statistics && (
+            <AssignmentStatsCard
+              totalCount={statistics.totalCount}
+              mainCount={statistics.mainCount}
+              subCount={statistics.subCount}
+              language={language}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto">
+        <div className="p-6 px-8 pt-0">
+          {/* 로딩 상태 */}
+          {isLoading && (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 size={32} className="animate-spin text-text-secondary" />
+              <span className="ml-2 text-text-secondary">{getText('loading')}</span>
+            </div>
+          )}
+
+          {/* 배정 목록 섹션 */}
+          {!isLoading && (
+            <>
+              {/* 필터 */}
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-lg font-medium text-text-primary">
+                  {getText('myAssignments')}
+                </h2>
+                <div className="flex gap-2">
+                  {(['all', 'ACTIVE', 'REPLACED', 'CANCELLED'] as const).map((status) => (
+                    <Button
+                      key={status}
+                      variant={statusFilter === status ? 'neutral' : 'ghost'}
+                      size="sm"
+                      onClick={() => setStatusFilter(status)}
+                    >
+                      {status === 'all' ? getText('filterAll') : getText(`filter${status.charAt(0) + status.slice(1).toLowerCase()}` as keyof typeof t)}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+
+              {/* 배정 개수 */}
+              <p className="text-sm text-text-secondary mb-4">
+                {filteredAssignments.length}{getText('assignmentCount')}
+              </p>
+
+              {/* 빈 상태 */}
+              {filteredAssignments.length === 0 && (
+                <div className="text-center py-12">
+                  <CalendarDays size={48} className="mx-auto mb-3 text-text-placeholder" />
+                  <p className="text-text-secondary mb-1">{getText('noAssignments')}</p>
+                  <p className="text-sm text-text-placeholder">{getText('noAssignmentsDesc')}</p>
+                </div>
+              )}
+
+              {/* 배정 카드 그리드 */}
+              {filteredAssignments.length > 0 && (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+                  {filteredAssignments.map((assignment) => (
+                    <AssignmentCard
+                      key={assignment.id}
+                      assignment={assignment}
+                      language={language}
+                    />
+                  ))}
+                </div>
+              )}
+
+              {/* 차수별 통계 섹션 */}
+              {statistics && statistics.courseTimeStats.length > 0 && (
+                <>
+                  <h2 className="text-lg font-medium text-text-primary mb-4">
+                    {getText('courseStats')}
+                  </h2>
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                    {statistics.courseTimeStats.map((stat) => (
+                      <CourseTimeStatCard
+                        key={stat.timeKey}
+                        stat={stat}
+                        language={language}
+                      />
+                    ))}
+                  </div>
+                </>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/teaching/assignments/index.ts
+++ b/src/pages/tu/teaching/assignments/index.ts
@@ -1,0 +1,1 @@
+export { MyAssignmentsPage } from './MyAssignmentsPage';

--- a/src/pages/tu/teaching/index.ts
+++ b/src/pages/tu/teaching/index.ts
@@ -1,2 +1,3 @@
 export { MyCoursesPage, CourseCreatePage } from './courses';
 export { MyContentPage, ContentCreatePage as TuContentCreatePage, ContentDetailPage } from './content';
+export { MyAssignmentsPage } from './assignments';

--- a/src/routes/tu.courses.routes.tsx
+++ b/src/routes/tu.courses.routes.tsx
@@ -8,6 +8,7 @@ import {
   TuContentCreatePage,
   ContentDetailPage,
   SettingsLanguagePage,
+  MyAssignmentsPage,
 } from '@/pages/tu';
 import {
   SettingsPage,
@@ -38,7 +39,7 @@ export const tuCoursesRoutes = (
     <Route path="teaching/content" element={<MyContentPage />} />
     <Route path="teaching/content/create" element={<TuContentCreatePage />} />
     <Route path="teaching/content/:id" element={<ContentDetailPage />} />
-    <Route path="teaching/assignments" element={<PlaceholderPage title="내 과제" />} />
+    <Route path="teaching/assignments" element={<MyAssignmentsPage />} />
 
     {/* 교육 과정 탐색 */}
     <Route path="catalog" element={<PlaceholderPage title="과정 둘러보기" />} />


### PR DESCRIPTION
## Summary

TU(강사) 역할의 "내 배정" 페이지 및 관련 컴포넌트 구현

## Related Issue

- Closes #64

## Changes

- `src/components/domain/tu/assignment/` 컴포넌트 추가
  - InstructorRoleBadge: 강사 역할 배지
  - AssignmentStatusBadge: 배정 상태 배지
  - AssignmentStatsCard: 통계 카드
  - AssignmentCard: 배정 정보 카드
  - CourseTimeStatCard: 차수별 통계 카드
- `src/pages/tu/teaching/assignments/MyAssignmentsPage.tsx` 페이지 추가
- `src/routes/tu.courses.routes.tsx` 라우트 연결
- `src/pages/tu/teaching/index.ts`, `src/pages/tu/index.ts` export 추가

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

- Phase 1 (타입/서비스), Phase 2 (React Query Hooks)에 이어 Phase 3 구현 완료
- 기능: 배정 목록 조회, 상태별 필터링, 통계 카드, 차수별 통계, 빈 상태/로딩/에러 처리, 다국어 지원