### PR TITLE
feat(tu): 강의 상세 페이지(CourseDetailPage) 구현

### DIFF
--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -73,3 +73,14 @@ export {
   useMyAssignments,
   useMyInstructorStatistics,
 } from './useMyAssignmentQueries';
+
+// Course Hooks
+export {
+  courseKeys,
+  useCourses,
+  useMyCourses,
+  useCourse,
+  useCourseItemsHierarchy,
+  useUpdateCourse,
+  useDeleteCourse,
+} from './useCourseQueries';

--- a/src/hooks/tu/useCourseQueries.ts
+++ b/src/hooks/tu/useCourseQueries.ts
@@ -1,0 +1,83 @@
+/**
+ * Course React Query Hooks
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { courseService } from '@/services/common/courseService';
+import type {
+  CourseFilterParams,
+} from '@/services/common/courseService';
+import type { UpdateCourseRequest } from '@/types/common/course.types';
+
+// Query Keys
+export const courseKeys = {
+  all: ['courses'] as const,
+  lists: () => [...courseKeys.all, 'list'] as const,
+  list: (params?: CourseFilterParams) => [...courseKeys.lists(), params] as const,
+  myLists: () => [...courseKeys.all, 'my'] as const,
+  myList: (params?: CourseFilterParams) => [...courseKeys.myLists(), params] as const,
+  details: () => [...courseKeys.all, 'detail'] as const,
+  detail: (id: number) => [...courseKeys.details(), id] as const,
+  itemsHierarchy: (id: number) => [...courseKeys.detail(id), 'itemsHierarchy'] as const,
+};
+
+// 강의 목록 조회
+export const useCourses = (params?: CourseFilterParams) => {
+  return useQuery({
+    queryKey: courseKeys.list(params),
+    queryFn: () => courseService.getCourses(params),
+  });
+};
+
+// 내 강의 목록 조회
+export const useMyCourses = (params?: CourseFilterParams) => {
+  return useQuery({
+    queryKey: courseKeys.myList(params),
+    queryFn: () => courseService.getMyCourses(params),
+  });
+};
+
+// 강의 상세 조회
+export const useCourse = (id: number) => {
+  return useQuery({
+    queryKey: courseKeys.detail(id),
+    queryFn: () => courseService.getCourse(id),
+    enabled: !!id,
+  });
+};
+
+// 커리큘럼 계층 구조 조회
+export const useCourseItemsHierarchy = (courseId: number) => {
+  return useQuery({
+    queryKey: courseKeys.itemsHierarchy(courseId),
+    queryFn: () => courseService.getItemsHierarchy(courseId),
+    enabled: !!courseId,
+  });
+};
+
+// 강의 수정
+export const useUpdateCourse = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: { id: number; request: UpdateCourseRequest }) =>
+      courseService.update(id, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: courseKeys.detail(variables.id) });
+      queryClient.invalidateQueries({ queryKey: courseKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: courseKeys.myLists() });
+    },
+  });
+};
+
+// 강의 삭제
+export const useDeleteCourse = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => courseService.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: courseKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: courseKeys.myLists() });
+    },
+  });
+};

--- a/src/pages/tu/index.ts
+++ b/src/pages/tu/index.ts
@@ -1,4 +1,4 @@
-export { MyCoursesPage, MyContentPage, CourseCreatePage, TuContentCreatePage, ContentDetailPage, MyAssignmentsPage } from './teaching';
+export { MyCoursesPage, MyContentPage, CourseCreatePage, CourseDetailPage, TuContentCreatePage, ContentDetailPage, MyAssignmentsPage } from './teaching';
 export { SettingsLanguagePage } from './settings';
 export { LandingPage, Page1, Page2, Page3 } from './main';
 export { CatalogPage, CatalogDetailPage } from './catalog';

--- a/src/pages/tu/teaching/courses/CourseDetailPage.tsx
+++ b/src/pages/tu/teaching/courses/CourseDetailPage.tsx
@@ -1,0 +1,207 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  ArrowLeft,
+  Edit2,
+  Trash2,
+  Loader2,
+  AlertCircle,
+} from 'lucide-react';
+import { Button, Badge } from '@/components/common';
+import type { BadgeColor } from '@/components/common/Badge/Badge.types';
+import {
+  useCourse,
+  useCourseItemsHierarchy,
+  useDeleteCourse,
+} from '@/hooks/tu';
+import { categoryService } from '@/services/common';
+import { CourseInfoSection } from './components/CourseInfoSection';
+import { CourseCurriculumSection } from './components/CourseCurriculumSection';
+import { CourseEditModal } from './components/CourseEditModal';
+import type { CourseLevel, CourseType } from '@/types/common/course.types';
+import type { CategoryResponse } from '@/types/common';
+
+// 난이도별 Badge 컬러
+const levelBadgeColor: Record<CourseLevel, BadgeColor> = {
+  BEGINNER: 'green',
+  INTERMEDIATE: 'blue',
+  ADVANCED: 'purple',
+};
+
+// 유형별 Badge 컬러
+const typeBadgeColor: Record<CourseType, BadgeColor> = {
+  ONLINE: 'indigo',
+  OFFLINE: 'orange',
+  BLENDED: 'gray',
+};
+
+// 라벨 맵
+const LEVEL_LABELS: Record<CourseLevel, string> = {
+  BEGINNER: '초급',
+  INTERMEDIATE: '중급',
+  ADVANCED: '고급',
+};
+
+const TYPE_LABELS: Record<CourseType, string> = {
+  ONLINE: '온라인',
+  OFFLINE: '오프라인',
+  BLENDED: '블렌디드',
+};
+
+export function CourseDetailPage() {
+  const { courseId } = useParams<{ courseId: string }>();
+  const navigate = useNavigate();
+  const id = courseId ? parseInt(courseId, 10) : 0;
+
+  // 모달 상태
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [categories, setCategories] = useState<CategoryResponse[]>([]);
+
+  // React Query hooks
+  const { data: course, isLoading, error } = useCourse(id);
+  const { data: curriculum } = useCourseItemsHierarchy(id);
+  const deleteCourseMutation = useDeleteCourse();
+
+  // 카테고리 목록 조회
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const data = await categoryService.getCategories();
+        setCategories(data);
+      } catch (err) {
+        console.error('카테고리 목록 조회 실패:', err);
+      }
+    };
+    fetchCategories();
+  }, []);
+
+  // 삭제 핸들러
+  const handleDelete = async () => {
+    if (!confirm('정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.')) return;
+
+    try {
+      await deleteCourseMutation.mutateAsync(id);
+      alert('삭제되었습니다.');
+      navigate('/tu/teaching/courses');
+    } catch (err) {
+      console.error('Delete failed:', err);
+      alert('삭제에 실패했습니다.');
+    }
+  };
+
+  // 로딩 상태
+  if (isLoading) {
+    return (
+      <div className="h-full flex items-center justify-center bg-bg-app">
+        <Loader2 size={32} className="animate-spin text-text-secondary" />
+        <span className="ml-2 text-text-secondary">로딩 중...</span>
+      </div>
+    );
+  }
+
+  // 에러 상태
+  if (error || !course) {
+    return (
+      <div className="h-full flex items-center justify-center bg-bg-app">
+        <div className="text-center">
+          <AlertCircle size={48} className="mx-auto mb-3 text-status-error" />
+          <p className="text-text-secondary">
+            {error ? '오류가 발생했습니다.' : '강의를 찾을 수 없습니다.'}
+          </p>
+          <Button
+            variant="ghost"
+            className="mt-4 border border-border"
+            onClick={() => navigate('/tu/teaching/courses')}
+          >
+            <ArrowLeft size={16} />
+            목록으로
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col bg-bg-app">
+      {/* Header */}
+      <div className="border-b border-border bg-bg-default sticky top-0 z-10">
+        <div className="p-6 px-8">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="border border-border"
+                onClick={() => navigate('/tu/teaching/courses')}
+              >
+                <ArrowLeft size={16} />
+                목록으로
+              </Button>
+              <div>
+                <h1 className="text-text-primary text-xl mb-1">{course.title}</h1>
+                <div className="flex items-center gap-2">
+                  {course.level && (
+                    <Badge variant={levelBadgeColor[course.level]}>
+                      {LEVEL_LABELS[course.level]}
+                    </Badge>
+                  )}
+                  {course.type && (
+                    <Badge variant={typeBadgeColor[course.type]}>
+                      {TYPE_LABELS[course.type]}
+                    </Badge>
+                  )}
+                  <span className="text-text-secondary text-sm">
+                    {course.itemCount}차시
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* Action Buttons */}
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="border border-border"
+                onClick={() => setIsEditModalOpen(true)}
+              >
+                <Edit2 size={16} />
+                수정
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={handleDelete}
+                disabled={deleteCourseMutation.isPending}
+              >
+                <Trash2 size={16} />
+                삭제
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto">
+        <div className="p-6 px-8 max-w-5xl space-y-6">
+          {/* 기본 정보 섹션 */}
+          <CourseInfoSection course={course} categories={categories} />
+
+          {/* 커리큘럼 섹션 */}
+          <CourseCurriculumSection
+            itemCount={course.itemCount}
+            curriculum={curriculum ?? []}
+          />
+        </div>
+      </div>
+
+      {/* 수정 모달 */}
+      <CourseEditModal
+        isOpen={isEditModalOpen}
+        onClose={() => setIsEditModalOpen(false)}
+        course={course}
+      />
+    </div>
+  );
+}

--- a/src/pages/tu/teaching/courses/components/CourseCurriculumSection.tsx
+++ b/src/pages/tu/teaching/courses/components/CourseCurriculumSection.tsx
@@ -1,0 +1,71 @@
+import { BookOpen, Folder, FileText } from 'lucide-react';
+import type { CourseItemHierarchyResponse } from '@/types/common/course.types';
+
+interface CourseCurriculumSectionProps {
+  itemCount: number;
+  curriculum: CourseItemHierarchyResponse[];
+}
+
+// 재귀적으로 트리 아이템 렌더링
+function CurriculumTreeItem({
+  item,
+  depth = 0,
+}: {
+  item: CourseItemHierarchyResponse;
+  depth?: number;
+}) {
+  const paddingLeft = depth * 24;
+  const Icon = item.isFolder ? Folder : FileText;
+  const iconColor = item.isFolder ? 'text-amber-500' : 'text-text-secondary';
+
+  return (
+    <div>
+      <div
+        className="flex items-center gap-2 py-2 px-3 hover:bg-bg-secondary rounded-md transition-colors"
+        style={{ paddingLeft: `${paddingLeft + 12}px` }}
+      >
+        <Icon size={16} className={iconColor} />
+        <span className="text-text-primary text-sm">{item.itemName}</span>
+      </div>
+      {item.children && item.children.length > 0 && (
+        <div>
+          {item.children.map((child) => (
+            <CurriculumTreeItem key={child.itemId} item={child} depth={depth + 1} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function CourseCurriculumSection({
+  itemCount,
+  curriculum,
+}: Readonly<CourseCurriculumSectionProps>) {
+  return (
+    <div className="bg-bg-default border border-border rounded-lg p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-text-primary text-lg font-medium flex items-center gap-2">
+          <BookOpen size={20} />
+          커리큘럼
+          <span className="text-text-secondary font-normal">({itemCount}차시)</span>
+        </h2>
+      </div>
+
+      {curriculum.length > 0 ? (
+        <div className="border border-border rounded-lg overflow-hidden">
+          <div className="max-h-96 overflow-auto">
+            {curriculum.map((item) => (
+              <CurriculumTreeItem key={item.itemId} item={item} />
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className="text-center py-12 text-text-secondary">
+          <BookOpen size={48} className="mx-auto mb-3 opacity-50" />
+          <p>등록된 커리큘럼이 없습니다.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/tu/teaching/courses/components/CourseEditModal.tsx
+++ b/src/pages/tu/teaching/courses/components/CourseEditModal.tsx
@@ -1,0 +1,281 @@
+import { useState, useEffect } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/common';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/common/Dialog/Dialog';
+import { useUpdateCourse } from '@/hooks/tu';
+import type {
+  CourseDetailResponse,
+  CourseLevel,
+  CourseType,
+  UpdateCourseRequest,
+} from '@/types/common/course.types';
+
+interface CourseEditModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  course: CourseDetailResponse;
+}
+
+// 난이도 옵션
+const levelOptions: { value: CourseLevel | ''; label: string }[] = [
+  { value: '', label: '선택 안 함' },
+  { value: 'BEGINNER', label: '초급' },
+  { value: 'INTERMEDIATE', label: '중급' },
+  { value: 'ADVANCED', label: '고급' },
+];
+
+// 유형 옵션
+const typeOptions: { value: CourseType | ''; label: string }[] = [
+  { value: '', label: '선택 안 함' },
+  { value: 'ONLINE', label: '온라인' },
+  { value: 'OFFLINE', label: '오프라인' },
+  { value: 'BLENDED', label: '블렌디드' },
+];
+
+export function CourseEditModal({
+  isOpen,
+  onClose,
+  course,
+}: Readonly<CourseEditModalProps>) {
+  const updateCourseMutation = useUpdateCourse();
+
+  // 폼 상태
+  const [formData, setFormData] = useState({
+    title: '',
+    description: '',
+    level: '' as CourseLevel | '',
+    type: '' as CourseType | '',
+    estimatedHours: '',
+    startDate: '',
+    endDate: '',
+    tags: '',
+  });
+
+  // 모달이 열릴 때 course 데이터로 폼 초기화
+  useEffect(() => {
+    if (isOpen && course) {
+      setFormData({
+        title: course.title || '',
+        description: course.description || '',
+        level: course.level || '',
+        type: course.type || '',
+        estimatedHours: course.estimatedHours?.toString() || '',
+        startDate: course.startDate || '',
+        endDate: course.endDate || '',
+        tags: course.tags?.join(', ') || '',
+      });
+    }
+  }, [isOpen, course]);
+
+  // 입력 핸들러
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  // 저장 핸들러
+  const handleSave = async () => {
+    if (!formData.title.trim()) {
+      alert('강의명을 입력해주세요.');
+      return;
+    }
+
+    const request: UpdateCourseRequest = {
+      title: formData.title.trim(),
+      description: formData.description.trim() || undefined,
+      level: formData.level || undefined,
+      type: formData.type || undefined,
+      estimatedHours: formData.estimatedHours
+        ? parseInt(formData.estimatedHours, 10)
+        : undefined,
+      startDate: formData.startDate || undefined,
+      endDate: formData.endDate || undefined,
+      tags: formData.tags
+        ? formData.tags.split(',').map((tag) => tag.trim()).filter(Boolean)
+        : undefined,
+    };
+
+    try {
+      await updateCourseMutation.mutateAsync({ id: course.courseId, request });
+      alert('수정되었습니다.');
+      onClose();
+    } catch (err) {
+      console.error('Update failed:', err);
+      alert('수정에 실패했습니다.');
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-2xl bg-bg-default">
+        <DialogHeader>
+          <DialogTitle>강의 정보 수정</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4 max-h-[60vh] overflow-auto">
+          {/* 강의명 */}
+          <div>
+            <label className="block text-sm font-medium text-text-primary mb-1">
+              강의명 <span className="text-status-error">*</span>
+            </label>
+            <input
+              type="text"
+              name="title"
+              value={formData.title}
+              onChange={handleChange}
+              placeholder="강의명을 입력하세요"
+              className="w-full px-3 py-2 border border-border rounded-lg text-text-primary text-sm outline-none focus:ring-2 focus:ring-action-primary bg-bg-default"
+            />
+          </div>
+
+          {/* 설명 */}
+          <div>
+            <label className="block text-sm font-medium text-text-primary mb-1">
+              설명
+            </label>
+            <textarea
+              name="description"
+              value={formData.description}
+              onChange={handleChange}
+              placeholder="강의에 대한 설명을 입력하세요"
+              rows={3}
+              className="w-full px-3 py-2 border border-border rounded-lg text-text-primary text-sm outline-none focus:ring-2 focus:ring-action-primary bg-bg-default resize-none"
+            />
+          </div>
+
+          {/* 난이도 & 유형 */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-text-primary mb-1">
+                난이도
+              </label>
+              <select
+                name="level"
+                value={formData.level}
+                onChange={handleChange}
+                className="w-full px-3 py-2 border border-border rounded-lg text-text-primary text-sm outline-none focus:ring-2 focus:ring-action-primary bg-bg-default"
+              >
+                {levelOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-text-primary mb-1">
+                유형
+              </label>
+              <select
+                name="type"
+                value={formData.type}
+                onChange={handleChange}
+                className="w-full px-3 py-2 border border-border rounded-lg text-text-primary text-sm outline-none focus:ring-2 focus:ring-action-primary bg-bg-default"
+              >
+                {typeOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* 예상 학습시간 */}
+          <div>
+            <label className="block text-sm font-medium text-text-primary mb-1">
+              예상 학습시간 (시간)
+            </label>
+            <input
+              type="number"
+              name="estimatedHours"
+              value={formData.estimatedHours}
+              onChange={handleChange}
+              placeholder="예: 10"
+              min="1"
+              className="w-full px-3 py-2 border border-border rounded-lg text-text-primary text-sm outline-none focus:ring-2 focus:ring-action-primary bg-bg-default"
+            />
+          </div>
+
+          {/* 기간 */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-text-primary mb-1">
+                시작일
+              </label>
+              <input
+                type="date"
+                name="startDate"
+                value={formData.startDate}
+                onChange={handleChange}
+                className="w-full px-3 py-2 border border-border rounded-lg text-text-primary text-sm outline-none focus:ring-2 focus:ring-action-primary bg-bg-default"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-text-primary mb-1">
+                종료일
+              </label>
+              <input
+                type="date"
+                name="endDate"
+                value={formData.endDate}
+                onChange={handleChange}
+                className="w-full px-3 py-2 border border-border rounded-lg text-text-primary text-sm outline-none focus:ring-2 focus:ring-action-primary bg-bg-default"
+              />
+            </div>
+          </div>
+
+          {/* 태그 */}
+          <div>
+            <label className="block text-sm font-medium text-text-primary mb-1">
+              태그
+            </label>
+            <input
+              type="text"
+              name="tags"
+              value={formData.tags}
+              onChange={handleChange}
+              placeholder="쉼표로 구분하여 입력 (예: React, JavaScript, 웹개발)"
+              className="w-full px-3 py-2 border border-border rounded-lg text-text-primary text-sm outline-none focus:ring-2 focus:ring-action-primary bg-bg-default"
+            />
+            <p className="mt-1 text-xs text-text-secondary">
+              쉼표(,)로 구분하여 여러 개의 태그를 입력할 수 있습니다.
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            className="border border-border"
+            onClick={onClose}
+            disabled={updateCourseMutation.isPending}
+          >
+            취소
+          </Button>
+          <Button
+            onClick={handleSave}
+            disabled={updateCourseMutation.isPending}
+          >
+            {updateCourseMutation.isPending ? (
+              <>
+                <Loader2 size={16} className="animate-spin" />
+                저장 중...
+              </>
+            ) : (
+              '저장'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/tu/teaching/courses/components/CourseInfoSection.tsx
+++ b/src/pages/tu/teaching/courses/components/CourseInfoSection.tsx
@@ -1,0 +1,139 @@
+import { FileText, Calendar, Clock, Tag } from 'lucide-react';
+import type { CourseDetailResponse } from '@/types/common/course.types';
+import type { CategoryResponse } from '@/types/common';
+
+interface CourseInfoSectionProps {
+  course: CourseDetailResponse;
+  categories: CategoryResponse[];
+}
+
+// 날짜 포맷팅
+function formatDate(dateString: string | null): string {
+  if (!dateString) return '-';
+  return new Date(dateString).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+}
+
+// 난이도 라벨
+const LEVEL_LABELS: Record<string, string> = {
+  BEGINNER: '초급',
+  INTERMEDIATE: '중급',
+  ADVANCED: '고급',
+};
+
+// 유형 라벨
+const TYPE_LABELS: Record<string, string> = {
+  ONLINE: '온라인',
+  OFFLINE: '오프라인',
+  BLENDED: '블렌디드',
+};
+
+export function CourseInfoSection({ course, categories }: Readonly<CourseInfoSectionProps>) {
+  // categoryId로 카테고리 이름 찾기
+  const getCategoryName = (categoryId: number | null): string => {
+    if (!categoryId) return '-';
+    const category = categories.find((c) => c.id === categoryId);
+    return category?.name ?? '-';
+  };
+  return (
+    <div className="bg-bg-default border border-border rounded-lg p-6">
+      <h2 className="text-text-primary text-lg font-medium flex items-center gap-2 mb-4">
+        <FileText size={20} />
+        기본 정보
+      </h2>
+
+      <div className="space-y-6">
+        {/* 설명 */}
+        <div>
+          <label className="block text-sm text-text-secondary mb-1">설명</label>
+          <p className="text-text-primary">
+            {course.description || (
+              <span className="text-text-placeholder">설명 없음</span>
+            )}
+          </p>
+        </div>
+
+        {/* 그리드 정보 */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          {/* 난이도 */}
+          <div>
+            <label className="block text-sm text-text-secondary mb-1">난이도</label>
+            <p className="text-text-primary">
+              {course.level ? LEVEL_LABELS[course.level] : '-'}
+            </p>
+          </div>
+
+          {/* 유형 */}
+          <div>
+            <label className="block text-sm text-text-secondary mb-1">유형</label>
+            <p className="text-text-primary">
+              {course.type ? TYPE_LABELS[course.type] : '-'}
+            </p>
+          </div>
+
+          {/* 예상 학습시간 */}
+          <div>
+            <label className="block text-sm text-text-secondary mb-1">
+              예상 학습시간
+            </label>
+            <p className="text-text-primary flex items-center gap-1">
+              <Clock size={16} className="text-text-secondary" />
+              {course.estimatedHours ? `${course.estimatedHours}시간` : '-'}
+            </p>
+          </div>
+
+          {/* 카테고리 */}
+          <div>
+            <label className="block text-sm text-text-secondary mb-1">카테고리</label>
+            <p className="text-text-primary">
+              {getCategoryName(course.categoryId)}
+            </p>
+          </div>
+        </div>
+
+        {/* 기간 */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm text-text-secondary mb-1">시작일</label>
+            <p className="text-text-primary flex items-center gap-1">
+              <Calendar size={16} className="text-text-secondary" />
+              {formatDate(course.startDate)}
+            </p>
+          </div>
+          <div>
+            <label className="block text-sm text-text-secondary mb-1">종료일</label>
+            <p className="text-text-primary flex items-center gap-1">
+              <Calendar size={16} className="text-text-secondary" />
+              {formatDate(course.endDate)}
+            </p>
+          </div>
+        </div>
+
+        {/* 태그 */}
+        <div>
+          <label className="block text-sm text-text-secondary mb-1 flex items-center gap-1">
+            <Tag size={14} />
+            태그
+          </label>
+          {course.tags && course.tags.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {course.tags.map((tag, index) => (
+                <span
+                  key={index}
+                  className="inline-flex items-center px-2 py-1 bg-bg-secondary border border-border rounded-full text-sm text-text-primary"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <p className="text-text-placeholder">태그 없음</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/teaching/courses/index.ts
+++ b/src/pages/tu/teaching/courses/index.ts
@@ -1,2 +1,3 @@
 export { MyCoursesPage } from './MyCoursesPage';
 export { CourseCreatePage } from './CourseCreatePage';
+export { CourseDetailPage } from './CourseDetailPage';

--- a/src/pages/tu/teaching/index.ts
+++ b/src/pages/tu/teaching/index.ts
@@ -1,3 +1,3 @@
-export { MyCoursesPage, CourseCreatePage } from './courses';
+export { MyCoursesPage, CourseCreatePage, CourseDetailPage } from './courses';
 export { MyContentPage, ContentCreatePage as TuContentCreatePage, ContentDetailPage } from './content';
 export { MyAssignmentsPage } from './assignments';

--- a/src/routes/tu.courses.routes.tsx
+++ b/src/routes/tu.courses.routes.tsx
@@ -5,6 +5,7 @@ import {
   MyCoursesPage,
   MyContentPage,
   CourseCreatePage,
+  CourseDetailPage,
   TuContentCreatePage,
   ContentDetailPage,
   MyAssignmentsPage,
@@ -29,6 +30,7 @@ export const tuCoursesRoutes = (
     {/* 내 강의 */}
     <Route path="teaching/courses" element={<MyCoursesPage />} />
     <Route path="teaching/courses/create" element={<CourseCreatePage />} />
+    <Route path="teaching/courses/:courseId" element={<CourseDetailPage />} />
     <Route path="teaching/content" element={<MyContentPage />} />
     <Route path="teaching/content/create" element={<TuContentCreatePage />} />
     <Route path="teaching/content/:id" element={<ContentDetailPage />} />

--- a/src/services/common/courseService.ts
+++ b/src/services/common/courseService.ts
@@ -73,10 +73,10 @@ export const courseService = {
 
   /** 강의 상세 조회 */
   async getCourse(id: number): Promise<CourseDetailResponse> {
-    const { data } = await axiosInstance.get<CourseDetailResponse>(
+    const { data } = await axiosInstance.get<{ data: CourseDetailResponse }>(
       API_ENDPOINTS.COURSES.BY_ID(id)
     );
-    return data;
+    return data.data;
   },
 
   /** 강의 수정 */
@@ -84,11 +84,11 @@ export const courseService = {
     id: number,
     request: UpdateCourseRequest
   ): Promise<CourseResponse> {
-    const { data } = await axiosInstance.put<CourseResponse>(
+    const { data } = await axiosInstance.put<{ data: CourseResponse }>(
       API_ENDPOINTS.COURSES.BY_ID(id),
       request
     );
-    return data;
+    return data.data;
   },
 
   /** 강의 삭제 */
@@ -128,10 +128,10 @@ export const courseService = {
   async getItemsHierarchy(
     courseId: number
   ): Promise<CourseItemHierarchyResponse[]> {
-    const { data } = await axiosInstance.get<CourseItemHierarchyResponse[]>(
+    const { data } = await axiosInstance.get<{ data: CourseItemHierarchyResponse[] }>(
       API_ENDPOINTS.COURSES.ITEMS_HIERARCHY(courseId)
     );
-    return data;
+    return data.data;
   },
 
   /** 순서대로 차시 조회 */

--- a/src/services/tu/contentService.ts
+++ b/src/services/tu/contentService.ts
@@ -58,7 +58,7 @@ export const contentService = {
       formData,
       {
         headers: {
-          'Content-Type': 'multipart/form-data',
+          'Content-Type': undefined, // 브라우저가 boundary 포함하여 자동 설정
         },
       }
     );
@@ -121,7 +121,7 @@ export const contentService = {
       formData,
       {
         headers: {
-          'Content-Type': 'multipart/form-data',
+          'Content-Type': undefined, // 브라우저가 boundary 포함하여 자동 설정
         },
       }
     );


### PR DESCRIPTION
## Summary
- 강의 상세 페이지(CourseDetailPage) 신규 구현
- 강의 기본 정보 조회/수정/삭제 기능
- 커리큘럼 트리 뷰 (읽기 전용)
- React Query hooks 추가 (useCourseQueries)
- courseService API 응답 처리 수정

## Changes
- `CourseDetailPage.tsx`: 메인 상세 페이지
- `CourseInfoSection.tsx`: 기본 정보 섹션
- `CourseCurriculumSection.tsx`: 커리큘럼 트리
- `CourseEditModal.tsx`: 수정 모달
- `useCourseQueries.ts`: React Query hooks
- `courseService.ts`: API 응답 wrapper 처리 수정

## Test plan
- [ ] /tu/teaching/courses 목록에서 강의 카드 클릭 시 상세 페이지 이동
- [ ] 강의 기본 정보 표시 확인 (카테고리 이름 포함)
- [ ] 수정 모달에서 정보 수정 후 저장
- [ ] 삭제 버튼 클릭 시 삭제 및 목록으로 이동

Closes #92