### PR TITLE
feat: SA/TA 공통 컴포넌트 및 타입 추가 (#97)

### DIFF
--- a/src/components/domain/admin/AdminPageHeader.tsx
+++ b/src/components/domain/admin/AdminPageHeader.tsx
@@ -1,0 +1,76 @@
+import { type LucideIcon } from 'lucide-react';
+import { Button } from '@/components/common/Button';
+
+interface AdminPageHeaderProps {
+  title: string;
+  description?: string;
+  actions?: {
+    label: string;
+    icon?: LucideIcon;
+    onClick: () => void;
+    variant?: 'default' | 'outline' | 'secondary' | 'ghost' | 'destructive';
+  }[];
+  breadcrumb?: {
+    label: string;
+    href?: string;
+  }[];
+}
+
+export function AdminPageHeader({
+  title,
+  description,
+  actions,
+  breadcrumb,
+}: AdminPageHeaderProps) {
+  return (
+    <div className="mb-6">
+      {/* Breadcrumb */}
+      {breadcrumb && breadcrumb.length > 0 && (
+        <nav className="mb-2">
+          <ol className="flex items-center gap-2 text-sm text-text-secondary">
+            {breadcrumb.map((item, index) => (
+              <li key={index} className="flex items-center gap-2">
+                {index > 0 && <span>/</span>}
+                {item.href ? (
+                  <a href={item.href} className="hover:text-text-primary">
+                    {item.label}
+                  </a>
+                ) : (
+                  <span className="text-text-primary">{item.label}</span>
+                )}
+              </li>
+            ))}
+          </ol>
+        </nav>
+      )}
+
+      {/* Title and Actions */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">{title}</h1>
+          {description && (
+            <p className="text-text-secondary mt-1">{description}</p>
+          )}
+        </div>
+
+        {actions && actions.length > 0 && (
+          <div className="flex items-center gap-2">
+            {actions.map((action, index) => {
+              const Icon = action.icon;
+              return (
+                <Button
+                  key={index}
+                  variant={action.variant || 'default'}
+                  onClick={action.onClick}
+                >
+                  {Icon && <Icon className="w-4 h-4 mr-2" />}
+                  {action.label}
+                </Button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/domain/admin/AdminStatsCard.tsx
+++ b/src/components/domain/admin/AdminStatsCard.tsx
@@ -1,0 +1,107 @@
+import { type LucideIcon } from 'lucide-react';
+import { Card, CardContent } from '@/components/common/Card';
+import { cn } from '@/utils/cn';
+
+interface AdminStatsCardProps {
+  title: string;
+  value: string | number;
+  subtitle?: string;
+  icon: LucideIcon;
+  trend?: {
+    value: number;
+    label: string;
+  };
+  variant?: 'default' | 'primary' | 'success' | 'warning' | 'error';
+  className?: string;
+}
+
+const variantStyles = {
+  default: {
+    iconBg: 'bg-bg-secondary',
+    iconColor: 'text-text-secondary',
+  },
+  primary: {
+    iconBg: 'bg-brand-primary/10',
+    iconColor: 'text-brand-primary',
+  },
+  success: {
+    iconBg: 'bg-status-success/10',
+    iconColor: 'text-status-success',
+  },
+  warning: {
+    iconBg: 'bg-status-warning/10',
+    iconColor: 'text-status-warning',
+  },
+  error: {
+    iconBg: 'bg-status-error/10',
+    iconColor: 'text-status-error',
+  },
+};
+
+export function AdminStatsCard({
+  title,
+  value,
+  subtitle,
+  icon: Icon,
+  trend,
+  variant = 'default',
+  className,
+}: AdminStatsCardProps) {
+  const styles = variantStyles[variant];
+
+  return (
+    <Card className={cn('overflow-hidden', className)}>
+      <CardContent className="p-6">
+        <div className="flex items-start justify-between">
+          <div className="flex-1">
+            <p className="text-sm font-medium text-text-secondary">{title}</p>
+            <p className="text-3xl font-bold mt-2">{value}</p>
+            {subtitle && (
+              <p className="text-sm text-text-secondary mt-1">{subtitle}</p>
+            )}
+            {trend && (
+              <p
+                className={cn(
+                  'text-sm mt-2 flex items-center gap-1',
+                  trend.value > 0 ? 'text-status-success' : trend.value < 0 ? 'text-status-error' : 'text-text-secondary'
+                )}
+              >
+                <span>{trend.value > 0 ? '+' : ''}{trend.value}%</span>
+                <span className="text-text-secondary">{trend.label}</span>
+              </p>
+            )}
+          </div>
+          <div
+            className={cn(
+              'w-12 h-12 rounded-lg flex items-center justify-center',
+              styles.iconBg
+            )}
+          >
+            <Icon className={cn('w-6 h-6', styles.iconColor)} />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// 그리드 레이아웃 컴포넌트
+interface AdminStatsGridProps {
+  children: React.ReactNode;
+  columns?: 2 | 3 | 4;
+  className?: string;
+}
+
+export function AdminStatsGrid({ children, columns = 4, className }: AdminStatsGridProps) {
+  const gridCols = {
+    2: 'grid-cols-1 md:grid-cols-2',
+    3: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
+    4: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4',
+  };
+
+  return (
+    <div className={cn('grid gap-4', gridCols[columns], className)}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/domain/admin/RecentItemsList.tsx
+++ b/src/components/domain/admin/RecentItemsList.tsx
@@ -1,0 +1,83 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/common/Card';
+import { cn } from '@/utils/cn';
+
+interface RecentItem {
+  id: string | number;
+  title: string;
+  subtitle?: string;
+  timestamp: string;
+  badge?: React.ReactNode;
+  avatar?: React.ReactNode;
+}
+
+interface RecentItemsListProps {
+  title: string;
+  items: RecentItem[];
+  emptyMessage?: string;
+  onItemClick?: (id: string | number) => void;
+  viewAllLink?: string;
+  className?: string;
+}
+
+export function RecentItemsList({
+  title,
+  items,
+  emptyMessage = '항목이 없습니다.',
+  onItemClick,
+  viewAllLink,
+  className,
+}: RecentItemsListProps) {
+  return (
+    <Card className={className}>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardTitle className="text-lg font-semibold">{title}</CardTitle>
+        {viewAllLink && (
+          <a
+            href={viewAllLink}
+            className="text-sm text-brand-primary hover:underline"
+          >
+            전체 보기
+          </a>
+        )}
+      </CardHeader>
+      <CardContent>
+        {items.length === 0 ? (
+          <p className="text-center text-text-secondary py-8">{emptyMessage}</p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {items.map((item) => (
+              <li
+                key={item.id}
+                className={cn(
+                  'py-3 first:pt-0 last:pb-0',
+                  onItemClick && 'cursor-pointer hover:bg-bg-secondary rounded-lg px-2 -mx-2 transition-colors'
+                )}
+                onClick={() => onItemClick?.(item.id)}
+              >
+                <div className="flex items-center gap-3">
+                  {item.avatar && (
+                    <div className="flex-shrink-0">{item.avatar}</div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium truncate">{item.title}</p>
+                    {item.subtitle && (
+                      <p className="text-sm text-text-secondary truncate">
+                        {item.subtitle}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    {item.badge}
+                    <span className="text-xs text-text-secondary">
+                      {item.timestamp}
+                    </span>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/domain/admin/RoleBadge.tsx
+++ b/src/components/domain/admin/RoleBadge.tsx
@@ -1,0 +1,75 @@
+import { Badge } from '@/components/common/Badge';
+
+// 배지 variant 타입
+type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline' | 'success' | 'warning' | 'error' | 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'indigo' | 'purple' | 'gray';
+
+// 시스템 역할
+export type SystemRole = 'SUPER_ADMIN' | 'TENANT_ADMIN' | 'OPERATOR' | 'USER';
+
+// 강의 역할
+export type CourseRole = 'DESIGNER' | 'OWNER' | 'INSTRUCTOR' | 'TUTOR' | 'VIEWER';
+
+interface RoleBadgeProps {
+  role: SystemRole | CourseRole;
+  className?: string;
+}
+
+const systemRoleConfig: Record<
+  SystemRole,
+  { label: { ko: string; en: string }; variant: BadgeVariant }
+> = {
+  SUPER_ADMIN: { label: { ko: '슈퍼 관리자', en: 'Super Admin' }, variant: 'purple' },
+  TENANT_ADMIN: { label: { ko: '테넌트 관리자', en: 'Tenant Admin' }, variant: 'indigo' },
+  OPERATOR: { label: { ko: '운영자', en: 'Operator' }, variant: 'blue' },
+  USER: { label: { ko: '사용자', en: 'User' }, variant: 'gray' },
+};
+
+const courseRoleConfig: Record<
+  CourseRole,
+  { label: { ko: string; en: string }; variant: BadgeVariant }
+> = {
+  DESIGNER: { label: { ko: '설계자', en: 'Designer' }, variant: 'orange' },
+  OWNER: { label: { ko: '소유자', en: 'Owner' }, variant: 'green' },
+  INSTRUCTOR: { label: { ko: '강사', en: 'Instructor' }, variant: 'blue' },
+  TUTOR: { label: { ko: '튜터', en: 'Tutor' }, variant: 'indigo' },
+  VIEWER: { label: { ko: '열람자', en: 'Viewer' }, variant: 'gray' },
+};
+
+export function RoleBadge({ role, className }: RoleBadgeProps) {
+  const isSystemRole = role in systemRoleConfig;
+  const config = isSystemRole
+    ? systemRoleConfig[role as SystemRole]
+    : courseRoleConfig[role as CourseRole];
+
+  // TODO: language store 연동
+  const language = 'ko';
+
+  return (
+    <Badge variant={config.variant} className={className}>
+      {config.label[language]}
+    </Badge>
+  );
+}
+
+// 여러 역할을 표시하는 컴포넌트
+interface RoleBadgeListProps {
+  roles: (SystemRole | CourseRole)[];
+  className?: string;
+  maxDisplay?: number;
+}
+
+export function RoleBadgeList({ roles, className, maxDisplay = 3 }: RoleBadgeListProps) {
+  const displayRoles = roles.slice(0, maxDisplay);
+  const remainingCount = roles.length - maxDisplay;
+
+  return (
+    <div className={`flex flex-wrap gap-1 ${className}`}>
+      {displayRoles.map((role) => (
+        <RoleBadge key={role} role={role} />
+      ))}
+      {remainingCount > 0 && (
+        <Badge variant="gray">+{remainingCount}</Badge>
+      )}
+    </div>
+  );
+}

--- a/src/components/domain/admin/StatusBadge.tsx
+++ b/src/components/domain/admin/StatusBadge.tsx
@@ -1,0 +1,66 @@
+import { Badge } from '@/components/common/Badge';
+
+// 배지 variant 타입
+type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline' | 'success' | 'warning' | 'error' | 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'indigo' | 'purple' | 'gray';
+
+// 테넌트 상태
+export type TenantStatus = 'ACTIVE' | 'INACTIVE' | 'SUSPENDED' | 'PENDING';
+
+// 사용자 상태
+export type UserStatus = 'ACTIVE' | 'INACTIVE' | 'PENDING' | 'BLOCKED';
+
+// 플랜 타입
+export type PlanType = 'BASIC' | 'PRO' | 'ENTERPRISE';
+
+interface StatusBadgeProps {
+  status: TenantStatus | UserStatus;
+  className?: string;
+}
+
+const statusConfig: Record<
+  TenantStatus | UserStatus,
+  { label: { ko: string; en: string }; variant: BadgeVariant }
+> = {
+  ACTIVE: { label: { ko: '활성', en: 'Active' }, variant: 'success' },
+  INACTIVE: { label: { ko: '비활성', en: 'Inactive' }, variant: 'gray' },
+  SUSPENDED: { label: { ko: '정지', en: 'Suspended' }, variant: 'error' },
+  PENDING: { label: { ko: '대기', en: 'Pending' }, variant: 'warning' },
+  BLOCKED: { label: { ko: '차단', en: 'Blocked' }, variant: 'error' },
+};
+
+export function StatusBadge({ status, className }: StatusBadgeProps) {
+  const config = statusConfig[status];
+  // TODO: language store 연동
+  const language = 'ko';
+
+  return (
+    <Badge variant={config.variant} className={className}>
+      {config.label[language]}
+    </Badge>
+  );
+}
+
+// 플랜 배지
+interface PlanBadgeProps {
+  plan: PlanType;
+  className?: string;
+}
+
+const planConfig: Record<
+  PlanType,
+  { label: string; variant: BadgeVariant }
+> = {
+  BASIC: { label: 'Basic', variant: 'gray' },
+  PRO: { label: 'Pro', variant: 'blue' },
+  ENTERPRISE: { label: 'Enterprise', variant: 'purple' },
+};
+
+export function PlanBadge({ plan, className }: PlanBadgeProps) {
+  const config = planConfig[plan];
+
+  return (
+    <Badge variant={config.variant} className={className}>
+      {config.label}
+    </Badge>
+  );
+}

--- a/src/components/domain/admin/index.ts
+++ b/src/components/domain/admin/index.ts
@@ -1,0 +1,6 @@
+// Admin domain components
+export { StatusBadge, PlanBadge, type TenantStatus, type UserStatus, type PlanType } from './StatusBadge';
+export { RoleBadge, RoleBadgeList, type SystemRole, type CourseRole } from './RoleBadge';
+export { AdminStatsCard, AdminStatsGrid } from './AdminStatsCard';
+export { AdminPageHeader } from './AdminPageHeader';
+export { RecentItemsList } from './RecentItemsList';

--- a/src/types/admin/dashboard.types.ts
+++ b/src/types/admin/dashboard.types.ts
@@ -1,0 +1,60 @@
+/**
+ * 어드민 대시보드 관련 타입 정의
+ */
+
+import type { TenantStats, Tenant } from './tenant.types';
+import type { UserStats } from './user.types';
+
+// SA 대시보드 응답
+export interface SADashboardResponse {
+  tenantStats: TenantStats;
+  userStats: {
+    totalUsers: number;
+    activeToday: number;
+  };
+  recentTenants: Tenant[];
+  systemHealth: SystemHealth;
+}
+
+export interface SystemHealth {
+  status: 'healthy' | 'degraded' | 'down';
+  uptime: string;
+  cpuUsage: number;
+  memoryUsage: number;
+  diskUsage: number;
+}
+
+// TA 대시보드 응답
+export interface TADashboardResponse {
+  userStats: UserStats;
+  courseStats: CourseStats;
+  enrollmentStats: EnrollmentStats;
+  recentActivities: RecentActivity[];
+}
+
+export interface CourseStats {
+  total: number;
+  published: number;
+  draft: number;
+  archived: number;
+  totalEnrollments: number;
+}
+
+export interface EnrollmentStats {
+  total: number;
+  inProgress: number;
+  completed: number;
+  avgCompletionRate: number;
+  completionsThisMonth: number;
+}
+
+export interface RecentActivity {
+  id: number;
+  type: 'USER_JOINED' | 'COURSE_CREATED' | 'ENROLLMENT' | 'COURSE_COMPLETED' | 'ROLE_CHANGED';
+  userId: number;
+  userName: string;
+  description: string;
+  targetId?: number;
+  targetName?: string;
+  createdAt: string;
+}

--- a/src/types/admin/index.ts
+++ b/src/types/admin/index.ts
@@ -1,0 +1,4 @@
+// Admin types
+export * from './tenant.types';
+export * from './user.types';
+export * from './dashboard.types';

--- a/src/types/admin/tenant.types.ts
+++ b/src/types/admin/tenant.types.ts
@@ -1,0 +1,86 @@
+/**
+ * 테넌트 관련 타입 정의
+ */
+
+export type TenantStatus = 'ACTIVE' | 'INACTIVE' | 'SUSPENDED' | 'PENDING';
+export type TenantType = 'B2C' | 'B2B';
+export type PlanType = 'BASIC' | 'PRO' | 'ENTERPRISE';
+
+export interface Tenant {
+  id: number;
+  code: string;
+  name: string;
+  type: TenantType;
+  status: TenantStatus;
+  plan: PlanType;
+  subdomain: string;
+  customDomain?: string;
+  logoUrl?: string;
+  primaryColor?: string;
+  userCount?: number;
+  courseCount?: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TenantBranding {
+  tenantId: number;
+  logoUrl?: string;
+  faviconUrl?: string;
+  primaryColor: string;
+  secondaryColor?: string;
+  fontFamily?: string;
+}
+
+export interface TenantSettings {
+  tenantId: number;
+  allowSelfRegistration: boolean;
+  requireEmailVerification: boolean;
+  defaultLanguage: 'ko' | 'en';
+  timezone: string;
+  maxStorageGB: number;
+  maxUsersCount: number;
+}
+
+// Request/Response types
+export interface CreateTenantRequest {
+  code: string;
+  name: string;
+  type: TenantType;
+  plan: PlanType;
+  subdomain: string;
+  adminEmail: string;
+  adminName: string;
+}
+
+export interface UpdateTenantRequest {
+  name?: string;
+  status?: TenantStatus;
+  plan?: PlanType;
+  customDomain?: string;
+}
+
+export interface TenantListResponse {
+  content: Tenant[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+}
+
+// Dashboard stats
+export interface TenantStats {
+  total: number;
+  active: number;
+  inactive: number;
+  suspended: number;
+  byPlan: {
+    BASIC: number;
+    PRO: number;
+    ENTERPRISE: number;
+  };
+  byType: {
+    B2C: number;
+    B2B: number;
+  };
+}

--- a/src/types/admin/user.types.ts
+++ b/src/types/admin/user.types.ts
@@ -1,0 +1,77 @@
+/**
+ * 어드민 사용자 관리 관련 타입 정의
+ */
+
+export type UserStatus = 'ACTIVE' | 'INACTIVE' | 'PENDING' | 'BLOCKED';
+export type SystemRole = 'SUPER_ADMIN' | 'TENANT_ADMIN' | 'OPERATOR' | 'USER';
+export type CourseRole = 'DESIGNER' | 'OWNER' | 'INSTRUCTOR' | 'TUTOR' | 'VIEWER';
+
+export interface AdminUser {
+  id: number;
+  email: string;
+  name: string;
+  profileImageUrl?: string;
+  status: UserStatus;
+  systemRole: SystemRole;
+  courseRoles: CourseRoleAssignment[];
+  tenantId: number;
+  organizationId?: number;
+  organizationName?: string;
+  lastLoginAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CourseRoleAssignment {
+  id: number;
+  userId: number;
+  courseId: number;
+  courseName: string;
+  role: CourseRole;
+  assignedAt: string;
+  assignedBy: number;
+}
+
+// Request/Response types
+export interface UpdateUserRoleRequest {
+  systemRole: SystemRole;
+}
+
+export interface AssignCourseRoleRequest {
+  courseId: number;
+  role: CourseRole;
+}
+
+export interface UserListParams {
+  page?: number;
+  size?: number;
+  status?: UserStatus;
+  systemRole?: SystemRole;
+  search?: string;
+  sortBy?: string;
+  sortDirection?: 'asc' | 'desc';
+}
+
+export interface UserListResponse {
+  content: AdminUser[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+}
+
+// Dashboard stats
+export interface UserStats {
+  total: number;
+  active: number;
+  inactive: number;
+  pending: number;
+  blocked: number;
+  byRole: {
+    TENANT_ADMIN: number;
+    OPERATOR: number;
+    USER: number;
+  };
+  newUsersThisMonth: number;
+  activeToday: number;
+}


### PR DESCRIPTION
## Summary

SA/TA 어드민 페이지에서 공통으로 사용할 컴포넌트와 타입 정의를 추가합니다.

## Related Issue

- Closes #97

## Changes

- StatusBadge: 테넌트/사용자 상태 표시 배지 (ACTIVE, INACTIVE, SUSPENDED, PENDING, BLOCKED)
- PlanBadge: 요금제 표시 배지 (BASIC, PRO, ENTERPRISE)
- RoleBadge: 역할 표시 배지 (시스템/코스 역할)
- AdminStatsCard: 대시보드 통계 카드 컴포넌트
- AdminStatsGrid: 통계 카드 그리드 레이아웃
- AdminPageHeader: 페이지 헤더 (제목, 설명, 액션 버튼)
- RecentItemsList: 최근 항목 목록 컴포넌트
- Admin 도메인 타입 정의 (tenant, user, dashboard)

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

SA/TA 대시보드 및 관리 페이지 구현을 위한 기반 컴포넌트입니다.