### PR TITLE
feat: 강의 생성 페이지에 유형(type) 필드 추가

### DIFF
--- a/src/pages/tu/teaching/courses/CourseCreatePage.tsx
+++ b/src/pages/tu/teaching/courses/CourseCreatePage.tsx
@@ -35,6 +35,7 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
     categoryId: null,
     tags: [],
     level: '',
+    type: '',
     lessons: [],
     isDraft: false,
     multiLanguage: {
@@ -84,6 +85,7 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
         title: formData.title,
         description: formData.description || undefined,
         level: formData.level || undefined,
+        type: formData.type || undefined,
         categoryId: formData.categoryId ?? undefined,
         startDate: formData.startDate || undefined,
         endDate: formData.endDate || undefined,

--- a/src/pages/tu/teaching/courses/components/Step1BasicInfo.tsx
+++ b/src/pages/tu/teaching/courses/components/Step1BasicInfo.tsx
@@ -17,9 +17,9 @@ import {
   Alert,
   AlertDescription,
 } from '@/components/common';
-import type { CourseFormData, LanguageVersion, CourseLevel } from '@/types';
+import type { CourseFormData, LanguageVersion, CourseLevel, CourseType } from '@/types';
 import type { CategoryResponse } from '@/types/common';
-import { translations, levelOptions, type TranslationKey } from './courseCreate.constants';
+import { translations, levelOptions, typeOptions, type TranslationKey } from './courseCreate.constants';
 
 interface Step1BasicInfoProps {
   language: 'ko' | 'en';
@@ -89,7 +89,7 @@ export function Step1BasicInfo({
         />
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         <NativeSelect
           id="categoryId"
           label={getText('category')}
@@ -109,6 +109,14 @@ export function Step1BasicInfo({
           value={formData.level}
           onChange={(e) => onFormDataChange({ level: e.target.value as CourseLevel | '' })}
           options={levelOptions}
+        />
+
+        <NativeSelect
+          id="type"
+          label={getText('courseType')}
+          value={formData.type}
+          onChange={(e) => onFormDataChange({ type: e.target.value as CourseType | '' })}
+          options={typeOptions}
         />
       </div>
 

--- a/src/pages/tu/teaching/courses/components/courseCreate.constants.ts
+++ b/src/pages/tu/teaching/courses/components/courseCreate.constants.ts
@@ -22,6 +22,11 @@ export const translations = {
   selectCategory: { ko: '카테고리 선택', en: 'Select category' },
   difficulty: { ko: '난이도', en: 'Difficulty' },
   selectDifficulty: { ko: '난이도 선택', en: 'Select difficulty' },
+  courseType: { ko: '유형', en: 'Type' },
+  selectType: { ko: '유형 선택', en: 'Select type' },
+  online: { ko: '온라인', en: 'Online' },
+  offline: { ko: '오프라인', en: 'Offline' },
+  blended: { ko: '블렌디드', en: 'Blended' },
   beginner: { ko: '입문', en: 'Beginner' },
   elementary: { ko: '초급', en: 'Elementary' },
   intermediate: { ko: '중급', en: 'Intermediate' },
@@ -110,4 +115,11 @@ export const levelOptions = [
   { value: 'BEGINNER', label: '초급' },
   { value: 'INTERMEDIATE', label: '중급' },
   { value: 'ADVANCED', label: '고급' },
+];
+
+export const typeOptions = [
+  { value: '', label: '유형 선택' },
+  { value: 'ONLINE', label: '온라인' },
+  { value: 'OFFLINE', label: '오프라인' },
+  { value: 'BLENDED', label: '블렌디드' },
 ];

--- a/src/types/to/course.types.ts
+++ b/src/types/to/course.types.ts
@@ -18,7 +18,7 @@ export type {
   UpdateCourseRequest,
 } from '../common/course.types';
 
-import type { CourseLevel } from '../common/course.types';
+import type { CourseLevel, CourseType } from '../common/course.types';
 
 export {
   COURSE_LEVEL_LABELS,
@@ -85,6 +85,7 @@ export interface CourseFormData {
   categoryId: number | null;
   tags: string[];
   level: CourseLevel | '';
+  type: CourseType | '';
   lessons: LessonData[];
   isDraft: boolean;
   lastSaved?: string;


### PR DESCRIPTION
## Summary
- 강의 생성 페이지에 유형(Type) 선택 필드 추가
- 지원 유형: 온라인(ONLINE), 오프라인(OFFLINE), 블렌디드(BLENDED)
- 카테고리, 난이도, 유형을 3컬럼 그리드로 배치하여 UI 개선

## Changes
- `CourseCreatePage.tsx`: formData에 type 필드 추가 및 API 요청에 포함
- `Step1BasicInfo.tsx`: 유형 선택 NativeSelect 컴포넌트 추가
- `courseCreate.constants.ts`: 유형 관련 번역 및 옵션 상수 추가
- `course.types.ts`: CourseFormData에 type 필드 타입 정의 추가

## Test plan
- [ ] 강의 생성 페이지에서 유형 선택 드롭다운 표시 확인
- [ ] 온라인/오프라인/블렌디드 옵션 선택 가능 확인
- [ ] 강의 생성 시 선택한 유형이 API 요청에 포함되는지 확인

Closes #104