### PR TITLE
[Feat] TU 마이페이지 다크모드 스타일링 개선

### DIFF
--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -53,26 +53,26 @@ export function LandingHeader() {
         </div>
       )}
 
-      {/* Main Navigation - Dark Glass Effect */}
-      <div className="w-full glass-dark sticky top-0 z-50">
+      {/* Main Navigation */}
+      <div className={`w-full sticky top-0 z-50 border-b ${isDark ? 'glass-dark border-white/10' : 'border-gray-200'}`} style={{ backgroundColor: isDark ? undefined : '#fafafa' }}>
         <div className="w-full px-6 md:px-12 lg:px-16 h-16 flex items-center justify-between gap-6">
           {/* Left: Logo & Menu */}
           <div className="flex items-center gap-8 ml-2 md:ml-4">
             {/* Logo */}
-            <Link to="/" className="flex items-center gap-2 font-bold text-xl tracking-tight">
+            <Link to="/" className={`flex items-center gap-2 font-bold text-xl tracking-tight ${isDark ? '' : 'text-gray-900'}`}>
               <span className="text-2xl">M</span>
               <span className="gradient-text">MZC Learn</span>
             </Link>
 
             {/* Desktop Nav Links */}
-            <nav className="hidden md:flex items-center gap-8 text-gray-300 font-medium text-[15px]">
-              <Link to="/tu/main/page1" className="hover:text-white transition-colors">
+            <nav className={`hidden md:flex items-center gap-8 font-medium text-[15px] ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
+              <Link to="/tu/main/page1" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
                 1페이지
               </Link>
-              <Link to="/tu/main/page2" className="hover:text-white transition-colors">
+              <Link to="/tu/main/page2" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
                 2페이지
               </Link>
-              <Link to="/tu/main/page3" className="hover:text-white transition-colors">
+              <Link to="/tu/main/page3" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
                 3페이지
               </Link>
             </nav>
@@ -85,7 +85,12 @@ export function LandingHeader() {
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder={t.landing.searchPlaceholder}
-              className="w-full bg-white/5 border border-white/10 rounded-full pl-5 pr-12 py-2.5 text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-[#6778ff] focus:border-[#6778ff] transition-all"
+              className={`w-full rounded-full pl-5 pr-12 py-2.5 text-sm focus:outline-none focus:ring-1 focus:ring-[#6778ff] focus:border-[#6778ff] transition-all ${
+                isDark
+                  ? 'bg-white/5 border border-white/10 text-white placeholder-gray-500'
+                  : 'border border-gray-300 text-gray-900 placeholder-gray-400'
+              }`}
+              style={{ backgroundColor: isDark ? undefined : '#fafafa' }}
             />
             <button
               type="submit"
@@ -101,20 +106,32 @@ export function LandingHeader() {
               {/* Theme Toggle Button */}
               <button
                 onClick={toggleTheme}
-                className="p-2 text-gray-400 hover:text-white hover:bg-white/10 rounded-lg transition-colors"
+                className={`p-2 rounded-lg transition-colors ${
+                  isDark
+                    ? 'text-gray-400 hover:text-white hover:bg-white/10'
+                    : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100'
+                }`}
                 aria-label={isDark ? t.landing.switchToLight : t.landing.switchToDark}
               >
                 {isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
               </button>
               <Link
                 to="/tu/cart"
-                className="p-2 text-gray-400 hover:text-white hover:bg-white/10 rounded-lg transition-colors relative"
+                className={`p-2 rounded-lg transition-colors relative ${
+                  isDark
+                    ? 'text-gray-400 hover:text-white hover:bg-white/10'
+                    : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100'
+                }`}
               >
                 <ShoppingCart className="h-5 w-5" />
               </Link>
               <Link
                 to="/tu/notifications"
-                className="p-2 text-gray-400 hover:text-white hover:bg-white/10 rounded-lg transition-colors relative"
+                className={`p-2 rounded-lg transition-colors relative ${
+                  isDark
+                    ? 'text-gray-400 hover:text-white hover:bg-white/10'
+                    : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100'
+                }`}
               >
                 <Bell className="h-5 w-5" />
               </Link>
@@ -123,7 +140,11 @@ export function LandingHeader() {
                 <div className="relative">
                   <button
                     onClick={() => setShowDropdown(!showDropdown)}
-                    className="hidden md:flex items-center gap-2 px-3 py-1.5 rounded-full bg-white/5 hover:bg-white/10 transition-colors"
+                    className={`hidden md:flex items-center gap-2 px-3 py-1.5 rounded-full transition-colors ${
+                      isDark
+                        ? 'bg-white/5 hover:bg-white/10'
+                        : 'bg-gray-100 hover:bg-gray-200'
+                    }`}
                   >
                     <div className="w-8 h-8 rounded-full bg-gradient-to-r from-[#6778ff] to-[#a855f7] flex items-center justify-center overflow-hidden">
                       {profileImageUrl ? (
@@ -132,7 +153,7 @@ export function LandingHeader() {
                         <User className="w-4 h-4 text-white" />
                       )}
                     </div>
-                    <span className="text-sm text-white font-medium max-w-[100px] truncate">
+                    <span className={`text-sm font-medium max-w-[100px] truncate ${isDark ? 'text-white' : 'text-gray-900'}`}>
                       {user.name}
                     </span>
                   </button>
@@ -141,7 +162,7 @@ export function LandingHeader() {
                   {showDropdown && (
                     <div className={`absolute right-0 top-12 w-64 rounded-xl p-4 shadow-xl border ${
                       isDark
-                        ? 'bg-[#1a1a2e]/95 backdrop-blur-md border-white/10'
+                        ? 'bg-[#151515] border-white/10'
                         : 'bg-white border-gray-200'
                     }`}>
                       {/* 프로필 정보 */}
@@ -250,7 +271,11 @@ export function LandingHeader() {
                 <>
                   <Link
                     to="/login"
-                    className="hidden md:flex px-4 py-2 landing-btn-outline text-white rounded-full text-sm font-medium"
+                    className={`hidden md:flex px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+                      isDark
+                        ? 'landing-btn-outline text-white'
+                        : 'border border-gray-300 text-gray-700 hover:bg-gray-100'
+                    }`}
                   >
                     {t.common.login}
                   </Link>
@@ -264,7 +289,7 @@ export function LandingHeader() {
               )}
 
               {/* Mobile Menu Toggle */}
-              <button className="p-2 md:hidden text-gray-400" aria-label={t.landing.openMenu}>
+              <button className={`p-2 md:hidden ${isDark ? 'text-gray-400' : 'text-gray-500'}`} aria-label={t.landing.openMenu}>
                 <Menu className="h-6 w-6" />
               </button>
             </div>

--- a/src/components/layout/mypage/MyPageLayout.tsx
+++ b/src/components/layout/mypage/MyPageLayout.tsx
@@ -35,7 +35,7 @@ export function MyPageLayout({ children }: MyPageLayoutProps) {
   };
 
   return (
-    <div className={`flex flex-col min-h-screen ${isDark ? 'bg-[#0a0a14]' : 'bg-gray-50'}`}>
+    <div className={`flex flex-col min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
       {/* 상단 헤더 */}
       <LandingHeader />
 

--- a/src/components/layout/mypage/MyPageSidebar.tsx
+++ b/src/components/layout/mypage/MyPageSidebar.tsx
@@ -123,7 +123,7 @@ export function MyPageSidebar({ onMenuItemClick }: MyPageSidebarProps) {
   return (
     <aside
       className={`w-72 flex-shrink-0 p-4 ${
-        isDark ? 'bg-[#0a0a14]' : 'bg-gray-50'
+        isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'
       }`}
     >
       {/* 카드형 사이드바 */}

--- a/src/index.css
+++ b/src/index.css
@@ -117,6 +117,10 @@
   --radius-md: 8px;
   --radius-lg: 12px;
   --radius-xl: 16px;
+
+  /* === TU Theme Colors === */
+  --tu-bg-light: #f9fafb;
+  --tu-bg-dark: #1e1e1e;
 }
 
 @layer base {
@@ -217,7 +221,7 @@
 }
 
 .glass-dark {
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(30, 30, 30, 0.95);
   backdrop-filter: blur(15px);
   -webkit-backdrop-filter: blur(15px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
@@ -275,7 +279,7 @@
 }
 
 .animated-bg {
-  background: linear-gradient(-45deg, #0a0a0a, #1a1a2e, #16213e, #0a0a0a);
+  background: linear-gradient(-45deg, #1a1a2e, #2a2a4e, #243358, #1a1a2e);
   background-size: 400% 400%;
   animation: bg-gradient 15s ease infinite;
 }
@@ -312,22 +316,22 @@
   --landing-header-bg: rgba(255, 255, 255, 0.9);
   --landing-card-bg: rgba(255, 255, 255, 1);
   --landing-card-border: rgba(0, 0, 0, 0.08);
-  --landing-footer-bg: #F4F4F4;
+  --landing-footer-bg: #fafafa;
 }
 
 /* Dark theme for landing */
 .landing-dark {
-  --landing-bg: #0a0a0a;
-  --landing-bg-secondary: #0f0f1a;
+  --landing-bg: #1e1e1e;
+  --landing-bg-secondary: #252525;
   --landing-bg-card: rgba(255, 255, 255, 0.05);
   --landing-text-primary: #FFFFFF;
   --landing-text-secondary: #D4D4D4;
   --landing-text-muted: #9E9E9E;
   --landing-border: rgba(255, 255, 255, 0.1);
-  --landing-header-bg: rgba(0, 0, 0, 0.6);
+  --landing-header-bg: rgba(30, 30, 30, 0.95);
   --landing-card-bg: rgba(255, 255, 255, 0.05);
   --landing-card-border: rgba(255, 255, 255, 0.1);
-  --landing-footer-bg: #000000;
+  --landing-footer-bg: #1e1e1e;
 }
 
 /* Landing page base styles using CSS variables */
@@ -606,7 +610,7 @@
 
 /* Header glass effect for themes */
 .landing-dark .glass-dark {
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(30, 30, 30, 0.95);
   backdrop-filter: blur(15px);
   -webkit-backdrop-filter: blur(15px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
@@ -664,13 +668,11 @@
 
 /* Footer theme support */
 .landing-dark .landing-footer-wrapper {
-  background: #000000;
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  background: var(--landing-footer-bg);
 }
 
 .landing-light .landing-footer-wrapper {
-  background: #F4F4F4;
-  border-top: 1px solid #E0E0E0;
+  background: var(--landing-footer-bg);
 }
 
 /* Card background and border utilities */
@@ -739,9 +741,9 @@
   color: #6778ff;
 }
 
-/* Hero section for light mode - medium gradient background */
+/* Hero section for light mode - lighter gradient background */
 .landing-light .animated-bg {
-  background: linear-gradient(135deg, #252542 0%, #3a3a70 50%, #252542 100%);
+  background: linear-gradient(135deg, #4a4a80 0%, #6060a0 50%, #4a4a80 100%);
 }
 
 .landing-light .animated-bg h2.text-white {

--- a/src/pages/tu/index.ts
+++ b/src/pages/tu/index.ts
@@ -3,4 +3,4 @@ export { SettingsLanguagePage } from './settings';
 export { LandingPage, Page1, Page2, Page3 } from './main';
 export { CatalogPage, CatalogDetailPage } from './catalog';
 export { MyLearningPage, LearningDetailPage, LearningPlayerPage } from './learning';
-export { MyPage, MyPageHome, ProfilePage, MyTeachingPage } from './mypage';
+export { MyPage, MyPageHome, ProfilePage, MyTeachingPage, TeachingStatsPage, CompletedCoursesPage, CertificationsPage } from './mypage';

--- a/src/pages/tu/learning/LearningPlayerPage.tsx
+++ b/src/pages/tu/learning/LearningPlayerPage.tsx
@@ -275,7 +275,7 @@ export function LearningPlayerPage() {
   // 로딩 상태 (데모 모드에서는 스킵)
   if (!isDemoMode && isLoading) {
     return (
-      <div className={`flex items-center justify-center min-h-screen ${isDark ? 'bg-[#0a0a14]' : 'bg-gray-50'}`}>
+      <div className={`flex items-center justify-center min-h-screen ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
         <Loader2 className={`w-8 h-8 animate-spin ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
       </div>
     );
@@ -284,7 +284,7 @@ export function LearningPlayerPage() {
   // 에러 상태 (데모 모드에서는 스킵)
   if (!isDemoMode && (isError || !enrollment)) {
     return (
-      <div className={`flex flex-col items-center justify-center min-h-screen ${isDark ? 'bg-[#0a0a14]' : 'bg-gray-50'}`}>
+      <div className={`flex flex-col items-center justify-center min-h-screen ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
         <BookOpen className={`w-16 h-16 mb-4 ${isDark ? 'text-gray-600' : 'text-gray-400'}`} />
         <h3 className={`text-lg font-medium mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
           {t.learning.enrollmentNotFound}
@@ -297,7 +297,7 @@ export function LearningPlayerPage() {
   }
 
   return (
-    <div className={`flex flex-col h-screen ${isDark ? 'bg-[#0a0a14]' : 'bg-gray-50'}`}>
+    <div className={`flex flex-col h-screen ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
       {/* 데모 모드 배너 */}
       {isDemoMode && (
         <div className="flex items-center justify-center gap-2 px-4 py-2 bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200">

--- a/src/pages/tu/learning/MyLearningPage.tsx
+++ b/src/pages/tu/learning/MyLearningPage.tsx
@@ -12,7 +12,6 @@ import {
   XCircle,
   AlertCircle,
 } from 'lucide-react';
-import { designTokens } from '@/styles/admin-design-tokens';
 import {
   Button,
   Badge,
@@ -28,6 +27,7 @@ import {
 } from '@/components/common';
 import { useMyEnrollments } from '@/hooks/tu';
 import { useTranslation } from '@/store/common/languageStore';
+import { useThemeStore } from '@/store/common/themeStore';
 import type { Enrollment, EnrollmentStatus, EnrollmentFilterParams } from '@/services/tu/enrollmentService';
 
 type StatusFilter = EnrollmentStatus | 'all';
@@ -48,21 +48,28 @@ const statusIcons: Record<EnrollmentStatus, React.ReactNode> = {
   COMPLETED: <CheckCircle className="w-4 h-4" />,
 };
 
-function ProgressBar({ progress }: { progress: number }) {
+function ProgressBar({ progress, isDark }: { progress: number; isDark: boolean }) {
   return (
-    <div className="w-full h-2 rounded-full overflow-hidden" style={{ backgroundColor: designTokens.bg.secondary }}>
+    <div className={`w-full h-2 rounded-full overflow-hidden ${isDark ? 'bg-white/10' : 'bg-gray-200'}`}>
       <div
         className="h-full rounded-full transition-all"
         style={{
           width: `${progress}%`,
-          backgroundColor: progress === 100 ? designTokens.status.success_text : designTokens.button.brand_default,
+          backgroundColor: progress === 100 ? '#22c55e' : '#6778ff',
         }}
       />
     </div>
   );
 }
 
-function EnrollmentCard({ enrollment, onClick, t }: { enrollment: Enrollment; onClick: () => void; t: ReturnType<typeof useTranslation>['t'] }) {
+interface EnrollmentCardProps {
+  enrollment: Enrollment;
+  onClick: () => void;
+  t: ReturnType<typeof useTranslation>['t'];
+  isDark: boolean;
+}
+
+function EnrollmentCard({ enrollment, onClick, t, isDark }: EnrollmentCardProps) {
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr);
     return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`;
@@ -78,9 +85,10 @@ function EnrollmentCard({ enrollment, onClick, t }: { enrollment: Enrollment; on
 
   return (
     <Card
-      className="cursor-pointer transition-all hover:shadow-md"
+      className={`cursor-pointer transition-all hover:shadow-md ${
+        isDark ? 'bg-white/5 border-white/10 hover:bg-white/10' : 'bg-white border-gray-200'
+      }`}
       onClick={onClick}
-      style={{ backgroundColor: designTokens.bg.default }}
     >
       <CardContent className="p-5">
         {/* Header: Status Badge */}
@@ -92,34 +100,28 @@ function EnrollmentCard({ enrollment, onClick, t }: { enrollment: Enrollment; on
         </div>
 
         {/* Program Title */}
-        <h3
-          className="font-semibold text-base mb-2 line-clamp-2"
-          style={{ color: designTokens.text.primary }}
-        >
+        <h3 className={`font-semibold text-base mb-2 line-clamp-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
           {enrollment.programTitle}
         </h3>
 
         {/* Course Time Name */}
-        <p
-          className="text-sm mb-3"
-          style={{ color: designTokens.text.secondary }}
-        >
+        <p className={`text-sm mb-3 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
           {enrollment.courseTimeName}
         </p>
 
         {/* Progress Bar (only for APPROVED status) */}
         {enrollment.status === 'APPROVED' && enrollment.progress !== undefined && (
           <div className="mb-3">
-            <div className="flex items-center justify-between text-xs mb-1" style={{ color: designTokens.text.secondary }}>
+            <div className={`flex items-center justify-between text-xs mb-1 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
               <span>{t.learning.progress}</span>
-              <span style={{ color: designTokens.text.primary, fontWeight: 500 }}>{enrollment.progress}%</span>
+              <span className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>{enrollment.progress}%</span>
             </div>
-            <ProgressBar progress={enrollment.progress} />
+            <ProgressBar progress={enrollment.progress} isDark={isDark} />
           </div>
         )}
 
         {/* Date Info */}
-        <div className="flex items-center gap-2 text-xs" style={{ color: designTokens.text.secondary }}>
+        <div className={`flex items-center gap-2 text-xs ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
           <Clock className="w-3.5 h-3.5" />
           <span>{formatDate(enrollment.startDate)} ~ {formatDate(enrollment.endDate)}</span>
         </div>
@@ -127,6 +129,7 @@ function EnrollmentCard({ enrollment, onClick, t }: { enrollment: Enrollment; on
         {/* Continue Learning Button (only for APPROVED) */}
         {enrollment.status === 'APPROVED' && (
           <Button
+            variant="brand"
             className="w-full mt-4"
             size="sm"
             onClick={(e) => {
@@ -145,6 +148,8 @@ function EnrollmentCard({ enrollment, onClick, t }: { enrollment: Enrollment; on
 
 export function MyLearningPage() {
   const { t } = useTranslation();
+  const { theme } = useThemeStore();
+  const isDark = theme === 'dark';
 
   const statusLabels: Record<EnrollmentStatus, string> = {
     PENDING: t.learning.statusPending,
@@ -184,38 +189,24 @@ export function MyLearningPage() {
   };
 
   return (
-    <div
-      style={{
-        padding: '40px',
-        backgroundColor: designTokens.bg.app_default,
-        minHeight: '100%',
-      }}
-    >
-      <div style={{ maxWidth: '1400px', margin: '0 auto' }}>
+    <div className={`min-h-full p-6 sm:p-10 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+      <div className="max-w-[1400px] mx-auto">
         {/* Header */}
         <div className="mb-8">
           <div className="flex items-center gap-2">
-            <h1
-              style={{
-                color: designTokens.text.primary,
-                fontSize: '28px',
-                fontWeight: 600,
-                marginBottom: '8px',
-              }}
-            >
+            <h1 className={`text-2xl font-semibold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
               {t.learning.title}
             </h1>
             {/* 데모 버튼 (테스트용 - 숨김) */}
             <button
               onClick={() => navigate('/mypage/learning/demo/player')}
-              className="opacity-10 hover:opacity-100 transition-opacity text-xs px-2 py-1 rounded"
-              style={{ color: designTokens.text.placeholder }}
+              className={`opacity-10 hover:opacity-100 transition-opacity text-xs px-2 py-1 rounded ${isDark ? 'text-gray-500' : 'text-gray-400'}`}
               title="Demo Mode"
             >
               [demo]
             </button>
           </div>
-          <p style={{ color: designTokens.text.secondary, fontSize: '14px' }}>
+          <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
             {t.learning.description}
           </p>
         </div>
@@ -226,15 +217,14 @@ export function MyLearningPage() {
           <form onSubmit={handleSearch} className="flex-1 min-w-[280px] max-w-md">
             <div className="relative">
               <Search
-                className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4"
-                style={{ color: designTokens.text.placeholder }}
+                className={`absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 ${isDark ? 'text-gray-500' : 'text-gray-400'}`}
               />
               <Input
                 type="text"
                 placeholder={t.learning.searchPlaceholder}
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-10"
+                className={`pl-10 ${isDark ? 'bg-white/5 border-white/10 text-white placeholder:text-gray-500' : ''}`}
               />
             </div>
           </form>
@@ -243,7 +233,7 @@ export function MyLearningPage() {
           <Button
             variant="outline"
             onClick={() => setShowFilters(!showFilters)}
-            className="gap-2"
+            className={`gap-2 ${isDark ? 'border-white/20 text-white hover:bg-white/10' : ''}`}
           >
             <Filter className="w-4 h-4" />
             {t.learning.filter}
@@ -253,38 +243,34 @@ export function MyLearningPage() {
 
         {/* Filter Panel */}
         {showFilters && (
-          <div
-            className="p-4 rounded-lg mb-6"
-            style={{ backgroundColor: designTokens.bg.default, border: `1px solid ${designTokens.bg.border}` }}
-          >
+          <div className={`p-4 rounded-lg mb-6 border ${isDark ? 'bg-white/5 border-white/10' : 'bg-white border-gray-200'}`}>
             <div className="flex flex-wrap items-center gap-4">
               <div>
-                <label
-                  className="block text-sm font-medium mb-2"
-                  style={{ color: designTokens.text.secondary }}
-                >
+                <label className={`block text-sm font-medium mb-2 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
                   {t.learning.enrollmentStatus}
                 </label>
                 <div className="flex flex-wrap gap-2">
                   <Button
-                    variant={statusFilter === 'all' ? 'default' : 'outline'}
+                    variant={statusFilter === 'all' ? 'brand' : 'outline'}
                     size="sm"
                     onClick={() => {
                       setStatusFilter('all');
                       setPage(0);
                     }}
+                    className={statusFilter !== 'all' && isDark ? 'border-white/20 text-white hover:bg-white/10' : ''}
                   >
                     {t.landing.all}
                   </Button>
                   {(['APPROVED', 'PENDING', 'COMPLETED', 'CANCELLED', 'REJECTED'] as EnrollmentStatus[]).map((status) => (
                     <Button
                       key={status}
-                      variant={statusFilter === status ? 'default' : 'outline'}
+                      variant={statusFilter === status ? 'brand' : 'outline'}
                       size="sm"
                       onClick={() => {
                         setStatusFilter(status);
                         setPage(0);
                       }}
+                      className={statusFilter !== status && isDark ? 'border-white/20 text-white hover:bg-white/10' : ''}
                     >
                       {statusLabels[status]}
                     </Button>
@@ -297,22 +283,24 @@ export function MyLearningPage() {
 
         {/* Results Count */}
         {data && (
-          <p className="mb-4 text-sm" style={{ color: designTokens.text.secondary }}>
-            {t.learning.totalEnrollments} <span style={{ color: designTokens.text.primary, fontWeight: 600 }}>{filteredContent.length}</span> {t.learning.enrollments}
+          <p className={`mb-4 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+            {t.learning.totalEnrollments}{' '}
+            <span className={`font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>{filteredContent.length}</span>{' '}
+            {t.learning.enrollments}
           </p>
         )}
 
         {/* Loading State */}
         {isLoading && (
           <div className="flex items-center justify-center py-20">
-            <Loader2 className="w-8 h-8 animate-spin" style={{ color: designTokens.text.secondary }} />
+            <Loader2 className={`w-8 h-8 animate-spin ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
           </div>
         )}
 
         {/* Error State */}
         {isError && (
           <div className="text-center py-20">
-            <p style={{ color: designTokens.status.error_text }}>
+            <p className="text-red-500">
               {t.learning.loadError}
             </p>
           </div>
@@ -321,17 +309,14 @@ export function MyLearningPage() {
         {/* Empty State */}
         {data && filteredContent.length === 0 && (
           <div className="text-center py-20">
-            <BookOpen className="w-16 h-16 mx-auto mb-4" style={{ color: designTokens.text.placeholder }} />
-            <h3
-              className="text-lg font-medium mb-2"
-              style={{ color: designTokens.text.primary }}
-            >
+            <BookOpen className={`w-16 h-16 mx-auto mb-4 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
+            <h3 className={`text-lg font-medium mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
               {t.learning.noEnrollments}
             </h3>
-            <p className="mb-4" style={{ color: designTokens.text.secondary }}>
+            <p className={`mb-4 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
               {t.learning.noEnrollmentsDesc}
             </p>
-            <Button onClick={() => navigate('/tu/catalog')}>
+            <Button variant="brand" onClick={() => navigate('/tu/catalog')}>
               {t.learning.browseCourses}
             </Button>
           </div>
@@ -347,6 +332,7 @@ export function MyLearningPage() {
                   enrollment={enrollment}
                   onClick={() => handleEnrollmentClick(enrollment.id)}
                   t={t}
+                  isDark={isDark}
                 />
               ))}
             </div>

--- a/src/pages/tu/mypage/CertificationsPage.tsx
+++ b/src/pages/tu/mypage/CertificationsPage.tsx
@@ -1,9 +1,9 @@
-import { Bell, Construction } from 'lucide-react';
+import { Award, Construction } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation } from '@/store/common/languageStore';
 import { Card, CardHeader, CardTitle, CardContent, EmptyState } from '@/components/common';
 
-export function SettingsNotificationsPage() {
+export function CertificationsPage() {
   const { theme } = useThemeStore();
   const { t } = useTranslation();
   const isDark = theme === 'dark';
@@ -18,20 +18,20 @@ export function SettingsNotificationsPage() {
         {/* Header */}
         <div className="mb-8">
           <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            {t.mypage.notifications}
+            {t.mypage.certificates}
           </h1>
           <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
-            {t.settings.notificationsDesc}
+            {t.mypage.certificatesDesc}
           </p>
         </div>
 
-        {/* Notifications Card */}
+        {/* Certifications Card */}
         <Card className={cardClass}>
           <CardHeader>
             <div className="flex items-center gap-3">
-              <Bell className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+              <Award className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
               <CardTitle className={isDark ? 'text-white' : 'text-gray-900'}>
-                {t.settings.notificationSettings}
+                {t.mypage.certificatesList}
               </CardTitle>
             </div>
           </CardHeader>
@@ -40,7 +40,7 @@ export function SettingsNotificationsPage() {
             <EmptyState
               icon={Construction}
               title={t.common.comingSoon}
-              description={t.settings.notificationsComingSoon}
+              description={t.mypage.certificatesComingSoon}
               className={`border-2 border-dashed rounded-lg ${isDark ? 'border-white/10' : 'border-gray-200'}`}
             />
           </CardContent>

--- a/src/pages/tu/mypage/CompletedCoursesPage.tsx
+++ b/src/pages/tu/mypage/CompletedCoursesPage.tsx
@@ -1,9 +1,9 @@
-import { Bell, Construction } from 'lucide-react';
+import { CheckCircle, Construction } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation } from '@/store/common/languageStore';
 import { Card, CardHeader, CardTitle, CardContent, EmptyState } from '@/components/common';
 
-export function SettingsNotificationsPage() {
+export function CompletedCoursesPage() {
   const { theme } = useThemeStore();
   const { t } = useTranslation();
   const isDark = theme === 'dark';
@@ -18,20 +18,20 @@ export function SettingsNotificationsPage() {
         {/* Header */}
         <div className="mb-8">
           <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            {t.mypage.notifications}
+            {t.mypage.completed}
           </h1>
           <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
-            {t.settings.notificationsDesc}
+            {t.mypage.completedDesc}
           </p>
         </div>
 
-        {/* Notifications Card */}
+        {/* Completed Courses Card */}
         <Card className={cardClass}>
           <CardHeader>
             <div className="flex items-center gap-3">
-              <Bell className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+              <CheckCircle className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
               <CardTitle className={isDark ? 'text-white' : 'text-gray-900'}>
-                {t.settings.notificationSettings}
+                {t.mypage.completedCourses}
               </CardTitle>
             </div>
           </CardHeader>
@@ -40,7 +40,7 @@ export function SettingsNotificationsPage() {
             <EmptyState
               icon={Construction}
               title={t.common.comingSoon}
-              description={t.settings.notificationsComingSoon}
+              description={t.mypage.completedComingSoon}
               className={`border-2 border-dashed rounded-lg ${isDark ? 'border-white/10' : 'border-gray-200'}`}
             />
           </CardContent>

--- a/src/pages/tu/mypage/MyPage.tsx
+++ b/src/pages/tu/mypage/MyPage.tsx
@@ -102,7 +102,7 @@ export function MyPage() {
   // 로그인하지 않은 경우
   if (!isAuthenticated || !user) {
     return (
-      <div className={`min-h-screen ${isDark ? 'bg-[#0a0a14]' : 'bg-gray-50'}`}>
+      <div className={`min-h-screen ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
         <LandingHeader />
         <div className="flex items-center justify-center min-h-[60vh]">
           <div className="text-center">
@@ -122,7 +122,7 @@ export function MyPage() {
   }
 
   return (
-    <div className={`min-h-screen ${isDark ? 'bg-[#0a0a14]' : 'bg-gray-50'}`}>
+    <div className={`min-h-screen ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
       <LandingHeader />
 
       <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">

--- a/src/pages/tu/mypage/MyPageHome.tsx
+++ b/src/pages/tu/mypage/MyPageHome.tsx
@@ -156,14 +156,14 @@ export function MyPageHome() {
     .slice(0, 3) ?? [];
 
   return (
-    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#0a0a14]' : 'bg-gray-50'}`}>
+    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
       <div className="max-w-5xl mx-auto">
         {/* 프로필 섹션 */}
         <section className="mb-8">
           <div
             className={`rounded-2xl p-6 sm:p-8 ${
               isDark
-                ? 'bg-gradient-to-r from-[#1a1a2e] to-[#16162a] border border-white/10'
+                ? 'bg-[#1e1e1e] border border-white/10'
                 : 'bg-white shadow-sm border border-gray-200'
             }`}
           >
@@ -215,7 +215,7 @@ export function MyPageHome() {
               <Button
                 variant="outline"
                 onClick={() => navigate('/mypage/profile')}
-                className={isDark ? 'border-white/20 text-white hover:bg-white/10' : ''}
+                className={isDark ? 'border-white/30 text-white bg-white/10 hover:bg-white/20' : ''}
               >
                 {t.mypage.editProfile}
               </Button>

--- a/src/pages/tu/mypage/MyTeachingPage.tsx
+++ b/src/pages/tu/mypage/MyTeachingPage.tsx
@@ -133,14 +133,14 @@ export function MyTeachingPage() {
 
   if (isLoading) {
     return (
-      <div className={`flex items-center justify-center min-h-full ${isDark ? 'bg-[#0a0a14]' : 'bg-gray-50'}`}>
+      <div className={`flex items-center justify-center min-h-full ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
         <Loader2 className={`w-8 h-8 animate-spin ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
       </div>
     );
   }
 
   return (
-    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#0a0a14]' : 'bg-gray-50'}`}>
+    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
       <div className="max-w-5xl mx-auto">
         {/* 헤더 */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">

--- a/src/pages/tu/mypage/ProfilePage.tsx
+++ b/src/pages/tu/mypage/ProfilePage.tsx
@@ -189,14 +189,14 @@ export function ProfilePage() {
 
   if (isLoadingProfile) {
     return (
-      <div className={`flex items-center justify-center min-h-full ${isDark ? 'bg-[#0a0a14]' : 'bg-gray-50'}`}>
+      <div className={`flex items-center justify-center min-h-full ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
         <Loader2 className={`w-8 h-8 animate-spin ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
       </div>
     );
   }
 
   return (
-    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#0a0a14]' : 'bg-gray-50'}`}>
+    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
       <div className="max-w-3xl mx-auto">
         {/* Header */}
         <div className="mb-8">

--- a/src/pages/tu/mypage/TeachingStatsPage.tsx
+++ b/src/pages/tu/mypage/TeachingStatsPage.tsx
@@ -1,9 +1,9 @@
-import { Bell, Construction } from 'lucide-react';
+import { BarChart3, Construction } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation } from '@/store/common/languageStore';
 import { Card, CardHeader, CardTitle, CardContent, EmptyState } from '@/components/common';
 
-export function SettingsNotificationsPage() {
+export function TeachingStatsPage() {
   const { theme } = useThemeStore();
   const { t } = useTranslation();
   const isDark = theme === 'dark';
@@ -18,20 +18,20 @@ export function SettingsNotificationsPage() {
         {/* Header */}
         <div className="mb-8">
           <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            {t.mypage.notifications}
+            {t.teaching.stats}
           </h1>
           <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
-            {t.settings.notificationsDesc}
+            {t.teaching.statsDesc}
           </p>
         </div>
 
-        {/* Notifications Card */}
+        {/* Stats Card */}
         <Card className={cardClass}>
           <CardHeader>
             <div className="flex items-center gap-3">
-              <Bell className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+              <BarChart3 className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
               <CardTitle className={isDark ? 'text-white' : 'text-gray-900'}>
-                {t.settings.notificationSettings}
+                {t.teaching.statsOverview}
               </CardTitle>
             </div>
           </CardHeader>
@@ -40,7 +40,7 @@ export function SettingsNotificationsPage() {
             <EmptyState
               icon={Construction}
               title={t.common.comingSoon}
-              description={t.settings.notificationsComingSoon}
+              description={t.teaching.statsComingSoon}
               className={`border-2 border-dashed rounded-lg ${isDark ? 'border-white/10' : 'border-gray-200'}`}
             />
           </CardContent>

--- a/src/pages/tu/mypage/index.ts
+++ b/src/pages/tu/mypage/index.ts
@@ -2,3 +2,6 @@ export { MyPage } from './MyPage';
 export { MyPageHome } from './MyPageHome';
 export { ProfilePage } from './ProfilePage';
 export { MyTeachingPage } from './MyTeachingPage';
+export { TeachingStatsPage } from './TeachingStatsPage';
+export { CompletedCoursesPage } from './CompletedCoursesPage';
+export { CertificationsPage } from './CertificationsPage';

--- a/src/pages/tu/settings/SettingsLanguagePage.tsx
+++ b/src/pages/tu/settings/SettingsLanguagePage.tsx
@@ -24,7 +24,7 @@ export function SettingsLanguagePage() {
     : 'bg-white border-gray-200 shadow-sm';
 
   return (
-    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#0a0a14]' : 'bg-gray-50'}`}>
+    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
       <div className="max-w-3xl mx-auto">
         {/* Header */}
         <div className="mb-8">

--- a/src/routes/tu.routes.tsx
+++ b/src/routes/tu.routes.tsx
@@ -11,12 +11,14 @@ import {
   LearningPlayerPage,
   SettingsLanguagePage,
   MyTeachingPage,
+  TeachingStatsPage,
+  CompletedCoursesPage,
+  CertificationsPage,
 } from '@/pages/tu';
 import { MyPageLayout } from '@/components/layout';
 import { ProtectedRoute } from '@/components/common/ProtectedRoute';
 import { SettingsNotificationsPage } from '@/pages/common';
 import { tuCoursesRoutes } from './tu.courses.routes';
-import { PlaceholderPage } from './pages';
 
 function MyPageWrapper() {
   return (
@@ -45,11 +47,11 @@ export const tuRoutes = (
       <Route path="learning/:enrollmentId" element={<LearningDetailPage />} />
       <Route path="learning/:enrollmentId/player" element={<LearningPlayerPage />} />
       <Route path="learning/:enrollmentId/player/:itemId" element={<LearningPlayerPage />} />
-      <Route path="completed" element={<PlaceholderPage title="완료한 강의" />} />
-      <Route path="certifications" element={<PlaceholderPage title="인증서" />} />
+      <Route path="completed" element={<CompletedCoursesPage />} />
+      <Route path="certifications" element={<CertificationsPage />} />
       {/* 내 강의 관리 */}
       <Route path="teaching" element={<MyTeachingPage />} />
-      <Route path="teaching/stats" element={<PlaceholderPage title="내 강의 통계" />} />
+      <Route path="teaching/stats" element={<TeachingStatsPage />} />
       {/* 설정 */}
       <Route path="security" element={<Navigate to="/mypage/profile" replace />} />
       <Route path="notifications" element={<SettingsNotificationsPage />} />

--- a/src/store/common/languageStore.ts
+++ b/src/store/common/languageStore.ts
@@ -47,6 +47,7 @@ type TranslationKeys = {
     signup: string;
     darkMode: string;
     lightMode: string;
+    comingSoon: string;
   };
   // 마이페이지
   mypage: {
@@ -57,6 +58,9 @@ type TranslationKeys = {
     learningStatus: string;
     inProgress: string;
     completed: string;
+    completedDesc: string;
+    completedCourses: string;
+    completedComingSoon: string;
     pending: string;
     total: string;
     recentLearning: string;
@@ -66,6 +70,8 @@ type TranslationKeys = {
     myLearningDesc: string;
     certificates: string;
     certificatesDesc: string;
+    certificatesList: string;
+    certificatesComingSoon: string;
     profileSecurityDesc: string;
     notifications: string;
     notificationsDesc: string;
@@ -102,6 +108,10 @@ type TranslationKeys = {
     rejected: string;
     students: string;
     lastModified: string;
+    stats: string;
+    statsDesc: string;
+    statsOverview: string;
+    statsComingSoon: string;
   };
   // 프로필 및 보안
   profileSecurity: {
@@ -144,6 +154,9 @@ type TranslationKeys = {
     selectLanguage: string;
     korean: string;
     english: string;
+    notificationsDesc: string;
+    notificationSettings: string;
+    notificationsComingSoon: string;
   };
   // 랜딩 페이지
   landing: {
@@ -318,6 +331,7 @@ const ko: TranslationKeys = {
     signup: '회원가입',
     darkMode: '다크 모드',
     lightMode: '라이트 모드',
+    comingSoon: '개발 예정',
   },
   mypage: {
     title: '마이페이지',
@@ -326,7 +340,10 @@ const ko: TranslationKeys = {
     profileDescription: '프로필 정보를 수정하고 프로필 이미지를 변경하세요',
     learningStatus: '학습 현황',
     inProgress: '수강 중',
-    completed: '완료',
+    completed: '완료한 강의',
+    completedDesc: '완료한 강의 목록을 확인하세요',
+    completedCourses: '완료한 강의 목록',
+    completedComingSoon: '완료한 강의 기능은 현재 개발 중입니다. 곧 완료한 강의 목록과 수료증을 확인할 수 있습니다.',
     pending: '승인 대기',
     total: '전체',
     recentLearning: '최근 학습',
@@ -336,6 +353,8 @@ const ko: TranslationKeys = {
     myLearningDesc: '수강 중인 강의를 확인하세요',
     certificates: '인증서',
     certificatesDesc: '취득한 인증서를 확인하세요',
+    certificatesList: '인증서 목록',
+    certificatesComingSoon: '인증서 기능은 현재 개발 중입니다. 곧 취득한 인증서를 확인하고 다운로드할 수 있습니다.',
     profileSecurityDesc: '프로필 정보 및 보안 설정',
     notifications: '알림 설정',
     notificationsDesc: '알림 설정을 관리하세요',
@@ -371,6 +390,10 @@ const ko: TranslationKeys = {
     rejected: '반려됨',
     students: '수강생',
     lastModified: '최종 수정',
+    stats: '내 강의 통계',
+    statsDesc: '내 강의의 수강생 및 학습 통계를 확인하세요',
+    statsOverview: '통계 개요',
+    statsComingSoon: '강의 통계 기능은 현재 개발 중입니다. 곧 수강생 현황, 학습 완료율 등 다양한 통계를 확인할 수 있습니다.',
   },
   profileSecurity: {
     title: '프로필 및 보안',
@@ -411,6 +434,9 @@ const ko: TranslationKeys = {
     selectLanguage: '언어 선택',
     korean: '한국어',
     english: 'English',
+    notificationsDesc: '알림 수신 방법을 설정하세요',
+    notificationSettings: '알림 설정',
+    notificationsComingSoon: '알림 설정 기능은 현재 개발 중입니다. 곧 다양한 알림 옵션을 제공할 예정입니다.',
   },
   landing: {
     banner: 'MZC Learn Platform - 클라우드 교육의 새로운 시작',
@@ -573,6 +599,7 @@ const en: TranslationKeys = {
     signup: 'Sign up',
     darkMode: 'Dark Mode',
     lightMode: 'Light Mode',
+    comingSoon: 'Coming Soon',
   },
   mypage: {
     title: 'My Page',
@@ -581,7 +608,10 @@ const en: TranslationKeys = {
     profileDescription: 'Edit your profile information and change your profile image',
     learningStatus: 'Learning Status',
     inProgress: 'In Progress',
-    completed: 'Completed',
+    completed: 'Completed Courses',
+    completedDesc: 'View your completed courses',
+    completedCourses: 'Completed Courses List',
+    completedComingSoon: 'Completed courses feature is currently under development. You will soon be able to view your completed courses and certificates.',
     pending: 'Pending',
     total: 'Total',
     recentLearning: 'Recent Learning',
@@ -591,6 +621,8 @@ const en: TranslationKeys = {
     myLearningDesc: 'Check your enrolled courses',
     certificates: 'Certificates',
     certificatesDesc: 'View your earned certificates',
+    certificatesList: 'Certificates List',
+    certificatesComingSoon: 'Certificates feature is currently under development. You will soon be able to view and download your earned certificates.',
     profileSecurityDesc: 'Profile and security settings',
     notifications: 'Notifications',
     notificationsDesc: 'Manage your notification settings',
@@ -626,6 +658,10 @@ const en: TranslationKeys = {
     rejected: 'Rejected',
     students: 'Students',
     lastModified: 'Last Modified',
+    stats: 'Course Statistics',
+    statsDesc: 'View student and learning statistics for your courses',
+    statsOverview: 'Statistics Overview',
+    statsComingSoon: 'Course statistics feature is currently under development. You will soon be able to view student enrollment, completion rates, and other statistics.',
   },
   profileSecurity: {
     title: 'Profile & Security',
@@ -666,6 +702,9 @@ const en: TranslationKeys = {
     selectLanguage: 'Select Language',
     korean: '한국어',
     english: 'English',
+    notificationsDesc: 'Configure how you receive notifications',
+    notificationSettings: 'Notification Settings',
+    notificationsComingSoon: 'Notification settings are currently under development. Various notification options will be available soon.',
   },
   landing: {
     banner: 'MZC Learn Platform - A New Beginning in Cloud Education',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -117,6 +117,10 @@ export default {
           'active-bg': 'var(--sidebar-light-active-bg)',
           'active-text': 'var(--sidebar-light-active-text)',
         },
+
+        // TU Theme Colors
+        'tu-bg-light': 'var(--tu-bg-light)',
+        'tu-bg-dark': 'var(--tu-bg-dark)',
       },
       borderRadius: {
         sm: 'var(--radius-sm)',


### PR DESCRIPTION
## Summary
- TU 마이페이지 및 관련 페이지의 다크모드 스타일링 개선
- 다크모드 배경색을 #0a0a0a에서 #1e1e1e로 변경하여 가독성 향상
- 마이페이지 내 모든 페이지에 일관된 테마 적용

## Related Issue
- Closes #116

## Changes
### 스타일 개선
- 다크모드 배경색 통일 (#1e1e1e)
- LandingHeader 라이트/다크 모드 스타일 개선
- MyLearningPage 버튼에 brand variant 적용

### 신규 페이지
- CompletedCoursesPage (완료한 강의)
- CertificationsPage (수료증)
- TeachingStatsPage (강의 통계)

### 리팩토링
- SettingsNotificationsPage: designTokens → useThemeStore 전환
- 번역 키 추가 (teaching.stats, mypage.certificates 등)

## Type of Change
- [x] Feat: 새로운 기능

## Checklist
- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 다크모드/라이트모드 전환 테스트 완료

## Test plan
- [ ] 다크모드에서 마이페이지 전체 페이지 스타일 확인
- [ ] 라이트모드에서 마이페이지 전체 페이지 스타일 확인
- [ ] LandingHeader 테마 전환 동작 확인
- [ ] 신규 페이지 접근 및 렌더링 확인