### PR TITLE
feat: 차수 관리 페이지 구현 (#91)

### DIFF
--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -186,7 +186,7 @@ export const tenantOperatorMenuData: MenuItem[] = [
     label: { ko: '교육 운영 관리', en: 'Program Management' },
     icon: Layers,
     subItems: [
-      { id: 'session-management', label: { ko: '차수 관리', en: 'Session Management' }, icon: Calendar, path: '/to/sessions' },
+      { id: 'time-management', label: { ko: '차수 관리', en: 'Course Time Management' }, icon: Calendar, path: '/to/times' },
       { id: 'instructor-assignment', label: { ko: '강사 배정', en: 'Instructor Assignment' }, icon: UserCheck, path: '/to/instructors' },
     ],
   },

--- a/src/pages/to/time/CourseTimeCreatePage.tsx
+++ b/src/pages/to/time/CourseTimeCreatePage.tsx
@@ -1,0 +1,449 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, ArrowRight, Save, Loader2, Calendar, Clock } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import { Button, Input, Label, NativeSelect, Textarea } from '@/components/common';
+import { useCreateTime } from '@/hooks/to/useTimeQueries';
+import type {
+  CreateCourseTimeRequest,
+  DeliveryType,
+  EnrollmentMethod,
+} from '@/types/to/time.types';
+import { DELIVERY_TYPE_LABELS, ENROLLMENT_METHOD_LABELS } from '@/types/to/time.types';
+
+interface CourseTimeCreatePageProps {
+  language?: 'ko' | 'en';
+}
+
+const t = {
+  title: { ko: '차수 생성', en: 'Create Course Time' },
+  close: { ko: '닫기', en: 'Close' },
+  previous: { ko: '이전', en: 'Previous' },
+  next: { ko: '다음', en: 'Next' },
+  submit: { ko: '저장', en: 'Save' },
+  saving: { ko: '저장 중...', en: 'Saving...' },
+  // Steps
+  step1: { ko: '기본 정보', en: 'Basic Info' },
+  step2: { ko: '기간 설정', en: 'Period' },
+  step3: { ko: '정원 및 가격', en: 'Capacity & Price' },
+  // Step 1 - Basic Info
+  programId: { ko: '프로그램 ID', en: 'Program ID' },
+  programIdPlaceholder: { ko: '프로그램 ID를 입력하세요', en: 'Enter program ID' },
+  cmCourseId: { ko: '강의 ID', en: 'Course ID' },
+  cmCourseIdPlaceholder: { ko: '강의 ID를 입력하세요', en: 'Enter course ID' },
+  timeTitle: { ko: '차수명', en: 'Title' },
+  timeTitlePlaceholder: { ko: '예: 2025년 1차', en: 'e.g., 2025 Session 1' },
+  description: { ko: '설명', en: 'Description' },
+  descriptionPlaceholder: { ko: '차수에 대한 설명을 입력하세요 (선택)', en: 'Enter description (optional)' },
+  deliveryType: { ko: '진행 방식', en: 'Delivery Type' },
+  enrollmentMethod: { ko: '수강 신청 방식', en: 'Enrollment Method' },
+  location: { ko: '장소', en: 'Location' },
+  locationPlaceholder: { ko: '오프라인/블렌디드 진행 시 장소 입력', en: 'Enter location for offline/blended' },
+  // Step 2 - Period
+  enrollmentPeriod: { ko: '모집 기간', en: 'Enrollment Period' },
+  enrollmentStartDate: { ko: '모집 시작일', en: 'Enrollment Start' },
+  enrollmentEndDate: { ko: '모집 종료일', en: 'Enrollment End' },
+  learningPeriod: { ko: '학습 기간', en: 'Learning Period' },
+  startDate: { ko: '학습 시작일', en: 'Start Date' },
+  endDate: { ko: '학습 종료일', en: 'End Date' },
+  // Step 3 - Capacity & Price
+  capacity: { ko: '정원', en: 'Capacity' },
+  capacityPlaceholder: { ko: '0 입력 시 무제한', en: '0 for unlimited' },
+  capacityHint: { ko: '최대 수강 인원을 설정합니다. 0을 입력하면 무제한입니다.', en: 'Set maximum enrollment. Enter 0 for unlimited.' },
+  price: { ko: '가격', en: 'Price' },
+  pricePlaceholder: { ko: '0 입력 시 무료', en: '0 for free' },
+  priceHint: { ko: '수강료를 설정합니다. 0을 입력하면 무료입니다.', en: 'Set course fee. Enter 0 for free.' },
+  // Validation
+  required: { ko: '필수 항목입니다.', en: 'This field is required.' },
+  createSuccess: { ko: '차수가 생성되었습니다.', en: 'Course time created successfully.' },
+  createError: { ko: '차수 생성에 실패했습니다.', en: 'Failed to create course time.' },
+};
+
+export function CourseTimeCreatePage({ language = 'ko' }: Readonly<CourseTimeCreatePageProps>) {
+  const navigate = useNavigate();
+  const createTime = useCreateTime();
+  const [currentStep, setCurrentStep] = useState(1);
+  const totalSteps = 3;
+
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+
+  // Form State
+  const [formData, setFormData] = useState<CreateCourseTimeRequest>({
+    programId: 0,
+    cmCourseId: 0,
+    title: '',
+    deliveryType: 'ONLINE',
+    enrollmentMethod: 'FIRST_COME',
+    enrollmentStartDate: '',
+    enrollmentEndDate: '',
+    startDate: '',
+    endDate: '',
+    capacity: null,
+    price: null,
+    description: '',
+    location: '',
+  });
+
+  const [errors, setErrors] = useState<Partial<Record<keyof CreateCourseTimeRequest, string>>>({});
+
+  const validateStep = (step: number): boolean => {
+    const newErrors: Partial<Record<keyof CreateCourseTimeRequest, string>> = {};
+
+    if (step === 1) {
+      if (!formData.programId) newErrors.programId = getText('required');
+      if (!formData.cmCourseId) newErrors.cmCourseId = getText('required');
+      if (!formData.title.trim()) newErrors.title = getText('required');
+    } else if (step === 2) {
+      if (!formData.enrollmentStartDate) newErrors.enrollmentStartDate = getText('required');
+      if (!formData.enrollmentEndDate) newErrors.enrollmentEndDate = getText('required');
+      if (!formData.startDate) newErrors.startDate = getText('required');
+      if (!formData.endDate) newErrors.endDate = getText('required');
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleNext = () => {
+    if (validateStep(currentStep) && currentStep < totalSteps) {
+      setCurrentStep(currentStep + 1);
+    }
+  };
+
+  const handlePrevious = () => {
+    if (currentStep > 1) {
+      setCurrentStep(currentStep - 1);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!validateStep(currentStep)) return;
+
+    try {
+      const request: CreateCourseTimeRequest = {
+        ...formData,
+        capacity: formData.capacity === 0 ? null : formData.capacity,
+        price: formData.price === 0 ? null : formData.price,
+      };
+
+      await createTime.mutateAsync(request);
+      alert(getText('createSuccess'));
+      navigate('/to/times');
+    } catch (err) {
+      console.error('Create failed:', err);
+      alert(getText('createError'));
+    }
+  };
+
+  const handleInputChange = (
+    field: keyof CreateCourseTimeRequest,
+    value: string | number | null
+  ) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    if (errors[field]) {
+      setErrors((prev) => ({ ...prev, [field]: undefined }));
+    }
+  };
+
+  const stepLabels = [getText('step1'), getText('step2'), getText('step3')];
+
+  return (
+    <div className="bg-bg-app min-h-screen">
+      {/* Header */}
+      <div className="bg-bg-default border-b border-border px-6 py-4">
+        <div className="max-w-5xl mx-auto flex justify-between items-center">
+          <h1 className="text-text-primary m-0">{getText('title')}</h1>
+          <Button variant="ghost" onClick={() => navigate('/to/times')} className="border border-border">
+            {getText('close')}
+          </Button>
+        </div>
+      </div>
+
+      {/* Progress Steps */}
+      <div className="bg-bg-default border-b border-border px-6 py-6">
+        <div className="max-w-5xl mx-auto">
+          <div className="flex items-center gap-2">
+            {[1, 2, 3].map((step) => (
+              <div key={step} className="flex-1 flex items-center gap-2">
+                <div
+                  className={cn(
+                    'w-8 h-8 rounded-full flex items-center justify-center font-medium text-sm',
+                    currentStep >= step ? 'bg-btn-neutral text-white' : 'bg-border text-text-secondary'
+                  )}
+                >
+                  {step}
+                </div>
+                <span
+                  className={cn(
+                    'text-sm',
+                    currentStep >= step ? 'text-text-primary' : 'text-text-secondary',
+                    currentStep === step && 'font-medium'
+                  )}
+                >
+                  {stepLabels[step - 1]}
+                </span>
+                {step < 3 && (
+                  <div
+                    className={cn('flex-1 h-0.5', currentStep > step ? 'bg-btn-neutral' : 'bg-border')}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="max-w-5xl mx-auto p-6">
+        <div className="bg-bg-default rounded-xl p-8 border border-border">
+          {/* Step 1: 기본 정보 */}
+          {currentStep === 1 && (
+            <div className="flex flex-col gap-6">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="space-y-2">
+                  <Label htmlFor="programId">{getText('programId')} *</Label>
+                  <Input
+                    id="programId"
+                    type="number"
+                    placeholder={getText('programIdPlaceholder')}
+                    value={formData.programId || ''}
+                    onChange={(e) => handleInputChange('programId', parseInt(e.target.value) || 0)}
+                    className={errors.programId ? 'border-status-error' : ''}
+                  />
+                  {errors.programId && (
+                    <p className="text-sm text-status-error">{errors.programId}</p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="cmCourseId">{getText('cmCourseId')} *</Label>
+                  <Input
+                    id="cmCourseId"
+                    type="number"
+                    placeholder={getText('cmCourseIdPlaceholder')}
+                    value={formData.cmCourseId || ''}
+                    onChange={(e) => handleInputChange('cmCourseId', parseInt(e.target.value) || 0)}
+                    className={errors.cmCourseId ? 'border-status-error' : ''}
+                  />
+                  {errors.cmCourseId && (
+                    <p className="text-sm text-status-error">{errors.cmCourseId}</p>
+                  )}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="title">{getText('timeTitle')} *</Label>
+                <Input
+                  id="title"
+                  type="text"
+                  placeholder={getText('timeTitlePlaceholder')}
+                  value={formData.title}
+                  onChange={(e) => handleInputChange('title', e.target.value)}
+                  className={errors.title ? 'border-status-error' : ''}
+                />
+                {errors.title && (
+                  <p className="text-sm text-status-error">{errors.title}</p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="description">{getText('description')}</Label>
+                <Textarea
+                  id="description"
+                  placeholder={getText('descriptionPlaceholder')}
+                  value={formData.description || ''}
+                  onChange={(e) => handleInputChange('description', e.target.value)}
+                  rows={3}
+                />
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <NativeSelect
+                  id="deliveryType"
+                  label={getText('deliveryType')}
+                  value={formData.deliveryType}
+                  onChange={(e) => handleInputChange('deliveryType', e.target.value as DeliveryType)}
+                  options={Object.entries(DELIVERY_TYPE_LABELS).map(([value, label]) => ({
+                    value,
+                    label,
+                  }))}
+                />
+                <NativeSelect
+                  id="enrollmentMethod"
+                  label={getText('enrollmentMethod')}
+                  value={formData.enrollmentMethod}
+                  onChange={(e) => handleInputChange('enrollmentMethod', e.target.value as EnrollmentMethod)}
+                  options={Object.entries(ENROLLMENT_METHOD_LABELS).map(([value, label]) => ({
+                    value,
+                    label,
+                  }))}
+                />
+              </div>
+
+              {(formData.deliveryType === 'OFFLINE' || formData.deliveryType === 'BLENDED') && (
+                <div className="space-y-2">
+                  <Label htmlFor="location">{getText('location')}</Label>
+                  <Input
+                    id="location"
+                    type="text"
+                    placeholder={getText('locationPlaceholder')}
+                    value={formData.location || ''}
+                    onChange={(e) => handleInputChange('location', e.target.value)}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Step 2: 기간 설정 */}
+          {currentStep === 2 && (
+            <div className="flex flex-col gap-8">
+              {/* 모집 기간 */}
+              <div className="space-y-4">
+                <div className="flex items-center gap-2 text-text-primary">
+                  <Calendar size={20} />
+                  <h3 className="font-medium m-0">{getText('enrollmentPeriod')}</h3>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6 pl-7">
+                  <div className="space-y-2">
+                    <Label htmlFor="enrollmentStartDate">{getText('enrollmentStartDate')} *</Label>
+                    <Input
+                      id="enrollmentStartDate"
+                      type="datetime-local"
+                      value={formData.enrollmentStartDate}
+                      onChange={(e) => handleInputChange('enrollmentStartDate', e.target.value)}
+                      className={errors.enrollmentStartDate ? 'border-status-error' : ''}
+                    />
+                    {errors.enrollmentStartDate && (
+                      <p className="text-sm text-status-error">{errors.enrollmentStartDate}</p>
+                    )}
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="enrollmentEndDate">{getText('enrollmentEndDate')} *</Label>
+                    <Input
+                      id="enrollmentEndDate"
+                      type="datetime-local"
+                      value={formData.enrollmentEndDate}
+                      onChange={(e) => handleInputChange('enrollmentEndDate', e.target.value)}
+                      className={errors.enrollmentEndDate ? 'border-status-error' : ''}
+                    />
+                    {errors.enrollmentEndDate && (
+                      <p className="text-sm text-status-error">{errors.enrollmentEndDate}</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {/* 학습 기간 */}
+              <div className="space-y-4">
+                <div className="flex items-center gap-2 text-text-primary">
+                  <Clock size={20} />
+                  <h3 className="font-medium m-0">{getText('learningPeriod')}</h3>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6 pl-7">
+                  <div className="space-y-2">
+                    <Label htmlFor="startDate">{getText('startDate')} *</Label>
+                    <Input
+                      id="startDate"
+                      type="datetime-local"
+                      value={formData.startDate}
+                      onChange={(e) => handleInputChange('startDate', e.target.value)}
+                      className={errors.startDate ? 'border-status-error' : ''}
+                    />
+                    {errors.startDate && (
+                      <p className="text-sm text-status-error">{errors.startDate}</p>
+                    )}
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="endDate">{getText('endDate')} *</Label>
+                    <Input
+                      id="endDate"
+                      type="datetime-local"
+                      value={formData.endDate}
+                      onChange={(e) => handleInputChange('endDate', e.target.value)}
+                      className={errors.endDate ? 'border-status-error' : ''}
+                    />
+                    {errors.endDate && (
+                      <p className="text-sm text-status-error">{errors.endDate}</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Step 3: 정원 및 가격 */}
+          {currentStep === 3 && (
+            <div className="flex flex-col gap-6">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="space-y-2">
+                  <Label htmlFor="capacity">{getText('capacity')}</Label>
+                  <Input
+                    id="capacity"
+                    type="number"
+                    min="0"
+                    placeholder={getText('capacityPlaceholder')}
+                    value={formData.capacity ?? ''}
+                    onChange={(e) =>
+                      handleInputChange('capacity', e.target.value ? parseInt(e.target.value) : null)
+                    }
+                  />
+                  <p className="text-sm text-text-secondary">{getText('capacityHint')}</p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="price">{getText('price')}</Label>
+                  <Input
+                    id="price"
+                    type="number"
+                    min="0"
+                    placeholder={getText('pricePlaceholder')}
+                    value={formData.price ?? ''}
+                    onChange={(e) =>
+                      handleInputChange('price', e.target.value ? parseInt(e.target.value) : null)
+                    }
+                  />
+                  <p className="text-sm text-text-secondary">{getText('priceHint')}</p>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Navigation Buttons */}
+        <div className="flex justify-between mt-6">
+          <div>
+            {currentStep > 1 && (
+              <Button variant="ghost" onClick={handlePrevious} className="border border-border">
+                <ArrowLeft size={18} />
+                {getText('previous')}
+              </Button>
+            )}
+          </div>
+
+          <div>
+            {currentStep < totalSteps ? (
+              <Button onClick={handleNext}>
+                {getText('next')}
+                <ArrowRight size={18} />
+              </Button>
+            ) : (
+              <Button onClick={handleSubmit} disabled={createTime.isPending}>
+                {createTime.isPending ? (
+                  <>
+                    <Loader2 size={18} className="animate-spin" />
+                    {getText('saving')}
+                  </>
+                ) : (
+                  <>
+                    <Save size={18} />
+                    {getText('submit')}
+                  </>
+                )}
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/to/time/CourseTimeDetailPage.tsx
+++ b/src/pages/to/time/CourseTimeDetailPage.tsx
@@ -17,7 +17,6 @@ import {
   X,
   UserPlus,
 } from 'lucide-react';
-import { cn } from '@/utils/cn';
 import { Button, Badge, Input, Label, NativeSelect, Card } from '@/components/common';
 import {
   useTime,

--- a/src/pages/to/time/CourseTimeDetailPage.tsx
+++ b/src/pages/to/time/CourseTimeDetailPage.tsx
@@ -1,0 +1,582 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  ArrowLeft,
+  Edit,
+  Copy,
+  Trash2,
+  Play,
+  Square,
+  Archive,
+  Users,
+  Calendar,
+  MapPin,
+  Clock,
+  Loader2,
+  Save,
+  X,
+  UserPlus,
+} from 'lucide-react';
+import { cn } from '@/utils/cn';
+import { Button, Badge, Input, Label, NativeSelect, Card } from '@/components/common';
+import {
+  useTime,
+  useUpdateTime,
+  useDeleteTime,
+  useOpenTime,
+  useStartTime,
+  useCloseTime,
+  useArchiveTime,
+} from '@/hooks/to/useTimeQueries';
+import type { CourseTimeStatus, UpdateCourseTimeRequest, DeliveryType, EnrollmentMethod } from '@/types/to/time.types';
+import {
+  COURSE_TIME_STATUS_LABELS,
+  DELIVERY_TYPE_LABELS,
+  ENROLLMENT_METHOD_LABELS,
+  COURSE_TIME_STATUS_TRANSITIONS,
+} from '@/types/to/time.types';
+
+interface CourseTimeDetailPageProps {
+  language?: 'ko' | 'en';
+}
+
+const t = {
+  title: { ko: '차수 상세', en: 'Course Time Detail' },
+  back: { ko: '목록으로', en: 'Back to List' },
+  edit: { ko: '수정', en: 'Edit' },
+  save: { ko: '저장', en: 'Save' },
+  cancel: { ko: '취소', en: 'Cancel' },
+  clone: { ko: '복제', en: 'Clone' },
+  delete: { ko: '삭제', en: 'Delete' },
+  // Status Actions
+  openRecruiting: { ko: '모집 시작', en: 'Start Recruiting' },
+  startLearning: { ko: '학습 시작', en: 'Start Learning' },
+  closeCourse: { ko: '종료', en: 'Close' },
+  archiveCourse: { ko: '보관', en: 'Archive' },
+  // Sections
+  basicInfo: { ko: '기본 정보', en: 'Basic Information' },
+  timeTitle: { ko: '차수명', en: 'Title' },
+  status: { ko: '상태', en: 'Status' },
+  description: { ko: '설명', en: 'Description' },
+  programInfo: { ko: '프로그램 정보', en: 'Program Information' },
+  programId: { ko: '프로그램 ID', en: 'Program ID' },
+  programTitle: { ko: '프로그램명', en: 'Program Title' },
+  courseId: { ko: '강의 ID', en: 'Course ID' },
+  courseTitle: { ko: '강의명', en: 'Course Title' },
+  deliveryInfo: { ko: '진행 정보', en: 'Delivery Information' },
+  deliveryType: { ko: '진행 방식', en: 'Delivery Type' },
+  enrollmentMethod: { ko: '수강 신청 방식', en: 'Enrollment Method' },
+  location: { ko: '장소', en: 'Location' },
+  periodInfo: { ko: '기간 정보', en: 'Period Information' },
+  enrollmentPeriod: { ko: '모집 기간', en: 'Enrollment Period' },
+  learningPeriod: { ko: '학습 기간', en: 'Learning Period' },
+  capacityInfo: { ko: '정원 및 수강', en: 'Capacity & Enrollment' },
+  capacity: { ko: '정원', en: 'Capacity' },
+  currentEnrollment: { ko: '현재 수강 인원', en: 'Current Enrollment' },
+  availableSeats: { ko: '잔여 좌석', en: 'Available Seats' },
+  price: { ko: '가격', en: 'Price' },
+  unlimited: { ko: '무제한', en: 'Unlimited' },
+  free: { ko: '무료', en: 'Free' },
+  instructors: { ko: '강사 정보', en: 'Instructors' },
+  noInstructors: { ko: '배정된 강사가 없습니다.', en: 'No instructors assigned.' },
+  addInstructor: { ko: '강사 추가', en: 'Add Instructor' },
+  // Instructor Roles
+  MAIN: { ko: '메인 강사', en: 'Main Instructor' },
+  SUB: { ko: '서브 강사', en: 'Sub Instructor' },
+  ASSISTANT: { ko: '조교', en: 'Assistant' },
+  // Messages
+  loading: { ko: '로딩 중...', en: 'Loading...' },
+  error: { ko: '오류가 발생했습니다.', en: 'An error occurred.' },
+  notFound: { ko: '차수를 찾을 수 없습니다.', en: 'Course time not found.' },
+  confirmDelete: { ko: '정말 삭제하시겠습니까?', en: 'Are you sure you want to delete?' },
+  confirmStatusChange: { ko: '상태를 변경하시겠습니까?', en: 'Are you sure you want to change status?' },
+  updateSuccess: { ko: '수정되었습니다.', en: 'Updated successfully.' },
+  updateError: { ko: '수정에 실패했습니다.', en: 'Failed to update.' },
+  deleteSuccess: { ko: '삭제되었습니다.', en: 'Deleted successfully.' },
+  noDescription: { ko: '설명 없음', en: 'No description' },
+  noLocation: { ko: '장소 미지정', en: 'No location' },
+};
+
+const statusBadgeVariant: Record<CourseTimeStatus, 'default' | 'secondary' | 'success' | 'warning' | 'destructive'> = {
+  DRAFT: 'secondary',
+  RECRUITING: 'default',
+  ONGOING: 'success',
+  CLOSED: 'warning',
+  ARCHIVED: 'destructive',
+};
+
+export function CourseTimeDetailPage({ language = 'ko' }: Readonly<CourseTimeDetailPageProps>) {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const timeId = parseInt(id || '0');
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [editData, setEditData] = useState<UpdateCourseTimeRequest>({});
+
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+
+  // React Query Hooks
+  const { data: courseTime, isLoading, error } = useTime(timeId);
+  const updateTime = useUpdateTime();
+  const deleteTime = useDeleteTime();
+  const openTime = useOpenTime();
+  const startTime = useStartTime();
+  const closeTime = useCloseTime();
+  const archiveTime = useArchiveTime();
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleString(language === 'ko' ? 'ko-KR' : 'en-US', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const formatPrice = (price: number | null) => {
+    if (price === null || price === 0) return getText('free');
+    return language === 'ko' ? `${price.toLocaleString()}원` : `$${price.toLocaleString()}`;
+  };
+
+  const handleEdit = () => {
+    if (courseTime) {
+      setEditData({
+        title: courseTime.title,
+        description: courseTime.description || '',
+        deliveryType: courseTime.deliveryType,
+        enrollmentMethod: courseTime.enrollmentMethod,
+        location: courseTime.location || '',
+        capacity: courseTime.capacity,
+        price: courseTime.price,
+      });
+      setIsEditing(true);
+    }
+  };
+
+  const handleCancelEdit = () => {
+    setIsEditing(false);
+    setEditData({});
+  };
+
+  const handleSave = async () => {
+    try {
+      await updateTime.mutateAsync({ id: timeId, request: editData });
+      setIsEditing(false);
+      alert(getText('updateSuccess'));
+    } catch (err) {
+      console.error('Update failed:', err);
+      alert(getText('updateError'));
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirm(getText('confirmDelete'))) return;
+    try {
+      await deleteTime.mutateAsync(timeId);
+      alert(getText('deleteSuccess'));
+      navigate('/to/times');
+    } catch (err) {
+      console.error('Delete failed:', err);
+    }
+  };
+
+  const handleStatusTransition = async () => {
+    if (!courseTime || !confirm(getText('confirmStatusChange'))) return;
+
+    try {
+      switch (courseTime.status) {
+        case 'DRAFT':
+          await openTime.mutateAsync(timeId);
+          break;
+        case 'RECRUITING':
+          await startTime.mutateAsync(timeId);
+          break;
+        case 'ONGOING':
+          await closeTime.mutateAsync(timeId);
+          break;
+        case 'CLOSED':
+          await archiveTime.mutateAsync(timeId);
+          break;
+      }
+    } catch (err) {
+      console.error('Status transition failed:', err);
+    }
+  };
+
+  const getStatusActionButton = () => {
+    if (!courseTime) return null;
+    const nextStatus = COURSE_TIME_STATUS_TRANSITIONS[courseTime.status];
+    if (!nextStatus) return null;
+
+    const actionMap: Record<CourseTimeStatus, { label: keyof typeof t; icon: React.ReactNode }> = {
+      DRAFT: { label: 'openRecruiting', icon: <Play size={16} /> },
+      RECRUITING: { label: 'startLearning', icon: <Clock size={16} /> },
+      ONGOING: { label: 'closeCourse', icon: <Square size={16} /> },
+      CLOSED: { label: 'archiveCourse', icon: <Archive size={16} /> },
+      ARCHIVED: { label: 'archiveCourse', icon: <Archive size={16} /> },
+    };
+
+    const action = actionMap[courseTime.status];
+    const isLoading = openTime.isPending || startTime.isPending || closeTime.isPending || archiveTime.isPending;
+
+    return (
+      <Button onClick={handleStatusTransition} disabled={isLoading} variant="brand">
+        {isLoading ? <Loader2 size={16} className="animate-spin" /> : action.icon}
+        <span>{getText(action.label)}</span>
+      </Button>
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <div className="h-full flex items-center justify-center bg-bg-app">
+        <Loader2 size={32} className="animate-spin text-text-secondary" />
+        <span className="ml-2 text-text-secondary">{getText('loading')}</span>
+      </div>
+    );
+  }
+
+  if (error || !courseTime) {
+    return (
+      <div className="h-full flex items-center justify-center bg-bg-app">
+        <div className="text-center">
+          <Calendar size={48} className="mx-auto mb-3 text-text-placeholder" />
+          <p className="text-text-secondary">{error ? getText('error') : getText('notFound')}</p>
+          <Button variant="ghost" className="mt-4" onClick={() => navigate('/to/times')}>
+            {getText('back')}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col bg-bg-app">
+      {/* Header */}
+      <div className="sticky top-0 z-10 bg-bg-app border-b border-border">
+        <div className="p-6 px-8">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <Button variant="ghost" size="sm" onClick={() => navigate('/to/times')}>
+                <ArrowLeft size={20} />
+                <span>{getText('back')}</span>
+              </Button>
+              <div>
+                <div className="flex items-center gap-3">
+                  <h1 className="text-text-primary mb-0">{courseTime.title}</h1>
+                  <Badge variant={statusBadgeVariant[courseTime.status]}>
+                    {COURSE_TIME_STATUS_LABELS[courseTime.status]}
+                  </Badge>
+                </div>
+                <p className="text-text-secondary text-sm m-0">ID: {courseTime.id}</p>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              {isEditing ? (
+                <>
+                  <Button variant="ghost" onClick={handleCancelEdit}>
+                    <X size={20} />
+                    <span>{getText('cancel')}</span>
+                  </Button>
+                  <Button onClick={handleSave} disabled={updateTime.isPending}>
+                    {updateTime.isPending ? (
+                      <Loader2 size={20} className="animate-spin" />
+                    ) : (
+                      <Save size={20} />
+                    )}
+                    <span>{getText('save')}</span>
+                  </Button>
+                </>
+              ) : (
+                <>
+                  {courseTime.status === 'DRAFT' && (
+                    <Button variant="ghost" onClick={handleEdit}>
+                      <Edit size={20} />
+                      <span>{getText('edit')}</span>
+                    </Button>
+                  )}
+                  <Button variant="ghost" onClick={() => navigate(`/to/times/${timeId}/clone`)}>
+                    <Copy size={20} />
+                    <span>{getText('clone')}</span>
+                  </Button>
+                  {courseTime.status === 'DRAFT' && (
+                    <Button variant="ghost" onClick={handleDelete} disabled={deleteTime.isPending}>
+                      <Trash2 size={20} className="text-status-error" />
+                      <span className="text-status-error">{getText('delete')}</span>
+                    </Button>
+                  )}
+                  {getStatusActionButton()}
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto">
+        <div className="p-6 px-8 max-w-6xl">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {/* 기본 정보 */}
+            <Card className="p-6">
+              <h2 className="text-lg font-semibold text-text-primary mb-4">
+                {getText('basicInfo')}
+              </h2>
+              <div className="space-y-4">
+                <div>
+                  <Label className="text-text-secondary">{getText('timeTitle')}</Label>
+                  {isEditing ? (
+                    <Input
+                      value={editData.title || ''}
+                      onChange={(e) => setEditData({ ...editData, title: e.target.value })}
+                    />
+                  ) : (
+                    <p className="text-text-primary font-medium">{courseTime.title}</p>
+                  )}
+                </div>
+                <div>
+                  <Label className="text-text-secondary">{getText('description')}</Label>
+                  {isEditing ? (
+                    <Input
+                      value={editData.description || ''}
+                      onChange={(e) => setEditData({ ...editData, description: e.target.value })}
+                    />
+                  ) : (
+                    <p className="text-text-primary">
+                      {courseTime.description || getText('noDescription')}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </Card>
+
+            {/* 프로그램 정보 */}
+            <Card className="p-6">
+              <h2 className="text-lg font-semibold text-text-primary mb-4">
+                {getText('programInfo')}
+              </h2>
+              <div className="space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label className="text-text-secondary">{getText('programId')}</Label>
+                    <p className="text-text-primary">{courseTime.programId}</p>
+                  </div>
+                  <div>
+                    <Label className="text-text-secondary">{getText('programTitle')}</Label>
+                    <p className="text-text-primary">{courseTime.programTitle || '-'}</p>
+                  </div>
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label className="text-text-secondary">{getText('courseId')}</Label>
+                    <p className="text-text-primary">{courseTime.cmCourseId}</p>
+                  </div>
+                  <div>
+                    <Label className="text-text-secondary">{getText('courseTitle')}</Label>
+                    <p className="text-text-primary">{courseTime.cmCourseTitle || '-'}</p>
+                  </div>
+                </div>
+              </div>
+            </Card>
+
+            {/* 진행 정보 */}
+            <Card className="p-6">
+              <h2 className="text-lg font-semibold text-text-primary mb-4">
+                {getText('deliveryInfo')}
+              </h2>
+              <div className="space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label className="text-text-secondary">{getText('deliveryType')}</Label>
+                    {isEditing ? (
+                      <NativeSelect
+                        value={editData.deliveryType || courseTime.deliveryType}
+                        onChange={(e) =>
+                          setEditData({ ...editData, deliveryType: e.target.value as DeliveryType })
+                        }
+                        options={Object.entries(DELIVERY_TYPE_LABELS).map(([value, label]) => ({
+                          value,
+                          label,
+                        }))}
+                      />
+                    ) : (
+                      <p className="text-text-primary">
+                        {DELIVERY_TYPE_LABELS[courseTime.deliveryType]}
+                      </p>
+                    )}
+                  </div>
+                  <div>
+                    <Label className="text-text-secondary">{getText('enrollmentMethod')}</Label>
+                    {isEditing ? (
+                      <NativeSelect
+                        value={editData.enrollmentMethod || courseTime.enrollmentMethod}
+                        onChange={(e) =>
+                          setEditData({
+                            ...editData,
+                            enrollmentMethod: e.target.value as EnrollmentMethod,
+                          })
+                        }
+                        options={Object.entries(ENROLLMENT_METHOD_LABELS).map(([value, label]) => ({
+                          value,
+                          label,
+                        }))}
+                      />
+                    ) : (
+                      <p className="text-text-primary">
+                        {ENROLLMENT_METHOD_LABELS[courseTime.enrollmentMethod]}
+                      </p>
+                    )}
+                  </div>
+                </div>
+                <div>
+                  <Label className="text-text-secondary flex items-center gap-1">
+                    <MapPin size={14} />
+                    {getText('location')}
+                  </Label>
+                  {isEditing ? (
+                    <Input
+                      value={editData.location || ''}
+                      onChange={(e) => setEditData({ ...editData, location: e.target.value })}
+                    />
+                  ) : (
+                    <p className="text-text-primary">
+                      {courseTime.location || getText('noLocation')}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </Card>
+
+            {/* 기간 정보 */}
+            <Card className="p-6">
+              <h2 className="text-lg font-semibold text-text-primary mb-4">
+                {getText('periodInfo')}
+              </h2>
+              <div className="space-y-4">
+                <div>
+                  <Label className="text-text-secondary flex items-center gap-1">
+                    <Calendar size={14} />
+                    {getText('enrollmentPeriod')}
+                  </Label>
+                  <p className="text-text-primary">
+                    {formatDate(courseTime.enrollmentStartDate)} ~{' '}
+                    {formatDate(courseTime.enrollmentEndDate)}
+                  </p>
+                </div>
+                <div>
+                  <Label className="text-text-secondary flex items-center gap-1">
+                    <Clock size={14} />
+                    {getText('learningPeriod')}
+                  </Label>
+                  <p className="text-text-primary">
+                    {formatDate(courseTime.startDate)} ~ {formatDate(courseTime.endDate)}
+                  </p>
+                </div>
+              </div>
+            </Card>
+
+            {/* 정원 및 수강 */}
+            <Card className="p-6">
+              <h2 className="text-lg font-semibold text-text-primary mb-4">
+                {getText('capacityInfo')}
+              </h2>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <Label className="text-text-secondary flex items-center gap-1">
+                    <Users size={14} />
+                    {getText('capacity')}
+                  </Label>
+                  {isEditing ? (
+                    <Input
+                      type="number"
+                      value={editData.capacity ?? ''}
+                      onChange={(e) =>
+                        setEditData({
+                          ...editData,
+                          capacity: e.target.value ? parseInt(e.target.value) : null,
+                        })
+                      }
+                      placeholder="0 = 무제한"
+                    />
+                  ) : (
+                    <p className="text-text-primary text-xl font-semibold">
+                      {courseTime.capacity || getText('unlimited')}
+                    </p>
+                  )}
+                </div>
+                <div>
+                  <Label className="text-text-secondary">{getText('currentEnrollment')}</Label>
+                  <p className="text-text-primary text-xl font-semibold">
+                    {courseTime.currentEnrollment}
+                  </p>
+                </div>
+                <div>
+                  <Label className="text-text-secondary">{getText('availableSeats')}</Label>
+                  <p className="text-text-primary text-xl font-semibold">
+                    {courseTime.availableSeats ?? getText('unlimited')}
+                  </p>
+                </div>
+                <div>
+                  <Label className="text-text-secondary">{getText('price')}</Label>
+                  {isEditing ? (
+                    <Input
+                      type="number"
+                      value={editData.price ?? ''}
+                      onChange={(e) =>
+                        setEditData({
+                          ...editData,
+                          price: e.target.value ? parseInt(e.target.value) : null,
+                        })
+                      }
+                      placeholder="0 = 무료"
+                    />
+                  ) : (
+                    <p className="text-text-primary text-xl font-semibold">
+                      {formatPrice(courseTime.price)}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </Card>
+
+            {/* 강사 정보 */}
+            <Card className="p-6">
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-lg font-semibold text-text-primary">
+                  {getText('instructors')}
+                </h2>
+                {courseTime.status === 'DRAFT' && (
+                  <Button variant="ghost" size="sm">
+                    <UserPlus size={16} />
+                    <span>{getText('addInstructor')}</span>
+                  </Button>
+                )}
+              </div>
+              {courseTime.instructors && courseTime.instructors.length > 0 ? (
+                <div className="space-y-3">
+                  {courseTime.instructors.map((instructor) => (
+                    <div
+                      key={instructor.id}
+                      className="flex items-center justify-between p-3 bg-bg-secondary rounded-lg"
+                    >
+                      <div>
+                        <p className="text-text-primary font-medium">{instructor.userName}</p>
+                        <p className="text-text-secondary text-sm">{instructor.userEmail}</p>
+                      </div>
+                      <Badge variant={instructor.role === 'MAIN' ? 'default' : 'secondary'}>
+                        {getText(instructor.role)}
+                      </Badge>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-text-secondary text-center py-4">{getText('noInstructors')}</p>
+              )}
+            </Card>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/to/time/CourseTimesPage.tsx
+++ b/src/pages/to/time/CourseTimesPage.tsx
@@ -1,0 +1,442 @@
+import { useState, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { ColumnDef } from '@tanstack/react-table';
+import {
+  Plus,
+  Search,
+  Filter,
+  ChevronDown,
+  Loader2,
+  Calendar,
+  Users,
+  Clock,
+  LayoutGrid,
+  Trash2,
+  Copy,
+  Eye,
+} from 'lucide-react';
+import { cn } from '@/utils/cn';
+import {
+  Button,
+  Badge,
+  DataTable,
+  DataTableColumnHeader,
+  IconStatCard,
+} from '@/components/common';
+import { useTimes, useDeleteTime } from '@/hooks/to/useTimeQueries';
+import type {
+  CourseTimeResponse,
+  CourseTimeStatus,
+  CourseTimeFilterParams,
+} from '@/types/to/time.types';
+import {
+  COURSE_TIME_STATUS_LABELS,
+  DELIVERY_TYPE_LABELS,
+} from '@/types/to/time.types';
+
+interface CourseTimesPageProps {
+  language?: 'ko' | 'en';
+}
+
+const t = {
+  title: { ko: '차수 관리', en: 'Course Time Management' },
+  subtitle: { ko: '차수를 생성하고 관리하세요.', en: 'Create and manage course times.' },
+  createTime: { ko: '차수 생성', en: 'Create Course Time' },
+  searchPlaceholder: { ko: '차수명 검색...', en: 'Search course time...' },
+  filter: { ko: '필터', en: 'Filter' },
+  status: { ko: '상태', en: 'Status' },
+  all: { ko: '전체', en: 'All' },
+  DRAFT: { ko: '작성 중', en: 'Draft' },
+  RECRUITING: { ko: '모집 중', en: 'Recruiting' },
+  ONGOING: { ko: '진행 중', en: 'Ongoing' },
+  CLOSED: { ko: '종료됨', en: 'Closed' },
+  ARCHIVED: { ko: '보관됨', en: 'Archived' },
+  totalTimes: { ko: '전체 차수', en: 'Total Times' },
+  recruitingTimes: { ko: '모집 중', en: 'Recruiting' },
+  ongoingTimes: { ko: '진행 중', en: 'Ongoing' },
+  closedTimes: { ko: '종료됨', en: 'Closed' },
+  noResults: { ko: '검색 결과가 없습니다.', en: 'No results found.' },
+  noTimes: { ko: '차수가 없습니다.', en: 'No course times.' },
+  noTimesDescription: { ko: '새 차수를 생성해 보세요.', en: 'Try creating a new course time.' },
+  loading: { ko: '로딩 중...', en: 'Loading...' },
+  error: { ko: '오류가 발생했습니다.', en: 'An error occurred.' },
+  confirmDelete: { ko: '정말 삭제하시겠습니까?', en: 'Are you sure you want to delete?' },
+  prev: { ko: '이전', en: 'Prev' },
+  next: { ko: '다음', en: 'Next' },
+  timeCount: { ko: '개의 차수', en: ' course times' },
+  columnTitle: { ko: '차수명', en: 'Title' },
+  columnStatus: { ko: '상태', en: 'Status' },
+  columnDelivery: { ko: '진행 방식', en: 'Delivery' },
+  columnPeriod: { ko: '학습 기간', en: 'Period' },
+  columnCapacity: { ko: '정원', en: 'Capacity' },
+  columnActions: { ko: '액션', en: 'Actions' },
+  unlimited: { ko: '무제한', en: 'Unlimited' },
+  view: { ko: '상세', en: 'View' },
+  clone: { ko: '복제', en: 'Clone' },
+  delete: { ko: '삭제', en: 'Delete' },
+};
+
+const statusBadgeVariant: Record<CourseTimeStatus, 'default' | 'secondary' | 'success' | 'warning' | 'destructive'> = {
+  DRAFT: 'secondary',
+  RECRUITING: 'default',
+  ONGOING: 'success',
+  CLOSED: 'warning',
+  ARCHIVED: 'destructive',
+};
+
+export function CourseTimesPage({ language = 'ko' }: Readonly<CourseTimesPageProps>) {
+  const navigate = useNavigate();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState<CourseTimeStatus | 'all'>('all');
+  const [showFilters, setShowFilters] = useState(false);
+  const [page, setPage] = useState(0);
+
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+
+  // API 파라미터 구성
+  const params: CourseTimeFilterParams = {
+    page,
+    size: 20,
+    ...(statusFilter !== 'all' && { status: statusFilter }),
+  };
+
+  // React Query 훅 사용
+  const { data, isLoading, error } = useTimes(params);
+  const deleteTime = useDeleteTime();
+
+  const times = data?.content ?? [];
+  const totalElements = data?.totalElements ?? 0;
+
+  // 검색 필터링 (클라이언트 사이드)
+  const filteredTimes = useMemo(() => {
+    if (!searchQuery) return times;
+    const query = searchQuery.toLowerCase();
+    return times.filter((time) => time.title.toLowerCase().includes(query));
+  }, [times, searchQuery]);
+
+  // 통계 계산
+  const timeStats = useMemo(() => ({
+    total: totalElements,
+    recruiting: times.filter((t) => t.status === 'RECRUITING').length,
+    ongoing: times.filter((t) => t.status === 'ONGOING').length,
+    closed: times.filter((t) => t.status === 'CLOSED').length,
+  }), [times, totalElements]);
+
+  const handleDelete = async (id: number) => {
+    if (!confirm(getText('confirmDelete'))) return;
+    try {
+      await deleteTime.mutateAsync(id);
+    } catch (err) {
+      console.error('Delete failed:', err);
+    }
+  };
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString(language === 'ko' ? 'ko-KR' : 'en-US', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+  };
+
+  const formatCapacity = (capacity: number | null, current: number) => {
+    if (capacity === null) return getText('unlimited');
+    return `${current} / ${capacity}`;
+  };
+
+  // 리스트뷰 컬럼 정의
+  const columns: ColumnDef<CourseTimeResponse>[] = useMemo(
+    () => [
+      {
+        accessorKey: 'title',
+        header: ({ column }) => (
+          <DataTableColumnHeader column={column} title={getText('columnTitle')} />
+        ),
+        cell: ({ row }) => (
+          <div className="max-w-md">
+            <p className="text-sm font-medium text-text-primary truncate">
+              {row.original.title}
+            </p>
+            <p className="text-xs text-text-secondary mt-0.5">
+              ID: {row.original.id}
+            </p>
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'status',
+        header: ({ column }) => (
+          <DataTableColumnHeader column={column} title={getText('columnStatus')} />
+        ),
+        cell: ({ row }) => (
+          <Badge variant={statusBadgeVariant[row.original.status]}>
+            {COURSE_TIME_STATUS_LABELS[row.original.status]}
+          </Badge>
+        ),
+      },
+      {
+        accessorKey: 'deliveryType',
+        header: ({ column }) => (
+          <DataTableColumnHeader column={column} title={getText('columnDelivery')} />
+        ),
+        cell: ({ row }) => (
+          <span className="text-sm text-text-secondary">
+            {DELIVERY_TYPE_LABELS[row.original.deliveryType]}
+          </span>
+        ),
+      },
+      {
+        id: 'period',
+        header: getText('columnPeriod'),
+        cell: ({ row }) => (
+          <div className="text-sm text-text-secondary">
+            <p>{formatDate(row.original.startDate)}</p>
+            <p className="text-xs">~ {formatDate(row.original.endDate)}</p>
+          </div>
+        ),
+      },
+      {
+        id: 'capacity',
+        header: getText('columnCapacity'),
+        cell: ({ row }) => (
+          <div className="flex items-center gap-1.5">
+            <Users size={14} className="text-text-secondary" />
+            <span className="text-sm text-text-primary">
+              {formatCapacity(row.original.capacity, row.original.currentEnrollment)}
+            </span>
+          </div>
+        ),
+      },
+      {
+        id: 'actions',
+        header: () => <div className="text-right">{getText('columnActions')}</div>,
+        cell: ({ row }) => {
+          const item = row.original;
+          return (
+            <div
+              className="flex items-center justify-end gap-2"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <button
+                onClick={() => navigate(`/to/times/${item.id}`)}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-border rounded-lg text-sm text-text-primary hover:bg-bg-secondary transition-colors"
+                title={getText('view')}
+              >
+                <Eye size={16} />
+              </button>
+              <button
+                onClick={() => navigate(`/to/times/${item.id}/clone`)}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-border rounded-lg text-sm text-text-primary hover:bg-bg-secondary transition-colors"
+                title={getText('clone')}
+              >
+                <Copy size={16} />
+              </button>
+              {item.status === 'DRAFT' && (
+                <button
+                  onClick={() => handleDelete(item.id)}
+                  disabled={deleteTime.isPending}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-border rounded-lg text-sm hover:bg-status-error/10 transition-colors"
+                  title={getText('delete')}
+                >
+                  <Trash2 size={16} className="text-status-error" />
+                </button>
+              )}
+            </div>
+          );
+        },
+      },
+    ],
+    [language, deleteTime.isPending, navigate]
+  );
+
+  if (error) {
+    return (
+      <div className="h-full flex items-center justify-center bg-bg-app">
+        <div className="text-center">
+          <Calendar size={48} className="mx-auto mb-3 text-text-placeholder" />
+          <p className="text-text-secondary">{getText('error')}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col bg-bg-app">
+      {/* Top Bar */}
+      <div className="sticky top-0 z-10 bg-bg-app">
+        <div className="p-6 px-8">
+          <div className="flex items-center justify-between mb-6">
+            <div>
+              <h1 className="text-text-primary mb-1">{getText('title')}</h1>
+              <p className="text-text-secondary text-sm m-0">{getText('subtitle')}</p>
+            </div>
+            <Button onClick={() => navigate('/to/times/create')}>
+              <Plus size={20} />
+              <span>{getText('createTime')}</span>
+            </Button>
+          </div>
+
+          {/* Search and Filter Bar */}
+          <div className="flex items-center gap-3">
+            <div className="flex-1 relative">
+              <Search
+                size={20}
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary"
+              />
+              <input
+                type="text"
+                placeholder={getText('searchPlaceholder')}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full pl-10 pr-4 py-2.5 bg-bg-default border border-border rounded-lg text-text-primary text-sm outline-none focus:ring-2 focus:ring-btn-neutral"
+              />
+            </div>
+            <Button
+              variant="ghost"
+              onClick={() => setShowFilters(!showFilters)}
+              className="border border-border"
+            >
+              <Filter size={20} />
+              <span>{getText('filter')}</span>
+              <ChevronDown
+                size={16}
+                className={cn('transition-transform', showFilters && 'rotate-180')}
+              />
+            </Button>
+          </div>
+
+          {/* Filter Options */}
+          {showFilters && (
+            <div className="mt-4 p-4 border border-border rounded-lg bg-bg-secondary">
+              <label className="block text-sm text-text-primary mb-2">
+                {getText('status')}
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {(['all', 'DRAFT', 'RECRUITING', 'ONGOING', 'CLOSED', 'ARCHIVED'] as const).map(
+                  (status) => (
+                    <button
+                      key={status}
+                      onClick={() => {
+                        setStatusFilter(status);
+                        setPage(0);
+                      }}
+                      className={cn(
+                        'px-4 py-2 rounded-lg text-sm cursor-pointer transition-colors',
+                        statusFilter === status
+                          ? 'bg-btn-neutral text-white'
+                          : 'bg-bg-default text-text-primary border border-border hover:bg-bg-secondary'
+                      )}
+                    >
+                      {getText(status)}
+                    </button>
+                  )
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Content List */}
+      <div className="flex-1 overflow-auto">
+        <div className="p-6 px-8 pt-0">
+          {/* Statistics Cards */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+            <IconStatCard
+              icon={<LayoutGrid size={20} />}
+              label={getText('totalTimes')}
+              value={timeStats.total}
+            />
+            <IconStatCard
+              icon={<Users size={20} />}
+              label={getText('recruitingTimes')}
+              value={timeStats.recruiting}
+            />
+            <IconStatCard
+              icon={<Clock size={20} />}
+              label={getText('ongoingTimes')}
+              value={timeStats.ongoing}
+            />
+            <IconStatCard
+              icon={<Calendar size={20} />}
+              label={getText('closedTimes')}
+              value={timeStats.closed}
+            />
+          </div>
+
+          {/* Count */}
+          <div className="flex items-center justify-between mb-4">
+            <p className="text-sm text-text-secondary">
+              {filteredTimes.length}
+              {getText('timeCount')}
+            </p>
+          </div>
+
+          {/* Loading State */}
+          {isLoading && (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 size={32} className="animate-spin text-text-secondary" />
+              <span className="ml-2 text-text-secondary">{getText('loading')}</span>
+            </div>
+          )}
+
+          {/* Empty State */}
+          {!isLoading && totalElements === 0 && !searchQuery && statusFilter === 'all' && (
+            <div className="text-center py-12 text-text-secondary">
+              <Calendar size={48} className="mx-auto mb-3 text-text-placeholder" />
+              <p className="mb-1">{getText('noTimes')}</p>
+              <p className="text-sm">{getText('noTimesDescription')}</p>
+            </div>
+          )}
+
+          {/* Empty Search Results */}
+          {!isLoading && filteredTimes.length === 0 && (searchQuery || statusFilter !== 'all') && (
+            <div className="text-center py-12 text-text-secondary">
+              <Search size={48} className="mx-auto mb-3 text-text-placeholder" />
+              <p>{getText('noResults')}</p>
+            </div>
+          )}
+
+          {/* Data Table */}
+          {!isLoading && filteredTimes.length > 0 && (
+            <DataTable
+              columns={columns}
+              data={filteredTimes}
+              showColumnToggle={false}
+              showPagination={false}
+              onRowClick={(item) => navigate(`/to/times/${item.id}`)}
+              labels={{
+                noResults: getText('noResults'),
+              }}
+            />
+          )}
+
+          {/* Pagination */}
+          {data && data.totalPages > 1 && (
+            <div className="flex justify-center gap-2 mt-6">
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={page === 0}
+                onClick={() => setPage((p) => p - 1)}
+              >
+                {getText('prev')}
+              </Button>
+              <span className="px-4 py-2 text-sm text-text-secondary">
+                {page + 1} / {data.totalPages}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={page >= data.totalPages - 1}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                {getText('next')}
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/to/time/index.ts
+++ b/src/pages/to/time/index.ts
@@ -1,0 +1,6 @@
+/**
+ * TO 차수(CourseTime) 관리 페이지 exports
+ */
+export { CourseTimesPage } from './CourseTimesPage';
+export { CourseTimeCreatePage } from './CourseTimeCreatePage';
+export { CourseTimeDetailPage } from './CourseTimeDetailPage';

--- a/src/routes/to.routes.tsx
+++ b/src/routes/to.routes.tsx
@@ -7,6 +7,11 @@ import {
   SettingsNotificationsPage,
   SettingsAppearancePage,
 } from '@/pages/common';
+import {
+  CourseTimesPage,
+  CourseTimeCreatePage,
+  CourseTimeDetailPage,
+} from '@/pages/to/time';
 import { DashboardPage, PlaceholderPage } from './pages';
 
 function TenantOperatorWrapper() {
@@ -27,8 +32,11 @@ export const toRoutes = (
     <Route path="courses" element={<PlaceholderPage title="과정 목록" />} />
     <Route path="courses/create" element={<PlaceholderPage title="과정 생성" />} />
     <Route path="courses/:id" element={<PlaceholderPage title="과정 상세" />} />
-    {/* 교육 운영 관리 */}
-    <Route path="sessions" element={<PlaceholderPage title="차수 관리" />} />
+    {/* 교육 운영 관리 - 차수(CourseTime) */}
+    <Route path="times" element={<CourseTimesPage />} />
+    <Route path="times/create" element={<CourseTimeCreatePage />} />
+    <Route path="times/:id" element={<CourseTimeDetailPage />} />
+    {/* 강사 배정 */}
     <Route path="instructors" element={<PlaceholderPage title="강사 배정" />} />
     {/* 콘텐츠 관리 */}
     <Route path="content" element={<PlaceholderPage title="콘텐츠 풀" />} />


### PR DESCRIPTION
## Summary

TO(Tenant Operator) 차수(CourseTime) 관리 페이지를 구현합니다.

## Related Issue

- Closes #91

## Changes

- 차수 목록 페이지 (CourseTimesPage.tsx): DataTable 기반 목록, 상태별 필터링, 검색, 페이지네이션
- 차수 생성 페이지 (CourseTimeCreatePage.tsx): 3단계 위저드 폼 (기본 정보 → 기간 설정 → 정원/가격)
- 차수 상세 페이지 (CourseTimeDetailPage.tsx): 상세 조회/수정, 상태 전이, 강사 배정 관리
- 라우팅 설정 (to.routes.tsx): /to/times, /to/times/create, /to/times/:id
- 사이드바 메뉴 경로 변경: /to/sessions → /to/times

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)
<img width="1919" height="871" alt="image" src="https://github.com/user-attachments/assets/61bd5229-fb63-4b64-b89e-295df21cc701" />

## Additional Notes

- #90 (프로그램 관리 페이지) 구현 후 후속 작업 예정