### PR TITLE
feat: CourseItem displayName/description UI 연동 #119

### DIFF
--- a/src/pages/tu/teaching/courses/CourseCreatePage.tsx
+++ b/src/pages/tu/teaching/courses/CourseCreatePage.tsx
@@ -96,12 +96,28 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
       const courseResponse = await courseService.create(request);
       const courseId = courseResponse.courseId;
 
-      // 2. 회차(폴더) 생성
+      // 2. 회차(폴더) 및 콘텐츠(차시) 생성
       if (formData.lessons.length > 0) {
         for (const lesson of formData.lessons) {
-          await courseService.createFolder(courseId, {
+          // 폴더 생성
+          const folderResponse = await courseService.createFolder(courseId, {
             folderName: lesson.title || `회차 ${lesson.order}`,
           });
+          const folderId = folderResponse.itemId;
+
+          // 해당 폴더 내 콘텐츠(차시) 생성
+          for (const content of lesson.contents) {
+            if (content.contentId) {
+              // LO가 연결된 콘텐츠인 경우 차시 생성
+              await courseService.createItem(courseId, {
+                itemName: content.name,
+                parentId: folderId,
+                learningObjectId: content.contentId,
+                displayName: content.displayName || undefined,
+                description: content.description || undefined,
+              });
+            }
+          }
         }
       }
 

--- a/src/pages/tu/teaching/courses/components/CourseCurriculumSection.tsx
+++ b/src/pages/tu/teaching/courses/components/CourseCurriculumSection.tsx
@@ -17,15 +17,29 @@ function CurriculumTreeItem({
   const paddingLeft = depth * 24;
   const Icon = item.isFolder ? Folder : FileText;
   const iconColor = item.isFolder ? 'text-amber-500' : 'text-text-secondary';
+  // displayName이 있으면 우선 표시, 없으면 itemName 사용
+  const displayName = item.displayName || item.itemName;
 
   return (
     <div>
       <div
-        className="flex items-center gap-2 py-2 px-3 hover:bg-bg-secondary rounded-md transition-colors"
+        className="flex items-start gap-2 py-2 px-3 hover:bg-bg-secondary rounded-md transition-colors"
         style={{ paddingLeft: `${paddingLeft + 12}px` }}
       >
-        <Icon size={16} className={iconColor} />
-        <span className="text-text-primary text-sm">{item.itemName}</span>
+        <Icon size={16} className={`${iconColor} mt-0.5 flex-shrink-0`} />
+        <div className="flex-1 min-w-0">
+          <span className="text-text-primary text-sm block">{displayName}</span>
+          {item.displayName && item.displayName !== item.itemName && (
+            <span className="text-text-tertiary text-xs block truncate">
+              원본: {item.itemName}
+            </span>
+          )}
+          {item.description && (
+            <span className="text-text-secondary text-xs block mt-0.5">
+              {item.description}
+            </span>
+          )}
+        </div>
       </div>
       {item.children && item.children.length > 0 && (
         <div>

--- a/src/pages/tu/teaching/courses/components/LessonCard.tsx
+++ b/src/pages/tu/teaching/courses/components/LessonCard.tsx
@@ -2,6 +2,7 @@
  * 회차 카드 컴포넌트
  * 담당: 콘텐츠 테이블 관련
  */
+import { useState } from 'react';
 import {
   GripVertical,
   ChevronDown,
@@ -10,10 +11,11 @@ import {
   Link as LinkIcon,
   FileText,
   Trash2,
+  Settings2,
 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button, Input, Textarea } from '@/components/common';
-import type { LessonData } from '@/types';
+import type { LessonData, ContentAttachment } from '@/types';
 import { translations, type TranslationKey } from './courseCreate.constants';
 
 interface LessonCardProps {
@@ -26,6 +28,7 @@ interface LessonCardProps {
   onDelete: () => void;
   onAddContent: (type: 'upload' | 'link' | 'existing') => void;
   onDeleteContent: (contentId: string) => void;
+  onUpdateContent: (contentId: string, updates: Partial<ContentAttachment>) => void;
   onDragStart: () => void;
   onDragOver: (e: React.DragEvent) => void;
   onDrop: () => void;
@@ -41,12 +44,19 @@ export function LessonCard({
   onDelete,
   onAddContent,
   onDeleteContent,
+  onUpdateContent,
   onDragStart,
   onDragOver,
   onDrop,
 }: Readonly<LessonCardProps>) {
+  const [expandedContentId, setExpandedContentId] = useState<string | null>(null);
+
   const getText = (key: TranslationKey) =>
     language === 'ko' ? translations[key].ko : translations[key].en;
+
+  const toggleContentExpand = (contentId: string) => {
+    setExpandedContentId(prev => prev === contentId ? null : contentId);
+  };
 
   return (
     <div
@@ -118,32 +128,75 @@ export function LessonCard({
             </label>
             {lesson.contents.length > 0 ? (
               <div className="flex flex-col gap-2 mb-3">
-                {lesson.contents.map((content) => (
-                  <div key={content.id} className="p-3 bg-bg-secondary rounded-md flex items-center gap-3">
-                    {content.type === 'upload' ? (
-                      <Upload size={18} className="text-text-secondary" />
-                    ) : content.type === 'existing' ? (
-                      <FileText size={18} className="text-text-secondary" />
-                    ) : (
-                      <LinkIcon size={18} className="text-text-secondary" />
-                    )}
-                    <div className="flex-1">
-                      <span className="text-text-primary text-sm">{content.name}</span>
-                      <span className="text-text-secondary text-xs ml-2">
-                        ({content.type === 'upload' ? '파일 업로드' : content.type === 'existing' ? getText('existingContent') : '외부 링크'})
-                      </span>
+                {lesson.contents.map((content) => {
+                  const isContentExpanded = expandedContentId === content.id;
+                  return (
+                    <div key={content.id} className="bg-bg-secondary rounded-md overflow-hidden">
+                      {/* 콘텐츠 헤더 */}
+                      <div className="p-3 flex items-center gap-3">
+                        {content.type === 'upload' ? (
+                          <Upload size={18} className="text-text-secondary flex-shrink-0" />
+                        ) : content.type === 'existing' ? (
+                          <FileText size={18} className="text-text-secondary flex-shrink-0" />
+                        ) : (
+                          <LinkIcon size={18} className="text-text-secondary flex-shrink-0" />
+                        )}
+                        <div className="flex-1 min-w-0">
+                          <span className="text-text-primary text-sm block truncate">
+                            {content.displayName || content.name}
+                          </span>
+                          {content.displayName && content.displayName !== content.name && (
+                            <span className="text-text-tertiary text-xs truncate block">
+                              원본: {content.name}
+                            </span>
+                          )}
+                        </div>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            toggleContentExpand(content.id);
+                          }}
+                          className={cn(
+                            "p-1.5 bg-transparent border-none cursor-pointer rounded transition-colors",
+                            isContentExpanded ? "bg-bg-tertiary" : "hover:bg-bg-tertiary"
+                          )}
+                          title={getText('contentDisplayName')}
+                        >
+                          <Settings2 size={16} className="text-text-secondary" />
+                        </button>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onDeleteContent(content.id);
+                          }}
+                          className="p-1.5 bg-transparent border-none cursor-pointer rounded hover:bg-status-error-bg"
+                        >
+                          <Trash2 size={16} className="text-action-delete" />
+                        </button>
+                      </div>
+                      {/* 콘텐츠 표시 정보 입력 (확장 시) */}
+                      {isContentExpanded && (
+                        <div className="px-3 pb-3 pt-1 border-t border-border bg-bg-default flex flex-col gap-3">
+                          <Input
+                            label={getText('contentDisplayName')}
+                            value={content.displayName || ''}
+                            onChange={(e) => onUpdateContent(content.id, { displayName: e.target.value })}
+                            placeholder={getText('contentDisplayNamePlaceholder')}
+                            onClick={(e) => e.stopPropagation()}
+                          />
+                          <Textarea
+                            label={getText('contentDescription')}
+                            value={content.description || ''}
+                            onChange={(e) => onUpdateContent(content.id, { description: e.target.value })}
+                            placeholder={getText('contentDescriptionPlaceholder')}
+                            onClick={(e) => e.stopPropagation()}
+                            rows={2}
+                          />
+                        </div>
+                      )}
                     </div>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onDeleteContent(content.id);
-                      }}
-                      className="p-1.5 bg-transparent border-none cursor-pointer rounded hover:bg-bg-secondary"
-                    >
-                      <Trash2 size={16} className="text-action-delete" />
-                    </button>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             ) : (
               <p className="text-text-secondary text-sm mb-3">{getText('noContents')}</p>

--- a/src/pages/tu/teaching/courses/components/Step2Curriculum.tsx
+++ b/src/pages/tu/teaching/courses/components/Step2Curriculum.tsx
@@ -97,6 +97,20 @@ export function Step2Curriculum({
     onFormDataChange({ lessons: updatedLessons });
   };
 
+  const updateContent = (lessonId: string, contentId: string, updates: Partial<ContentAttachment>) => {
+    const updatedLessons = formData.lessons.map((lesson) =>
+      lesson.id === lessonId
+        ? {
+            ...lesson,
+            contents: lesson.contents.map((c) =>
+              c.id === contentId ? { ...c, ...updates } : c
+            ),
+          }
+        : lesson
+    );
+    onFormDataChange({ lessons: updatedLessons });
+  };
+
   const handleDragStart = (lessonId: string) => setDraggedItem(lessonId);
   const handleDragOver = (e: React.DragEvent) => e.preventDefault();
 
@@ -143,6 +157,7 @@ export function Step2Curriculum({
                   onDelete={() => deleteLesson(lesson.id)}
                   onAddContent={(type) => openContentModal(lesson.id, type)}
                   onDeleteContent={(contentId) => deleteContent(lesson.id, contentId)}
+                  onUpdateContent={(contentId, updates) => updateContent(lesson.id, contentId, updates)}
                   onDragStart={() => handleDragStart(lesson.id)}
                   onDragOver={handleDragOver}
                   onDrop={() => handleDrop(lesson.id)}

--- a/src/pages/tu/teaching/courses/components/courseCreate.constants.ts
+++ b/src/pages/tu/teaching/courses/components/courseCreate.constants.ts
@@ -103,6 +103,11 @@ export const translations = {
   noContentFound: { ko: '콘텐츠가 없습니다', en: 'No content found' },
   select: { ko: '선택', en: 'Select' },
   existingContent: { ko: '기존 콘텐츠', en: 'Existing Content' },
+  // 콘텐츠 표시 정보
+  contentDisplayName: { ko: '강의 내 표시 이름', en: 'Display Name in Course' },
+  contentDisplayNamePlaceholder: { ko: '강의에서 표시할 이름 (미입력 시 원본 이름 사용)', en: 'Name to display in course (uses original name if empty)' },
+  contentDescription: { ko: '강의 내 설명', en: 'Description in Course' },
+  contentDescriptionPlaceholder: { ko: '강의에서 표시할 설명', en: 'Description to display in course' },
   // 공통
   cancel: { ko: '취소', en: 'Cancel' },
   processing: { ko: '처리 중...', en: 'Processing...' },

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -53,6 +53,8 @@ export const API_ENDPOINTS = {
       `/courses/${courseId}/items/${itemId}/name`,
     ITEM_LEARNING_OBJECT: (courseId: number, itemId: number) =>
       `/courses/${courseId}/items/${itemId}/learning-object`,
+    ITEM_DISPLAY_INFO: (courseId: number, itemId: number) =>
+      `/courses/${courseId}/items/${itemId}/display-info`,
     // Course Folders
     FOLDERS: (courseId: number) => `/courses/${courseId}/folders`,
   },

--- a/src/services/common/courseService.ts
+++ b/src/services/common/courseService.ts
@@ -15,6 +15,7 @@ import type {
   MoveItemRequest,
   UpdateItemNameRequest,
   UpdateLearningObjectRequest,
+  UpdateDisplayInfoRequest,
 } from '@/types/common/course.types';
 
 // Spring Page 응답 타입
@@ -185,5 +186,18 @@ export const courseService = {
     await axiosInstance.delete(
       API_ENDPOINTS.COURSES.ITEM_BY_ID(courseId, itemId)
     );
+  },
+
+  /** 표시 정보 변경 (displayName, description) */
+  async updateItemDisplayInfo(
+    courseId: number,
+    itemId: number,
+    request: UpdateDisplayInfoRequest
+  ): Promise<CourseItemResponse> {
+    const { data } = await axiosInstance.patch<{ data: CourseItemResponse }>(
+      API_ENDPOINTS.COURSES.ITEM_DISPLAY_INFO(courseId, itemId),
+      request
+    );
+    return data.data;
   },
 };

--- a/src/types/common/course.types.ts
+++ b/src/types/common/course.types.ts
@@ -42,6 +42,8 @@ export interface CourseItemResponse {
   parentId: number | null;
   learningObjectId: number | null;
   isFolder: boolean;
+  displayName: string | null;
+  description: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -53,6 +55,8 @@ export interface CourseItemHierarchyResponse {
   depth: number;
   learningObjectId: number | null;
   isFolder: boolean;
+  displayName: string | null;
+  description: string | null;
   children: CourseItemHierarchyResponse[];
 }
 
@@ -116,6 +120,8 @@ export interface CreateItemRequest {
   itemName: string;
   parentId?: number | null;
   learningObjectId: number;
+  displayName?: string;
+  description?: string;
 }
 
 /** 폴더 생성 요청 */
@@ -139,6 +145,12 @@ export interface UpdateItemNameRequest {
 /** 학습 객체 변경 요청 */
 export interface UpdateLearningObjectRequest {
   learningObjectId: number;
+}
+
+/** 표시 정보 변경 요청 */
+export interface UpdateDisplayInfoRequest {
+  displayName?: string;
+  description?: string;
 }
 
 // ============================================

--- a/src/types/to/course.types.ts
+++ b/src/types/to/course.types.ts
@@ -39,6 +39,10 @@ export interface ContentAttachment {
   contentType?: string;
   status?: 'pending' | 'uploading' | 'completed' | 'error';
   uploadProgress?: number;
+  /** 강의 내 표시용 이름 (CourseItem.displayName) */
+  displayName?: string;
+  /** 강의 내 표시용 설명 (CourseItem.description) */
+  description?: string;
 }
 
 /** 회차(레슨) 데이터 타입 */


### PR DESCRIPTION
## Summary
- 강의에 콘텐츠 추가 시 각 콘텐츠별로 표시 이름과 설명을 설정할 수 있는 UI 추가
- 강의 상세 페이지 커리큘럼 섹션에서 displayName/description 표시

## Changes
- LessonCard: 콘텐츠별 Settings2 아이콘으로 확장/축소 토글, displayName/description 입력 필드
- Step2Curriculum: updateContent 함수 추가, onUpdateContent prop 전달
- CourseCurriculumSection: displayName 우선 표시, description 표시
- courseCreate.constants: 콘텐츠 표시 정보 관련 번역 키 추가
- course.types: UpdateDisplayInfoRequest, Response DTO에 displayName/description 추가
- courseService: updateItemDisplayInfo API 메서드 추가
- endpoints: ITEM_DISPLAY_INFO 엔드포인트 추가
- CourseCreatePage: handleSubmit에서 콘텐츠 생성 시 displayName/description 전달

## Test plan
- [x] 강의 등록 > 회차 구성에서 콘텐츠 추가 후 톱니바퀴 아이콘 클릭
- [x] displayName, description 입력 후 저장
- [x] 강의 상세 페이지에서 설정된 이름/설명 표시 확인
- [x] DB에 display_name, description 저장 확인

Closes #119