### PR TITLE
feat: SA 테넌트/TA 사용자 상세 페이지 API 연동

### DIFF
--- a/src/components/domain/admin/RoleBadge.tsx
+++ b/src/components/domain/admin/RoleBadge.tsx
@@ -18,7 +18,7 @@ const systemRoleConfig: Record<
   SystemRole,
   { label: { ko: string; en: string }; variant: BadgeVariant }
 > = {
-  SUPER_ADMIN: { label: { ko: '슈퍼 관리자', en: 'Super Admin' }, variant: 'purple' },
+  SUPER_ADMIN: { label: { ko: '시스템 관리자', en: 'System Admin' }, variant: 'purple' },
   TENANT_ADMIN: { label: { ko: '테넌트 관리자', en: 'Tenant Admin' }, variant: 'indigo' },
   OPERATOR: { label: { ko: '운영자', en: 'Operator' }, variant: 'blue' },
   USER: { label: { ko: '사용자', en: 'User' }, variant: 'gray' },

--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -286,7 +286,7 @@ export const myPageMenuData: MenuItem[] = [
  * 역할별 라벨
  */
 export const roleLabels = {
-  superAdmin: { ko: '슈퍼 어드민', en: 'Super Admin' },
+  superAdmin: { ko: '시스템 어드민', en: 'System Admin' },
   tenantAdmin: { ko: '테넌트 어드민', en: 'Tenant Admin' },
   tenantOperator: { ko: '교육 운영자', en: 'Operator' },
   tenantUser: { ko: 'Enterprise LMS', en: 'Enterprise LMS' },

--- a/src/hooks/sa/index.ts
+++ b/src/hooks/sa/index.ts
@@ -1,0 +1,9 @@
+export {
+  tenantKeys,
+  useTenants,
+  useTenant,
+  useTenantStats,
+  useCreateTenant,
+  useUpdateTenant,
+  useDeleteTenant,
+} from './useTenantQueries';

--- a/src/hooks/sa/useTenantQueries.ts
+++ b/src/hooks/sa/useTenantQueries.ts
@@ -1,0 +1,89 @@
+/**
+ * Tenant React Query Hooks (SA - System Admin)
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { tenantService, type TenantFilterParams } from '@/services/sa';
+import type { CreateTenantRequest, UpdateTenantDetailRequest } from '@/types/admin';
+
+// Query Keys
+export const tenantKeys = {
+  all: ['tenants'] as const,
+  lists: () => [...tenantKeys.all, 'list'] as const,
+  list: (params?: TenantFilterParams) => [...tenantKeys.lists(), params] as const,
+  details: () => [...tenantKeys.all, 'detail'] as const,
+  detail: (id: number) => [...tenantKeys.details(), id] as const,
+  stats: () => [...tenantKeys.all, 'stats'] as const,
+};
+
+// ============================================
+// Queries
+// ============================================
+
+/** 테넌트 목록 조회 */
+export const useTenants = (params?: TenantFilterParams) => {
+  return useQuery({
+    queryKey: tenantKeys.list(params),
+    queryFn: () => tenantService.getTenants(params),
+  });
+};
+
+/** 테넌트 상세 조회 */
+export const useTenant = (id: number) => {
+  return useQuery({
+    queryKey: tenantKeys.detail(id),
+    queryFn: () => tenantService.getTenant(id),
+    enabled: !!id,
+  });
+};
+
+/** 테넌트 통계 조회 */
+export const useTenantStats = () => {
+  return useQuery({
+    queryKey: tenantKeys.stats(),
+    queryFn: () => tenantService.getStats(),
+  });
+};
+
+// ============================================
+// Mutations
+// ============================================
+
+/** 테넌트 생성 */
+export const useCreateTenant = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateTenantRequest) => tenantService.create(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: tenantKeys.stats() });
+    },
+  });
+};
+
+/** 테넌트 수정 */
+export const useUpdateTenant = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: { id: number; request: UpdateTenantDetailRequest }) =>
+      tenantService.update(id, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: tenantKeys.detail(variables.id) });
+      queryClient.invalidateQueries({ queryKey: tenantKeys.lists() });
+    },
+  });
+};
+
+/** 테넌트 삭제 */
+export const useDeleteTenant = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => tenantService.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: tenantKeys.stats() });
+    },
+  });
+};

--- a/src/hooks/ta/index.ts
+++ b/src/hooks/ta/index.ts
@@ -1,0 +1,10 @@
+export {
+  userKeys,
+  useUsers,
+  useUser,
+  useUserStats,
+  useUpdateUser,
+  useUpdateUserRole,
+  useUpdateUserStatus,
+  useDeleteUser,
+} from './useUserQueries';

--- a/src/hooks/ta/useUserQueries.ts
+++ b/src/hooks/ta/useUserQueries.ts
@@ -1,0 +1,108 @@
+/**
+ * User React Query Hooks (TA - Tenant Admin)
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { userService } from '@/services/ta';
+import type {
+  UserListParams,
+  UpdateUserDetailRequest,
+  UpdateUserRoleRequest,
+} from '@/types/admin';
+
+// Query Keys
+export const userKeys = {
+  all: ['users'] as const,
+  lists: () => [...userKeys.all, 'list'] as const,
+  list: (params?: UserListParams) => [...userKeys.lists(), params] as const,
+  details: () => [...userKeys.all, 'detail'] as const,
+  detail: (id: number) => [...userKeys.details(), id] as const,
+  stats: () => [...userKeys.all, 'stats'] as const,
+};
+
+// ============================================
+// Queries
+// ============================================
+
+/** 사용자 목록 조회 */
+export const useUsers = (params?: UserListParams) => {
+  return useQuery({
+    queryKey: userKeys.list(params),
+    queryFn: () => userService.getUsers(params),
+  });
+};
+
+/** 사용자 상세 조회 */
+export const useUser = (id: number) => {
+  return useQuery({
+    queryKey: userKeys.detail(id),
+    queryFn: () => userService.getUser(id),
+    enabled: !!id,
+  });
+};
+
+/** 사용자 통계 조회 */
+export const useUserStats = () => {
+  return useQuery({
+    queryKey: userKeys.stats(),
+    queryFn: () => userService.getStats(),
+  });
+};
+
+// ============================================
+// Mutations
+// ============================================
+
+/** 사용자 정보 수정 */
+export const useUpdateUser = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: { id: number; request: UpdateUserDetailRequest }) =>
+      userService.update(id, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: userKeys.detail(variables.id) });
+      queryClient.invalidateQueries({ queryKey: userKeys.lists() });
+    },
+  });
+};
+
+/** 사용자 역할 변경 */
+export const useUpdateUserRole = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: { id: number; request: UpdateUserRoleRequest }) =>
+      userService.updateRole(id, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: userKeys.detail(variables.id) });
+      queryClient.invalidateQueries({ queryKey: userKeys.lists() });
+    },
+  });
+};
+
+/** 사용자 상태 변경 */
+export const useUpdateUserStatus = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, status }: { id: number; status: string }) =>
+      userService.updateStatus(id, status),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: userKeys.detail(variables.id) });
+      queryClient.invalidateQueries({ queryKey: userKeys.lists() });
+    },
+  });
+};
+
+/** 사용자 삭제 */
+export const useDeleteUser = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => userService.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: userKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: userKeys.stats() });
+    },
+  });
+};

--- a/src/pages/sa/index.ts
+++ b/src/pages/sa/index.ts
@@ -1,3 +1,3 @@
 // Super Admin pages
 export { DashboardPage } from "./dashboard";
-export { TenantsPage } from "./tenants";
+export { TenantsPage, TenantDetailPage } from "./tenants";

--- a/src/pages/sa/tenants/TenantDetailPage.tsx
+++ b/src/pages/sa/tenants/TenantDetailPage.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useState, useEffect, useMemo } from 'react';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import {
   ArrowLeft,
   Building2,
@@ -9,6 +9,8 @@ import {
   Settings,
   Palette,
   Info,
+  Loader2,
+  AlertCircle,
 } from 'lucide-react';
 import {
   AdminPageHeader,
@@ -28,60 +30,42 @@ import {
   SelectValue,
 } from '@/components/common/Select';
 import { Switch } from '@/components/common/Switch';
-import type { TenantStatus, PlanType } from '@/types/admin';
+import { Skeleton } from '@/components/common/Skeleton';
+import { useTenant, useUpdateTenant, useDeleteTenant } from '@/hooks/sa';
+import type { TenantStatus, PlanType, TenantDetail } from '@/types/admin';
 
 // Mock 데이터
-interface TenantDetail {
-  id: number;
-  code: string;
-  name: string;
-  status: TenantStatus;
-  plan: PlanType;
-  userCount: number;
-  courseCount: number;
-  createdAt: string;
-  adminEmail: string;
-  adminName: string;
-  domain?: string;
-  branding: {
-    logoUrl?: string;
-    primaryColor: string;
-    secondaryColor: string;
-    faviconUrl?: string;
-  };
-  settings: {
-    maxUsers: number;
-    maxCourses: number;
-    maxStorage: number; // GB
-    allowCustomDomain: boolean;
-    allowCustomBranding: boolean;
-    ssoEnabled: boolean;
-    apiAccessEnabled: boolean;
-  };
-}
-
-const mockTenantDetail: TenantDetail = {
+const MOCK_TENANT: TenantDetail = {
   id: 1,
   code: 'mzc',
   name: '메가존클라우드',
+  type: 'B2B',
   status: 'ACTIVE',
   plan: 'ENTERPRISE',
+  subdomain: 'mzc',
+  customDomain: 'learn.megazone.com',
   userCount: 250,
   courseCount: 45,
   createdAt: '2025-01-15',
+  updatedAt: '2025-01-15',
   adminEmail: 'admin@megazone.com',
   adminName: '김관리자',
-  domain: 'learn.megazone.com',
   branding: {
-    logoUrl: '/logos/mzc-logo.png',
+    tenantId: 1,
+    logoUrl: '',
+    faviconUrl: '',
     primaryColor: '#3B82F6',
     secondaryColor: '#1E40AF',
-    faviconUrl: '/favicons/mzc-favicon.ico',
   },
   settings: {
-    maxUsers: 500,
+    tenantId: 1,
+    allowSelfRegistration: true,
+    requireEmailVerification: true,
+    defaultLanguage: 'ko',
+    timezone: 'Asia/Seoul',
+    maxStorageGB: 50,
+    maxUsersCount: 500,
     maxCourses: 100,
-    maxStorage: 50,
     allowCustomDomain: true,
     allowCustomBranding: true,
     ssoEnabled: true,
@@ -89,48 +73,244 @@ const mockTenantDetail: TenantDetail = {
   },
 };
 
+// 폼 상태용 로컬 타입
+interface TenantFormState {
+  name: string;
+  code: string;
+  status: TenantStatus;
+  plan: PlanType;
+  customDomain: string;
+  createdAt: string;
+  adminName: string;
+  adminEmail: string;
+  userCount: number;
+  courseCount: number;
+  branding: {
+    logoUrl: string;
+    primaryColor: string;
+    secondaryColor: string;
+    faviconUrl: string;
+  };
+  settings: {
+    maxUsersCount: number;
+    maxCourses: number;
+    maxStorageGB: number;
+    allowCustomDomain: boolean;
+    allowCustomBranding: boolean;
+    ssoEnabled: boolean;
+    apiAccessEnabled: boolean;
+  };
+}
+
+// API 데이터를 폼 상태로 변환
+const toFormState = (data: TenantDetail): TenantFormState => ({
+  name: data.name,
+  code: data.code,
+  status: data.status,
+  plan: data.plan,
+  customDomain: data.customDomain || '',
+  createdAt: data.createdAt,
+  adminName: data.adminName,
+  adminEmail: data.adminEmail,
+  userCount: data.userCount || 0,
+  courseCount: data.courseCount || 0,
+  branding: {
+    logoUrl: data.branding?.logoUrl || '',
+    primaryColor: data.branding?.primaryColor || '#3B82F6',
+    secondaryColor: data.branding?.secondaryColor || '#1E40AF',
+    faviconUrl: data.branding?.faviconUrl || '',
+  },
+  settings: {
+    maxUsersCount: data.settings?.maxUsersCount || 100,
+    maxCourses: data.settings?.maxCourses || 50,
+    maxStorageGB: data.settings?.maxStorageGB || 10,
+    allowCustomDomain: data.settings?.allowCustomDomain || false,
+    allowCustomBranding: data.settings?.allowCustomBranding || false,
+    ssoEnabled: data.settings?.ssoEnabled || false,
+    apiAccessEnabled: data.settings?.apiAccessEnabled || false,
+  },
+});
+
+// 로딩 스켈레톤
+function TenantDetailSkeleton() {
+  return (
+    <div className="p-6">
+      <div className="mb-6">
+        <Skeleton className="h-8 w-48 mb-2" />
+        <Skeleton className="h-4 w-32" />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+        {[1, 2, 3, 4].map((i) => (
+          <Card key={i}>
+            <CardContent className="pt-6">
+              <Skeleton className="h-4 w-16 mb-2" />
+              <Skeleton className="h-8 w-24" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// 에러 UI
+function TenantDetailError({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="p-6">
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex flex-col items-center justify-center py-12">
+            <AlertCircle className="h-12 w-12 text-red-500 mb-4" />
+            <h3 className="text-lg font-medium mb-2">데이터를 불러올 수 없습니다</h3>
+            <p className="text-text-secondary mb-4">{message}</p>
+            <Button onClick={onRetry}>다시 시도</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
 export function TenantDetailPage() {
-  const { id: _id } = useParams<{ id: string }>();
+  const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const tenantId = Number(id);
 
-  // 실제로는 API에서 id를 사용해 데이터를 가져옴
-  const [tenant, setTenant] = useState<TenantDetail>(mockTenantDetail);
+  // 데모 모드 체크 (?demo=true)
+  const isDemoMode = searchParams.get('demo') === 'true';
 
-  const handleSave = () => {
-    // API 호출
-    console.log('Save tenant:', tenant);
+  // API 호출 (데모 모드가 아닐 때만)
+  const { data: tenantData, isLoading, isError, error, refetch } = useTenant(tenantId);
+  const updateMutation = useUpdateTenant();
+  const deleteMutation = useDeleteTenant();
+
+  // 실제 데이터 또는 Mock 데이터
+  const effectiveData = useMemo(() => {
+    if (isDemoMode) return MOCK_TENANT;
+    return tenantData;
+  }, [isDemoMode, tenantData]);
+
+  // 폼 상태
+  const [formState, setFormState] = useState<TenantFormState | null>(null);
+
+  // 데이터 로드 시 폼 상태 초기화
+  useEffect(() => {
+    if (effectiveData) {
+      setFormState(toFormState(effectiveData));
+    }
+  }, [effectiveData]);
+
+  const handleSave = async () => {
+    if (!formState) return;
+
+    try {
+      await updateMutation.mutateAsync({
+        id: tenantId,
+        request: {
+          name: formState.name,
+          status: formState.status,
+          plan: formState.plan,
+          customDomain: formState.customDomain || undefined,
+          adminName: formState.adminName,
+          adminEmail: formState.adminEmail,
+          branding: {
+            tenantId: tenantId,
+            logoUrl: formState.branding.logoUrl || undefined,
+            faviconUrl: formState.branding.faviconUrl || undefined,
+            primaryColor: formState.branding.primaryColor,
+            secondaryColor: formState.branding.secondaryColor || undefined,
+          },
+          settings: {
+            tenantId: tenantId,
+            allowSelfRegistration: false,
+            requireEmailVerification: false,
+            defaultLanguage: 'ko',
+            timezone: 'Asia/Seoul',
+            maxStorageGB: formState.settings.maxStorageGB,
+            maxUsersCount: formState.settings.maxUsersCount,
+          },
+        },
+      });
+    } catch (err) {
+      console.error('Failed to save tenant:', err);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm('정말 이 테넌트를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.')) {
+      return;
+    }
+
+    try {
+      await deleteMutation.mutateAsync(tenantId);
+      navigate('/sa/tenants');
+    } catch (err) {
+      console.error('Failed to delete tenant:', err);
+    }
   };
 
   const handleStatusChange = (status: TenantStatus) => {
-    setTenant({ ...tenant, status });
+    if (formState) setFormState({ ...formState, status });
   };
 
   const handlePlanChange = (plan: PlanType) => {
-    setTenant({ ...tenant, plan });
+    if (formState) setFormState({ ...formState, plan });
   };
 
-  const handleBrandingChange = (key: keyof TenantDetail['branding'], value: string) => {
-    setTenant({
-      ...tenant,
-      branding: { ...tenant.branding, [key]: value },
-    });
+  const handleBrandingChange = (key: keyof TenantFormState['branding'], value: string) => {
+    if (formState) {
+      setFormState({
+        ...formState,
+        branding: { ...formState.branding, [key]: value },
+      });
+    }
   };
 
-  const handleSettingChange = (key: keyof TenantDetail['settings'], value: boolean | number) => {
-    setTenant({
-      ...tenant,
-      settings: { ...tenant.settings, [key]: value },
-    });
+  const handleSettingChange = (key: keyof TenantFormState['settings'], value: boolean | number) => {
+    if (formState) {
+      setFormState({
+        ...formState,
+        settings: { ...formState.settings, [key]: value },
+      });
+    }
   };
+
+  // 로딩 상태 (데모 모드가 아닐 때만)
+  if (!isDemoMode && isLoading) {
+    return <TenantDetailSkeleton />;
+  }
+
+  // 에러 상태 (데모 모드가 아닐 때만)
+  if (!isDemoMode && isError) {
+    return (
+      <TenantDetailError
+        message={error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다'}
+        onRetry={() => refetch()}
+      />
+    );
+  }
+
+  // 데이터 없음
+  if (!formState) {
+    return <TenantDetailSkeleton />;
+  }
 
   return (
     <div className="p-6">
       <AdminPageHeader
-        title={tenant.name}
-        description={`테넌트 코드: ${tenant.code}`}
+        title={formState.name}
+        description={`테넌트 코드: ${formState.code}`}
         breadcrumb={[
           { label: '테넌트 관리', href: '/sa/tenants' },
-          { label: tenant.name },
+          { label: formState.name },
         ]}
         actions={
           <div className="flex gap-2">
@@ -138,8 +318,12 @@ export function TenantDetailPage() {
               <ArrowLeft className="mr-2 h-4 w-4" />
               목록으로
             </Button>
-            <Button onClick={handleSave}>
-              <Save className="mr-2 h-4 w-4" />
+            <Button onClick={handleSave} disabled={updateMutation.isPending}>
+              {updateMutation.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="mr-2 h-4 w-4" />
+              )}
               저장
             </Button>
           </div>
@@ -154,7 +338,7 @@ export function TenantDetailPage() {
               <div>
                 <p className="text-sm text-text-secondary">상태</p>
                 <div className="mt-1">
-                  <StatusBadge status={tenant.status} />
+                  <StatusBadge status={formState.status} />
                 </div>
               </div>
               <Building2 className="h-8 w-8 text-text-secondary opacity-50" />
@@ -167,7 +351,7 @@ export function TenantDetailPage() {
               <div>
                 <p className="text-sm text-text-secondary">플랜</p>
                 <div className="mt-1">
-                  <PlanBadge plan={tenant.plan} />
+                  <PlanBadge plan={formState.plan} />
                 </div>
               </div>
             </div>
@@ -178,9 +362,9 @@ export function TenantDetailPage() {
             <div>
               <p className="text-sm text-text-secondary">사용자</p>
               <p className="text-2xl font-bold mt-1">
-                {tenant.userCount.toLocaleString()}
+                {formState.userCount.toLocaleString()}
                 <span className="text-sm font-normal text-text-secondary ml-1">
-                  / {tenant.settings.maxUsers.toLocaleString()}
+                  / {formState.settings.maxUsersCount.toLocaleString()}
                 </span>
               </p>
             </div>
@@ -191,9 +375,9 @@ export function TenantDetailPage() {
             <div>
               <p className="text-sm text-text-secondary">강좌</p>
               <p className="text-2xl font-bold mt-1">
-                {tenant.courseCount}
+                {formState.courseCount}
                 <span className="text-sm font-normal text-text-secondary ml-1">
-                  / {tenant.settings.maxCourses}
+                  / {formState.settings.maxCourses}
                 </span>
               </p>
             </div>
@@ -231,15 +415,15 @@ export function TenantDetailPage() {
                   <Label htmlFor="name">테넌트명</Label>
                   <Input
                     id="name"
-                    value={tenant.name}
-                    onChange={(e) => setTenant({ ...tenant, name: e.target.value })}
+                    value={formState.name}
+                    onChange={(e) => setFormState({ ...formState, name: e.target.value })}
                   />
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="code">테넌트 코드</Label>
                   <Input
                     id="code"
-                    value={tenant.code}
+                    value={formState.code}
                     disabled
                     className="bg-bg-secondary"
                   />
@@ -247,7 +431,7 @@ export function TenantDetailPage() {
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="status">상태</Label>
-                  <Select value={tenant.status} onValueChange={(v) => handleStatusChange(v as TenantStatus)}>
+                  <Select value={formState.status} onValueChange={(v) => handleStatusChange(v as TenantStatus)}>
                     <SelectTrigger>
                       <SelectValue />
                     </SelectTrigger>
@@ -261,7 +445,7 @@ export function TenantDetailPage() {
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="plan">플랜</Label>
-                  <Select value={tenant.plan} onValueChange={(v) => handlePlanChange(v as PlanType)}>
+                  <Select value={formState.plan} onValueChange={(v) => handlePlanChange(v as PlanType)}>
                     <SelectTrigger>
                       <SelectValue />
                     </SelectTrigger>
@@ -276,8 +460,8 @@ export function TenantDetailPage() {
                   <Label htmlFor="domain">커스텀 도메인</Label>
                   <Input
                     id="domain"
-                    value={tenant.domain || ''}
-                    onChange={(e) => setTenant({ ...tenant, domain: e.target.value })}
+                    value={formState.customDomain}
+                    onChange={(e) => setFormState({ ...formState, customDomain: e.target.value })}
                     placeholder="learn.example.com"
                   />
                 </div>
@@ -285,7 +469,7 @@ export function TenantDetailPage() {
                   <Label htmlFor="createdAt">생성일</Label>
                   <Input
                     id="createdAt"
-                    value={tenant.createdAt}
+                    value={formState.createdAt}
                     disabled
                     className="bg-bg-secondary"
                   />
@@ -299,8 +483,8 @@ export function TenantDetailPage() {
                     <Label htmlFor="adminName">관리자명</Label>
                     <Input
                       id="adminName"
-                      value={tenant.adminName}
-                      onChange={(e) => setTenant({ ...tenant, adminName: e.target.value })}
+                      value={formState.adminName}
+                      onChange={(e) => setFormState({ ...formState, adminName: e.target.value })}
                     />
                   </div>
                   <div className="space-y-2">
@@ -308,8 +492,8 @@ export function TenantDetailPage() {
                     <Input
                       id="adminEmail"
                       type="email"
-                      value={tenant.adminEmail}
-                      onChange={(e) => setTenant({ ...tenant, adminEmail: e.target.value })}
+                      value={formState.adminEmail}
+                      onChange={(e) => setFormState({ ...formState, adminEmail: e.target.value })}
                     />
                   </div>
                 </div>
@@ -331,9 +515,9 @@ export function TenantDetailPage() {
                 <Label>로고</Label>
                 <div className="flex items-start gap-6">
                   <div className="w-32 h-32 border-2 border-dashed rounded-lg flex items-center justify-center bg-bg-secondary">
-                    {tenant.branding.logoUrl ? (
+                    {formState.branding.logoUrl ? (
                       <img
-                        src={tenant.branding.logoUrl}
+                        src={formState.branding.logoUrl}
                         alt="Logo"
                         className="max-w-full max-h-full object-contain"
                       />
@@ -346,7 +530,7 @@ export function TenantDetailPage() {
                       <Upload className="mr-2 h-4 w-4" />
                       로고 업로드
                     </Button>
-                    {tenant.branding.logoUrl && (
+                    {formState.branding.logoUrl && (
                       <Button
                         variant="ghost"
                         size="sm"
@@ -369,9 +553,9 @@ export function TenantDetailPage() {
                 <Label>파비콘</Label>
                 <div className="flex items-start gap-6">
                   <div className="w-16 h-16 border-2 border-dashed rounded-lg flex items-center justify-center bg-bg-secondary">
-                    {tenant.branding.faviconUrl ? (
+                    {formState.branding.faviconUrl ? (
                       <img
-                        src={tenant.branding.faviconUrl}
+                        src={formState.branding.faviconUrl}
                         alt="Favicon"
                         className="max-w-full max-h-full object-contain"
                       />
@@ -398,11 +582,11 @@ export function TenantDetailPage() {
                   <div className="flex gap-2">
                     <div
                       className="w-10 h-10 rounded-lg border cursor-pointer"
-                      style={{ backgroundColor: tenant.branding.primaryColor }}
+                      style={{ backgroundColor: formState.branding.primaryColor }}
                     />
                     <Input
                       id="primaryColor"
-                      value={tenant.branding.primaryColor}
+                      value={formState.branding.primaryColor}
                       onChange={(e) => handleBrandingChange('primaryColor', e.target.value)}
                       placeholder="#3B82F6"
                     />
@@ -413,11 +597,11 @@ export function TenantDetailPage() {
                   <div className="flex gap-2">
                     <div
                       className="w-10 h-10 rounded-lg border cursor-pointer"
-                      style={{ backgroundColor: tenant.branding.secondaryColor }}
+                      style={{ backgroundColor: formState.branding.secondaryColor }}
                     />
                     <Input
                       id="secondaryColor"
-                      value={tenant.branding.secondaryColor}
+                      value={formState.branding.secondaryColor}
                       onChange={(e) => handleBrandingChange('secondaryColor', e.target.value)}
                       placeholder="#1E40AF"
                     />
@@ -431,20 +615,20 @@ export function TenantDetailPage() {
                 <div className="p-4 border rounded-lg">
                   <div
                     className="h-12 rounded-lg flex items-center px-4 text-white font-medium"
-                    style={{ backgroundColor: tenant.branding.primaryColor }}
+                    style={{ backgroundColor: formState.branding.primaryColor }}
                   >
-                    {tenant.name} 학습 플랫폼
+                    {formState.name} 학습 플랫폼
                   </div>
                   <div className="mt-4 flex gap-2">
                     <button
                       className="px-4 py-2 rounded-lg text-white text-sm"
-                      style={{ backgroundColor: tenant.branding.primaryColor }}
+                      style={{ backgroundColor: formState.branding.primaryColor }}
                     >
                       주 버튼
                     </button>
                     <button
                       className="px-4 py-2 rounded-lg text-white text-sm"
-                      style={{ backgroundColor: tenant.branding.secondaryColor }}
+                      style={{ backgroundColor: formState.branding.secondaryColor }}
                     >
                       보조 버튼
                     </button>
@@ -472,11 +656,11 @@ export function TenantDetailPage() {
                     <Input
                       id="maxUsers"
                       type="number"
-                      value={tenant.settings.maxUsers}
-                      onChange={(e) => handleSettingChange('maxUsers', parseInt(e.target.value))}
+                      value={formState.settings.maxUsersCount}
+                      onChange={(e) => handleSettingChange('maxUsersCount', parseInt(e.target.value))}
                     />
                     <p className="text-xs text-text-secondary">
-                      현재: {tenant.userCount}명 사용 중
+                      현재: {formState.userCount}명 사용 중
                     </p>
                   </div>
                   <div className="space-y-2">
@@ -484,11 +668,11 @@ export function TenantDetailPage() {
                     <Input
                       id="maxCourses"
                       type="number"
-                      value={tenant.settings.maxCourses}
+                      value={formState.settings.maxCourses}
                       onChange={(e) => handleSettingChange('maxCourses', parseInt(e.target.value))}
                     />
                     <p className="text-xs text-text-secondary">
-                      현재: {tenant.courseCount}개 사용 중
+                      현재: {formState.courseCount}개 사용 중
                     </p>
                   </div>
                   <div className="space-y-2">
@@ -496,8 +680,8 @@ export function TenantDetailPage() {
                     <Input
                       id="maxStorage"
                       type="number"
-                      value={tenant.settings.maxStorage}
-                      onChange={(e) => handleSettingChange('maxStorage', parseInt(e.target.value))}
+                      value={formState.settings.maxStorageGB}
+                      onChange={(e) => handleSettingChange('maxStorageGB', parseInt(e.target.value))}
                     />
                   </div>
                 </div>
@@ -515,7 +699,7 @@ export function TenantDetailPage() {
                       </p>
                     </div>
                     <Switch
-                      checked={tenant.settings.allowCustomDomain}
+                      checked={formState.settings.allowCustomDomain}
                       onCheckedChange={(checked) => handleSettingChange('allowCustomDomain', checked)}
                     />
                   </div>
@@ -527,7 +711,7 @@ export function TenantDetailPage() {
                       </p>
                     </div>
                     <Switch
-                      checked={tenant.settings.allowCustomBranding}
+                      checked={formState.settings.allowCustomBranding}
                       onCheckedChange={(checked) => handleSettingChange('allowCustomBranding', checked)}
                     />
                   </div>
@@ -539,7 +723,7 @@ export function TenantDetailPage() {
                       </p>
                     </div>
                     <Switch
-                      checked={tenant.settings.ssoEnabled}
+                      checked={formState.settings.ssoEnabled}
                       onCheckedChange={(checked) => handleSettingChange('ssoEnabled', checked)}
                     />
                   </div>
@@ -551,7 +735,7 @@ export function TenantDetailPage() {
                       </p>
                     </div>
                     <Switch
-                      checked={tenant.settings.apiAccessEnabled}
+                      checked={formState.settings.apiAccessEnabled}
                       onCheckedChange={(checked) => handleSettingChange('apiAccessEnabled', checked)}
                     />
                   </div>
@@ -569,8 +753,17 @@ export function TenantDetailPage() {
                         이 작업은 되돌릴 수 없습니다. 모든 데이터가 영구적으로 삭제됩니다.
                       </p>
                     </div>
-                    <Button variant="destructive" size="sm">
-                      <Trash2 className="mr-2 h-4 w-4" />
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={handleDelete}
+                      disabled={deleteMutation.isPending}
+                    >
+                      {deleteMutation.isPending ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      ) : (
+                        <Trash2 className="mr-2 h-4 w-4" />
+                      )}
                       테넌트 삭제
                     </Button>
                   </div>

--- a/src/pages/sa/tenants/TenantDetailPage.tsx
+++ b/src/pages/sa/tenants/TenantDetailPage.tsx
@@ -1,0 +1,585 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  ArrowLeft,
+  Building2,
+  Save,
+  Upload,
+  Trash2,
+  Settings,
+  Palette,
+  Info,
+} from 'lucide-react';
+import {
+  AdminPageHeader,
+  StatusBadge,
+  PlanBadge,
+} from '@/components/domain/admin';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Label } from '@/components/common/Label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/common/Card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/common/Tabs';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/common/Select';
+import { Switch } from '@/components/common/Switch';
+import type { TenantStatus, PlanType } from '@/types/admin';
+
+// Mock 데이터
+interface TenantDetail {
+  id: number;
+  code: string;
+  name: string;
+  status: TenantStatus;
+  plan: PlanType;
+  userCount: number;
+  courseCount: number;
+  createdAt: string;
+  adminEmail: string;
+  adminName: string;
+  domain?: string;
+  branding: {
+    logoUrl?: string;
+    primaryColor: string;
+    secondaryColor: string;
+    faviconUrl?: string;
+  };
+  settings: {
+    maxUsers: number;
+    maxCourses: number;
+    maxStorage: number; // GB
+    allowCustomDomain: boolean;
+    allowCustomBranding: boolean;
+    ssoEnabled: boolean;
+    apiAccessEnabled: boolean;
+  };
+}
+
+const mockTenantDetail: TenantDetail = {
+  id: 1,
+  code: 'mzc',
+  name: '메가존클라우드',
+  status: 'ACTIVE',
+  plan: 'ENTERPRISE',
+  userCount: 250,
+  courseCount: 45,
+  createdAt: '2025-01-15',
+  adminEmail: 'admin@megazone.com',
+  adminName: '김관리자',
+  domain: 'learn.megazone.com',
+  branding: {
+    logoUrl: '/logos/mzc-logo.png',
+    primaryColor: '#3B82F6',
+    secondaryColor: '#1E40AF',
+    faviconUrl: '/favicons/mzc-favicon.ico',
+  },
+  settings: {
+    maxUsers: 500,
+    maxCourses: 100,
+    maxStorage: 50,
+    allowCustomDomain: true,
+    allowCustomBranding: true,
+    ssoEnabled: true,
+    apiAccessEnabled: true,
+  },
+};
+
+export function TenantDetailPage() {
+  const { id: _id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  // 실제로는 API에서 id를 사용해 데이터를 가져옴
+  const [tenant, setTenant] = useState<TenantDetail>(mockTenantDetail);
+
+  const handleSave = () => {
+    // API 호출
+    console.log('Save tenant:', tenant);
+  };
+
+  const handleStatusChange = (status: TenantStatus) => {
+    setTenant({ ...tenant, status });
+  };
+
+  const handlePlanChange = (plan: PlanType) => {
+    setTenant({ ...tenant, plan });
+  };
+
+  const handleBrandingChange = (key: keyof TenantDetail['branding'], value: string) => {
+    setTenant({
+      ...tenant,
+      branding: { ...tenant.branding, [key]: value },
+    });
+  };
+
+  const handleSettingChange = (key: keyof TenantDetail['settings'], value: boolean | number) => {
+    setTenant({
+      ...tenant,
+      settings: { ...tenant.settings, [key]: value },
+    });
+  };
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title={tenant.name}
+        description={`테넌트 코드: ${tenant.code}`}
+        breadcrumb={[
+          { label: '테넌트 관리', href: '/sa/tenants' },
+          { label: tenant.name },
+        ]}
+        actions={
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => navigate('/sa/tenants')}>
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              목록으로
+            </Button>
+            <Button onClick={handleSave}>
+              <Save className="mr-2 h-4 w-4" />
+              저장
+            </Button>
+          </div>
+        }
+      />
+
+      {/* 상태 요약 카드 */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-text-secondary">상태</p>
+                <div className="mt-1">
+                  <StatusBadge status={tenant.status} />
+                </div>
+              </div>
+              <Building2 className="h-8 w-8 text-text-secondary opacity-50" />
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-text-secondary">플랜</p>
+                <div className="mt-1">
+                  <PlanBadge plan={tenant.plan} />
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div>
+              <p className="text-sm text-text-secondary">사용자</p>
+              <p className="text-2xl font-bold mt-1">
+                {tenant.userCount.toLocaleString()}
+                <span className="text-sm font-normal text-text-secondary ml-1">
+                  / {tenant.settings.maxUsers.toLocaleString()}
+                </span>
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div>
+              <p className="text-sm text-text-secondary">강좌</p>
+              <p className="text-2xl font-bold mt-1">
+                {tenant.courseCount}
+                <span className="text-sm font-normal text-text-secondary ml-1">
+                  / {tenant.settings.maxCourses}
+                </span>
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 탭 컨텐츠 */}
+      <Tabs defaultValue="info" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="info">
+            <Info className="w-4 h-4 mr-2" />
+            기본 정보
+          </TabsTrigger>
+          <TabsTrigger value="branding">
+            <Palette className="w-4 h-4 mr-2" />
+            브랜딩 설정
+          </TabsTrigger>
+          <TabsTrigger value="settings">
+            <Settings className="w-4 h-4 mr-2" />
+            테넌트 설정
+          </TabsTrigger>
+        </TabsList>
+
+        {/* 기본 정보 탭 */}
+        <TabsContent value="info">
+          <Card>
+            <CardHeader>
+              <CardTitle>기본 정보</CardTitle>
+              <CardDescription>테넌트의 기본 정보를 관리합니다.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="space-y-2">
+                  <Label htmlFor="name">테넌트명</Label>
+                  <Input
+                    id="name"
+                    value={tenant.name}
+                    onChange={(e) => setTenant({ ...tenant, name: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="code">테넌트 코드</Label>
+                  <Input
+                    id="code"
+                    value={tenant.code}
+                    disabled
+                    className="bg-bg-secondary"
+                  />
+                  <p className="text-xs text-text-secondary">테넌트 코드는 변경할 수 없습니다.</p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="status">상태</Label>
+                  <Select value={tenant.status} onValueChange={(v) => handleStatusChange(v as TenantStatus)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="ACTIVE">활성</SelectItem>
+                      <SelectItem value="INACTIVE">비활성</SelectItem>
+                      <SelectItem value="SUSPENDED">정지</SelectItem>
+                      <SelectItem value="PENDING">대기</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="plan">플랜</Label>
+                  <Select value={tenant.plan} onValueChange={(v) => handlePlanChange(v as PlanType)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="BASIC">Basic</SelectItem>
+                      <SelectItem value="PRO">Pro</SelectItem>
+                      <SelectItem value="ENTERPRISE">Enterprise</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="domain">커스텀 도메인</Label>
+                  <Input
+                    id="domain"
+                    value={tenant.domain || ''}
+                    onChange={(e) => setTenant({ ...tenant, domain: e.target.value })}
+                    placeholder="learn.example.com"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="createdAt">생성일</Label>
+                  <Input
+                    id="createdAt"
+                    value={tenant.createdAt}
+                    disabled
+                    className="bg-bg-secondary"
+                  />
+                </div>
+              </div>
+
+              <div className="border-t pt-6">
+                <h4 className="font-medium mb-4">관리자 정보</h4>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div className="space-y-2">
+                    <Label htmlFor="adminName">관리자명</Label>
+                    <Input
+                      id="adminName"
+                      value={tenant.adminName}
+                      onChange={(e) => setTenant({ ...tenant, adminName: e.target.value })}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="adminEmail">관리자 이메일</Label>
+                    <Input
+                      id="adminEmail"
+                      type="email"
+                      value={tenant.adminEmail}
+                      onChange={(e) => setTenant({ ...tenant, adminEmail: e.target.value })}
+                    />
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* 브랜딩 설정 탭 */}
+        <TabsContent value="branding">
+          <Card>
+            <CardHeader>
+              <CardTitle>브랜딩 설정</CardTitle>
+              <CardDescription>테넌트의 로고, 색상 등 브랜딩을 설정합니다.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {/* 로고 업로드 */}
+              <div className="space-y-4">
+                <Label>로고</Label>
+                <div className="flex items-start gap-6">
+                  <div className="w-32 h-32 border-2 border-dashed rounded-lg flex items-center justify-center bg-bg-secondary">
+                    {tenant.branding.logoUrl ? (
+                      <img
+                        src={tenant.branding.logoUrl}
+                        alt="Logo"
+                        className="max-w-full max-h-full object-contain"
+                      />
+                    ) : (
+                      <Building2 className="w-12 h-12 text-text-secondary" />
+                    )}
+                  </div>
+                  <div className="space-y-2">
+                    <Button variant="outline" size="sm">
+                      <Upload className="mr-2 h-4 w-4" />
+                      로고 업로드
+                    </Button>
+                    {tenant.branding.logoUrl && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-red-600"
+                        onClick={() => handleBrandingChange('logoUrl', '')}
+                      >
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        삭제
+                      </Button>
+                    )}
+                    <p className="text-xs text-text-secondary">
+                      권장 크기: 200x200px, PNG 또는 SVG
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* 파비콘 업로드 */}
+              <div className="space-y-4">
+                <Label>파비콘</Label>
+                <div className="flex items-start gap-6">
+                  <div className="w-16 h-16 border-2 border-dashed rounded-lg flex items-center justify-center bg-bg-secondary">
+                    {tenant.branding.faviconUrl ? (
+                      <img
+                        src={tenant.branding.faviconUrl}
+                        alt="Favicon"
+                        className="max-w-full max-h-full object-contain"
+                      />
+                    ) : (
+                      <Building2 className="w-6 h-6 text-text-secondary" />
+                    )}
+                  </div>
+                  <div className="space-y-2">
+                    <Button variant="outline" size="sm">
+                      <Upload className="mr-2 h-4 w-4" />
+                      파비콘 업로드
+                    </Button>
+                    <p className="text-xs text-text-secondary">
+                      권장 크기: 32x32px, ICO 또는 PNG
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* 색상 설정 */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="space-y-2">
+                  <Label htmlFor="primaryColor">주 색상 (Primary)</Label>
+                  <div className="flex gap-2">
+                    <div
+                      className="w-10 h-10 rounded-lg border cursor-pointer"
+                      style={{ backgroundColor: tenant.branding.primaryColor }}
+                    />
+                    <Input
+                      id="primaryColor"
+                      value={tenant.branding.primaryColor}
+                      onChange={(e) => handleBrandingChange('primaryColor', e.target.value)}
+                      placeholder="#3B82F6"
+                    />
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="secondaryColor">보조 색상 (Secondary)</Label>
+                  <div className="flex gap-2">
+                    <div
+                      className="w-10 h-10 rounded-lg border cursor-pointer"
+                      style={{ backgroundColor: tenant.branding.secondaryColor }}
+                    />
+                    <Input
+                      id="secondaryColor"
+                      value={tenant.branding.secondaryColor}
+                      onChange={(e) => handleBrandingChange('secondaryColor', e.target.value)}
+                      placeholder="#1E40AF"
+                    />
+                  </div>
+                </div>
+              </div>
+
+              {/* 미리보기 */}
+              <div className="border-t pt-6">
+                <h4 className="font-medium mb-4">미리보기</h4>
+                <div className="p-4 border rounded-lg">
+                  <div
+                    className="h-12 rounded-lg flex items-center px-4 text-white font-medium"
+                    style={{ backgroundColor: tenant.branding.primaryColor }}
+                  >
+                    {tenant.name} 학습 플랫폼
+                  </div>
+                  <div className="mt-4 flex gap-2">
+                    <button
+                      className="px-4 py-2 rounded-lg text-white text-sm"
+                      style={{ backgroundColor: tenant.branding.primaryColor }}
+                    >
+                      주 버튼
+                    </button>
+                    <button
+                      className="px-4 py-2 rounded-lg text-white text-sm"
+                      style={{ backgroundColor: tenant.branding.secondaryColor }}
+                    >
+                      보조 버튼
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* 테넌트 설정 탭 */}
+        <TabsContent value="settings">
+          <Card>
+            <CardHeader>
+              <CardTitle>테넌트 설정</CardTitle>
+              <CardDescription>테넌트의 기능 제한 및 권한을 설정합니다.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {/* 제한 설정 */}
+              <div>
+                <h4 className="font-medium mb-4">리소스 제한</h4>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                  <div className="space-y-2">
+                    <Label htmlFor="maxUsers">최대 사용자 수</Label>
+                    <Input
+                      id="maxUsers"
+                      type="number"
+                      value={tenant.settings.maxUsers}
+                      onChange={(e) => handleSettingChange('maxUsers', parseInt(e.target.value))}
+                    />
+                    <p className="text-xs text-text-secondary">
+                      현재: {tenant.userCount}명 사용 중
+                    </p>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="maxCourses">최대 강좌 수</Label>
+                    <Input
+                      id="maxCourses"
+                      type="number"
+                      value={tenant.settings.maxCourses}
+                      onChange={(e) => handleSettingChange('maxCourses', parseInt(e.target.value))}
+                    />
+                    <p className="text-xs text-text-secondary">
+                      현재: {tenant.courseCount}개 사용 중
+                    </p>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="maxStorage">최대 저장 용량 (GB)</Label>
+                    <Input
+                      id="maxStorage"
+                      type="number"
+                      value={tenant.settings.maxStorage}
+                      onChange={(e) => handleSettingChange('maxStorage', parseInt(e.target.value))}
+                    />
+                  </div>
+                </div>
+              </div>
+
+              {/* 기능 설정 */}
+              <div className="border-t pt-6">
+                <h4 className="font-medium mb-4">기능 설정</h4>
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between py-2">
+                    <div>
+                      <p className="font-medium">커스텀 도메인</p>
+                      <p className="text-sm text-text-secondary">
+                        자체 도메인으로 학습 플랫폼 접속 허용
+                      </p>
+                    </div>
+                    <Switch
+                      checked={tenant.settings.allowCustomDomain}
+                      onCheckedChange={(checked) => handleSettingChange('allowCustomDomain', checked)}
+                    />
+                  </div>
+                  <div className="flex items-center justify-between py-2">
+                    <div>
+                      <p className="font-medium">커스텀 브랜딩</p>
+                      <p className="text-sm text-text-secondary">
+                        로고, 색상 등 브랜딩 커스터마이징 허용
+                      </p>
+                    </div>
+                    <Switch
+                      checked={tenant.settings.allowCustomBranding}
+                      onCheckedChange={(checked) => handleSettingChange('allowCustomBranding', checked)}
+                    />
+                  </div>
+                  <div className="flex items-center justify-between py-2">
+                    <div>
+                      <p className="font-medium">SSO (Single Sign-On)</p>
+                      <p className="text-sm text-text-secondary">
+                        SAML, OAuth 등 SSO 연동 허용
+                      </p>
+                    </div>
+                    <Switch
+                      checked={tenant.settings.ssoEnabled}
+                      onCheckedChange={(checked) => handleSettingChange('ssoEnabled', checked)}
+                    />
+                  </div>
+                  <div className="flex items-center justify-between py-2">
+                    <div>
+                      <p className="font-medium">API 접근</p>
+                      <p className="text-sm text-text-secondary">
+                        REST API를 통한 데이터 접근 허용
+                      </p>
+                    </div>
+                    <Switch
+                      checked={tenant.settings.apiAccessEnabled}
+                      onCheckedChange={(checked) => handleSettingChange('apiAccessEnabled', checked)}
+                    />
+                  </div>
+                </div>
+              </div>
+
+              {/* 위험 영역 */}
+              <div className="border-t pt-6">
+                <h4 className="font-medium mb-4 text-red-600">위험 영역</h4>
+                <div className="p-4 border border-red-200 rounded-lg bg-red-50 dark:bg-red-950/20">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-medium text-red-600">테넌트 삭제</p>
+                      <p className="text-sm text-text-secondary">
+                        이 작업은 되돌릴 수 없습니다. 모든 데이터가 영구적으로 삭제됩니다.
+                      </p>
+                    </div>
+                    <Button variant="destructive" size="sm">
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      테넌트 삭제
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/pages/sa/tenants/TenantsPage.tsx
+++ b/src/pages/sa/tenants/TenantsPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Plus, Search, MoreHorizontal, Eye, Edit, Trash2, Building2 } from 'lucide-react';
 import { ColumnDef } from '@tanstack/react-table';
 import {
@@ -60,11 +61,11 @@ const mockTenants: TenantRow[] = [
 ];
 
 export function TenantsPage() {
+  const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [planFilter, setPlanFilter] = useState<string>('all');
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
-  const [isDetailDialogOpen, setIsDetailDialogOpen] = useState(false);
   const [selectedTenant, setSelectedTenant] = useState<TenantRow | null>(null);
 
   // 필터링된 데이터
@@ -166,8 +167,7 @@ export function TenantsPage() {
   ];
 
   const handleViewDetail = (tenant: TenantRow) => {
-    setSelectedTenant(tenant);
-    setIsDetailDialogOpen(true);
+    navigate(`/sa/tenants/${tenant.id}`);
   };
 
   const handleEdit = (tenant: TenantRow) => {
@@ -335,64 +335,6 @@ export function TenantsPage() {
         </DialogContent>
       </Dialog>
 
-      {/* 테넌트 상세 다이얼로그 */}
-      <Dialog open={isDetailDialogOpen} onOpenChange={setIsDetailDialogOpen}>
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle>테넌트 상세 정보</DialogTitle>
-          </DialogHeader>
-          {selectedTenant && (
-            <div className="space-y-4 py-4">
-              <div className="flex items-center gap-4 pb-4 border-b">
-                <div className="w-12 h-12 rounded-lg bg-brand-primary/10 flex items-center justify-center">
-                  <Building2 className="w-6 h-6 text-brand-primary" />
-                </div>
-                <div>
-                  <h3 className="font-semibold text-lg">{selectedTenant.name}</h3>
-                  <p className="text-sm text-text-secondary">{selectedTenant.code}</p>
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <p className="text-sm text-text-secondary">상태</p>
-                  <div className="mt-1">
-                    <StatusBadge status={selectedTenant.status} />
-                  </div>
-                </div>
-                <div>
-                  <p className="text-sm text-text-secondary">플랜</p>
-                  <div className="mt-1">
-                    <PlanBadge plan={selectedTenant.plan} />
-                  </div>
-                </div>
-                <div>
-                  <p className="text-sm text-text-secondary">사용자 수</p>
-                  <p className="font-medium">{selectedTenant.userCount.toLocaleString()}명</p>
-                </div>
-                <div>
-                  <p className="text-sm text-text-secondary">강좌 수</p>
-                  <p className="font-medium">{selectedTenant.courseCount}개</p>
-                </div>
-                <div className="col-span-2">
-                  <p className="text-sm text-text-secondary">생성일</p>
-                  <p className="font-medium">{selectedTenant.createdAt}</p>
-                </div>
-              </div>
-            </div>
-          )}
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setIsDetailDialogOpen(false)}>
-              닫기
-            </Button>
-            <Button onClick={() => {
-              setIsDetailDialogOpen(false);
-              if (selectedTenant) handleEdit(selectedTenant);
-            }}>
-              수정
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 }

--- a/src/pages/sa/tenants/index.ts
+++ b/src/pages/sa/tenants/index.ts
@@ -1,1 +1,2 @@
 export { TenantsPage } from './TenantsPage';
+export { TenantDetailPage } from './TenantDetailPage';

--- a/src/pages/ta/index.ts
+++ b/src/pages/ta/index.ts
@@ -1,3 +1,3 @@
 // Tenant Admin pages
 export { DashboardPage } from './dashboard';
-export { UsersPage } from './users';
+export { UsersPage, UserDetailPage } from './users';

--- a/src/pages/ta/users/UserDetailPage.tsx
+++ b/src/pages/ta/users/UserDetailPage.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useState, useEffect, useMemo } from 'react';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import {
   ArrowLeft,
   Save,
@@ -11,6 +11,8 @@ import {
   Building,
   Calendar,
   Activity,
+  Loader2,
+  AlertCircle,
 } from 'lucide-react';
 import {
   AdminPageHeader,
@@ -31,59 +33,26 @@ import {
 } from '@/components/common/Select';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/common/Avatar';
 import { Progress } from '@/components/common/Progress';
-import type { UserStatus, SystemRole } from '@/components/domain/admin';
+import { Skeleton } from '@/components/common/Skeleton';
+import { useUser, useUpdateUser, useUpdateUserRole, useDeleteUser } from '@/hooks/ta';
+import type { UserStatus, SystemRole, UserDetail, UserEnrollment, UserActivityLog } from '@/types/admin';
 
 // Mock 데이터
-interface CourseEnrollment {
-  id: number;
-  title: string;
-  progress: number;
-  status: 'IN_PROGRESS' | 'COMPLETED' | 'NOT_STARTED';
-  enrolledAt: string;
-  completedAt?: string;
-}
-
-interface ActivityLog {
-  id: number;
-  action: string;
-  description: string;
-  timestamp: string;
-  type: 'login' | 'course' | 'assessment' | 'profile';
-}
-
-interface UserDetail {
-  id: number;
-  name: string;
-  email: string;
-  status: UserStatus;
-  role: SystemRole;
-  department?: string;
-  phone?: string;
-  position?: string;
-  createdAt: string;
-  lastActiveAt: string;
-  stats: {
-    totalCourses: number;
-    completedCourses: number;
-    inProgressCourses: number;
-    totalLearningTime: number; // hours
-    averageScore: number;
-  };
-  enrollments: CourseEnrollment[];
-  activityLogs: ActivityLog[];
-}
-
-const mockUserDetail: UserDetail = {
+const MOCK_USER: UserDetail = {
   id: 1,
-  name: '김민수',
   email: 'minsu.kim@company.com',
+  name: '김민수',
   status: 'ACTIVE',
-  role: 'OPERATOR',
-  department: '개발팀',
-  phone: '010-1234-5678',
-  position: '시니어 개발자',
+  systemRole: 'OPERATOR',
+  courseRoles: [],
+  tenantId: 1,
+  organizationName: '개발팀',
   createdAt: '2025-01-15',
-  lastActiveAt: '2025-12-29',
+  updatedAt: '2025-01-15',
+  lastLoginAt: '2025-12-29',
+  phone: '010-1234-5678',
+  department: '개발팀',
+  position: '시니어 개발자',
   stats: {
     totalCourses: 12,
     completedCourses: 8,
@@ -92,20 +61,63 @@ const mockUserDetail: UserDetail = {
     averageScore: 87,
   },
   enrollments: [
-    { id: 1, title: 'AWS 기초 마스터', progress: 100, status: 'COMPLETED', enrolledAt: '2025-01-20', completedAt: '2025-02-15' },
-    { id: 2, title: 'React 실전 프로젝트', progress: 75, status: 'IN_PROGRESS', enrolledAt: '2025-02-01' },
-    { id: 3, title: 'TypeScript 완벽 가이드', progress: 60, status: 'IN_PROGRESS', enrolledAt: '2025-02-10' },
-    { id: 4, title: 'Docker & Kubernetes', progress: 100, status: 'COMPLETED', enrolledAt: '2025-01-10', completedAt: '2025-01-25' },
-    { id: 5, title: 'Python 데이터 분석', progress: 0, status: 'NOT_STARTED', enrolledAt: '2025-12-20' },
+    { id: 1, courseTitle: 'AWS 기초 마스터', progress: 100, status: 'COMPLETED', enrolledAt: '2025-01-20', completedAt: '2025-02-15' },
+    { id: 2, courseTitle: 'React 실전 프로젝트', progress: 75, status: 'IN_PROGRESS', enrolledAt: '2025-02-01' },
+    { id: 3, courseTitle: 'TypeScript 완벽 가이드', progress: 60, status: 'IN_PROGRESS', enrolledAt: '2025-02-10' },
+    { id: 4, courseTitle: 'Docker & Kubernetes', progress: 100, status: 'COMPLETED', enrolledAt: '2025-01-10', completedAt: '2025-01-25' },
+    { id: 5, courseTitle: 'Python 데이터 분석', progress: 0, status: 'NOT_STARTED', enrolledAt: '2025-12-20' },
   ],
   activityLogs: [
     { id: 1, action: '로그인', description: '시스템에 로그인했습니다.', timestamp: '2025-12-29 09:15:00', type: 'login' },
     { id: 2, action: '강의 수강', description: 'React 실전 프로젝트 - 챕터 5 완료', timestamp: '2025-12-29 10:30:00', type: 'course' },
     { id: 3, action: '평가 완료', description: 'TypeScript 중간 테스트 완료 (85점)', timestamp: '2025-12-28 14:20:00', type: 'assessment' },
     { id: 4, action: '프로필 수정', description: '프로필 정보를 업데이트했습니다.', timestamp: '2025-12-27 16:45:00', type: 'profile' },
-    { id: 5, action: '강의 수강', description: 'AWS 기초 마스터 - 수료', timestamp: '2025-12-25 11:00:00', type: 'course' },
   ],
 };
+
+// 폼 상태용 로컬 타입
+interface UserFormState {
+  name: string;
+  email: string;
+  phone: string;
+  department: string;
+  position: string;
+  status: UserStatus;
+  systemRole: SystemRole;
+  createdAt: string;
+  lastLoginAt: string;
+  stats: {
+    totalCourses: number;
+    completedCourses: number;
+    inProgressCourses: number;
+    totalLearningTime: number;
+    averageScore: number;
+  };
+  enrollments: UserEnrollment[];
+  activityLogs: UserActivityLog[];
+}
+
+// API 데이터를 폼 상태로 변환
+const toFormState = (data: UserDetail): UserFormState => ({
+  name: data.name,
+  email: data.email,
+  phone: data.phone || '',
+  department: data.department || '',
+  position: data.position || '',
+  status: data.status,
+  systemRole: data.systemRole,
+  createdAt: data.createdAt,
+  lastLoginAt: data.lastLoginAt || '',
+  stats: data.stats || {
+    totalCourses: 0,
+    completedCourses: 0,
+    inProgressCourses: 0,
+    totalLearningTime: 0,
+    averageScore: 0,
+  },
+  enrollments: data.enrollments || [],
+  activityLogs: data.activityLogs || [],
+});
 
 const courseStatusLabels = {
   IN_PROGRESS: '진행 중',
@@ -126,33 +138,169 @@ const activityIcons = {
   profile: User,
 };
 
+// 로딩 스켈레톤
+function UserDetailSkeleton() {
+  return (
+    <div className="p-6">
+      <div className="mb-6">
+        <Skeleton className="h-8 w-48 mb-2" />
+        <Skeleton className="h-4 w-32" />
+      </div>
+      <Card className="mb-6">
+        <CardContent className="pt-6">
+          <div className="flex items-start gap-6">
+            <Skeleton className="h-20 w-20 rounded-full" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-6 w-32" />
+              <Skeleton className="h-4 w-64" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+      <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <Card key={i}>
+            <CardContent className="pt-6 text-center">
+              <Skeleton className="h-8 w-12 mx-auto mb-2" />
+              <Skeleton className="h-4 w-16 mx-auto" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// 에러 UI
+function UserDetailError({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="p-6">
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex flex-col items-center justify-center py-12">
+            <AlertCircle className="h-12 w-12 text-red-500 mb-4" />
+            <h3 className="text-lg font-medium mb-2">데이터를 불러올 수 없습니다</h3>
+            <p className="text-text-secondary mb-4">{message}</p>
+            <Button onClick={onRetry}>다시 시도</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
 export function UserDetailPage() {
-  const { id: _id } = useParams<{ id: string }>();
+  const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const userId = Number(id);
 
-  // 실제로는 API에서 id를 사용해 데이터를 가져옴
-  const [user, setUser] = useState<UserDetail>(mockUserDetail);
+  // 데모 모드 체크 (?demo=true)
+  const isDemoMode = searchParams.get('demo') === 'true';
 
-  const handleSave = () => {
-    console.log('Save user:', user);
+  // API 호출
+  const { data: userData, isLoading, isError, error, refetch } = useUser(userId);
+  const updateMutation = useUpdateUser();
+  const updateRoleMutation = useUpdateUserRole();
+  const deleteMutation = useDeleteUser();
+
+  // 실제 데이터 또는 Mock 데이터
+  const effectiveData = useMemo(() => {
+    if (isDemoMode) return MOCK_USER;
+    return userData;
+  }, [isDemoMode, userData]);
+
+  // 폼 상태
+  const [formState, setFormState] = useState<UserFormState | null>(null);
+
+  // 데이터 로드 시 폼 상태 초기화
+  useEffect(() => {
+    if (effectiveData) {
+      setFormState(toFormState(effectiveData));
+    }
+  }, [effectiveData]);
+
+  const handleSave = async () => {
+    if (!formState) return;
+
+    try {
+      await updateMutation.mutateAsync({
+        id: userId,
+        request: {
+          name: formState.name,
+          phone: formState.phone || undefined,
+          department: formState.department || undefined,
+          position: formState.position || undefined,
+          status: formState.status,
+          systemRole: formState.systemRole,
+        },
+      });
+    } catch (err) {
+      console.error('Failed to save user:', err);
+    }
   };
 
   const handleStatusChange = (status: UserStatus) => {
-    setUser({ ...user, status });
+    if (formState) setFormState({ ...formState, status });
   };
 
-  const handleRoleChange = (role: SystemRole) => {
-    setUser({ ...user, role });
+  const handleRoleChange = async (role: SystemRole) => {
+    if (formState) {
+      setFormState({ ...formState, systemRole: role });
+      try {
+        await updateRoleMutation.mutateAsync({
+          id: userId,
+          request: { systemRole: role },
+        });
+      } catch (err) {
+        console.error('Failed to update role:', err);
+      }
+    }
   };
+
+  const handleDelete = async () => {
+    if (!window.confirm('정말 이 사용자를 삭제하시겠습니까?')) {
+      return;
+    }
+
+    try {
+      await deleteMutation.mutateAsync(userId);
+      navigate('/ta/users');
+    } catch (err) {
+      console.error('Failed to delete user:', err);
+    }
+  };
+
+  // 로딩 상태 (데모 모드가 아닐 때만)
+  if (!isDemoMode && isLoading) {
+    return <UserDetailSkeleton />;
+  }
+
+  // 에러 상태 (데모 모드가 아닐 때만)
+  if (!isDemoMode && isError) {
+    return (
+      <UserDetailError
+        message={error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다'}
+        onRetry={() => refetch()}
+      />
+    );
+  }
+
+  // 데이터 없음
+  if (!formState) {
+    return <UserDetailSkeleton />;
+  }
+
+  const isSaving = updateMutation.isPending || updateRoleMutation.isPending;
 
   return (
     <div className="p-6">
       <AdminPageHeader
-        title={user.name}
-        description={user.email}
+        title={formState.name}
+        description={formState.email}
         breadcrumb={[
           { label: '사용자 관리', href: '/ta/users' },
-          { label: user.name },
+          { label: formState.name },
         ]}
         actions={
           <div className="flex gap-2">
@@ -160,8 +308,12 @@ export function UserDetailPage() {
               <ArrowLeft className="mr-2 h-4 w-4" />
               목록으로
             </Button>
-            <Button onClick={handleSave}>
-              <Save className="mr-2 h-4 w-4" />
+            <Button onClick={handleSave} disabled={isSaving}>
+              {isSaving ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="mr-2 h-4 w-4" />
+              )}
               저장
             </Button>
           </div>
@@ -173,31 +325,31 @@ export function UserDetailPage() {
         <CardContent className="pt-6">
           <div className="flex items-start gap-6">
             <Avatar className="h-20 w-20">
-              <AvatarImage src={`https://api.dicebear.com/7.x/initials/svg?seed=${user.name}`} />
-              <AvatarFallback className="text-2xl">{user.name.slice(0, 2)}</AvatarFallback>
+              <AvatarImage src={`https://api.dicebear.com/7.x/initials/svg?seed=${formState.name}`} />
+              <AvatarFallback className="text-2xl">{formState.name.slice(0, 2)}</AvatarFallback>
             </Avatar>
             <div className="flex-1">
               <div className="flex items-center gap-3 mb-2">
-                <h2 className="text-xl font-bold">{user.name}</h2>
-                <StatusBadge status={user.status} />
-                <RoleBadge role={user.role} />
+                <h2 className="text-xl font-bold">{formState.name}</h2>
+                <StatusBadge status={formState.status} />
+                <RoleBadge role={formState.systemRole} />
               </div>
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
                 <div className="flex items-center gap-2 text-text-secondary">
                   <Mail className="h-4 w-4" />
-                  {user.email}
+                  {formState.email}
                 </div>
                 <div className="flex items-center gap-2 text-text-secondary">
                   <Building className="h-4 w-4" />
-                  {user.department || '-'} {user.position && `/ ${user.position}`}
+                  {formState.department || '-'} {formState.position && `/ ${formState.position}`}
                 </div>
                 <div className="flex items-center gap-2 text-text-secondary">
                   <Calendar className="h-4 w-4" />
-                  가입일: {user.createdAt}
+                  가입일: {formState.createdAt}
                 </div>
                 <div className="flex items-center gap-2 text-text-secondary">
                   <Activity className="h-4 w-4" />
-                  최근 활동: {user.lastActiveAt}
+                  최근 활동: {formState.lastLoginAt || '-'}
                 </div>
               </div>
             </div>
@@ -209,31 +361,31 @@ export function UserDetailPage() {
       <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6">
         <Card>
           <CardContent className="pt-6 text-center">
-            <p className="text-3xl font-bold text-brand-primary">{user.stats.totalCourses}</p>
+            <p className="text-3xl font-bold text-brand-primary">{formState.stats.totalCourses}</p>
             <p className="text-sm text-text-secondary">전체 강좌</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="pt-6 text-center">
-            <p className="text-3xl font-bold text-green-600">{user.stats.completedCourses}</p>
+            <p className="text-3xl font-bold text-green-600">{formState.stats.completedCourses}</p>
             <p className="text-sm text-text-secondary">완료</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="pt-6 text-center">
-            <p className="text-3xl font-bold text-blue-600">{user.stats.inProgressCourses}</p>
+            <p className="text-3xl font-bold text-blue-600">{formState.stats.inProgressCourses}</p>
             <p className="text-sm text-text-secondary">진행 중</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="pt-6 text-center">
-            <p className="text-3xl font-bold">{user.stats.totalLearningTime}h</p>
+            <p className="text-3xl font-bold">{formState.stats.totalLearningTime}h</p>
             <p className="text-sm text-text-secondary">총 학습 시간</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="pt-6 text-center">
-            <p className="text-3xl font-bold text-yellow-600">{user.stats.averageScore}점</p>
+            <p className="text-3xl font-bold text-yellow-600">{formState.stats.averageScore}점</p>
             <p className="text-sm text-text-secondary">평균 점수</p>
           </CardContent>
         </Card>
@@ -269,8 +421,8 @@ export function UserDetailPage() {
                   <Label htmlFor="name">이름</Label>
                   <Input
                     id="name"
-                    value={user.name}
-                    onChange={(e) => setUser({ ...user, name: e.target.value })}
+                    value={formState.name}
+                    onChange={(e) => setFormState({ ...formState, name: e.target.value })}
                   />
                 </div>
                 <div className="space-y-2">
@@ -278,7 +430,7 @@ export function UserDetailPage() {
                   <Input
                     id="email"
                     type="email"
-                    value={user.email}
+                    value={formState.email}
                     disabled
                     className="bg-bg-secondary"
                   />
@@ -288,8 +440,8 @@ export function UserDetailPage() {
                   <Label htmlFor="phone">연락처</Label>
                   <Input
                     id="phone"
-                    value={user.phone || ''}
-                    onChange={(e) => setUser({ ...user, phone: e.target.value })}
+                    value={formState.phone}
+                    onChange={(e) => setFormState({ ...formState, phone: e.target.value })}
                     placeholder="010-0000-0000"
                   />
                 </div>
@@ -297,21 +449,21 @@ export function UserDetailPage() {
                   <Label htmlFor="department">부서</Label>
                   <Input
                     id="department"
-                    value={user.department || ''}
-                    onChange={(e) => setUser({ ...user, department: e.target.value })}
+                    value={formState.department}
+                    onChange={(e) => setFormState({ ...formState, department: e.target.value })}
                   />
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="position">직책</Label>
                   <Input
                     id="position"
-                    value={user.position || ''}
-                    onChange={(e) => setUser({ ...user, position: e.target.value })}
+                    value={formState.position}
+                    onChange={(e) => setFormState({ ...formState, position: e.target.value })}
                   />
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="status">상태</Label>
-                  <Select value={user.status} onValueChange={(v) => handleStatusChange(v as UserStatus)}>
+                  <Select value={formState.status} onValueChange={(v) => handleStatusChange(v as UserStatus)}>
                     <SelectTrigger>
                       <SelectValue />
                     </SelectTrigger>
@@ -330,7 +482,7 @@ export function UserDetailPage() {
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div className="space-y-2">
                     <Label htmlFor="role">시스템 역할</Label>
-                    <Select value={user.role} onValueChange={(v) => handleRoleChange(v as SystemRole)}>
+                    <Select value={formState.systemRole} onValueChange={(v) => handleRoleChange(v as SystemRole)}>
                       <SelectTrigger>
                         <SelectValue />
                       </SelectTrigger>
@@ -346,6 +498,34 @@ export function UserDetailPage() {
                   </div>
                 </div>
               </div>
+
+              {/* 위험 영역 */}
+              <div className="border-t pt-6">
+                <h4 className="font-medium mb-4 text-red-600">위험 영역</h4>
+                <div className="p-4 border border-red-200 rounded-lg bg-red-50 dark:bg-red-950/20">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-medium text-red-600">사용자 삭제</p>
+                      <p className="text-sm text-text-secondary">
+                        이 작업은 되돌릴 수 없습니다. 사용자의 모든 데이터가 삭제됩니다.
+                      </p>
+                    </div>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={handleDelete}
+                      disabled={deleteMutation.isPending}
+                    >
+                      {deleteMutation.isPending ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      ) : (
+                        <AlertCircle className="mr-2 h-4 w-4" />
+                      )}
+                      사용자 삭제
+                    </Button>
+                  </div>
+                </div>
+              </div>
             </CardContent>
           </Card>
         </TabsContent>
@@ -358,33 +538,39 @@ export function UserDetailPage() {
               <CardDescription>사용자가 등록한 강좌와 진도율을 확인합니다.</CardDescription>
             </CardHeader>
             <CardContent>
-              <div className="space-y-4">
-                {user.enrollments.map((enrollment) => (
-                  <div
-                    key={enrollment.id}
-                    className="flex items-center justify-between p-4 border rounded-lg hover:bg-bg-secondary transition-colors"
-                  >
-                    <div className="flex-1">
-                      <div className="flex items-center gap-3 mb-2">
-                        <h4 className="font-medium">{enrollment.title}</h4>
-                        <span className={`px-2 py-0.5 rounded text-xs font-medium ${courseStatusColors[enrollment.status]}`}>
-                          {courseStatusLabels[enrollment.status]}
-                        </span>
+              {formState.enrollments.length === 0 ? (
+                <div className="text-center py-12 text-text-secondary">
+                  수강 중인 강좌가 없습니다.
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {formState.enrollments.map((enrollment) => (
+                    <div
+                      key={enrollment.id}
+                      className="flex items-center justify-between p-4 border rounded-lg hover:bg-bg-secondary transition-colors"
+                    >
+                      <div className="flex-1">
+                        <div className="flex items-center gap-3 mb-2">
+                          <h4 className="font-medium">{enrollment.courseTitle}</h4>
+                          <span className={`px-2 py-0.5 rounded text-xs font-medium ${courseStatusColors[enrollment.status]}`}>
+                            {courseStatusLabels[enrollment.status]}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-4 text-sm text-text-secondary">
+                          <span>등록일: {enrollment.enrolledAt}</span>
+                          {enrollment.completedAt && <span>완료일: {enrollment.completedAt}</span>}
+                        </div>
                       </div>
-                      <div className="flex items-center gap-4 text-sm text-text-secondary">
-                        <span>등록일: {enrollment.enrolledAt}</span>
-                        {enrollment.completedAt && <span>완료일: {enrollment.completedAt}</span>}
+                      <div className="w-32">
+                        <div className="flex items-center justify-between mb-1">
+                          <span className="text-sm font-medium">{enrollment.progress}%</span>
+                        </div>
+                        <Progress value={enrollment.progress} />
                       </div>
                     </div>
-                    <div className="w-32">
-                      <div className="flex items-center justify-between mb-1">
-                        <span className="text-sm font-medium">{enrollment.progress}%</span>
-                      </div>
-                      <Progress value={enrollment.progress} />
-                    </div>
-                  </div>
-                ))}
-              </div>
+                  ))}
+                </div>
+              )}
             </CardContent>
           </Card>
         </TabsContent>
@@ -397,31 +583,37 @@ export function UserDetailPage() {
               <CardDescription>사용자의 최근 활동 내역을 확인합니다.</CardDescription>
             </CardHeader>
             <CardContent>
-              <div className="relative">
-                {/* Timeline line */}
-                <div className="absolute left-4 top-0 bottom-0 w-0.5 bg-border" />
-
-                <div className="space-y-6">
-                  {user.activityLogs.map((log) => {
-                    const Icon = activityIcons[log.type];
-                    return (
-                      <div key={log.id} className="relative flex gap-4 pl-10">
-                        {/* Timeline dot */}
-                        <div className="absolute left-0 w-8 h-8 rounded-full bg-bg-secondary border-2 border-border flex items-center justify-center">
-                          <Icon className="w-4 h-4 text-text-secondary" />
-                        </div>
-                        <div className="flex-1 pb-6">
-                          <div className="flex items-center justify-between">
-                            <h4 className="font-medium">{log.action}</h4>
-                            <span className="text-sm text-text-secondary">{log.timestamp}</span>
-                          </div>
-                          <p className="text-sm text-text-secondary mt-1">{log.description}</p>
-                        </div>
-                      </div>
-                    );
-                  })}
+              {formState.activityLogs.length === 0 ? (
+                <div className="text-center py-12 text-text-secondary">
+                  활동 이력이 없습니다.
                 </div>
-              </div>
+              ) : (
+                <div className="relative">
+                  {/* Timeline line */}
+                  <div className="absolute left-4 top-0 bottom-0 w-0.5 bg-border" />
+
+                  <div className="space-y-6">
+                    {formState.activityLogs.map((log) => {
+                      const Icon = activityIcons[log.type];
+                      return (
+                        <div key={log.id} className="relative flex gap-4 pl-10">
+                          {/* Timeline dot */}
+                          <div className="absolute left-0 w-8 h-8 rounded-full bg-bg-secondary border-2 border-border flex items-center justify-center">
+                            <Icon className="w-4 h-4 text-text-secondary" />
+                          </div>
+                          <div className="flex-1 pb-6">
+                            <div className="flex items-center justify-between">
+                              <h4 className="font-medium">{log.action}</h4>
+                              <span className="text-sm text-text-secondary">{log.timestamp}</span>
+                            </div>
+                            <p className="text-sm text-text-secondary mt-1">{log.description}</p>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
             </CardContent>
           </Card>
         </TabsContent>

--- a/src/pages/ta/users/UserDetailPage.tsx
+++ b/src/pages/ta/users/UserDetailPage.tsx
@@ -1,0 +1,431 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  ArrowLeft,
+  Save,
+  BookOpen,
+  Clock,
+  Award,
+  User,
+  Mail,
+  Building,
+  Calendar,
+  Activity,
+} from 'lucide-react';
+import {
+  AdminPageHeader,
+  StatusBadge,
+  RoleBadge,
+} from '@/components/domain/admin';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Label } from '@/components/common/Label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/common/Card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/common/Tabs';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/common/Select';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/common/Avatar';
+import { Progress } from '@/components/common/Progress';
+import type { UserStatus, SystemRole } from '@/components/domain/admin';
+
+// Mock 데이터
+interface CourseEnrollment {
+  id: number;
+  title: string;
+  progress: number;
+  status: 'IN_PROGRESS' | 'COMPLETED' | 'NOT_STARTED';
+  enrolledAt: string;
+  completedAt?: string;
+}
+
+interface ActivityLog {
+  id: number;
+  action: string;
+  description: string;
+  timestamp: string;
+  type: 'login' | 'course' | 'assessment' | 'profile';
+}
+
+interface UserDetail {
+  id: number;
+  name: string;
+  email: string;
+  status: UserStatus;
+  role: SystemRole;
+  department?: string;
+  phone?: string;
+  position?: string;
+  createdAt: string;
+  lastActiveAt: string;
+  stats: {
+    totalCourses: number;
+    completedCourses: number;
+    inProgressCourses: number;
+    totalLearningTime: number; // hours
+    averageScore: number;
+  };
+  enrollments: CourseEnrollment[];
+  activityLogs: ActivityLog[];
+}
+
+const mockUserDetail: UserDetail = {
+  id: 1,
+  name: '김민수',
+  email: 'minsu.kim@company.com',
+  status: 'ACTIVE',
+  role: 'OPERATOR',
+  department: '개발팀',
+  phone: '010-1234-5678',
+  position: '시니어 개발자',
+  createdAt: '2025-01-15',
+  lastActiveAt: '2025-12-29',
+  stats: {
+    totalCourses: 12,
+    completedCourses: 8,
+    inProgressCourses: 3,
+    totalLearningTime: 45,
+    averageScore: 87,
+  },
+  enrollments: [
+    { id: 1, title: 'AWS 기초 마스터', progress: 100, status: 'COMPLETED', enrolledAt: '2025-01-20', completedAt: '2025-02-15' },
+    { id: 2, title: 'React 실전 프로젝트', progress: 75, status: 'IN_PROGRESS', enrolledAt: '2025-02-01' },
+    { id: 3, title: 'TypeScript 완벽 가이드', progress: 60, status: 'IN_PROGRESS', enrolledAt: '2025-02-10' },
+    { id: 4, title: 'Docker & Kubernetes', progress: 100, status: 'COMPLETED', enrolledAt: '2025-01-10', completedAt: '2025-01-25' },
+    { id: 5, title: 'Python 데이터 분석', progress: 0, status: 'NOT_STARTED', enrolledAt: '2025-12-20' },
+  ],
+  activityLogs: [
+    { id: 1, action: '로그인', description: '시스템에 로그인했습니다.', timestamp: '2025-12-29 09:15:00', type: 'login' },
+    { id: 2, action: '강의 수강', description: 'React 실전 프로젝트 - 챕터 5 완료', timestamp: '2025-12-29 10:30:00', type: 'course' },
+    { id: 3, action: '평가 완료', description: 'TypeScript 중간 테스트 완료 (85점)', timestamp: '2025-12-28 14:20:00', type: 'assessment' },
+    { id: 4, action: '프로필 수정', description: '프로필 정보를 업데이트했습니다.', timestamp: '2025-12-27 16:45:00', type: 'profile' },
+    { id: 5, action: '강의 수강', description: 'AWS 기초 마스터 - 수료', timestamp: '2025-12-25 11:00:00', type: 'course' },
+  ],
+};
+
+const courseStatusLabels = {
+  IN_PROGRESS: '진행 중',
+  COMPLETED: '완료',
+  NOT_STARTED: '미시작',
+};
+
+const courseStatusColors = {
+  IN_PROGRESS: 'text-blue-600 bg-blue-50',
+  COMPLETED: 'text-green-600 bg-green-50',
+  NOT_STARTED: 'text-gray-600 bg-gray-50',
+};
+
+const activityIcons = {
+  login: Clock,
+  course: BookOpen,
+  assessment: Award,
+  profile: User,
+};
+
+export function UserDetailPage() {
+  const { id: _id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  // 실제로는 API에서 id를 사용해 데이터를 가져옴
+  const [user, setUser] = useState<UserDetail>(mockUserDetail);
+
+  const handleSave = () => {
+    console.log('Save user:', user);
+  };
+
+  const handleStatusChange = (status: UserStatus) => {
+    setUser({ ...user, status });
+  };
+
+  const handleRoleChange = (role: SystemRole) => {
+    setUser({ ...user, role });
+  };
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title={user.name}
+        description={user.email}
+        breadcrumb={[
+          { label: '사용자 관리', href: '/ta/users' },
+          { label: user.name },
+        ]}
+        actions={
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => navigate('/ta/users')}>
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              목록으로
+            </Button>
+            <Button onClick={handleSave}>
+              <Save className="mr-2 h-4 w-4" />
+              저장
+            </Button>
+          </div>
+        }
+      />
+
+      {/* 사용자 프로필 카드 */}
+      <Card className="mb-6">
+        <CardContent className="pt-6">
+          <div className="flex items-start gap-6">
+            <Avatar className="h-20 w-20">
+              <AvatarImage src={`https://api.dicebear.com/7.x/initials/svg?seed=${user.name}`} />
+              <AvatarFallback className="text-2xl">{user.name.slice(0, 2)}</AvatarFallback>
+            </Avatar>
+            <div className="flex-1">
+              <div className="flex items-center gap-3 mb-2">
+                <h2 className="text-xl font-bold">{user.name}</h2>
+                <StatusBadge status={user.status} />
+                <RoleBadge role={user.role} />
+              </div>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                <div className="flex items-center gap-2 text-text-secondary">
+                  <Mail className="h-4 w-4" />
+                  {user.email}
+                </div>
+                <div className="flex items-center gap-2 text-text-secondary">
+                  <Building className="h-4 w-4" />
+                  {user.department || '-'} {user.position && `/ ${user.position}`}
+                </div>
+                <div className="flex items-center gap-2 text-text-secondary">
+                  <Calendar className="h-4 w-4" />
+                  가입일: {user.createdAt}
+                </div>
+                <div className="flex items-center gap-2 text-text-secondary">
+                  <Activity className="h-4 w-4" />
+                  최근 활동: {user.lastActiveAt}
+                </div>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 학습 통계 카드 */}
+      <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6">
+        <Card>
+          <CardContent className="pt-6 text-center">
+            <p className="text-3xl font-bold text-brand-primary">{user.stats.totalCourses}</p>
+            <p className="text-sm text-text-secondary">전체 강좌</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6 text-center">
+            <p className="text-3xl font-bold text-green-600">{user.stats.completedCourses}</p>
+            <p className="text-sm text-text-secondary">완료</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6 text-center">
+            <p className="text-3xl font-bold text-blue-600">{user.stats.inProgressCourses}</p>
+            <p className="text-sm text-text-secondary">진행 중</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6 text-center">
+            <p className="text-3xl font-bold">{user.stats.totalLearningTime}h</p>
+            <p className="text-sm text-text-secondary">총 학습 시간</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6 text-center">
+            <p className="text-3xl font-bold text-yellow-600">{user.stats.averageScore}점</p>
+            <p className="text-sm text-text-secondary">평균 점수</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 탭 컨텐츠 */}
+      <Tabs defaultValue="info" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="info">
+            <User className="w-4 h-4 mr-2" />
+            기본 정보
+          </TabsTrigger>
+          <TabsTrigger value="courses">
+            <BookOpen className="w-4 h-4 mr-2" />
+            수강 현황
+          </TabsTrigger>
+          <TabsTrigger value="activity">
+            <Activity className="w-4 h-4 mr-2" />
+            활동 이력
+          </TabsTrigger>
+        </TabsList>
+
+        {/* 기본 정보 탭 */}
+        <TabsContent value="info">
+          <Card>
+            <CardHeader>
+              <CardTitle>기본 정보</CardTitle>
+              <CardDescription>사용자의 기본 정보를 관리합니다.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="space-y-2">
+                  <Label htmlFor="name">이름</Label>
+                  <Input
+                    id="name"
+                    value={user.name}
+                    onChange={(e) => setUser({ ...user, name: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="email">이메일</Label>
+                  <Input
+                    id="email"
+                    type="email"
+                    value={user.email}
+                    disabled
+                    className="bg-bg-secondary"
+                  />
+                  <p className="text-xs text-text-secondary">이메일은 변경할 수 없습니다.</p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="phone">연락처</Label>
+                  <Input
+                    id="phone"
+                    value={user.phone || ''}
+                    onChange={(e) => setUser({ ...user, phone: e.target.value })}
+                    placeholder="010-0000-0000"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="department">부서</Label>
+                  <Input
+                    id="department"
+                    value={user.department || ''}
+                    onChange={(e) => setUser({ ...user, department: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="position">직책</Label>
+                  <Input
+                    id="position"
+                    value={user.position || ''}
+                    onChange={(e) => setUser({ ...user, position: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="status">상태</Label>
+                  <Select value={user.status} onValueChange={(v) => handleStatusChange(v as UserStatus)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="ACTIVE">활성</SelectItem>
+                      <SelectItem value="INACTIVE">비활성</SelectItem>
+                      <SelectItem value="PENDING">대기</SelectItem>
+                      <SelectItem value="BLOCKED">차단</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="border-t pt-6">
+                <h4 className="font-medium mb-4">권한 설정</h4>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div className="space-y-2">
+                    <Label htmlFor="role">시스템 역할</Label>
+                    <Select value={user.role} onValueChange={(v) => handleRoleChange(v as SystemRole)}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="USER">일반 사용자</SelectItem>
+                        <SelectItem value="OPERATOR">운영자</SelectItem>
+                        <SelectItem value="TENANT_ADMIN">테넌트 관리자</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-text-secondary">
+                      역할에 따라 접근 가능한 기능이 달라집니다.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* 수강 현황 탭 */}
+        <TabsContent value="courses">
+          <Card>
+            <CardHeader>
+              <CardTitle>수강 현황</CardTitle>
+              <CardDescription>사용자가 등록한 강좌와 진도율을 확인합니다.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                {user.enrollments.map((enrollment) => (
+                  <div
+                    key={enrollment.id}
+                    className="flex items-center justify-between p-4 border rounded-lg hover:bg-bg-secondary transition-colors"
+                  >
+                    <div className="flex-1">
+                      <div className="flex items-center gap-3 mb-2">
+                        <h4 className="font-medium">{enrollment.title}</h4>
+                        <span className={`px-2 py-0.5 rounded text-xs font-medium ${courseStatusColors[enrollment.status]}`}>
+                          {courseStatusLabels[enrollment.status]}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-4 text-sm text-text-secondary">
+                        <span>등록일: {enrollment.enrolledAt}</span>
+                        {enrollment.completedAt && <span>완료일: {enrollment.completedAt}</span>}
+                      </div>
+                    </div>
+                    <div className="w-32">
+                      <div className="flex items-center justify-between mb-1">
+                        <span className="text-sm font-medium">{enrollment.progress}%</span>
+                      </div>
+                      <Progress value={enrollment.progress} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* 활동 이력 탭 */}
+        <TabsContent value="activity">
+          <Card>
+            <CardHeader>
+              <CardTitle>활동 이력</CardTitle>
+              <CardDescription>사용자의 최근 활동 내역을 확인합니다.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="relative">
+                {/* Timeline line */}
+                <div className="absolute left-4 top-0 bottom-0 w-0.5 bg-border" />
+
+                <div className="space-y-6">
+                  {user.activityLogs.map((log) => {
+                    const Icon = activityIcons[log.type];
+                    return (
+                      <div key={log.id} className="relative flex gap-4 pl-10">
+                        {/* Timeline dot */}
+                        <div className="absolute left-0 w-8 h-8 rounded-full bg-bg-secondary border-2 border-border flex items-center justify-center">
+                          <Icon className="w-4 h-4 text-text-secondary" />
+                        </div>
+                        <div className="flex-1 pb-6">
+                          <div className="flex items-center justify-between">
+                            <h4 className="font-medium">{log.action}</h4>
+                            <span className="text-sm text-text-secondary">{log.timestamp}</span>
+                          </div>
+                          <p className="text-sm text-text-secondary mt-1">{log.description}</p>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/pages/ta/users/UsersPage.tsx
+++ b/src/pages/ta/users/UsersPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Plus, Search, MoreHorizontal, Eye, Edit, Trash2, Mail, UserPlus } from 'lucide-react';
 import { ColumnDef } from '@tanstack/react-table';
 import {
@@ -62,11 +63,11 @@ const mockUsers: UserRow[] = [
 ];
 
 export function UsersPage() {
+  const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [roleFilter, setRoleFilter] = useState<string>('all');
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
-  const [isDetailDialogOpen, setIsDetailDialogOpen] = useState(false);
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
   const [selectedUser, setSelectedUser] = useState<UserRow | null>(null);
 
@@ -168,8 +169,7 @@ export function UsersPage() {
   ];
 
   const handleViewDetail = (user: UserRow) => {
-    setSelectedUser(user);
-    setIsDetailDialogOpen(true);
+    navigate(`/ta/users/${user.id}`);
   };
 
   const handleEdit = (user: UserRow) => {
@@ -328,70 +328,6 @@ export function UsersPage() {
             </Button>
             <Button onClick={() => setIsCreateDialogOpen(false)}>
               {selectedUser ? '수정' : '생성'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* 사용자 상세 다이얼로그 */}
-      <Dialog open={isDetailDialogOpen} onOpenChange={setIsDetailDialogOpen}>
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle>사용자 상세 정보</DialogTitle>
-          </DialogHeader>
-          {selectedUser && (
-            <div className="space-y-4 py-4">
-              <div className="flex items-center gap-4 pb-4 border-b">
-                <Avatar className="h-16 w-16">
-                  <AvatarImage src={`https://api.dicebear.com/7.x/initials/svg?seed=${selectedUser.name}`} />
-                  <AvatarFallback className="text-xl">{selectedUser.name.slice(0, 2)}</AvatarFallback>
-                </Avatar>
-                <div>
-                  <h3 className="font-semibold text-lg">{selectedUser.name}</h3>
-                  <p className="text-sm text-text-secondary">{selectedUser.email}</p>
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <p className="text-sm text-text-secondary">상태</p>
-                  <div className="mt-1">
-                    <StatusBadge status={selectedUser.status} />
-                  </div>
-                </div>
-                <div>
-                  <p className="text-sm text-text-secondary">역할</p>
-                  <div className="mt-1">
-                    <RoleBadge role={selectedUser.role} />
-                  </div>
-                </div>
-                <div>
-                  <p className="text-sm text-text-secondary">부서</p>
-                  <p className="font-medium">{selectedUser.department || '-'}</p>
-                </div>
-                <div>
-                  <p className="text-sm text-text-secondary">수강 강좌</p>
-                  <p className="font-medium">{selectedUser.coursesEnrolled}개</p>
-                </div>
-                <div>
-                  <p className="text-sm text-text-secondary">최근 활동</p>
-                  <p className="font-medium">{selectedUser.lastActiveAt}</p>
-                </div>
-                <div>
-                  <p className="text-sm text-text-secondary">가입일</p>
-                  <p className="font-medium">{selectedUser.createdAt}</p>
-                </div>
-              </div>
-            </div>
-          )}
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setIsDetailDialogOpen(false)}>
-              닫기
-            </Button>
-            <Button onClick={() => {
-              setIsDetailDialogOpen(false);
-              if (selectedUser) handleEdit(selectedUser);
-            }}>
-              수정
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/pages/ta/users/index.ts
+++ b/src/pages/ta/users/index.ts
@@ -1,1 +1,2 @@
 export { UsersPage } from './UsersPage';
+export { UserDetailPage } from './UserDetailPage';

--- a/src/routes/sa.routes.tsx
+++ b/src/routes/sa.routes.tsx
@@ -7,7 +7,7 @@ import {
   SettingsNotificationsPage,
   SettingsAppearancePage,
 } from '@/pages/common';
-import { DashboardPage, TenantsPage } from '@/pages/sa';
+import { DashboardPage, TenantsPage, TenantDetailPage } from '@/pages/sa';
 import { PlaceholderPage } from './pages';
 
 function SuperAdminWrapper() {
@@ -26,6 +26,7 @@ export const saRoutes = (
     <Route path="dashboard" element={<DashboardPage />} />
     {/* 테넌트 관리 */}
     <Route path="tenants" element={<TenantsPage />} />
+    <Route path="tenants/:id" element={<TenantDetailPage />} />
     <Route path="tenants/billing" element={<PlaceholderPage title="요금제 및 라이선스 관리" />} />
     <Route path="tenants/status" element={<PlaceholderPage title="전체 현황 조회" />} />
     {/* 시스템 환경 관리 */}

--- a/src/routes/ta.routes.tsx
+++ b/src/routes/ta.routes.tsx
@@ -7,7 +7,7 @@ import {
   SettingsNotificationsPage,
   SettingsAppearancePage,
 } from '@/pages/common';
-import { DashboardPage, UsersPage } from '@/pages/ta';
+import { DashboardPage, UsersPage, UserDetailPage } from '@/pages/ta';
 import { PlaceholderPage } from './pages';
 
 function TenantAdminWrapper() {
@@ -33,6 +33,7 @@ export const taRoutes = (
     <Route path="branding/navigation" element={<PlaceholderPage title="네비게이션 구성 관리" />} />
     {/* 사용자 및 권한 */}
     <Route path="users" element={<UsersPage />} />
+    <Route path="users/:id" element={<UserDetailPage />} />
     <Route path="users/operators" element={<PlaceholderPage title="운영자 관리" />} />
     <Route path="users/groups" element={<PlaceholderPage title="사용자 그룹 및 역할 관리" />} />
     <Route path="users/permissions" element={<PlaceholderPage title="접근 권한 설정" />} />

--- a/src/services/sa/index.ts
+++ b/src/services/sa/index.ts
@@ -1,0 +1,2 @@
+export { tenantService } from './tenantService';
+export type { TenantFilterParams } from './tenantService';

--- a/src/services/sa/tenantService.ts
+++ b/src/services/sa/tenantService.ts
@@ -1,0 +1,81 @@
+/**
+ * Tenant API 서비스 (SA - System Admin)
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type {
+  Tenant,
+  TenantDetail,
+  TenantListResponse,
+  TenantStats,
+  CreateTenantRequest,
+  UpdateTenantDetailRequest,
+} from '@/types/admin';
+
+// 테넌트 필터 파라미터
+export interface TenantFilterParams {
+  keyword?: string;
+  status?: string;
+  plan?: string;
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+export const tenantService = {
+  // ============================================
+  // Tenant CRUD
+  // ============================================
+
+  /** 테넌트 생성 */
+  async create(request: CreateTenantRequest): Promise<Tenant> {
+    const { data } = await axiosInstance.post<{ data: Tenant }>(
+      API_ENDPOINTS.TENANTS.BASE,
+      request
+    );
+    return data.data;
+  },
+
+  /** 테넌트 목록 조회 */
+  async getTenants(params?: TenantFilterParams): Promise<TenantListResponse> {
+    const { data } = await axiosInstance.get<TenantListResponse>(
+      API_ENDPOINTS.TENANTS.BASE,
+      { params }
+    );
+    return data;
+  },
+
+  /** 테넌트 상세 조회 */
+  async getTenant(id: number): Promise<TenantDetail> {
+    const { data } = await axiosInstance.get<{ data: TenantDetail }>(
+      API_ENDPOINTS.TENANTS.BY_ID(id)
+    );
+    return data.data;
+  },
+
+  /** 테넌트 수정 */
+  async update(id: number, request: UpdateTenantDetailRequest): Promise<TenantDetail> {
+    const { data } = await axiosInstance.put<{ data: TenantDetail }>(
+      API_ENDPOINTS.TENANTS.BY_ID(id),
+      request
+    );
+    return data.data;
+  },
+
+  /** 테넌트 삭제 */
+  async delete(id: number): Promise<void> {
+    await axiosInstance.delete(API_ENDPOINTS.TENANTS.BY_ID(id));
+  },
+
+  // ============================================
+  // Statistics
+  // ============================================
+
+  /** 테넌트 통계 조회 */
+  async getStats(): Promise<TenantStats> {
+    const { data } = await axiosInstance.get<{ data: TenantStats }>(
+      `${API_ENDPOINTS.TENANTS.BASE}/stats`
+    );
+    return data.data;
+  },
+};

--- a/src/services/ta/index.ts
+++ b/src/services/ta/index.ts
@@ -1,0 +1,1 @@
+export { userService } from './userService';

--- a/src/services/ta/userService.ts
+++ b/src/services/ta/userService.ts
@@ -1,0 +1,81 @@
+/**
+ * User API 서비스 (TA - Tenant Admin)
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type {
+  AdminUser,
+  UserDetail,
+  UserListResponse,
+  UserListParams,
+  UserStats,
+  UpdateUserDetailRequest,
+  UpdateUserRoleRequest,
+} from '@/types/admin';
+
+export const userService = {
+  // ============================================
+  // User CRUD
+  // ============================================
+
+  /** 사용자 목록 조회 */
+  async getUsers(params?: UserListParams): Promise<UserListResponse> {
+    const { data } = await axiosInstance.get<UserListResponse>(
+      API_ENDPOINTS.USERS.BASE,
+      { params }
+    );
+    return data;
+  },
+
+  /** 사용자 상세 조회 */
+  async getUser(id: number): Promise<UserDetail> {
+    const { data } = await axiosInstance.get<{ data: UserDetail }>(
+      API_ENDPOINTS.USERS.BY_ID(id)
+    );
+    return data.data;
+  },
+
+  /** 사용자 정보 수정 */
+  async update(id: number, request: UpdateUserDetailRequest): Promise<UserDetail> {
+    const { data } = await axiosInstance.put<{ data: UserDetail }>(
+      API_ENDPOINTS.USERS.BY_ID(id),
+      request
+    );
+    return data.data;
+  },
+
+  /** 사용자 역할 변경 */
+  async updateRole(id: number, request: UpdateUserRoleRequest): Promise<AdminUser> {
+    const { data } = await axiosInstance.patch<{ data: AdminUser }>(
+      API_ENDPOINTS.USERS.ROLE(id),
+      request
+    );
+    return data.data;
+  },
+
+  /** 사용자 상태 변경 */
+  async updateStatus(id: number, status: string): Promise<AdminUser> {
+    const { data } = await axiosInstance.patch<{ data: AdminUser }>(
+      API_ENDPOINTS.USERS.STATUS(id),
+      { status }
+    );
+    return data.data;
+  },
+
+  /** 사용자 삭제 */
+  async delete(id: number): Promise<void> {
+    await axiosInstance.delete(API_ENDPOINTS.USERS.BY_ID(id));
+  },
+
+  // ============================================
+  // Statistics
+  // ============================================
+
+  /** 사용자 통계 조회 */
+  async getStats(): Promise<UserStats> {
+    const { data } = await axiosInstance.get<{ data: UserStats }>(
+      `${API_ENDPOINTS.USERS.BASE}/stats`
+    );
+    return data.data;
+  },
+};

--- a/src/types/admin/tenant.types.ts
+++ b/src/types/admin/tenant.types.ts
@@ -84,3 +84,29 @@ export interface TenantStats {
     B2B: number;
   };
 }
+
+// Tenant Detail (상세 페이지용)
+export interface TenantDetail extends Tenant {
+  adminEmail: string;
+  adminName: string;
+  branding: TenantBranding;
+  settings: TenantSettings & {
+    maxCourses: number;
+    allowCustomDomain: boolean;
+    allowCustomBranding: boolean;
+    ssoEnabled: boolean;
+    apiAccessEnabled: boolean;
+  };
+}
+
+// Update Tenant Detail Request
+export interface UpdateTenantDetailRequest {
+  name?: string;
+  status?: TenantStatus;
+  plan?: PlanType;
+  customDomain?: string;
+  adminName?: string;
+  adminEmail?: string;
+  branding?: Partial<TenantBranding>;
+  settings?: Partial<TenantSettings>;
+}

--- a/src/types/admin/user.types.ts
+++ b/src/types/admin/user.types.ts
@@ -75,3 +75,46 @@ export interface UserStats {
   newUsersThisMonth: number;
   activeToday: number;
 }
+
+// User Detail (상세 페이지용)
+export interface UserDetail extends AdminUser {
+  phone?: string;
+  department?: string;
+  position?: string;
+  stats: {
+    totalCourses: number;
+    completedCourses: number;
+    inProgressCourses: number;
+    totalLearningTime: number;
+    averageScore: number;
+  };
+  enrollments: UserEnrollment[];
+  activityLogs: UserActivityLog[];
+}
+
+export interface UserEnrollment {
+  id: number;
+  courseTitle: string;
+  progress: number;
+  status: 'IN_PROGRESS' | 'COMPLETED' | 'NOT_STARTED';
+  enrolledAt: string;
+  completedAt?: string;
+}
+
+export interface UserActivityLog {
+  id: number;
+  action: string;
+  description: string;
+  timestamp: string;
+  type: 'login' | 'course' | 'assessment' | 'profile';
+}
+
+// Update User Detail Request
+export interface UpdateUserDetailRequest {
+  name?: string;
+  phone?: string;
+  department?: string;
+  position?: string;
+  status?: UserStatus;
+  systemRole?: SystemRole;
+}


### PR DESCRIPTION
## Summary
SA(시스템 어드민) 테넌트 상세 페이지와 TA(테넌트 어드민) 사용자 상세 페이지에 API 연동을 구현하고, 데모 모드를 지원합니다.

## Related Issue
- 직접 관련된 이슈 없음

## Changes

### 신규 파일
- `src/services/sa/tenantService.ts` - 테넌트 API 서비스
- `src/services/ta/userService.ts` - 사용자 API 서비스
- `src/hooks/sa/useTenantQueries.ts` - 테넌트 React Query 훅
- `src/hooks/ta/useUserQueries.ts` - 사용자 React Query 훅

### 수정된 파일
- `src/pages/sa/tenants/TenantDetailPage.tsx` - API 연동, 로딩/에러 UI, 데모 모드 추가
- `src/pages/ta/users/UserDetailPage.tsx` - API 연동, 로딩/에러 UI, 데모 모드 추가
- `src/types/admin/tenant.types.ts` - TenantDetail, UpdateTenantDetailRequest 타입 추가
- `src/types/admin/user.types.ts` - UserDetail, UpdateUserDetailRequest 타입 추가
- `src/config/sidebar-menus.ts` - 슈퍼 어드민 → 시스템 어드민 용어 변경
- `src/components/domain/admin/RoleBadge.tsx` - 슈퍼 관리자 → 시스템 관리자 용어 변경

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Checklist
- [x] 코드가 프로젝트의 스타일 가이드라인을 따릅니다
- [x] 변경사항에 대한 셀프 리뷰를 완료했습니다
- [x] 로컬에서 변경사항을 테스트했습니다
- [ ] 관련 문서를 업데이트했습니다

## Screenshots
데모 모드로 테스트 가능:
- SA 테넌트 상세: `/sa/tenants/1?demo=true`
- TA 사용자 상세: `/ta/users/1?demo=true`

## Additional Notes
- 백엔드 API 연동 전까지 `?demo=true` 쿼리 파라미터로 목 데이터 테스트 가능
- React Query를 사용한 서버 상태 관리 패턴 적용
- 로딩 시 스켈레톤 UI, 에러 시 재시도 버튼 제공