### PR TITLE
feat: SA 관리자 페이지 구현 (#120)

### DIFF
--- a/src/components/domain/admin/RoleBadge.tsx
+++ b/src/components/domain/admin/RoleBadge.tsx
@@ -4,7 +4,7 @@ import { Badge } from '@/components/common/Badge';
 type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline' | 'success' | 'warning' | 'error' | 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'indigo' | 'purple' | 'gray';
 
 // 시스템 역할
-export type SystemRole = 'SUPER_ADMIN' | 'TENANT_ADMIN' | 'OPERATOR' | 'USER';
+export type SystemRole = 'SUPER_ADMIN' | 'SYSTEM_ADMIN' | 'TENANT_ADMIN' | 'OPERATOR' | 'USER';
 
 // 강의 역할
 export type CourseRole = 'DESIGNER' | 'OWNER' | 'INSTRUCTOR' | 'TUTOR' | 'VIEWER';
@@ -18,7 +18,8 @@ const systemRoleConfig: Record<
   SystemRole,
   { label: { ko: string; en: string }; variant: BadgeVariant }
 > = {
-  SUPER_ADMIN: { label: { ko: '시스템 관리자', en: 'System Admin' }, variant: 'purple' },
+  SUPER_ADMIN: { label: { ko: '최고 관리자', en: 'Super Admin' }, variant: 'purple' },
+  SYSTEM_ADMIN: { label: { ko: '시스템 관리자', en: 'System Admin' }, variant: 'purple' },
   TENANT_ADMIN: { label: { ko: '테넌트 관리자', en: 'Tenant Admin' }, variant: 'indigo' },
   OPERATOR: { label: { ko: '운영자', en: 'Operator' }, variant: 'blue' },
   USER: { label: { ko: '사용자', en: 'User' }, variant: 'gray' },

--- a/src/pages/sa/analytics/ActivityPage.tsx
+++ b/src/pages/sa/analytics/ActivityPage.tsx
@@ -1,0 +1,223 @@
+import { useState } from 'react';
+import {
+  Activity,
+  Users,
+  PlayCircle,
+  Clock,
+  Calendar,
+  TrendingUp,
+  TrendingDown,
+} from 'lucide-react';
+import { AdminPageHeader } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/common/Select';
+
+// Mock 데이터
+const mockActivityStats = {
+  dailyActiveUsers: 2450,
+  dailyActiveChange: 12.5,
+  avgSessionTime: 45,
+  sessionTimeChange: -3.2,
+  courseCompletions: 156,
+  completionChange: 8.7,
+  videoPlays: 12500,
+  videoPlayChange: 15.3,
+};
+
+const mockHourlyActivity = [
+  { hour: '00', users: 120 },
+  { hour: '06', users: 450 },
+  { hour: '09', users: 1850 },
+  { hour: '12', users: 1200 },
+  { hour: '15', users: 1650 },
+  { hour: '18', users: 980 },
+  { hour: '21', users: 560 },
+];
+
+const mockRecentActivity: {
+  id: number;
+  type: 'LOGIN' | 'COURSE_START' | 'COURSE_COMPLETE' | 'VIDEO_PLAY';
+  userName: string;
+  tenantName: string;
+  detail: string;
+  timestamp: string;
+}[] = [
+  { id: 1, type: 'LOGIN', userName: '김학습', tenantName: '메가존클라우드', detail: '로그인', timestamp: '1분 전' },
+  { id: 2, type: 'COURSE_COMPLETE', userName: '이수강', tenantName: '삼성전자', detail: 'AWS 기초 과정 완료', timestamp: '3분 전' },
+  { id: 3, type: 'VIDEO_PLAY', userName: '박시청', tenantName: 'LG전자', detail: 'React 입문 1강 시청', timestamp: '5분 전' },
+  { id: 4, type: 'COURSE_START', userName: '최학생', tenantName: '카카오', detail: 'Python 기초 시작', timestamp: '8분 전' },
+  { id: 5, type: 'LOGIN', userName: '정사용', tenantName: '네이버', detail: '로그인', timestamp: '10분 전' },
+];
+
+const activityTypeConfig = {
+  LOGIN: { label: '로그인', color: 'bg-blue-100 text-blue-700' },
+  COURSE_START: { label: '강좌 시작', color: 'bg-green-100 text-green-700' },
+  COURSE_COMPLETE: { label: '강좌 완료', color: 'bg-purple-100 text-purple-700' },
+  VIDEO_PLAY: { label: '영상 시청', color: 'bg-orange-100 text-orange-700' },
+};
+
+export function ActivityPage() {
+  const [period, setPeriod] = useState('today');
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="활동 분석"
+        description="사용자 활동 현황을 실시간으로 분석합니다"
+        actions={
+          <Select value={period} onValueChange={setPeriod}>
+            <SelectTrigger className="w-36">
+              <Calendar className="h-4 w-4 mr-2" />
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="today">오늘</SelectItem>
+              <SelectItem value="yesterday">어제</SelectItem>
+              <SelectItem value="7d">최근 7일</SelectItem>
+              <SelectItem value="30d">최근 30일</SelectItem>
+            </SelectContent>
+          </Select>
+        }
+      />
+
+      {/* Activity Stats */}
+      <div className="grid grid-cols-4 gap-4 mb-6">
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-brand-primary/10 rounded-lg">
+                <Users className="h-5 w-5 text-brand-primary" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockActivityStats.dailyActiveUsers.toLocaleString()}</p>
+                <p className="text-sm text-text-secondary">일일 활성 사용자</p>
+              </div>
+            </div>
+            <div className={`mt-2 text-xs flex items-center gap-1 ${mockActivityStats.dailyActiveChange >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+              {mockActivityStats.dailyActiveChange >= 0 ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
+              {Math.abs(mockActivityStats.dailyActiveChange)}% vs 어제
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-blue-100 rounded-lg">
+                <Clock className="h-5 w-5 text-blue-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockActivityStats.avgSessionTime}분</p>
+                <p className="text-sm text-text-secondary">평균 세션 시간</p>
+              </div>
+            </div>
+            <div className={`mt-2 text-xs flex items-center gap-1 ${mockActivityStats.sessionTimeChange >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+              {mockActivityStats.sessionTimeChange >= 0 ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
+              {Math.abs(mockActivityStats.sessionTimeChange)}% vs 어제
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-purple-100 rounded-lg">
+                <Activity className="h-5 w-5 text-purple-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockActivityStats.courseCompletions}</p>
+                <p className="text-sm text-text-secondary">강좌 완료</p>
+              </div>
+            </div>
+            <div className={`mt-2 text-xs flex items-center gap-1 ${mockActivityStats.completionChange >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+              {mockActivityStats.completionChange >= 0 ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
+              {Math.abs(mockActivityStats.completionChange)}% vs 어제
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-orange-100 rounded-lg">
+                <PlayCircle className="h-5 w-5 text-orange-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{(mockActivityStats.videoPlays / 1000).toFixed(1)}K</p>
+                <p className="text-sm text-text-secondary">영상 재생</p>
+              </div>
+            </div>
+            <div className={`mt-2 text-xs flex items-center gap-1 ${mockActivityStats.videoPlayChange >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+              {mockActivityStats.videoPlayChange >= 0 ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
+              {Math.abs(mockActivityStats.videoPlayChange)}% vs 어제
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid grid-cols-2 gap-6">
+        {/* Hourly Activity Chart Placeholder */}
+        <Card>
+          <CardHeader>
+            <CardTitle>시간대별 활성 사용자</CardTitle>
+            <CardDescription>오늘의 시간대별 사용자 활동 현황</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="h-64 flex items-end justify-between gap-2">
+              {mockHourlyActivity.map((item) => {
+                const maxUsers = Math.max(...mockHourlyActivity.map(h => h.users));
+                const height = (item.users / maxUsers) * 100;
+
+                return (
+                  <div key={item.hour} className="flex-1 flex flex-col items-center">
+                    <div
+                      className="w-full bg-brand-primary/80 rounded-t"
+                      style={{ height: `${height}%` }}
+                    />
+                    <span className="text-xs text-text-secondary mt-2">{item.hour}시</span>
+                  </div>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Recent Activity */}
+        <Card>
+          <CardHeader>
+            <CardTitle>실시간 활동</CardTitle>
+            <CardDescription>최근 사용자 활동 로그</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {mockRecentActivity.map((activity) => {
+                const config = activityTypeConfig[activity.type];
+
+                return (
+                  <div key={activity.id} className="flex items-center justify-between p-3 border rounded-lg">
+                    <div className="flex items-center gap-3">
+                      <span className={`px-2 py-1 rounded text-xs ${config.color}`}>
+                        {config.label}
+                      </span>
+                      <div>
+                        <p className="text-sm font-medium">{activity.userName}</p>
+                        <p className="text-xs text-text-secondary">{activity.tenantName}</p>
+                      </div>
+                    </div>
+                    <div className="text-right">
+                      <p className="text-sm">{activity.detail}</p>
+                      <p className="text-xs text-text-secondary">{activity.timestamp}</p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/sa/analytics/LogsPage.tsx
+++ b/src/pages/sa/analytics/LogsPage.tsx
@@ -1,0 +1,214 @@
+import { useState } from 'react';
+import {
+  FileText,
+  Search,
+  Download,
+  AlertTriangle,
+  Info,
+  AlertCircle,
+  CheckCircle,
+} from 'lucide-react';
+import { AdminPageHeader } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Badge } from '@/components/common/Badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/common/Select';
+
+// Mock 데이터
+const mockLogs: {
+  id: number;
+  timestamp: string;
+  level: 'INFO' | 'WARN' | 'ERROR' | 'DEBUG';
+  category: string;
+  message: string;
+  source: string;
+  userId?: string;
+  tenantId?: string;
+}[] = [
+  { id: 1, timestamp: '2025-12-30 10:45:23', level: 'INFO', category: 'AUTH', message: '사용자 로그인 성공', source: 'auth-service', userId: 'user-123', tenantId: 'tenant-1' },
+  { id: 2, timestamp: '2025-12-30 10:44:18', level: 'WARN', category: 'API', message: 'Rate limit 임계치 도달 (80%)', source: 'api-gateway', tenantId: 'tenant-2' },
+  { id: 3, timestamp: '2025-12-30 10:43:55', level: 'ERROR', category: 'VIDEO', message: '비디오 트랜스코딩 실패', source: 'video-service', tenantId: 'tenant-1' },
+  { id: 4, timestamp: '2025-12-30 10:42:30', level: 'INFO', category: 'COURSE', message: '강좌 생성 완료', source: 'course-service', userId: 'admin-1', tenantId: 'tenant-3' },
+  { id: 5, timestamp: '2025-12-30 10:41:12', level: 'DEBUG', category: 'SYSTEM', message: '캐시 갱신 완료', source: 'cache-service' },
+  { id: 6, timestamp: '2025-12-30 10:40:45', level: 'INFO', category: 'BILLING', message: '결제 처리 완료', source: 'billing-service', tenantId: 'tenant-1' },
+  { id: 7, timestamp: '2025-12-30 10:39:20', level: 'WARN', category: 'STORAGE', message: '스토리지 사용량 90% 초과', source: 'storage-service', tenantId: 'tenant-2' },
+  { id: 8, timestamp: '2025-12-30 10:38:05', level: 'ERROR', category: 'AUTH', message: '비밀번호 5회 오류로 계정 잠금', source: 'auth-service', userId: 'user-456', tenantId: 'tenant-1' },
+];
+
+const levelConfig = {
+  INFO: { icon: Info, color: 'bg-blue-100 text-blue-700' },
+  WARN: { icon: AlertTriangle, color: 'bg-yellow-100 text-yellow-700' },
+  ERROR: { icon: AlertCircle, color: 'bg-red-100 text-red-700' },
+  DEBUG: { icon: CheckCircle, color: 'bg-gray-100 text-gray-700' },
+};
+
+export function LogsPage() {
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [levelFilter, setLevelFilter] = useState<string>('all');
+  const [categoryFilter, setCategoryFilter] = useState<string>('all');
+
+  const categories = [...new Set(mockLogs.map(log => log.category))];
+
+  const filteredLogs = mockLogs.filter((log) => {
+    const matchesSearch = log.message.toLowerCase().includes(searchKeyword.toLowerCase()) ||
+      log.source.toLowerCase().includes(searchKeyword.toLowerCase());
+    const matchesLevel = levelFilter === 'all' || log.level === levelFilter;
+    const matchesCategory = categoryFilter === 'all' || log.category === categoryFilter;
+    return matchesSearch && matchesLevel && matchesCategory;
+  });
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="시스템 로그"
+        description="시스템 전체 로그를 조회하고 분석합니다"
+        actions={
+          <Button variant="outline">
+            <Download className="mr-2 h-4 w-4" />
+            로그 내보내기
+          </Button>
+        }
+      />
+
+      {/* Stats Summary */}
+      <div className="grid grid-cols-4 gap-4 mb-6">
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-blue-100 rounded-lg">
+                <Info className="h-5 w-5 text-blue-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockLogs.filter(l => l.level === 'INFO').length}</p>
+                <p className="text-sm text-text-secondary">INFO</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-yellow-100 rounded-lg">
+                <AlertTriangle className="h-5 w-5 text-yellow-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockLogs.filter(l => l.level === 'WARN').length}</p>
+                <p className="text-sm text-text-secondary">WARNING</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-red-100 rounded-lg">
+                <AlertCircle className="h-5 w-5 text-red-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockLogs.filter(l => l.level === 'ERROR').length}</p>
+                <p className="text-sm text-text-secondary">ERROR</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-gray-100 rounded-lg">
+                <FileText className="h-5 w-5 text-gray-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockLogs.length}</p>
+                <p className="text-sm text-text-secondary">전체 로그</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Logs List */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>로그 목록</CardTitle>
+              <CardDescription>최근 시스템 로그입니다</CardDescription>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-secondary" />
+                <Input
+                  placeholder="메시지 검색..."
+                  value={searchKeyword}
+                  onChange={(e) => setSearchKeyword(e.target.value)}
+                  className="pl-9 w-64"
+                />
+              </div>
+              <Select value={levelFilter} onValueChange={setLevelFilter}>
+                <SelectTrigger className="w-32">
+                  <SelectValue placeholder="레벨" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">전체 레벨</SelectItem>
+                  <SelectItem value="INFO">INFO</SelectItem>
+                  <SelectItem value="WARN">WARN</SelectItem>
+                  <SelectItem value="ERROR">ERROR</SelectItem>
+                  <SelectItem value="DEBUG">DEBUG</SelectItem>
+                </SelectContent>
+              </Select>
+              <Select value={categoryFilter} onValueChange={setCategoryFilter}>
+                <SelectTrigger className="w-32">
+                  <SelectValue placeholder="카테고리" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">전체</SelectItem>
+                  {categories.map((cat) => (
+                    <SelectItem key={cat} value={cat}>{cat}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {filteredLogs.map((log) => {
+              const config = levelConfig[log.level];
+              const LevelIcon = config.icon;
+
+              return (
+                <div key={log.id} className="flex items-start gap-3 p-3 border rounded-lg hover:bg-bg-secondary font-mono text-sm">
+                  <Badge className={`${config.color} shrink-0`}>
+                    <LevelIcon className="h-3 w-3 mr-1" />
+                    {log.level}
+                  </Badge>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="text-text-secondary">{log.timestamp}</span>
+                      <Badge variant="outline">{log.category}</Badge>
+                      <span className="text-text-secondary">[{log.source}]</span>
+                    </div>
+                    <p className="truncate">{log.message}</p>
+                    {(log.userId || log.tenantId) && (
+                      <div className="flex gap-2 mt-1 text-xs text-text-secondary">
+                        {log.userId && <span>User: {log.userId}</span>}
+                        {log.tenantId && <span>Tenant: {log.tenantId}</span>}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/sa/analytics/UsagePage.tsx
+++ b/src/pages/sa/analytics/UsagePage.tsx
@@ -1,0 +1,196 @@
+import { useState } from 'react';
+import {
+  BarChart3,
+  TrendingUp,
+  Users,
+  BookOpen,
+  HardDrive,
+  Calendar,
+} from 'lucide-react';
+import { AdminPageHeader } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/common/Select';
+import { Progress } from '@/components/common/Progress';
+
+// Mock 데이터
+const mockUsageStats = {
+  totalUsers: 12450,
+  activeUsers: 8920,
+  totalCourses: 156,
+  activeCourses: 134,
+  storageUsed: 245.8,
+  storageLimit: 500,
+  apiCalls: 1250000,
+  bandwidth: 2.4,
+};
+
+const mockTenantUsage: {
+  id: number;
+  name: string;
+  users: number;
+  courses: number;
+  storage: number;
+  storageLimit: number;
+}[] = [
+  { id: 1, name: '메가존클라우드', users: 2500, courses: 45, storage: 85.2, storageLimit: 100 },
+  { id: 2, name: '삼성전자', users: 3200, courses: 38, storage: 62.4, storageLimit: 100 },
+  { id: 3, name: 'LG전자', users: 1800, courses: 28, storage: 45.6, storageLimit: 100 },
+  { id: 4, name: '카카오', users: 1500, courses: 22, storage: 32.8, storageLimit: 50 },
+  { id: 5, name: '네이버', users: 1200, courses: 18, storage: 19.8, storageLimit: 50 },
+];
+
+export function UsagePage() {
+  const [period, setPeriod] = useState('30d');
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="사용량 통계"
+        description="플랫폼 전체 사용량을 분석합니다"
+        actions={
+          <Select value={period} onValueChange={setPeriod}>
+            <SelectTrigger className="w-36">
+              <Calendar className="h-4 w-4 mr-2" />
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="7d">최근 7일</SelectItem>
+              <SelectItem value="30d">최근 30일</SelectItem>
+              <SelectItem value="90d">최근 90일</SelectItem>
+              <SelectItem value="1y">최근 1년</SelectItem>
+            </SelectContent>
+          </Select>
+        }
+      />
+
+      {/* Overview Stats */}
+      <div className="grid grid-cols-4 gap-4 mb-6">
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-brand-primary/10 rounded-lg">
+                <Users className="h-5 w-5 text-brand-primary" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockUsageStats.totalUsers.toLocaleString()}</p>
+                <p className="text-sm text-text-secondary">전체 사용자</p>
+              </div>
+            </div>
+            <div className="mt-2 text-xs text-green-600 flex items-center gap-1">
+              <TrendingUp className="h-3 w-3" />
+              활성: {mockUsageStats.activeUsers.toLocaleString()}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-blue-100 rounded-lg">
+                <BookOpen className="h-5 w-5 text-blue-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockUsageStats.totalCourses}</p>
+                <p className="text-sm text-text-secondary">전체 강좌</p>
+              </div>
+            </div>
+            <div className="mt-2 text-xs text-green-600 flex items-center gap-1">
+              <TrendingUp className="h-3 w-3" />
+              활성: {mockUsageStats.activeCourses}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-purple-100 rounded-lg">
+                <HardDrive className="h-5 w-5 text-purple-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockUsageStats.storageUsed} GB</p>
+                <p className="text-sm text-text-secondary">스토리지 사용</p>
+              </div>
+            </div>
+            <div className="mt-2">
+              <Progress value={(mockUsageStats.storageUsed / mockUsageStats.storageLimit) * 100} className="h-1" />
+              <p className="text-xs text-text-secondary mt-1">{mockUsageStats.storageLimit} GB 중</p>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-green-100 rounded-lg">
+                <BarChart3 className="h-5 w-5 text-green-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{(mockUsageStats.apiCalls / 1000000).toFixed(1)}M</p>
+                <p className="text-sm text-text-secondary">API 호출</p>
+              </div>
+            </div>
+            <div className="mt-2 text-xs text-text-secondary">
+              대역폭: {mockUsageStats.bandwidth} TB
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Tenant Usage */}
+      <Card>
+        <CardHeader>
+          <CardTitle>테넌트별 사용량</CardTitle>
+          <CardDescription>각 테넌트의 리소스 사용 현황입니다</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {mockTenantUsage.map((tenant) => {
+              const storagePercent = (tenant.storage / tenant.storageLimit) * 100;
+
+              return (
+                <div key={tenant.id} className="p-4 border rounded-lg">
+                  <div className="flex items-center justify-between mb-3">
+                    <h3 className="font-medium">{tenant.name}</h3>
+                    <Button variant="ghost" size="sm">상세 보기</Button>
+                  </div>
+
+                  <div className="grid grid-cols-3 gap-4">
+                    <div>
+                      <div className="flex items-center gap-2 text-sm text-text-secondary mb-1">
+                        <Users className="h-4 w-4" />
+                        사용자
+                      </div>
+                      <p className="text-lg font-semibold">{tenant.users.toLocaleString()}</p>
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-2 text-sm text-text-secondary mb-1">
+                        <BookOpen className="h-4 w-4" />
+                        강좌
+                      </div>
+                      <p className="text-lg font-semibold">{tenant.courses}</p>
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-2 text-sm text-text-secondary mb-1">
+                        <HardDrive className="h-4 w-4" />
+                        스토리지
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Progress value={storagePercent} className="flex-1 h-2" />
+                        <span className="text-sm">{tenant.storage} / {tenant.storageLimit} GB</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/sa/analytics/index.ts
+++ b/src/pages/sa/analytics/index.ts
@@ -1,0 +1,3 @@
+export { UsagePage } from './UsagePage';
+export { ActivityPage } from './ActivityPage';
+export { LogsPage } from './LogsPage';

--- a/src/pages/sa/billing/BillingPage.tsx
+++ b/src/pages/sa/billing/BillingPage.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react';
+import {
+  CreditCard,
+  Download,
+  Filter,
+  Search,
+  Building2,
+  TrendingUp,
+  DollarSign,
+} from 'lucide-react';
+import { AdminPageHeader, AdminStatsCard, AdminStatsGrid, PlanBadge } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/common/Select';
+import { Badge } from '@/components/common/Badge';
+import type { PlanType } from '@/types/admin';
+
+// Mock 데이터
+const mockBillingStats = {
+  totalRevenue: 125000000,
+  monthlyRevenue: 12500000,
+  activeLicenses: 24,
+  pendingPayments: 3,
+};
+
+const mockBillingHistory: {
+  id: number;
+  tenantName: string;
+  tenantCode: string;
+  plan: PlanType;
+  amount: number;
+  status: 'PAID' | 'PENDING' | 'OVERDUE';
+  billingDate: string;
+  dueDate: string;
+}[] = [
+  { id: 1, tenantName: '메가존클라우드', tenantCode: 'mzc', plan: 'ENTERPRISE', amount: 5000000, status: 'PAID', billingDate: '2025-12-01', dueDate: '2025-12-15' },
+  { id: 2, tenantName: '삼성전자', tenantCode: 'samsung', plan: 'ENTERPRISE', amount: 5000000, status: 'PAID', billingDate: '2025-12-01', dueDate: '2025-12-15' },
+  { id: 3, tenantName: '네이버', tenantCode: 'naver', plan: 'PRO', amount: 1500000, status: 'PENDING', billingDate: '2025-12-01', dueDate: '2025-12-31' },
+  { id: 4, tenantName: '카카오', tenantCode: 'kakao', plan: 'PRO', amount: 1500000, status: 'PAID', billingDate: '2025-12-01', dueDate: '2025-12-15' },
+  { id: 5, tenantName: '라인', tenantCode: 'line', plan: 'BASIC', amount: 500000, status: 'OVERDUE', billingDate: '2025-11-01', dueDate: '2025-11-15' },
+];
+
+const billingStatusLabels = {
+  PAID: '결제완료',
+  PENDING: '대기중',
+  OVERDUE: '연체',
+};
+
+const billingStatusColors = {
+  PAID: 'bg-green-100 text-green-700',
+  PENDING: 'bg-yellow-100 text-yellow-700',
+  OVERDUE: 'bg-red-100 text-red-700',
+};
+
+export function BillingPage() {
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+
+  const filteredBilling = mockBillingHistory.filter((item) => {
+    const matchesSearch = item.tenantName.toLowerCase().includes(searchKeyword.toLowerCase()) ||
+      item.tenantCode.toLowerCase().includes(searchKeyword.toLowerCase());
+    const matchesStatus = statusFilter === 'all' || item.status === statusFilter;
+    return matchesSearch && matchesStatus;
+  });
+
+  const formatCurrency = (amount: number) => {
+    return new Intl.NumberFormat('ko-KR', { style: 'currency', currency: 'KRW' }).format(amount);
+  };
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="요금제 및 라이선스 관리"
+        description="테넌트 요금제와 결제 현황을 관리합니다"
+        actions={
+          <Button variant="outline">
+            <Download className="mr-2 h-4 w-4" />
+            내보내기
+          </Button>
+        }
+      />
+
+      {/* Stats */}
+      <AdminStatsGrid columns={4} className="mb-6">
+        <AdminStatsCard
+          title="총 매출"
+          value={formatCurrency(mockBillingStats.totalRevenue)}
+          icon={DollarSign}
+          variant="primary"
+        />
+        <AdminStatsCard
+          title="월 매출"
+          value={formatCurrency(mockBillingStats.monthlyRevenue)}
+          icon={TrendingUp}
+          variant="success"
+          trend={{ value: 15, label: '전월 대비' }}
+        />
+        <AdminStatsCard
+          title="활성 라이선스"
+          value={mockBillingStats.activeLicenses}
+          icon={Building2}
+          variant="default"
+        />
+        <AdminStatsCard
+          title="결제 대기"
+          value={mockBillingStats.pendingPayments}
+          icon={CreditCard}
+          variant="warning"
+        />
+      </AdminStatsGrid>
+
+      {/* Billing History */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>결제 내역</CardTitle>
+              <CardDescription>테넌트별 결제 현황을 확인합니다</CardDescription>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-secondary" />
+                <Input
+                  placeholder="테넌트 검색..."
+                  value={searchKeyword}
+                  onChange={(e) => setSearchKeyword(e.target.value)}
+                  className="pl-9 w-64"
+                />
+              </div>
+              <Select value={statusFilter} onValueChange={setStatusFilter}>
+                <SelectTrigger className="w-32">
+                  <Filter className="mr-2 h-4 w-4" />
+                  <SelectValue placeholder="상태" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">전체</SelectItem>
+                  <SelectItem value="PAID">결제완료</SelectItem>
+                  <SelectItem value="PENDING">대기중</SelectItem>
+                  <SelectItem value="OVERDUE">연체</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b">
+                  <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">테넌트</th>
+                  <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">플랜</th>
+                  <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">금액</th>
+                  <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">결제일</th>
+                  <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">만료일</th>
+                  <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">상태</th>
+                  <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">작업</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredBilling.map((item) => (
+                  <tr key={item.id} className="border-b last:border-b-0 hover:bg-bg-secondary">
+                    <td className="py-3 px-4">
+                      <div>
+                        <p className="font-medium">{item.tenantName}</p>
+                        <p className="text-sm text-text-secondary">{item.tenantCode}</p>
+                      </div>
+                    </td>
+                    <td className="py-3 px-4">
+                      <PlanBadge plan={item.plan} />
+                    </td>
+                    <td className="py-3 px-4 font-medium">{formatCurrency(item.amount)}</td>
+                    <td className="py-3 px-4 text-text-secondary">{item.billingDate}</td>
+                    <td className="py-3 px-4 text-text-secondary">{item.dueDate}</td>
+                    <td className="py-3 px-4">
+                      <Badge className={billingStatusColors[item.status]}>
+                        {billingStatusLabels[item.status]}
+                      </Badge>
+                    </td>
+                    <td className="py-3 px-4">
+                      <Button variant="ghost" size="sm">상세</Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/sa/billing/TenantStatusPage.tsx
+++ b/src/pages/sa/billing/TenantStatusPage.tsx
@@ -1,0 +1,222 @@
+import { useState } from 'react';
+import {
+  Building2,
+  Users,
+  BookOpen,
+  HardDrive,
+  Search,
+  TrendingUp,
+  TrendingDown,
+} from 'lucide-react';
+import { AdminPageHeader, AdminStatsCard, AdminStatsGrid, StatusBadge, PlanBadge } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Input } from '@/components/common/Input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/common/Select';
+import { Progress } from '@/components/common/Progress';
+import type { TenantStatus, PlanType } from '@/types/admin';
+
+// Mock 데이터
+const mockOverallStats = {
+  totalTenants: 24,
+  totalUsers: 12500,
+  totalCourses: 456,
+  totalStorage: 2.4, // TB
+};
+
+const mockTenantStatus: {
+  id: number;
+  name: string;
+  code: string;
+  status: TenantStatus;
+  plan: PlanType;
+  users: { current: number; max: number };
+  courses: { current: number; max: number };
+  storage: { current: number; max: number }; // GB
+  lastActivity: string;
+  trend: 'up' | 'down' | 'stable';
+}[] = [
+  { id: 1, name: '메가존클라우드', code: 'mzc', status: 'ACTIVE', plan: 'ENTERPRISE', users: { current: 250, max: 500 }, courses: { current: 45, max: 100 }, storage: { current: 85, max: 200 }, lastActivity: '2025-12-30 09:15', trend: 'up' },
+  { id: 2, name: '삼성전자', code: 'samsung', status: 'ACTIVE', plan: 'ENTERPRISE', users: { current: 480, max: 500 }, courses: { current: 78, max: 100 }, storage: { current: 156, max: 200 }, lastActivity: '2025-12-30 10:22', trend: 'up' },
+  { id: 3, name: '네이버', code: 'naver', status: 'PENDING', plan: 'PRO', users: { current: 45, max: 200 }, courses: { current: 12, max: 50 }, storage: { current: 15, max: 50 }, lastActivity: '2025-12-29 14:30', trend: 'stable' },
+  { id: 4, name: '카카오', code: 'kakao', status: 'ACTIVE', plan: 'PRO', users: { current: 180, max: 200 }, courses: { current: 42, max: 50 }, storage: { current: 38, max: 50 }, lastActivity: '2025-12-30 08:45', trend: 'up' },
+  { id: 5, name: '라인', code: 'line', status: 'INACTIVE', plan: 'BASIC', users: { current: 25, max: 50 }, courses: { current: 8, max: 20 }, storage: { current: 5, max: 10 }, lastActivity: '2025-12-15 11:20', trend: 'down' },
+  { id: 6, name: 'SK텔레콤', code: 'skt', status: 'ACTIVE', plan: 'ENTERPRISE', users: { current: 320, max: 500 }, courses: { current: 55, max: 100 }, storage: { current: 120, max: 200 }, lastActivity: '2025-12-30 11:00', trend: 'up' },
+];
+
+export function TenantStatusPage() {
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [planFilter, setPlanFilter] = useState<string>('all');
+
+  const filteredTenants = mockTenantStatus.filter((tenant) => {
+    const matchesSearch = tenant.name.toLowerCase().includes(searchKeyword.toLowerCase()) ||
+      tenant.code.toLowerCase().includes(searchKeyword.toLowerCase());
+    const matchesStatus = statusFilter === 'all' || tenant.status === statusFilter;
+    const matchesPlan = planFilter === 'all' || tenant.plan === planFilter;
+    return matchesSearch && matchesStatus && matchesPlan;
+  });
+
+  const getUsageColor = (current: number, max: number) => {
+    const percentage = (current / max) * 100;
+    if (percentage >= 90) return 'text-red-600';
+    if (percentage >= 70) return 'text-yellow-600';
+    return 'text-green-600';
+  };
+
+  const TrendIcon = ({ trend }: { trend: 'up' | 'down' | 'stable' }) => {
+    if (trend === 'up') return <TrendingUp className="h-4 w-4 text-green-500" />;
+    if (trend === 'down') return <TrendingDown className="h-4 w-4 text-red-500" />;
+    return <span className="h-4 w-4 text-gray-400">-</span>;
+  };
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="전체 현황 조회"
+        description="모든 테넌트의 사용 현황을 모니터링합니다"
+      />
+
+      {/* Overall Stats */}
+      <AdminStatsGrid columns={4} className="mb-6">
+        <AdminStatsCard
+          title="전체 테넌트"
+          value={mockOverallStats.totalTenants}
+          icon={Building2}
+          variant="primary"
+        />
+        <AdminStatsCard
+          title="전체 사용자"
+          value={mockOverallStats.totalUsers.toLocaleString()}
+          icon={Users}
+          variant="success"
+        />
+        <AdminStatsCard
+          title="전체 강좌"
+          value={mockOverallStats.totalCourses}
+          icon={BookOpen}
+          variant="default"
+        />
+        <AdminStatsCard
+          title="전체 스토리지"
+          value={`${mockOverallStats.totalStorage} TB`}
+          icon={HardDrive}
+          variant="warning"
+        />
+      </AdminStatsGrid>
+
+      {/* Tenant Status List */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>테넌트별 현황</CardTitle>
+              <CardDescription>각 테넌트의 리소스 사용량을 확인합니다</CardDescription>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-secondary" />
+                <Input
+                  placeholder="테넌트 검색..."
+                  value={searchKeyword}
+                  onChange={(e) => setSearchKeyword(e.target.value)}
+                  className="pl-9 w-64"
+                />
+              </div>
+              <Select value={statusFilter} onValueChange={setStatusFilter}>
+                <SelectTrigger className="w-32">
+                  <SelectValue placeholder="상태" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">전체 상태</SelectItem>
+                  <SelectItem value="ACTIVE">활성</SelectItem>
+                  <SelectItem value="INACTIVE">비활성</SelectItem>
+                  <SelectItem value="PENDING">대기</SelectItem>
+                  <SelectItem value="SUSPENDED">정지</SelectItem>
+                </SelectContent>
+              </Select>
+              <Select value={planFilter} onValueChange={setPlanFilter}>
+                <SelectTrigger className="w-32">
+                  <SelectValue placeholder="플랜" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">전체 플랜</SelectItem>
+                  <SelectItem value="BASIC">Basic</SelectItem>
+                  <SelectItem value="PRO">Pro</SelectItem>
+                  <SelectItem value="ENTERPRISE">Enterprise</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {filteredTenants.map((tenant) => (
+              <div key={tenant.id} className="p-4 border rounded-lg hover:bg-bg-secondary transition-colors">
+                <div className="flex items-center justify-between mb-4">
+                  <div className="flex items-center gap-3">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <h3 className="font-medium">{tenant.name}</h3>
+                        <TrendIcon trend={tenant.trend} />
+                      </div>
+                      <p className="text-sm text-text-secondary">{tenant.code}</p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <StatusBadge status={tenant.status} />
+                    <PlanBadge plan={tenant.plan} />
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-3 gap-4">
+                  {/* Users */}
+                  <div>
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="text-sm text-text-secondary">사용자</span>
+                      <span className={`text-sm font-medium ${getUsageColor(tenant.users.current, tenant.users.max)}`}>
+                        {tenant.users.current} / {tenant.users.max}
+                      </span>
+                    </div>
+                    <Progress value={(tenant.users.current / tenant.users.max) * 100} />
+                  </div>
+
+                  {/* Courses */}
+                  <div>
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="text-sm text-text-secondary">강좌</span>
+                      <span className={`text-sm font-medium ${getUsageColor(tenant.courses.current, tenant.courses.max)}`}>
+                        {tenant.courses.current} / {tenant.courses.max}
+                      </span>
+                    </div>
+                    <Progress value={(tenant.courses.current / tenant.courses.max) * 100} />
+                  </div>
+
+                  {/* Storage */}
+                  <div>
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="text-sm text-text-secondary">스토리지</span>
+                      <span className={`text-sm font-medium ${getUsageColor(tenant.storage.current, tenant.storage.max)}`}>
+                        {tenant.storage.current} GB / {tenant.storage.max} GB
+                      </span>
+                    </div>
+                    <Progress value={(tenant.storage.current / tenant.storage.max) * 100} />
+                  </div>
+                </div>
+
+                <div className="mt-3 text-xs text-text-secondary">
+                  최근 활동: {tenant.lastActivity}
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/sa/billing/index.ts
+++ b/src/pages/sa/billing/index.ts
@@ -1,0 +1,2 @@
+export { BillingPage } from './BillingPage';
+export { TenantStatusPage } from './TenantStatusPage';

--- a/src/pages/sa/index.ts
+++ b/src/pages/sa/index.ts
@@ -1,3 +1,18 @@
 // Super Admin pages
 export { DashboardPage } from "./dashboard";
 export { TenantsPage, TenantDetailPage } from "./tenants";
+
+// Billing
+export { BillingPage, TenantStatusPage } from "./billing";
+
+// System
+export { DomainSettingsPage, OperatorsPage, BrandingSettingsPage, EmailTemplatesPage } from "./system";
+
+// Notices
+export { NoticesPage, NoticeDistributionPage } from "./notices";
+
+// Analytics
+export { UsagePage, ActivityPage, LogsPage } from "./analytics";
+
+// Settings
+export { SystemSettingsPage, TenantDefaultsPage } from "./settings";

--- a/src/pages/sa/notices/NoticeDistributionPage.tsx
+++ b/src/pages/sa/notices/NoticeDistributionPage.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react';
+import {
+  Send,
+  Building2,
+  CheckCircle,
+  Clock,
+  AlertCircle,
+  Eye,
+  Search,
+} from 'lucide-react';
+import { AdminPageHeader } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Badge } from '@/components/common/Badge';
+import { Progress } from '@/components/common/Progress';
+
+// Mock 데이터
+const mockDistributions: {
+  id: number;
+  noticeTitle: string;
+  totalTenants: number;
+  sentCount: number;
+  readCount: number;
+  status: 'COMPLETED' | 'IN_PROGRESS' | 'SCHEDULED' | 'FAILED';
+  distributedAt: string;
+}[] = [
+  { id: 1, noticeTitle: '2025년 1월 시스템 업데이트 안내', totalTenants: 45, sentCount: 45, readCount: 38, status: 'COMPLETED', distributedAt: '2025-12-28 10:00' },
+  { id: 2, noticeTitle: '연말 시스템 점검 안내', totalTenants: 45, sentCount: 45, readCount: 42, status: 'COMPLETED', distributedAt: '2025-12-25 09:00' },
+  { id: 3, noticeTitle: '신규 강좌 오픈 이벤트', totalTenants: 45, sentCount: 30, readCount: 15, status: 'IN_PROGRESS', distributedAt: '2025-12-20 14:00' },
+  { id: 4, noticeTitle: '이용약관 변경 안내', totalTenants: 45, sentCount: 0, readCount: 0, status: 'SCHEDULED', distributedAt: '2026-01-01 00:00' },
+];
+
+const statusConfig = {
+  COMPLETED: { label: '완료', icon: CheckCircle, color: 'bg-green-100 text-green-700' },
+  IN_PROGRESS: { label: '진행중', icon: Clock, color: 'bg-blue-100 text-blue-700' },
+  SCHEDULED: { label: '예약됨', icon: Clock, color: 'bg-yellow-100 text-yellow-700' },
+  FAILED: { label: '실패', icon: AlertCircle, color: 'bg-red-100 text-red-700' },
+};
+
+export function NoticeDistributionPage() {
+  const [searchKeyword, setSearchKeyword] = useState('');
+
+  const filteredDistributions = mockDistributions.filter((dist) =>
+    dist.noticeTitle.toLowerCase().includes(searchKeyword.toLowerCase())
+  );
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="공지사항 배포 관리"
+        description="공지사항의 테넌트별 배포 현황을 관리합니다"
+      />
+
+      {/* Stats Summary */}
+      <div className="grid grid-cols-4 gap-4 mb-6">
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-brand-primary/10 rounded-lg">
+                <Send className="h-5 w-5 text-brand-primary" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockDistributions.length}</p>
+                <p className="text-sm text-text-secondary">전체 배포</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-green-100 rounded-lg">
+                <CheckCircle className="h-5 w-5 text-green-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockDistributions.filter(d => d.status === 'COMPLETED').length}</p>
+                <p className="text-sm text-text-secondary">완료</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-blue-100 rounded-lg">
+                <Clock className="h-5 w-5 text-blue-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockDistributions.filter(d => d.status === 'IN_PROGRESS').length}</p>
+                <p className="text-sm text-text-secondary">진행중</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-yellow-100 rounded-lg">
+                <Building2 className="h-5 w-5 text-yellow-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">45</p>
+                <p className="text-sm text-text-secondary">대상 테넌트</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Distribution List */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>배포 현황</CardTitle>
+              <CardDescription>공지사항별 배포 및 열람 현황입니다</CardDescription>
+            </div>
+            <div className="relative w-64">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-secondary" />
+              <Input
+                placeholder="공지 검색..."
+                value={searchKeyword}
+                onChange={(e) => setSearchKeyword(e.target.value)}
+                className="pl-9"
+              />
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {filteredDistributions.map((dist) => {
+              const config = statusConfig[dist.status];
+              const StatusIcon = config.icon;
+              const sentPercent = (dist.sentCount / dist.totalTenants) * 100;
+              const readPercent = dist.sentCount > 0 ? (dist.readCount / dist.sentCount) * 100 : 0;
+
+              return (
+                <div key={dist.id} className="p-4 border rounded-lg hover:bg-bg-secondary">
+                  <div className="flex items-center justify-between mb-3">
+                    <div className="flex items-center gap-2">
+                      <h3 className="font-medium">{dist.noticeTitle}</h3>
+                      <Badge className={config.color}>
+                        <StatusIcon className="h-3 w-3 mr-1" />
+                        {config.label}
+                      </Badge>
+                    </div>
+                    <span className="text-sm text-text-secondary">{dist.distributedAt}</span>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <div className="flex justify-between text-sm mb-1">
+                        <span className="text-text-secondary">발송 현황</span>
+                        <span>{dist.sentCount} / {dist.totalTenants} 테넌트</span>
+                      </div>
+                      <Progress value={sentPercent} className="h-2" />
+                    </div>
+                    <div>
+                      <div className="flex justify-between text-sm mb-1">
+                        <span className="text-text-secondary">열람율</span>
+                        <span>{dist.readCount} / {dist.sentCount} ({readPercent.toFixed(0)}%)</span>
+                      </div>
+                      <Progress value={readPercent} className="h-2" />
+                    </div>
+                  </div>
+
+                  <div className="flex justify-end mt-3">
+                    <Button variant="ghost" size="sm">
+                      <Eye className="h-4 w-4 mr-1" />
+                      상세 보기
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/sa/notices/NoticesPage.tsx
+++ b/src/pages/sa/notices/NoticesPage.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react';
+import {
+  Plus,
+  Search,
+  Edit,
+  Trash2,
+  Eye,
+  Pin,
+  Calendar,
+} from 'lucide-react';
+import { AdminPageHeader } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Badge } from '@/components/common/Badge';
+
+// Mock 데이터
+const mockNotices: {
+  id: number;
+  title: string;
+  content: string;
+  category: 'GENERAL' | 'UPDATE' | 'MAINTENANCE' | 'EVENT';
+  status: 'DRAFT' | 'PUBLISHED' | 'SCHEDULED';
+  isPinned: boolean;
+  views: number;
+  publishedAt: string | null;
+  createdAt: string;
+}[] = [
+  { id: 1, title: '2025년 1월 시스템 업데이트 안내', content: '새로운 기능이 추가됩니다...', category: 'UPDATE', status: 'PUBLISHED', isPinned: true, views: 1250, publishedAt: '2025-12-28', createdAt: '2025-12-27' },
+  { id: 2, title: '연말 시스템 점검 안내', content: '12월 31일 시스템 점검...', category: 'MAINTENANCE', status: 'PUBLISHED', isPinned: true, views: 890, publishedAt: '2025-12-25', createdAt: '2025-12-24' },
+  { id: 3, title: '신규 강좌 오픈 이벤트', content: '신규 강좌 50% 할인...', category: 'EVENT', status: 'PUBLISHED', isPinned: false, views: 2340, publishedAt: '2025-12-20', createdAt: '2025-12-19' },
+  { id: 4, title: '이용약관 변경 안내', content: '이용약관이 변경됩니다...', category: 'GENERAL', status: 'SCHEDULED', isPinned: false, views: 0, publishedAt: null, createdAt: '2025-12-29' },
+  { id: 5, title: '새해 맞이 특별 프로모션 (초안)', content: '2026년을 맞아...', category: 'EVENT', status: 'DRAFT', isPinned: false, views: 0, publishedAt: null, createdAt: '2025-12-30' },
+];
+
+const categoryConfig = {
+  GENERAL: { label: '일반', color: 'bg-gray-100 text-gray-700' },
+  UPDATE: { label: '업데이트', color: 'bg-blue-100 text-blue-700' },
+  MAINTENANCE: { label: '점검', color: 'bg-yellow-100 text-yellow-700' },
+  EVENT: { label: '이벤트', color: 'bg-purple-100 text-purple-700' },
+};
+
+const statusConfig = {
+  DRAFT: { label: '초안', color: 'bg-gray-100 text-gray-600' },
+  PUBLISHED: { label: '게시됨', color: 'bg-green-100 text-green-700' },
+  SCHEDULED: { label: '예약됨', color: 'bg-blue-100 text-blue-700' },
+};
+
+export function NoticesPage() {
+  const [searchKeyword, setSearchKeyword] = useState('');
+
+  const filteredNotices = mockNotices.filter((notice) =>
+    notice.title.toLowerCase().includes(searchKeyword.toLowerCase())
+  );
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="공지사항 관리"
+        description="전체 테넌트에 공지사항을 관리합니다"
+        actions={
+          <Button>
+            <Plus className="mr-2 h-4 w-4" />
+            공지 작성
+          </Button>
+        }
+      />
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>공지사항 목록</CardTitle>
+              <CardDescription>전체 {mockNotices.length}개의 공지사항</CardDescription>
+            </div>
+            <div className="relative w-64">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-secondary" />
+              <Input
+                placeholder="공지 검색..."
+                value={searchKeyword}
+                onChange={(e) => setSearchKeyword(e.target.value)}
+                className="pl-9"
+              />
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {filteredNotices.map((notice) => (
+              <div key={notice.id} className="flex items-center justify-between p-4 border rounded-lg hover:bg-bg-secondary">
+                <div className="flex items-start gap-3">
+                  {notice.isPinned && <Pin className="h-4 w-4 text-brand-primary mt-1" />}
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <h3 className="font-medium">{notice.title}</h3>
+                      <Badge className={categoryConfig[notice.category].color}>
+                        {categoryConfig[notice.category].label}
+                      </Badge>
+                      <Badge className={statusConfig[notice.status].color}>
+                        {statusConfig[notice.status].label}
+                      </Badge>
+                    </div>
+                    <div className="flex items-center gap-4 mt-1 text-sm text-text-secondary">
+                      <span className="flex items-center gap-1">
+                        <Calendar className="h-3 w-3" />
+                        {notice.publishedAt || notice.createdAt}
+                      </span>
+                      {notice.status === 'PUBLISHED' && (
+                        <span className="flex items-center gap-1">
+                          <Eye className="h-3 w-3" />
+                          {notice.views.toLocaleString()} 조회
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button variant="ghost" size="sm"><Eye className="h-4 w-4" /></Button>
+                  <Button variant="ghost" size="sm"><Edit className="h-4 w-4" /></Button>
+                  <Button variant="ghost" size="sm" className="text-red-500"><Trash2 className="h-4 w-4" /></Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/sa/notices/index.ts
+++ b/src/pages/sa/notices/index.ts
@@ -1,0 +1,2 @@
+export { NoticesPage } from './NoticesPage';
+export { NoticeDistributionPage } from './NoticeDistributionPage';

--- a/src/pages/sa/settings/SystemSettingsPage.tsx
+++ b/src/pages/sa/settings/SystemSettingsPage.tsx
@@ -1,0 +1,333 @@
+import { useState } from 'react';
+import {
+  Settings,
+  Save,
+  RotateCcw,
+  Shield,
+  Database,
+  Mail,
+} from 'lucide-react';
+import { AdminPageHeader } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Label } from '@/components/common/Label';
+import { Switch } from '@/components/common/Switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/common/Select';
+
+// Mock 데이터
+const mockSettings = {
+  general: {
+    platformName: 'MZC Learn Platform',
+    timezone: 'Asia/Seoul',
+    language: 'ko',
+    maintenanceMode: false,
+  },
+  security: {
+    sessionTimeout: 30,
+    maxLoginAttempts: 5,
+    passwordExpiry: 90,
+    mfaRequired: false,
+    ipWhitelist: '',
+  },
+  storage: {
+    maxUploadSize: 500,
+    allowedFormats: 'mp4,webm,pdf,pptx,docx',
+    autoCleanup: true,
+    cleanupDays: 30,
+  },
+  email: {
+    smtpHost: 'smtp.example.com',
+    smtpPort: 587,
+    smtpUser: 'noreply@mzc.com',
+    useTls: true,
+  },
+};
+
+export function SystemSettingsPage() {
+  const [settings, setSettings] = useState(mockSettings);
+
+  const handleReset = () => {
+    setSettings(mockSettings);
+  };
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="시스템 설정"
+        description="플랫폼 전역 시스템 설정을 관리합니다"
+        actions={
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={handleReset}>
+              <RotateCcw className="mr-2 h-4 w-4" />
+              초기화
+            </Button>
+            <Button>
+              <Save className="mr-2 h-4 w-4" />
+              저장
+            </Button>
+          </div>
+        }
+      />
+
+      <div className="space-y-6">
+        {/* General Settings */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Settings className="h-5 w-5 text-brand-primary" />
+              <CardTitle>일반 설정</CardTitle>
+            </div>
+            <CardDescription>기본 플랫폼 설정입니다</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>플랫폼 이름</Label>
+                <Input
+                  value={settings.general.platformName}
+                  onChange={(e) => setSettings({
+                    ...settings,
+                    general: { ...settings.general, platformName: e.target.value },
+                  })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>타임존</Label>
+                <Select
+                  value={settings.general.timezone}
+                  onValueChange={(v) => setSettings({
+                    ...settings,
+                    general: { ...settings.general, timezone: v },
+                  })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Asia/Seoul">Asia/Seoul (KST)</SelectItem>
+                    <SelectItem value="America/New_York">America/New_York (EST)</SelectItem>
+                    <SelectItem value="Europe/London">Europe/London (GMT)</SelectItem>
+                    <SelectItem value="Asia/Tokyo">Asia/Tokyo (JST)</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="flex items-center justify-between pt-4 border-t">
+              <div>
+                <p className="font-medium">유지보수 모드</p>
+                <p className="text-sm text-text-secondary">활성화 시 관리자만 접근 가능합니다</p>
+              </div>
+              <Switch
+                checked={settings.general.maintenanceMode}
+                onCheckedChange={(v) => setSettings({
+                  ...settings,
+                  general: { ...settings.general, maintenanceMode: v },
+                })}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Security Settings */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Shield className="h-5 w-5 text-brand-primary" />
+              <CardTitle>보안 설정</CardTitle>
+            </div>
+            <CardDescription>인증 및 보안 관련 설정입니다</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <Label>세션 타임아웃 (분)</Label>
+                <Input
+                  type="number"
+                  value={settings.security.sessionTimeout}
+                  onChange={(e) => setSettings({
+                    ...settings,
+                    security: { ...settings.security, sessionTimeout: Number(e.target.value) },
+                  })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>최대 로그인 시도</Label>
+                <Input
+                  type="number"
+                  value={settings.security.maxLoginAttempts}
+                  onChange={(e) => setSettings({
+                    ...settings,
+                    security: { ...settings.security, maxLoginAttempts: Number(e.target.value) },
+                  })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>비밀번호 만료일 (일)</Label>
+                <Input
+                  type="number"
+                  value={settings.security.passwordExpiry}
+                  onChange={(e) => setSettings({
+                    ...settings,
+                    security: { ...settings.security, passwordExpiry: Number(e.target.value) },
+                  })}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>IP 화이트리스트</Label>
+              <Input
+                placeholder="예: 192.168.1.0/24, 10.0.0.1"
+                value={settings.security.ipWhitelist}
+                onChange={(e) => setSettings({
+                  ...settings,
+                  security: { ...settings.security, ipWhitelist: e.target.value },
+                })}
+              />
+              <p className="text-xs text-text-secondary">비워두면 모든 IP에서 접근 가능합니다</p>
+            </div>
+            <div className="flex items-center justify-between pt-4 border-t">
+              <div>
+                <p className="font-medium">MFA 필수 적용</p>
+                <p className="text-sm text-text-secondary">모든 사용자에게 다중 인증을 요구합니다</p>
+              </div>
+              <Switch
+                checked={settings.security.mfaRequired}
+                onCheckedChange={(v) => setSettings({
+                  ...settings,
+                  security: { ...settings.security, mfaRequired: v },
+                })}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Storage Settings */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Database className="h-5 w-5 text-brand-primary" />
+              <CardTitle>스토리지 설정</CardTitle>
+            </div>
+            <CardDescription>파일 업로드 및 저장소 관련 설정입니다</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>최대 업로드 크기 (MB)</Label>
+                <Input
+                  type="number"
+                  value={settings.storage.maxUploadSize}
+                  onChange={(e) => setSettings({
+                    ...settings,
+                    storage: { ...settings.storage, maxUploadSize: Number(e.target.value) },
+                  })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>자동 정리 기간 (일)</Label>
+                <Input
+                  type="number"
+                  value={settings.storage.cleanupDays}
+                  onChange={(e) => setSettings({
+                    ...settings,
+                    storage: { ...settings.storage, cleanupDays: Number(e.target.value) },
+                  })}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>허용 파일 형식</Label>
+              <Input
+                value={settings.storage.allowedFormats}
+                onChange={(e) => setSettings({
+                  ...settings,
+                  storage: { ...settings.storage, allowedFormats: e.target.value },
+                })}
+              />
+              <p className="text-xs text-text-secondary">쉼표로 구분하여 입력</p>
+            </div>
+            <div className="flex items-center justify-between pt-4 border-t">
+              <div>
+                <p className="font-medium">자동 정리 활성화</p>
+                <p className="text-sm text-text-secondary">사용하지 않는 파일을 자동으로 정리합니다</p>
+              </div>
+              <Switch
+                checked={settings.storage.autoCleanup}
+                onCheckedChange={(v) => setSettings({
+                  ...settings,
+                  storage: { ...settings.storage, autoCleanup: v },
+                })}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Email Settings */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Mail className="h-5 w-5 text-brand-primary" />
+              <CardTitle>이메일 설정</CardTitle>
+            </div>
+            <CardDescription>SMTP 서버 설정입니다</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>SMTP 호스트</Label>
+                <Input
+                  value={settings.email.smtpHost}
+                  onChange={(e) => setSettings({
+                    ...settings,
+                    email: { ...settings.email, smtpHost: e.target.value },
+                  })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>SMTP 포트</Label>
+                <Input
+                  type="number"
+                  value={settings.email.smtpPort}
+                  onChange={(e) => setSettings({
+                    ...settings,
+                    email: { ...settings.email, smtpPort: Number(e.target.value) },
+                  })}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>SMTP 사용자</Label>
+              <Input
+                value={settings.email.smtpUser}
+                onChange={(e) => setSettings({
+                  ...settings,
+                  email: { ...settings.email, smtpUser: e.target.value },
+                })}
+              />
+            </div>
+            <div className="flex items-center justify-between pt-4 border-t">
+              <div>
+                <p className="font-medium">TLS 사용</p>
+                <p className="text-sm text-text-secondary">보안 연결을 사용합니다</p>
+              </div>
+              <Switch
+                checked={settings.email.useTls}
+                onCheckedChange={(v) => setSettings({
+                  ...settings,
+                  email: { ...settings.email, useTls: v },
+                })}
+              />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/sa/settings/TenantDefaultsPage.tsx
+++ b/src/pages/sa/settings/TenantDefaultsPage.tsx
@@ -1,0 +1,316 @@
+import { useState } from 'react';
+import {
+  Building2,
+  Save,
+  RotateCcw,
+  Users,
+  BookOpen,
+  HardDrive,
+  Palette,
+} from 'lucide-react';
+import { AdminPageHeader } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Label } from '@/components/common/Label';
+import { Switch } from '@/components/common/Switch';
+
+// Mock 데이터
+const mockDefaults = {
+  limits: {
+    maxUsers: 100,
+    maxCourses: 50,
+    maxStorage: 50,
+    maxAdmins: 5,
+  },
+  features: {
+    customDomain: false,
+    ssoIntegration: false,
+    apiAccess: false,
+    whiteLabeling: false,
+    advancedAnalytics: false,
+  },
+  branding: {
+    allowCustomLogo: true,
+    allowCustomColors: true,
+    allowCustomFonts: false,
+  },
+  notifications: {
+    emailNotifications: true,
+    pushNotifications: false,
+    smsNotifications: false,
+  },
+};
+
+export function TenantDefaultsPage() {
+  const [defaults, setDefaults] = useState(mockDefaults);
+
+  const handleReset = () => {
+    setDefaults(mockDefaults);
+  };
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="테넌트 기본값 설정"
+        description="새 테넌트 생성 시 적용되는 기본값을 설정합니다"
+        actions={
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={handleReset}>
+              <RotateCcw className="mr-2 h-4 w-4" />
+              초기화
+            </Button>
+            <Button>
+              <Save className="mr-2 h-4 w-4" />
+              저장
+            </Button>
+          </div>
+        }
+      />
+
+      <div className="grid grid-cols-2 gap-6">
+        {/* Resource Limits */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Building2 className="h-5 w-5 text-brand-primary" />
+              <CardTitle>리소스 제한</CardTitle>
+            </div>
+            <CardDescription>테넌트별 기본 리소스 제한입니다</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label className="flex items-center gap-2">
+                <Users className="h-4 w-4" />
+                최대 사용자 수
+              </Label>
+              <Input
+                type="number"
+                value={defaults.limits.maxUsers}
+                onChange={(e) => setDefaults({
+                  ...defaults,
+                  limits: { ...defaults.limits, maxUsers: Number(e.target.value) },
+                })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label className="flex items-center gap-2">
+                <BookOpen className="h-4 w-4" />
+                최대 강좌 수
+              </Label>
+              <Input
+                type="number"
+                value={defaults.limits.maxCourses}
+                onChange={(e) => setDefaults({
+                  ...defaults,
+                  limits: { ...defaults.limits, maxCourses: Number(e.target.value) },
+                })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label className="flex items-center gap-2">
+                <HardDrive className="h-4 w-4" />
+                스토리지 용량 (GB)
+              </Label>
+              <Input
+                type="number"
+                value={defaults.limits.maxStorage}
+                onChange={(e) => setDefaults({
+                  ...defaults,
+                  limits: { ...defaults.limits, maxStorage: Number(e.target.value) },
+                })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>최대 관리자 수</Label>
+              <Input
+                type="number"
+                value={defaults.limits.maxAdmins}
+                onChange={(e) => setDefaults({
+                  ...defaults,
+                  limits: { ...defaults.limits, maxAdmins: Number(e.target.value) },
+                })}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Features */}
+        <Card>
+          <CardHeader>
+            <CardTitle>기능 활성화</CardTitle>
+            <CardDescription>기본으로 활성화되는 기능입니다</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-medium">커스텀 도메인</p>
+                <p className="text-sm text-text-secondary">자체 도메인 연결 허용</p>
+              </div>
+              <Switch
+                checked={defaults.features.customDomain}
+                onCheckedChange={(v) => setDefaults({
+                  ...defaults,
+                  features: { ...defaults.features, customDomain: v },
+                })}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-medium">SSO 연동</p>
+                <p className="text-sm text-text-secondary">Single Sign-On 통합</p>
+              </div>
+              <Switch
+                checked={defaults.features.ssoIntegration}
+                onCheckedChange={(v) => setDefaults({
+                  ...defaults,
+                  features: { ...defaults.features, ssoIntegration: v },
+                })}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-medium">API 접근</p>
+                <p className="text-sm text-text-secondary">REST API 사용 허용</p>
+              </div>
+              <Switch
+                checked={defaults.features.apiAccess}
+                onCheckedChange={(v) => setDefaults({
+                  ...defaults,
+                  features: { ...defaults.features, apiAccess: v },
+                })}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-medium">화이트 라벨링</p>
+                <p className="text-sm text-text-secondary">브랜드 커스터마이징</p>
+              </div>
+              <Switch
+                checked={defaults.features.whiteLabeling}
+                onCheckedChange={(v) => setDefaults({
+                  ...defaults,
+                  features: { ...defaults.features, whiteLabeling: v },
+                })}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-medium">고급 분석</p>
+                <p className="text-sm text-text-secondary">상세 분석 리포트</p>
+              </div>
+              <Switch
+                checked={defaults.features.advancedAnalytics}
+                onCheckedChange={(v) => setDefaults({
+                  ...defaults,
+                  features: { ...defaults.features, advancedAnalytics: v },
+                })}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Branding Permissions */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Palette className="h-5 w-5 text-brand-primary" />
+              <CardTitle>브랜딩 권한</CardTitle>
+            </div>
+            <CardDescription>테넌트별 브랜딩 커스터마이징 권한입니다</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-medium">커스텀 로고</p>
+                <p className="text-sm text-text-secondary">자체 로고 업로드 허용</p>
+              </div>
+              <Switch
+                checked={defaults.branding.allowCustomLogo}
+                onCheckedChange={(v) => setDefaults({
+                  ...defaults,
+                  branding: { ...defaults.branding, allowCustomLogo: v },
+                })}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-medium">커스텀 색상</p>
+                <p className="text-sm text-text-secondary">색상 테마 변경 허용</p>
+              </div>
+              <Switch
+                checked={defaults.branding.allowCustomColors}
+                onCheckedChange={(v) => setDefaults({
+                  ...defaults,
+                  branding: { ...defaults.branding, allowCustomColors: v },
+                })}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-medium">커스텀 폰트</p>
+                <p className="text-sm text-text-secondary">폰트 변경 허용</p>
+              </div>
+              <Switch
+                checked={defaults.branding.allowCustomFonts}
+                onCheckedChange={(v) => setDefaults({
+                  ...defaults,
+                  branding: { ...defaults.branding, allowCustomFonts: v },
+                })}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Notification Defaults */}
+        <Card>
+          <CardHeader>
+            <CardTitle>알림 기본값</CardTitle>
+            <CardDescription>기본 알림 설정입니다</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-medium">이메일 알림</p>
+                <p className="text-sm text-text-secondary">이메일로 알림 발송</p>
+              </div>
+              <Switch
+                checked={defaults.notifications.emailNotifications}
+                onCheckedChange={(v) => setDefaults({
+                  ...defaults,
+                  notifications: { ...defaults.notifications, emailNotifications: v },
+                })}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-medium">푸시 알림</p>
+                <p className="text-sm text-text-secondary">브라우저 푸시 알림</p>
+              </div>
+              <Switch
+                checked={defaults.notifications.pushNotifications}
+                onCheckedChange={(v) => setDefaults({
+                  ...defaults,
+                  notifications: { ...defaults.notifications, pushNotifications: v },
+                })}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-medium">SMS 알림</p>
+                <p className="text-sm text-text-secondary">문자 메시지 알림</p>
+              </div>
+              <Switch
+                checked={defaults.notifications.smsNotifications}
+                onCheckedChange={(v) => setDefaults({
+                  ...defaults,
+                  notifications: { ...defaults.notifications, smsNotifications: v },
+                })}
+              />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/sa/settings/index.ts
+++ b/src/pages/sa/settings/index.ts
@@ -1,0 +1,2 @@
+export { SystemSettingsPage } from './SystemSettingsPage';
+export { TenantDefaultsPage } from './TenantDefaultsPage';

--- a/src/pages/sa/system/BrandingSettingsPage.tsx
+++ b/src/pages/sa/system/BrandingSettingsPage.tsx
@@ -1,0 +1,290 @@
+import { useState } from 'react';
+import {
+  Palette,
+  Upload,
+  Trash2,
+  Save,
+  RotateCcw,
+} from 'lucide-react';
+import { AdminPageHeader } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Label } from '@/components/common/Label';
+import { Tabs, TabsList, TabsTrigger } from '@/components/common/Tabs';
+
+// Mock 데이터
+const mockBranding = {
+  logo: {
+    lightUrl: '',
+    darkUrl: '',
+  },
+  favicon: '',
+  colors: {
+    primary: '#3B82F6',
+    secondary: '#1E40AF',
+    accent: '#10B981',
+    background: '#FFFFFF',
+    text: '#1F2937',
+  },
+  fonts: {
+    heading: 'Pretendard',
+    body: 'Pretendard',
+  },
+  customCss: '',
+};
+
+export function BrandingSettingsPage() {
+  const [branding, setBranding] = useState(mockBranding);
+  const [previewMode, setPreviewMode] = useState<'light' | 'dark'>('light');
+
+  const handleColorChange = (key: string, value: string) => {
+    setBranding({
+      ...branding,
+      colors: { ...branding.colors, [key]: value },
+    });
+  };
+
+  const handleReset = () => {
+    setBranding(mockBranding);
+  };
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="글로벌 브랜딩 설정"
+        description="플랫폼 전체에 적용되는 브랜딩을 설정합니다"
+        actions={
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={handleReset}>
+              <RotateCcw className="mr-2 h-4 w-4" />
+              초기화
+            </Button>
+            <Button>
+              <Save className="mr-2 h-4 w-4" />
+              저장
+            </Button>
+          </div>
+        }
+      />
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Settings */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* Logo & Favicon */}
+          <Card>
+            <CardHeader>
+              <CardTitle>로고 및 파비콘</CardTitle>
+              <CardDescription>플랫폼에 표시되는 로고와 파비콘을 설정합니다</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid grid-cols-2 gap-6">
+                {/* Light Logo */}
+                <div>
+                  <Label>라이트 모드 로고</Label>
+                  <div className="mt-2 border-2 border-dashed rounded-lg p-6 text-center bg-white">
+                    {branding.logo.lightUrl ? (
+                      <img src={branding.logo.lightUrl} alt="Light Logo" className="max-h-16 mx-auto" />
+                    ) : (
+                      <div className="text-text-secondary">
+                        <Palette className="h-12 w-12 mx-auto mb-2 opacity-50" />
+                        <p className="text-sm">로고 없음</p>
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex gap-2 mt-2">
+                    <Button variant="outline" size="sm" className="flex-1">
+                      <Upload className="mr-2 h-4 w-4" />
+                      업로드
+                    </Button>
+                    <Button variant="ghost" size="sm" className="text-red-500">
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+
+                {/* Dark Logo */}
+                <div>
+                  <Label>다크 모드 로고</Label>
+                  <div className="mt-2 border-2 border-dashed rounded-lg p-6 text-center bg-gray-900">
+                    {branding.logo.darkUrl ? (
+                      <img src={branding.logo.darkUrl} alt="Dark Logo" className="max-h-16 mx-auto" />
+                    ) : (
+                      <div className="text-gray-400">
+                        <Palette className="h-12 w-12 mx-auto mb-2 opacity-50" />
+                        <p className="text-sm">로고 없음</p>
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex gap-2 mt-2">
+                    <Button variant="outline" size="sm" className="flex-1">
+                      <Upload className="mr-2 h-4 w-4" />
+                      업로드
+                    </Button>
+                    <Button variant="ghost" size="sm" className="text-red-500">
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+
+              {/* Favicon */}
+              <div>
+                <Label>파비콘</Label>
+                <div className="flex items-center gap-4 mt-2">
+                  <div className="w-16 h-16 border-2 border-dashed rounded-lg flex items-center justify-center bg-bg-secondary">
+                    {branding.favicon ? (
+                      <img src={branding.favicon} alt="Favicon" className="w-8 h-8" />
+                    ) : (
+                      <Palette className="h-6 w-6 text-text-secondary opacity-50" />
+                    )}
+                  </div>
+                  <div>
+                    <Button variant="outline" size="sm">
+                      <Upload className="mr-2 h-4 w-4" />
+                      업로드
+                    </Button>
+                    <p className="text-xs text-text-secondary mt-1">권장: 32x32px, ICO 또는 PNG</p>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Colors */}
+          <Card>
+            <CardHeader>
+              <CardTitle>색상 설정</CardTitle>
+              <CardDescription>플랫폼의 주요 색상을 설정합니다</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                {Object.entries(branding.colors).map(([key, value]) => (
+                  <div key={key} className="space-y-2">
+                    <Label htmlFor={key} className="capitalize">
+                      {key === 'primary' ? '주 색상' :
+                       key === 'secondary' ? '보조 색상' :
+                       key === 'accent' ? '강조 색상' :
+                       key === 'background' ? '배경 색상' :
+                       key === 'text' ? '텍스트 색상' : key}
+                    </Label>
+                    <div className="flex gap-2">
+                      <div
+                        className="w-10 h-10 rounded-lg border cursor-pointer"
+                        style={{ backgroundColor: value }}
+                      />
+                      <Input
+                        id={key}
+                        value={value}
+                        onChange={(e) => handleColorChange(key, e.target.value)}
+                        className="flex-1"
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Fonts */}
+          <Card>
+            <CardHeader>
+              <CardTitle>폰트 설정</CardTitle>
+              <CardDescription>플랫폼에서 사용할 폰트를 설정합니다</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label>제목 폰트</Label>
+                  <Input value={branding.fonts.heading} readOnly />
+                </div>
+                <div className="space-y-2">
+                  <Label>본문 폰트</Label>
+                  <Input value={branding.fonts.body} readOnly />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Preview */}
+        <div className="lg:col-span-1">
+          <Card className="sticky top-6">
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle>미리보기</CardTitle>
+                <Tabs value={previewMode} onValueChange={(v) => setPreviewMode(v as 'light' | 'dark')}>
+                  <TabsList>
+                    <TabsTrigger value="light">라이트</TabsTrigger>
+                    <TabsTrigger value="dark">다크</TabsTrigger>
+                  </TabsList>
+                </Tabs>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div
+                className="rounded-lg overflow-hidden border"
+                style={{
+                  backgroundColor: previewMode === 'dark' ? '#1F2937' : branding.colors.background,
+                }}
+              >
+                {/* Header Preview */}
+                <div
+                  className="p-4"
+                  style={{ backgroundColor: branding.colors.primary }}
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="text-white font-medium">MZC Learn</span>
+                    <div className="flex gap-2">
+                      <div className="w-6 h-6 bg-white/20 rounded" />
+                      <div className="w-6 h-6 bg-white/20 rounded-full" />
+                    </div>
+                  </div>
+                </div>
+
+                {/* Content Preview */}
+                <div className="p-4 space-y-4">
+                  <h3
+                    className="font-semibold"
+                    style={{ color: previewMode === 'dark' ? '#F9FAFB' : branding.colors.text }}
+                  >
+                    제목 텍스트
+                  </h3>
+                  <p
+                    className="text-sm"
+                    style={{ color: previewMode === 'dark' ? '#9CA3AF' : '#6B7280' }}
+                  >
+                    본문 텍스트 예시입니다.
+                  </p>
+                  <div className="flex gap-2">
+                    <button
+                      className="px-4 py-2 rounded-lg text-white text-sm"
+                      style={{ backgroundColor: branding.colors.primary }}
+                    >
+                      주 버튼
+                    </button>
+                    <button
+                      className="px-4 py-2 rounded-lg text-white text-sm"
+                      style={{ backgroundColor: branding.colors.secondary }}
+                    >
+                      보조 버튼
+                    </button>
+                  </div>
+                  <div
+                    className="p-3 rounded-lg text-sm"
+                    style={{
+                      backgroundColor: branding.colors.accent + '20',
+                      color: branding.colors.accent,
+                    }}
+                  >
+                    강조 메시지
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/sa/system/DomainSettingsPage.tsx
+++ b/src/pages/sa/system/DomainSettingsPage.tsx
@@ -1,0 +1,145 @@
+import { useState } from 'react';
+import {
+  Globe,
+  Shield,
+  Plus,
+  Trash2,
+  RefreshCw,
+  CheckCircle,
+  AlertCircle,
+  Clock,
+} from 'lucide-react';
+import { AdminPageHeader } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Badge } from '@/components/common/Badge';
+import { Switch } from '@/components/common/Switch';
+
+// Mock 데이터
+const mockDomains: {
+  id: number;
+  domain: string;
+  type: 'PRIMARY' | 'CUSTOM';
+  sslStatus: 'ACTIVE' | 'PENDING' | 'EXPIRED';
+  sslExpiry: string;
+  tenantName: string;
+  createdAt: string;
+}[] = [
+  { id: 1, domain: 'learn.megazone.com', type: 'CUSTOM', sslStatus: 'ACTIVE', sslExpiry: '2026-06-15', tenantName: '메가존클라우드', createdAt: '2025-01-15' },
+  { id: 2, domain: 'edu.samsung.com', type: 'CUSTOM', sslStatus: 'ACTIVE', sslExpiry: '2026-03-20', tenantName: '삼성전자', createdAt: '2025-02-10' },
+  { id: 3, domain: 'mzc.lp.cloud', type: 'PRIMARY', sslStatus: 'ACTIVE', sslExpiry: '2026-12-01', tenantName: '기본 도메인', createdAt: '2024-01-01' },
+  { id: 4, domain: 'training.kakao.com', type: 'CUSTOM', sslStatus: 'PENDING', sslExpiry: '-', tenantName: '카카오', createdAt: '2025-12-28' },
+];
+
+const sslStatusConfig = {
+  ACTIVE: { label: '활성', icon: CheckCircle, color: 'bg-green-100 text-green-700' },
+  PENDING: { label: '발급중', icon: Clock, color: 'bg-yellow-100 text-yellow-700' },
+  EXPIRED: { label: '만료됨', icon: AlertCircle, color: 'bg-red-100 text-red-700' },
+};
+
+export function DomainSettingsPage() {
+  const [domains] = useState(mockDomains);
+  const [forceHttps, setForceHttps] = useState(true);
+  const [autoRenewSsl, setAutoRenewSsl] = useState(true);
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="도메인 및 SSL 설정"
+        description="시스템 도메인과 SSL 인증서를 관리합니다"
+        actions={
+          <Button>
+            <Plus className="mr-2 h-4 w-4" />
+            도메인 추가
+          </Button>
+        }
+      />
+
+      {/* Global Settings */}
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>전역 설정</CardTitle>
+          <CardDescription>모든 도메인에 적용되는 설정입니다</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-medium">HTTPS 강제 적용</p>
+              <p className="text-sm text-text-secondary">모든 HTTP 요청을 HTTPS로 리다이렉트합니다</p>
+            </div>
+            <Switch checked={forceHttps} onCheckedChange={setForceHttps} />
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-medium">SSL 인증서 자동 갱신</p>
+              <p className="text-sm text-text-secondary">만료 30일 전에 자동으로 갱신합니다</p>
+            </div>
+            <Switch checked={autoRenewSsl} onCheckedChange={setAutoRenewSsl} />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Domain List */}
+      <Card>
+        <CardHeader>
+          <CardTitle>등록된 도메인</CardTitle>
+          <CardDescription>시스템에 등록된 도메인 목록입니다</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {domains.map((domain) => {
+              const statusConfig = sslStatusConfig[domain.sslStatus];
+              const StatusIcon = statusConfig.icon;
+
+              return (
+                <div key={domain.id} className="flex items-center justify-between p-4 border rounded-lg hover:bg-bg-secondary">
+                  <div className="flex items-center gap-4">
+                    <div className="p-2 bg-bg-secondary rounded-lg">
+                      {domain.type === 'PRIMARY' ? (
+                        <Shield className="h-5 w-5 text-brand-primary" />
+                      ) : (
+                        <Globe className="h-5 w-5 text-text-secondary" />
+                      )}
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <p className="font-medium">{domain.domain}</p>
+                        {domain.type === 'PRIMARY' && (
+                          <Badge variant="outline">기본</Badge>
+                        )}
+                      </div>
+                      <p className="text-sm text-text-secondary">{domain.tenantName}</p>
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-4">
+                    <div className="text-right">
+                      <div className="flex items-center gap-1">
+                        <StatusIcon className="h-4 w-4" />
+                        <Badge className={statusConfig.color}>{statusConfig.label}</Badge>
+                      </div>
+                      {domain.sslExpiry !== '-' && (
+                        <p className="text-xs text-text-secondary mt-1">만료: {domain.sslExpiry}</p>
+                      )}
+                    </div>
+
+                    <div className="flex items-center gap-1">
+                      <Button variant="ghost" size="sm">
+                        <RefreshCw className="h-4 w-4" />
+                      </Button>
+                      {domain.type !== 'PRIMARY' && (
+                        <Button variant="ghost" size="sm" className="text-red-500 hover:text-red-600">
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/sa/system/EmailTemplatesPage.tsx
+++ b/src/pages/sa/system/EmailTemplatesPage.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import {
+  Mail,
+  Plus,
+  Search,
+  Edit,
+  Copy,
+  Eye,
+  Send,
+} from 'lucide-react';
+import { AdminPageHeader } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Badge } from '@/components/common/Badge';
+import { Tabs, TabsList, TabsTrigger } from '@/components/common/Tabs';
+
+// Mock 데이터
+const mockTemplates: {
+  id: number;
+  name: string;
+  code: string;
+  category: 'AUTH' | 'NOTIFICATION' | 'MARKETING' | 'SYSTEM';
+  subject: string;
+  description: string;
+  lastModified: string;
+  isActive: boolean;
+}[] = [
+  { id: 1, name: '회원가입 환영', code: 'WELCOME', category: 'AUTH', subject: '[MZC Learn] 회원가입을 환영합니다!', description: '새 사용자 회원가입 시 발송', lastModified: '2025-12-28', isActive: true },
+  { id: 2, name: '비밀번호 재설정', code: 'PASSWORD_RESET', category: 'AUTH', subject: '[MZC Learn] 비밀번호 재설정 안내', description: '비밀번호 재설정 요청 시 발송', lastModified: '2025-12-27', isActive: true },
+  { id: 3, name: '이메일 인증', code: 'EMAIL_VERIFY', category: 'AUTH', subject: '[MZC Learn] 이메일 인증을 완료해주세요', description: '이메일 인증 요청 시 발송', lastModified: '2025-12-26', isActive: true },
+  { id: 4, name: '수강신청 완료', code: 'ENROLLMENT_COMPLETE', category: 'NOTIFICATION', subject: '[MZC Learn] 수강신청이 완료되었습니다', description: '수강신청 완료 시 발송', lastModified: '2025-12-25', isActive: true },
+  { id: 5, name: '과정 완료 축하', code: 'COURSE_COMPLETE', category: 'NOTIFICATION', subject: '[MZC Learn] 축하합니다!', description: '과정 완료 시 발송', lastModified: '2025-12-23', isActive: true },
+  { id: 6, name: '뉴스레터', code: 'NEWSLETTER', category: 'MARKETING', subject: '[MZC Learn] 이번 주 추천 강좌', description: '정기 뉴스레터', lastModified: '2025-12-20', isActive: false },
+  { id: 7, name: '시스템 점검 안내', code: 'MAINTENANCE', category: 'SYSTEM', subject: '[MZC Learn] 시스템 점검 안내', description: '시스템 점검 공지', lastModified: '2025-12-15', isActive: true },
+];
+
+const categoryConfig = {
+  AUTH: { label: '인증', color: 'bg-blue-100 text-blue-700' },
+  NOTIFICATION: { label: '알림', color: 'bg-green-100 text-green-700' },
+  MARKETING: { label: '마케팅', color: 'bg-purple-100 text-purple-700' },
+  SYSTEM: { label: '시스템', color: 'bg-gray-100 text-gray-700' },
+};
+
+export function EmailTemplatesPage() {
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState<string>('all');
+
+  const filteredTemplates = mockTemplates.filter((template) => {
+    const matchesSearch = template.name.toLowerCase().includes(searchKeyword.toLowerCase()) ||
+      template.code.toLowerCase().includes(searchKeyword.toLowerCase());
+    const matchesCategory = categoryFilter === 'all' || template.category === categoryFilter;
+    return matchesSearch && matchesCategory;
+  });
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="이메일 템플릿 관리"
+        description="시스템에서 발송되는 이메일 템플릿을 관리합니다"
+        actions={
+          <Button>
+            <Plus className="mr-2 h-4 w-4" />
+            템플릿 추가
+          </Button>
+        }
+      />
+
+      <Tabs value={categoryFilter} onValueChange={setCategoryFilter} className="mb-6">
+        <TabsList>
+          <TabsTrigger value="all">전체</TabsTrigger>
+          <TabsTrigger value="AUTH">인증</TabsTrigger>
+          <TabsTrigger value="NOTIFICATION">알림</TabsTrigger>
+          <TabsTrigger value="MARKETING">마케팅</TabsTrigger>
+          <TabsTrigger value="SYSTEM">시스템</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      <div className="mb-6">
+        <div className="relative w-96">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-secondary" />
+          <Input
+            placeholder="템플릿 검색..."
+            value={searchKeyword}
+            onChange={(e) => setSearchKeyword(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {filteredTemplates.map((template) => {
+          const category = categoryConfig[template.category];
+          return (
+            <Card key={template.id} className={!template.isActive ? 'opacity-60' : ''}>
+              <CardHeader className="pb-2">
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center gap-2">
+                    <div className="p-2 bg-bg-secondary rounded-lg">
+                      <Mail className="h-4 w-4 text-text-secondary" />
+                    </div>
+                    <div>
+                      <CardTitle className="text-base">{template.name}</CardTitle>
+                      <code className="text-xs text-text-secondary">{template.code}</code>
+                    </div>
+                  </div>
+                  <Badge className={category.color}>{category.label}</Badge>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-text-secondary mb-3">{template.description}</p>
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-text-secondary">수정: {template.lastModified}</span>
+                  <div className="flex items-center gap-1">
+                    <Button variant="ghost" size="sm"><Eye className="h-4 w-4" /></Button>
+                    <Button variant="ghost" size="sm"><Edit className="h-4 w-4" /></Button>
+                    <Button variant="ghost" size="sm"><Copy className="h-4 w-4" /></Button>
+                    <Button variant="ghost" size="sm"><Send className="h-4 w-4" /></Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/sa/system/OperatorsPage.tsx
+++ b/src/pages/sa/system/OperatorsPage.tsx
@@ -1,0 +1,212 @@
+import { useState } from 'react';
+import {
+  UserCog,
+  Plus,
+  Search,
+  MoreVertical,
+  Mail,
+  Phone,
+  Shield,
+} from 'lucide-react';
+import { AdminPageHeader, StatusBadge, RoleBadge } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/common/Select';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/common/Avatar';
+import type { UserStatus, SystemRole } from '@/types/admin';
+
+// Mock 데이터
+const mockOperators: {
+  id: number;
+  name: string;
+  email: string;
+  phone: string;
+  role: SystemRole;
+  status: UserStatus;
+  department: string;
+  lastLogin: string;
+  createdAt: string;
+}[] = [
+  { id: 1, name: '김시스템', email: 'kim.system@mzc.com', phone: '010-1234-5678', role: 'SYSTEM_ADMIN', status: 'ACTIVE', department: '시스템운영팀', lastLogin: '2025-12-30 09:15', createdAt: '2024-01-15' },
+  { id: 2, name: '이운영', email: 'lee.ops@mzc.com', phone: '010-2345-6789', role: 'OPERATOR', status: 'ACTIVE', department: '고객지원팀', lastLogin: '2025-12-30 10:22', createdAt: '2024-03-20' },
+  { id: 3, name: '박관리', email: 'park.admin@mzc.com', phone: '010-3456-7890', role: 'OPERATOR', status: 'ACTIVE', department: '기술지원팀', lastLogin: '2025-12-29 16:45', createdAt: '2024-06-10' },
+  { id: 4, name: '최보안', email: 'choi.sec@mzc.com', phone: '010-4567-8901', role: 'SYSTEM_ADMIN', status: 'INACTIVE', department: '보안팀', lastLogin: '2025-12-01 11:30', createdAt: '2024-02-28' },
+  { id: 5, name: '정모니터', email: 'jung.mon@mzc.com', phone: '010-5678-9012', role: 'OPERATOR', status: 'ACTIVE', department: '모니터링팀', lastLogin: '2025-12-30 08:00', createdAt: '2024-08-15' },
+];
+
+export function OperatorsPage() {
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [roleFilter, setRoleFilter] = useState<string>('all');
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+
+  const filteredOperators = mockOperators.filter((op) => {
+    const matchesSearch = op.name.toLowerCase().includes(searchKeyword.toLowerCase()) ||
+      op.email.toLowerCase().includes(searchKeyword.toLowerCase());
+    const matchesRole = roleFilter === 'all' || op.role === roleFilter;
+    const matchesStatus = statusFilter === 'all' || op.status === statusFilter;
+    return matchesSearch && matchesRole && matchesStatus;
+  });
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="운영자 관리"
+        description="시스템 운영자를 관리합니다"
+        actions={
+          <Button>
+            <Plus className="mr-2 h-4 w-4" />
+            운영자 추가
+          </Button>
+        }
+      />
+
+      {/* Stats Summary */}
+      <div className="grid grid-cols-4 gap-4 mb-6">
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-brand-primary/10 rounded-lg">
+                <UserCog className="h-5 w-5 text-brand-primary" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockOperators.length}</p>
+                <p className="text-sm text-text-secondary">전체 운영자</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-green-100 rounded-lg">
+                <Shield className="h-5 w-5 text-green-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockOperators.filter(o => o.role === 'SYSTEM_ADMIN').length}</p>
+                <p className="text-sm text-text-secondary">시스템 관리자</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-blue-100 rounded-lg">
+                <UserCog className="h-5 w-5 text-blue-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockOperators.filter(o => o.role === 'OPERATOR').length}</p>
+                <p className="text-sm text-text-secondary">일반 운영자</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-gray-100 rounded-lg">
+                <UserCog className="h-5 w-5 text-gray-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{mockOperators.filter(o => o.status === 'ACTIVE').length}</p>
+                <p className="text-sm text-text-secondary">활성 운영자</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Operators List */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>운영자 목록</CardTitle>
+              <CardDescription>시스템에 등록된 운영자를 관리합니다</CardDescription>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-secondary" />
+                <Input
+                  placeholder="이름, 이메일 검색..."
+                  value={searchKeyword}
+                  onChange={(e) => setSearchKeyword(e.target.value)}
+                  className="pl-9 w-64"
+                />
+              </div>
+              <Select value={roleFilter} onValueChange={setRoleFilter}>
+                <SelectTrigger className="w-36">
+                  <SelectValue placeholder="역할" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">전체 역할</SelectItem>
+                  <SelectItem value="SYSTEM_ADMIN">시스템 관리자</SelectItem>
+                  <SelectItem value="OPERATOR">운영자</SelectItem>
+                </SelectContent>
+              </Select>
+              <Select value={statusFilter} onValueChange={setStatusFilter}>
+                <SelectTrigger className="w-32">
+                  <SelectValue placeholder="상태" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">전체 상태</SelectItem>
+                  <SelectItem value="ACTIVE">활성</SelectItem>
+                  <SelectItem value="INACTIVE">비활성</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {filteredOperators.map((operator) => (
+              <div key={operator.id} className="flex items-center justify-between p-4 border rounded-lg hover:bg-bg-secondary transition-colors">
+                <div className="flex items-center gap-4">
+                  <Avatar className="h-12 w-12">
+                    <AvatarImage src={`https://api.dicebear.com/7.x/initials/svg?seed=${operator.name}`} />
+                    <AvatarFallback>{operator.name.slice(0, 2)}</AvatarFallback>
+                  </Avatar>
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <p className="font-medium">{operator.name}</p>
+                      <RoleBadge role={operator.role} />
+                      <StatusBadge status={operator.status} />
+                    </div>
+                    <p className="text-sm text-text-secondary">{operator.department}</p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-6">
+                  <div className="text-sm">
+                    <div className="flex items-center gap-1 text-text-secondary">
+                      <Mail className="h-3 w-3" />
+                      {operator.email}
+                    </div>
+                    <div className="flex items-center gap-1 text-text-secondary mt-1">
+                      <Phone className="h-3 w-3" />
+                      {operator.phone}
+                    </div>
+                  </div>
+                  <div className="text-right text-sm">
+                    <p className="text-text-secondary">최근 로그인</p>
+                    <p>{operator.lastLogin}</p>
+                  </div>
+                  <Button variant="ghost" size="sm">
+                    <MoreVertical className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/sa/system/index.ts
+++ b/src/pages/sa/system/index.ts
@@ -1,0 +1,4 @@
+export { DomainSettingsPage } from './DomainSettingsPage';
+export { OperatorsPage } from './OperatorsPage';
+export { BrandingSettingsPage } from './BrandingSettingsPage';
+export { EmailTemplatesPage } from './EmailTemplatesPage';

--- a/src/routes/sa.routes.tsx
+++ b/src/routes/sa.routes.tsx
@@ -7,8 +7,24 @@ import {
   SettingsNotificationsPage,
   SettingsAppearancePage,
 } from '@/pages/common';
-import { DashboardPage, TenantsPage, TenantDetailPage } from '@/pages/sa';
-import { PlaceholderPage } from './pages';
+import {
+  DashboardPage,
+  TenantsPage,
+  TenantDetailPage,
+  BillingPage,
+  TenantStatusPage,
+  DomainSettingsPage,
+  OperatorsPage,
+  BrandingSettingsPage,
+  EmailTemplatesPage,
+  NoticesPage,
+  NoticeDistributionPage,
+  UsagePage,
+  ActivityPage,
+  LogsPage,
+  SystemSettingsPage,
+  TenantDefaultsPage,
+} from '@/pages/sa';
 
 function SuperAdminWrapper() {
   return (
@@ -27,26 +43,26 @@ export const saRoutes = (
     {/* 테넌트 관리 */}
     <Route path="tenants" element={<TenantsPage />} />
     <Route path="tenants/:id" element={<TenantDetailPage />} />
-    <Route path="tenants/billing" element={<PlaceholderPage title="요금제 및 라이선스 관리" />} />
-    <Route path="tenants/status" element={<PlaceholderPage title="전체 현황 조회" />} />
+    <Route path="tenants/billing" element={<BillingPage />} />
+    <Route path="tenants/status" element={<TenantStatusPage />} />
     {/* 시스템 환경 관리 */}
-    <Route path="system/domain" element={<PlaceholderPage title="도메인 및 SSL 설정" />} />
-    <Route path="system/operators" element={<PlaceholderPage title="운영자 관리" />} />
-    <Route path="system/branding" element={<PlaceholderPage title="글로벌 브랜딩 설정" />} />
-    <Route path="system/email-templates" element={<PlaceholderPage title="이메일 템플릿 관리" />} />
+    <Route path="system/domain" element={<DomainSettingsPage />} />
+    <Route path="system/operators" element={<OperatorsPage />} />
+    <Route path="system/branding" element={<BrandingSettingsPage />} />
+    <Route path="system/email-templates" element={<EmailTemplatesPage />} />
     {/* 글로벌 공지 관리 */}
-    <Route path="notices" element={<PlaceholderPage title="공지사항 관리" />} />
-    <Route path="notices/distribution" element={<PlaceholderPage title="공지사항 배포 관리" />} />
+    <Route path="notices" element={<NoticesPage />} />
+    <Route path="notices/distribution" element={<NoticeDistributionPage />} />
     {/* 데이터 및 로그 분석 */}
-    <Route path="analytics/usage" element={<PlaceholderPage title="사용량 트렌드 및 통계" />} />
-    <Route path="analytics/activity" element={<PlaceholderPage title="활동 분석" />} />
-    <Route path="analytics/logs" element={<PlaceholderPage title="로그 관리" />} />
+    <Route path="analytics/usage" element={<UsagePage />} />
+    <Route path="analytics/activity" element={<ActivityPage />} />
+    <Route path="analytics/logs" element={<LogsPage />} />
     {/* 설정 */}
     <Route path="settings" element={<SettingsPage />} />
     <Route path="settings/security" element={<SettingsSecurityPage />} />
     <Route path="settings/notifications" element={<SettingsNotificationsPage />} />
     <Route path="settings/appearance" element={<SettingsAppearancePage />} />
-    <Route path="settings/system-settings" element={<PlaceholderPage title="시스템 설정" />} />
-    <Route path="settings/tenant-defaults" element={<PlaceholderPage title="테넌트 기본값" />} />
+    <Route path="settings/system-settings" element={<SystemSettingsPage />} />
+    <Route path="settings/tenant-defaults" element={<TenantDefaultsPage />} />
   </Route>
 );

--- a/src/types/admin/user.types.ts
+++ b/src/types/admin/user.types.ts
@@ -3,7 +3,7 @@
  */
 
 export type UserStatus = 'ACTIVE' | 'INACTIVE' | 'PENDING' | 'BLOCKED';
-export type SystemRole = 'SUPER_ADMIN' | 'TENANT_ADMIN' | 'OPERATOR' | 'USER';
+export type SystemRole = 'SUPER_ADMIN' | 'SYSTEM_ADMIN' | 'TENANT_ADMIN' | 'OPERATOR' | 'USER';
 export type CourseRole = 'DESIGNER' | 'OWNER' | 'INSTRUCTOR' | 'TUTOR' | 'VIEWER';
 
 export interface AdminUser {


### PR DESCRIPTION
## Summary

SA(System Admin) 관리자 페이지 전체 구현. PlaceholderPage를 실제 기능을 갖춘 관리 페이지로 교체했습니다.

## Related Issue

- Closes #120

## Changes

- 요금제 관리 페이지 (BillingPage, TenantStatusPage)
- 시스템 관리 페이지 (DomainSettingsPage, OperatorsPage, BrandingSettingsPage, EmailTemplatesPage)
- 공지사항 관리 페이지 (NoticesPage, NoticeDistributionPage)
- 분석/통계 페이지 (UsagePage, ActivityPage, LogsPage)
- 설정 페이지 (SystemSettingsPage, TenantDefaultsPage)
- SA 라우트 업데이트 (PlaceholderPage → 실제 컴포넌트)
- SystemRole 타입에 SYSTEM_ADMIN 추가

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)
<img width="1898" height="869" alt="image" src="https://github.com/user-attachments/assets/c2b5d6fb-70b5-4c4e-bd1b-00894df0ec35" />
<img width="1919" height="893" alt="image" src="https://github.com/user-attachments/assets/c55ad51d-e033-427f-bd11-d627fd96ad1d" />

## Additional Notes

- 현재 모든 데이터는 Mock 데이터로 구현되어 있습니다
- 백엔드 API 연동은 별도 이슈에서 진행 예정입니다