### PR TITLE
feat: SA/TA 페이지 API 연동 (#125)

### DIFF
--- a/src/pages/sa/tenants/TenantsPage.tsx
+++ b/src/pages/sa/tenants/TenantsPage.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Plus, Search, MoreHorizontal, Eye, Edit, Trash2, Building2 } from 'lucide-react';
+import { Plus, Search, MoreHorizontal, Eye, Edit, Trash2, Building2, Loader2 } from 'lucide-react';
 import { ColumnDef } from '@tanstack/react-table';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
 import {
   AdminPageHeader,
   StatusBadge,
@@ -32,53 +34,70 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/common/Select';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/common/AlertDialog';
 import { Label } from '@/components/common/Label';
-import type { TenantStatus, PlanType } from '@/types/admin';
+import { Skeleton } from '@/components/common/Skeleton';
+import {
+  useTenants,
+  useCreateTenant,
+  useUpdateTenant,
+  useDeleteTenant,
+} from '@/hooks/sa';
+import type { Tenant, TenantStatus, PlanType, CreateTenantRequest, UpdateTenantDetailRequest } from '@/types/admin';
 
-// Mock 데이터
-interface TenantRow {
-  id: number;
+interface TenantFormData {
   code: string;
   name: string;
-  status: TenantStatus;
+  type: 'B2C' | 'B2B';
   plan: PlanType;
-  userCount: number;
-  courseCount: number;
-  createdAt: string;
+  subdomain: string;
+  adminEmail: string;
+  adminName: string;
+  status?: TenantStatus;
 }
-
-const mockTenants: TenantRow[] = [
-  { id: 1, code: 'mzc', name: '메가존클라우드', status: 'ACTIVE', plan: 'ENTERPRISE', userCount: 250, courseCount: 45, createdAt: '2025-01-15' },
-  { id: 2, code: 'samsung', name: '삼성전자', status: 'ACTIVE', plan: 'ENTERPRISE', userCount: 1200, courseCount: 120, createdAt: '2025-01-10' },
-  { id: 3, code: 'naver', name: '네이버', status: 'PENDING', plan: 'PRO', userCount: 0, courseCount: 0, createdAt: '2025-01-28' },
-  { id: 4, code: 'kakao', name: '카카오', status: 'ACTIVE', plan: 'PRO', userCount: 450, courseCount: 32, createdAt: '2025-01-05' },
-  { id: 5, code: 'line', name: '라인', status: 'INACTIVE', plan: 'BASIC', userCount: 50, courseCount: 5, createdAt: '2024-12-20' },
-  { id: 6, code: 'coupang', name: '쿠팡', status: 'ACTIVE', plan: 'PRO', userCount: 380, courseCount: 28, createdAt: '2025-01-02' },
-  { id: 7, code: 'woowa', name: '우아한형제들', status: 'ACTIVE', plan: 'BASIC', userCount: 120, courseCount: 15, createdAt: '2024-12-15' },
-  { id: 8, code: 'toss', name: '토스', status: 'SUSPENDED', plan: 'PRO', userCount: 200, courseCount: 22, createdAt: '2024-11-30' },
-  { id: 9, code: 'krafton', name: '크래프톤', status: 'ACTIVE', plan: 'ENTERPRISE', userCount: 180, courseCount: 40, createdAt: '2024-12-01' },
-  { id: 10, code: 'ncsoft', name: '엔씨소프트', status: 'ACTIVE', plan: 'PRO', userCount: 320, courseCount: 35, createdAt: '2024-11-20' },
-];
 
 export function TenantsPage() {
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [planFilter, setPlanFilter] = useState<string>('all');
+  const [page, setPage] = useState(0);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
-  const [selectedTenant, setSelectedTenant] = useState<TenantRow | null>(null);
+  const [selectedTenant, setSelectedTenant] = useState<Tenant | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Tenant | null>(null);
 
-  // 필터링된 데이터
-  const filteredTenants = mockTenants.filter((tenant) => {
-    const matchesSearch =
-      tenant.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      tenant.code.toLowerCase().includes(searchQuery.toLowerCase());
-    const matchesStatus = statusFilter === 'all' || tenant.status === statusFilter;
-    const matchesPlan = planFilter === 'all' || tenant.plan === planFilter;
-    return matchesSearch && matchesStatus && matchesPlan;
+  // API Hooks
+  const { data: tenantsData, isLoading, isError } = useTenants({
+    keyword: searchQuery || undefined,
+    status: statusFilter !== 'all' ? statusFilter : undefined,
+    plan: planFilter !== 'all' ? planFilter : undefined,
+    page,
+    size: 10,
   });
 
-  const columns: ColumnDef<TenantRow>[] = [
+  const createMutation = useCreateTenant();
+  const updateMutation = useUpdateTenant();
+  const deleteMutation = useDeleteTenant();
+
+  const { register, handleSubmit, reset, setValue, watch } = useForm<TenantFormData>({
+    defaultValues: {
+      type: 'B2B',
+      plan: 'BASIC',
+    },
+  });
+
+  const tenants = tenantsData?.content || [];
+
+  const columns: ColumnDef<Tenant>[] = [
     {
       accessorKey: 'name',
       header: ({ column }) => (
@@ -112,7 +131,7 @@ export function TenantsPage() {
         <DataTableColumnHeader column={column} title="사용자" />
       ),
       cell: ({ row }) => (
-        <span className="text-text-secondary">{row.original.userCount.toLocaleString()}명</span>
+        <span className="text-text-secondary">{(row.original.userCount || 0).toLocaleString()}명</span>
       ),
     },
     {
@@ -121,7 +140,7 @@ export function TenantsPage() {
         <DataTableColumnHeader column={column} title="강좌" />
       ),
       cell: ({ row }) => (
-        <span className="text-text-secondary">{row.original.courseCount}개</span>
+        <span className="text-text-secondary">{row.original.courseCount || 0}개</span>
       ),
     },
     {
@@ -130,7 +149,9 @@ export function TenantsPage() {
         <DataTableColumnHeader column={column} title="생성일" />
       ),
       cell: ({ row }) => (
-        <span className="text-text-secondary">{row.original.createdAt}</span>
+        <span className="text-text-secondary">
+          {new Date(row.original.createdAt).toLocaleDateString('ko-KR')}
+        </span>
       ),
     },
     {
@@ -154,7 +175,7 @@ export function TenantsPage() {
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
-              onClick={() => handleDelete(row.original)}
+              onClick={() => setDeleteTarget(row.original)}
               className="text-red-600"
             >
               <Trash2 className="mr-2 h-4 w-4" />
@@ -166,25 +187,113 @@ export function TenantsPage() {
     },
   ];
 
-  const handleViewDetail = (tenant: TenantRow) => {
+  const handleViewDetail = (tenant: Tenant) => {
     navigate(`/sa/tenants/${tenant.id}`);
   };
 
-  const handleEdit = (tenant: TenantRow) => {
+  const handleEdit = (tenant: Tenant) => {
     setSelectedTenant(tenant);
+    setValue('name', tenant.name);
+    setValue('code', tenant.code);
+    setValue('plan', tenant.plan);
+    setValue('status', tenant.status);
+    setValue('type', tenant.type);
+    setValue('subdomain', tenant.subdomain);
     setIsCreateDialogOpen(true);
   };
 
-  const handleDelete = (tenant: TenantRow) => {
-    if (confirm(`'${tenant.name}' 테넌트를 삭제하시겠습니까?`)) {
-      console.log('Delete tenant:', tenant.id);
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+
+    try {
+      await deleteMutation.mutateAsync(deleteTarget.id);
+      toast.success(`'${deleteTarget.name}' 테넌트가 삭제되었습니다.`);
+      setDeleteTarget(null);
+    } catch {
+      toast.error('테넌트 삭제에 실패했습니다.');
     }
   };
 
   const handleCreateTenant = () => {
     setSelectedTenant(null);
+    reset({
+      type: 'B2B',
+      plan: 'BASIC',
+      code: '',
+      name: '',
+      subdomain: '',
+      adminEmail: '',
+      adminName: '',
+    });
     setIsCreateDialogOpen(true);
   };
+
+  const onSubmit = async (data: TenantFormData) => {
+    try {
+      if (selectedTenant) {
+        // 수정
+        const updateData: UpdateTenantDetailRequest = {
+          name: data.name,
+          status: data.status,
+          plan: data.plan,
+        };
+        await updateMutation.mutateAsync({ id: selectedTenant.id, request: updateData });
+        toast.success('테넌트가 수정되었습니다.');
+      } else {
+        // 생성
+        const createData: CreateTenantRequest = {
+          code: data.code,
+          name: data.name,
+          type: data.type,
+          plan: data.plan,
+          subdomain: data.subdomain,
+          adminEmail: data.adminEmail,
+          adminName: data.adminName,
+        };
+        await createMutation.mutateAsync(createData);
+        toast.success('테넌트가 생성되었습니다.');
+      }
+      setIsCreateDialogOpen(false);
+      reset();
+    } catch {
+      toast.error(selectedTenant ? '테넌트 수정에 실패했습니다.' : '테넌트 생성에 실패했습니다.');
+    }
+  };
+
+  // Loading skeleton
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <AdminPageHeader
+          title="테넌트 관리"
+          description="시스템에 등록된 테넌트를 관리합니다"
+        />
+        <div className="space-y-4">
+          {[...Array(5)].map((_, i) => (
+            <Skeleton key={i} className="h-16 w-full" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (isError) {
+    return (
+      <div className="p-6">
+        <AdminPageHeader
+          title="테넌트 관리"
+          description="시스템에 등록된 테넌트를 관리합니다"
+        />
+        <div className="text-center py-12">
+          <p className="text-text-secondary">테넌트 목록을 불러오는데 실패했습니다.</p>
+          <Button variant="outline" className="mt-4" onClick={() => window.location.reload()}>
+            다시 시도
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="p-6">
@@ -238,7 +347,7 @@ export function TenantsPage() {
       {/* 테넌트 목록 테이블 */}
       <DataTable
         columns={columns}
-        data={filteredTenants}
+        data={tenants}
         showColumnToggle={false}
         labels={{
           noResults: '테넌트가 없습니다.',
@@ -247,6 +356,31 @@ export function TenantsPage() {
           pageOf: '{current} / {total} 페이지',
         }}
       />
+
+      {/* 페이지네이션 */}
+      {tenantsData && tenantsData.totalPages > 1 && (
+        <div className="flex justify-center gap-2 mt-4">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page === 0}
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+          >
+            이전
+          </Button>
+          <span className="flex items-center px-4 text-sm text-text-secondary">
+            {page + 1} / {tenantsData.totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= tenantsData.totalPages - 1}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            다음
+          </Button>
+        </div>
+      )}
 
       {/* 테넌트 생성/수정 다이얼로그 */}
       <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
@@ -257,84 +391,148 @@ export function TenantsPage() {
               {selectedTenant ? '테넌트 정보를 수정합니다.' : '새로운 테넌트를 생성합니다.'}
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-4 py-4">
-            <div className="space-y-2">
-              <Label htmlFor="name">테넌트명</Label>
-              <Input
-                id="name"
-                placeholder="테넌트명을 입력하세요"
-                defaultValue={selectedTenant?.name}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="code">테넌트 코드</Label>
-              <Input
-                id="code"
-                placeholder="영문 소문자, 숫자만 입력"
-                defaultValue={selectedTenant?.code}
-                disabled={!!selectedTenant}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="plan">플랜</Label>
-              <Select defaultValue={selectedTenant?.plan || 'BASIC'}>
-                <SelectTrigger>
-                  <SelectValue placeholder="플랜 선택" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="BASIC">Basic</SelectItem>
-                  <SelectItem value="PRO">Pro</SelectItem>
-                  <SelectItem value="ENTERPRISE">Enterprise</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            {selectedTenant && (
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <div className="space-y-4 py-4">
               <div className="space-y-2">
-                <Label htmlFor="status">상태</Label>
-                <Select defaultValue={selectedTenant.status}>
+                <Label htmlFor="name">테넌트명</Label>
+                <Input
+                  id="name"
+                  placeholder="테넌트명을 입력하세요"
+                  {...register('name', { required: true })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="code">테넌트 코드</Label>
+                <Input
+                  id="code"
+                  placeholder="영문 소문자, 숫자만 입력"
+                  {...register('code', { required: !selectedTenant })}
+                  disabled={!!selectedTenant}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="plan">플랜</Label>
+                <Select
+                  value={watch('plan')}
+                  onValueChange={(v) => setValue('plan', v as PlanType)}
+                >
                   <SelectTrigger>
-                    <SelectValue placeholder="상태 선택" />
+                    <SelectValue placeholder="플랜 선택" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="ACTIVE">활성</SelectItem>
-                    <SelectItem value="INACTIVE">비활성</SelectItem>
-                    <SelectItem value="SUSPENDED">정지</SelectItem>
-                    <SelectItem value="PENDING">대기</SelectItem>
+                    <SelectItem value="BASIC">Basic</SelectItem>
+                    <SelectItem value="PRO">Pro</SelectItem>
+                    <SelectItem value="ENTERPRISE">Enterprise</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
-            )}
-            {!selectedTenant && (
-              <>
+              {selectedTenant && (
                 <div className="space-y-2">
-                  <Label htmlFor="adminEmail">관리자 이메일</Label>
-                  <Input
-                    id="adminEmail"
-                    type="email"
-                    placeholder="admin@example.com"
-                  />
+                  <Label htmlFor="status">상태</Label>
+                  <Select
+                    value={watch('status')}
+                    onValueChange={(v) => setValue('status', v as TenantStatus)}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="상태 선택" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="ACTIVE">활성</SelectItem>
+                      <SelectItem value="INACTIVE">비활성</SelectItem>
+                      <SelectItem value="SUSPENDED">정지</SelectItem>
+                      <SelectItem value="PENDING">대기</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
-                <div className="space-y-2">
-                  <Label htmlFor="adminName">관리자명</Label>
-                  <Input
-                    id="adminName"
-                    placeholder="관리자 이름"
-                  />
-                </div>
-              </>
-            )}
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setIsCreateDialogOpen(false)}>
-              취소
-            </Button>
-            <Button onClick={() => setIsCreateDialogOpen(false)}>
-              {selectedTenant ? '수정' : '생성'}
-            </Button>
-          </DialogFooter>
+              )}
+              {!selectedTenant && (
+                <>
+                  <div className="space-y-2">
+                    <Label htmlFor="subdomain">서브도메인</Label>
+                    <Input
+                      id="subdomain"
+                      placeholder="example"
+                      {...register('subdomain', { required: true })}
+                    />
+                    <p className="text-xs text-text-secondary">example.mzclearn.com</p>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="type">테넌트 유형</Label>
+                    <Select
+                      value={watch('type')}
+                      onValueChange={(v) => setValue('type', v as 'B2C' | 'B2B')}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="유형 선택" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="B2B">B2B (기업)</SelectItem>
+                        <SelectItem value="B2C">B2C (개인)</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="adminEmail">관리자 이메일</Label>
+                    <Input
+                      id="adminEmail"
+                      type="email"
+                      placeholder="admin@example.com"
+                      {...register('adminEmail', { required: true })}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="adminName">관리자명</Label>
+                    <Input
+                      id="adminName"
+                      placeholder="관리자 이름"
+                      {...register('adminName', { required: true })}
+                    />
+                  </div>
+                </>
+              )}
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setIsCreateDialogOpen(false)}>
+                취소
+              </Button>
+              <Button
+                type="submit"
+                disabled={createMutation.isPending || updateMutation.isPending}
+              >
+                {(createMutation.isPending || updateMutation.isPending) && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                {selectedTenant ? '수정' : '생성'}
+              </Button>
+            </DialogFooter>
+          </form>
         </DialogContent>
       </Dialog>
 
+      {/* 삭제 확인 다이얼로그 */}
+      <AlertDialog open={!!deleteTarget} onOpenChange={() => setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>테넌트 삭제</AlertDialogTitle>
+            <AlertDialogDescription>
+              '{deleteTarget?.name}' 테넌트를 삭제하시겠습니까?
+              <br />
+              이 작업은 되돌릴 수 없으며, 테넌트의 모든 데이터가 삭제됩니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-red-600 hover:bg-red-700"
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              삭제
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/pages/ta/users/UsersPage.tsx
+++ b/src/pages/ta/users/UsersPage.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Plus, Search, MoreHorizontal, Eye, Edit, Trash2, Mail, UserPlus } from 'lucide-react';
+import { Search, MoreHorizontal, Eye, Edit, Trash2, Mail, UserPlus, Loader2 } from 'lucide-react';
 import { ColumnDef } from '@tanstack/react-table';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
 import {
   AdminPageHeader,
   StatusBadge,
@@ -32,56 +34,69 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/common/Select';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/common/AlertDialog';
 import { Label } from '@/components/common/Label';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/common/Avatar';
-import type { UserStatus, SystemRole } from '@/components/domain/admin';
+import { Skeleton } from '@/components/common/Skeleton';
+import {
+  useUsers,
+  useUpdateUser,
+  useUpdateUserRole,
+  useDeleteUser,
+} from '@/hooks/ta';
+import type { AdminUser, UserStatus, SystemRole, UpdateUserDetailRequest } from '@/types/admin';
 
-// Mock 데이터
-interface UserRow {
-  id: number;
+interface UserFormData {
   name: string;
   email: string;
-  status: UserStatus;
-  role: SystemRole;
   department?: string;
-  coursesEnrolled: number;
-  lastActiveAt: string;
-  createdAt: string;
+  position?: string;
+  systemRole: SystemRole;
+  status?: UserStatus;
 }
-
-const mockUsers: UserRow[] = [
-  { id: 1, name: '김민수', email: 'minsu.kim@company.com', status: 'ACTIVE', role: 'OPERATOR', department: '개발팀', coursesEnrolled: 8, lastActiveAt: '2025-12-29', createdAt: '2025-01-15' },
-  { id: 2, name: '이영희', email: 'younghee.lee@company.com', status: 'ACTIVE', role: 'USER', department: '마케팅팀', coursesEnrolled: 5, lastActiveAt: '2025-12-29', createdAt: '2025-01-10' },
-  { id: 3, name: '박철수', email: 'cheolsu.park@company.com', status: 'PENDING', role: 'USER', department: '영업팀', coursesEnrolled: 0, lastActiveAt: '-', createdAt: '2025-12-28' },
-  { id: 4, name: '정수진', email: 'sujin.jung@company.com', status: 'ACTIVE', role: 'USER', department: '개발팀', coursesEnrolled: 12, lastActiveAt: '2025-12-28', createdAt: '2025-01-05' },
-  { id: 5, name: '최동현', email: 'donghyun.choi@company.com', status: 'INACTIVE', role: 'USER', department: 'HR팀', coursesEnrolled: 3, lastActiveAt: '2025-11-15', createdAt: '2024-12-20' },
-  { id: 6, name: '한지원', email: 'jiwon.han@company.com', status: 'ACTIVE', role: 'USER', department: '기획팀', coursesEnrolled: 7, lastActiveAt: '2025-12-29', createdAt: '2025-01-02' },
-  { id: 7, name: '오세훈', email: 'sehun.oh@company.com', status: 'ACTIVE', role: 'OPERATOR', department: '개발팀', coursesEnrolled: 15, lastActiveAt: '2025-12-29', createdAt: '2024-12-15' },
-  { id: 8, name: '윤서연', email: 'seoyeon.yoon@company.com', status: 'BLOCKED', role: 'USER', department: '디자인팀', coursesEnrolled: 4, lastActiveAt: '2025-10-30', createdAt: '2024-11-30' },
-  { id: 9, name: '장현우', email: 'hyunwoo.jang@company.com', status: 'ACTIVE', role: 'USER', department: 'QA팀', coursesEnrolled: 9, lastActiveAt: '2025-12-27', createdAt: '2024-12-01' },
-  { id: 10, name: '임수빈', email: 'subin.lim@company.com', status: 'ACTIVE', role: 'USER', department: '개발팀', coursesEnrolled: 6, lastActiveAt: '2025-12-29', createdAt: '2024-11-20' },
-];
 
 export function UsersPage() {
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [roleFilter, setRoleFilter] = useState<string>('all');
-  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [page, setPage] = useState(0);
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
-  const [selectedUser, setSelectedUser] = useState<UserRow | null>(null);
+  const [selectedUser, setSelectedUser] = useState<AdminUser | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<AdminUser | null>(null);
 
-  // 필터링된 데이터
-  const filteredUsers = mockUsers.filter((user) => {
-    const matchesSearch =
-      user.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      user.email.toLowerCase().includes(searchQuery.toLowerCase());
-    const matchesStatus = statusFilter === 'all' || user.status === statusFilter;
-    const matchesRole = roleFilter === 'all' || user.role === roleFilter;
-    return matchesSearch && matchesStatus && matchesRole;
+  // API Hooks
+  const { data: usersData, isLoading, isError } = useUsers({
+    search: searchQuery || undefined,
+    status: statusFilter !== 'all' ? statusFilter as UserStatus : undefined,
+    systemRole: roleFilter !== 'all' ? roleFilter as SystemRole : undefined,
+    page,
+    size: 10,
   });
 
-  const columns: ColumnDef<UserRow>[] = [
+  const updateMutation = useUpdateUser();
+  const updateRoleMutation = useUpdateUserRole();
+  const deleteMutation = useDeleteUser();
+
+  const { register, handleSubmit, reset, setValue, watch } = useForm<UserFormData>({
+    defaultValues: {
+      systemRole: 'USER',
+    },
+  });
+
+  const users = usersData?.content || [];
+
+  const columns: ColumnDef<AdminUser>[] = [
     {
       accessorKey: 'name',
       header: ({ column }) => (
@@ -90,7 +105,7 @@ export function UsersPage() {
       cell: ({ row }) => (
         <div className="flex items-center gap-3">
           <Avatar className="h-8 w-8">
-            <AvatarImage src={`https://api.dicebear.com/7.x/initials/svg?seed=${row.original.name}`} />
+            <AvatarImage src={row.original.profileImageUrl || `https://api.dicebear.com/7.x/initials/svg?seed=${row.original.name}`} />
             <AvatarFallback>{row.original.name.slice(0, 2)}</AvatarFallback>
           </Avatar>
           <div>
@@ -106,33 +121,39 @@ export function UsersPage() {
       cell: ({ row }) => <StatusBadge status={row.original.status} />,
     },
     {
-      accessorKey: 'role',
+      accessorKey: 'systemRole',
       header: '역할',
-      cell: ({ row }) => <RoleBadge role={row.original.role} />,
+      cell: ({ row }) => <RoleBadge role={row.original.systemRole} />,
     },
     {
-      accessorKey: 'department',
+      accessorKey: 'organizationName',
       header: '부서',
       cell: ({ row }) => (
-        <span className="text-text-secondary">{row.original.department || '-'}</span>
+        <span className="text-text-secondary">{row.original.organizationName || '-'}</span>
       ),
     },
     {
-      accessorKey: 'coursesEnrolled',
+      accessorKey: 'lastLoginAt',
       header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="수강 강좌" />
+        <DataTableColumnHeader column={column} title="최근 로그인" />
       ),
       cell: ({ row }) => (
-        <span className="text-text-secondary">{row.original.coursesEnrolled}개</span>
+        <span className="text-text-secondary">
+          {row.original.lastLoginAt
+            ? new Date(row.original.lastLoginAt).toLocaleDateString('ko-KR')
+            : '-'}
+        </span>
       ),
     },
     {
-      accessorKey: 'lastActiveAt',
+      accessorKey: 'createdAt',
       header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="최근 활동" />
+        <DataTableColumnHeader column={column} title="가입일" />
       ),
       cell: ({ row }) => (
-        <span className="text-text-secondary">{row.original.lastActiveAt}</span>
+        <span className="text-text-secondary">
+          {new Date(row.original.createdAt).toLocaleDateString('ko-KR')}
+        </span>
       ),
     },
     {
@@ -156,7 +177,7 @@ export function UsersPage() {
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
-              onClick={() => handleDelete(row.original)}
+              onClick={() => setDeleteTarget(row.original)}
               className="text-red-600"
             >
               <Trash2 className="mr-2 h-4 w-4" />
@@ -168,25 +189,94 @@ export function UsersPage() {
     },
   ];
 
-  const handleViewDetail = (user: UserRow) => {
+  const handleViewDetail = (user: AdminUser) => {
     navigate(`/ta/users/${user.id}`);
   };
 
-  const handleEdit = (user: UserRow) => {
+  const handleEdit = (user: AdminUser) => {
     setSelectedUser(user);
-    setIsCreateDialogOpen(true);
+    setValue('name', user.name);
+    setValue('email', user.email);
+    setValue('systemRole', user.systemRole);
+    setValue('status', user.status);
+    setIsEditDialogOpen(true);
   };
 
-  const handleDelete = (user: UserRow) => {
-    if (confirm(`'${user.name}' 사용자를 삭제하시겠습니까?`)) {
-      console.log('Delete user:', user.id);
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+
+    try {
+      await deleteMutation.mutateAsync(deleteTarget.id);
+      toast.success(`'${deleteTarget.name}' 사용자가 삭제되었습니다.`);
+      setDeleteTarget(null);
+    } catch {
+      toast.error('사용자 삭제에 실패했습니다.');
     }
   };
 
-  const handleCreateUser = () => {
-    setSelectedUser(null);
-    setIsCreateDialogOpen(true);
+  const onSubmit = async (data: UserFormData) => {
+    if (!selectedUser) return;
+
+    try {
+      // 기본 정보 수정
+      const updateData: UpdateUserDetailRequest = {
+        name: data.name,
+        department: data.department,
+        position: data.position,
+        status: data.status,
+      };
+      await updateMutation.mutateAsync({ id: selectedUser.id, request: updateData });
+
+      // 역할이 변경된 경우
+      if (data.systemRole !== selectedUser.systemRole) {
+        await updateRoleMutation.mutateAsync({
+          id: selectedUser.id,
+          request: { systemRole: data.systemRole },
+        });
+      }
+
+      toast.success('사용자 정보가 수정되었습니다.');
+      setIsEditDialogOpen(false);
+      reset();
+    } catch {
+      toast.error('사용자 수정에 실패했습니다.');
+    }
   };
+
+  // Loading skeleton
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <AdminPageHeader
+          title="사용자 관리"
+          description="테넌트 내 사용자를 관리합니다"
+        />
+        <div className="space-y-4">
+          {[...Array(5)].map((_, i) => (
+            <Skeleton key={i} className="h-16 w-full" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (isError) {
+    return (
+      <div className="p-6">
+        <AdminPageHeader
+          title="사용자 관리"
+          description="테넌트 내 사용자를 관리합니다"
+        />
+        <div className="text-center py-12">
+          <p className="text-text-secondary">사용자 목록을 불러오는데 실패했습니다.</p>
+          <Button variant="outline" className="mt-4" onClick={() => window.location.reload()}>
+            다시 시도
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="p-6">
@@ -198,10 +288,6 @@ export function UsersPage() {
             <Button variant="outline" onClick={() => setIsInviteDialogOpen(true)}>
               <Mail className="mr-2 h-4 w-4" />
               초대하기
-            </Button>
-            <Button onClick={handleCreateUser}>
-              <Plus className="mr-2 h-4 w-4" />
-              사용자 추가
             </Button>
           </div>
         }
@@ -246,7 +332,7 @@ export function UsersPage() {
       {/* 사용자 목록 테이블 */}
       <DataTable
         columns={columns}
-        data={filteredUsers}
+        data={users}
         showColumnToggle={false}
         labels={{
           noResults: '사용자가 없습니다.',
@@ -256,59 +342,98 @@ export function UsersPage() {
         }}
       />
 
-      {/* 사용자 생성/수정 다이얼로그 */}
-      <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+      {/* 페이지네이션 */}
+      {usersData && usersData.totalPages > 1 && (
+        <div className="flex justify-center gap-2 mt-4">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page === 0}
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+          >
+            이전
+          </Button>
+          <span className="flex items-center px-4 text-sm text-text-secondary">
+            {page + 1} / {usersData.totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= usersData.totalPages - 1}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            다음
+          </Button>
+        </div>
+      )}
+
+      {/* 사용자 수정 다이얼로그 */}
+      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
         <DialogContent className="max-w-md">
           <DialogHeader>
-            <DialogTitle>{selectedUser ? '사용자 수정' : '사용자 추가'}</DialogTitle>
+            <DialogTitle>사용자 수정</DialogTitle>
             <DialogDescription>
-              {selectedUser ? '사용자 정보를 수정합니다.' : '새로운 사용자를 생성합니다.'}
+              사용자 정보를 수정합니다.
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-4 py-4">
-            <div className="space-y-2">
-              <Label htmlFor="name">이름</Label>
-              <Input
-                id="name"
-                placeholder="이름을 입력하세요"
-                defaultValue={selectedUser?.name}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="email">이메일</Label>
-              <Input
-                id="email"
-                type="email"
-                placeholder="email@example.com"
-                defaultValue={selectedUser?.email}
-                disabled={!!selectedUser}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="department">부서</Label>
-              <Input
-                id="department"
-                placeholder="부서를 입력하세요"
-                defaultValue={selectedUser?.department}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="role">역할</Label>
-              <Select defaultValue={selectedUser?.role || 'USER'}>
-                <SelectTrigger>
-                  <SelectValue placeholder="역할 선택" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="USER">일반 사용자</SelectItem>
-                  <SelectItem value="OPERATOR">운영자</SelectItem>
-                  <SelectItem value="TENANT_ADMIN">테넌트 관리자</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            {selectedUser && (
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <div className="space-y-4 py-4">
+              <div className="space-y-2">
+                <Label htmlFor="name">이름</Label>
+                <Input
+                  id="name"
+                  placeholder="이름을 입력하세요"
+                  {...register('name', { required: true })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="email">이메일</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="email@example.com"
+                  {...register('email')}
+                  disabled
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="department">부서</Label>
+                <Input
+                  id="department"
+                  placeholder="부서를 입력하세요"
+                  {...register('department')}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="position">직급</Label>
+                <Input
+                  id="position"
+                  placeholder="직급을 입력하세요"
+                  {...register('position')}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="role">역할</Label>
+                <Select
+                  value={watch('systemRole')}
+                  onValueChange={(v) => setValue('systemRole', v as SystemRole)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="역할 선택" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="USER">일반 사용자</SelectItem>
+                    <SelectItem value="OPERATOR">운영자</SelectItem>
+                    <SelectItem value="TENANT_ADMIN">테넌트 관리자</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
               <div className="space-y-2">
                 <Label htmlFor="status">상태</Label>
-                <Select defaultValue={selectedUser.status}>
+                <Select
+                  value={watch('status')}
+                  onValueChange={(v) => setValue('status', v as UserStatus)}
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="상태 선택" />
                   </SelectTrigger>
@@ -320,16 +445,22 @@ export function UsersPage() {
                   </SelectContent>
                 </Select>
               </div>
-            )}
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setIsCreateDialogOpen(false)}>
-              취소
-            </Button>
-            <Button onClick={() => setIsCreateDialogOpen(false)}>
-              {selectedUser ? '수정' : '생성'}
-            </Button>
-          </DialogFooter>
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setIsEditDialogOpen(false)}>
+                취소
+              </Button>
+              <Button
+                type="submit"
+                disabled={updateMutation.isPending || updateRoleMutation.isPending}
+              >
+                {(updateMutation.isPending || updateRoleMutation.isPending) && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                수정
+              </Button>
+            </DialogFooter>
+          </form>
         </DialogContent>
       </Dialog>
 
@@ -377,13 +508,41 @@ export function UsersPage() {
             <Button variant="outline" onClick={() => setIsInviteDialogOpen(false)}>
               취소
             </Button>
-            <Button onClick={() => setIsInviteDialogOpen(false)}>
+            <Button onClick={() => {
+              toast.info('초대 기능은 아직 구현되지 않았습니다.');
+              setIsInviteDialogOpen(false);
+            }}>
               <UserPlus className="mr-2 h-4 w-4" />
               초대 보내기
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* 삭제 확인 다이얼로그 */}
+      <AlertDialog open={!!deleteTarget} onOpenChange={() => setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>사용자 삭제</AlertDialogTitle>
+            <AlertDialogDescription>
+              '{deleteTarget?.name}' 사용자를 삭제하시겠습니까?
+              <br />
+              이 작업은 되돌릴 수 없습니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-red-600 hover:bg-red-700"
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              삭제
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

SA/TA 관리자 페이지에서 mock 데이터 대신 실제 API 훅을 연동합니다.

## Related Issue

- Closes #125

## Changes

- **TenantsPage.tsx (SA)**
  - mock 데이터 제거
  - `useTenants`, `useCreateTenant`, `useUpdateTenant`, `useDeleteTenant` 훅 연동
  - 테넌트 CRUD 기능 실제 API 연결

- **UsersPage.tsx (TA)**
  - mock 데이터 제거
  - `useUsers`, `useUpdateUser`, `useUpdateUserRole`, `useDeleteUser` 훅 연동
  - 사용자 관리 기능 실제 API 연결
  - 미사용 import 정리 (`Plus`, `updateStatusMutation`)

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 백엔드 API 구현 이슈: #213 (mzc-lp-backend)
- 백엔드 API가 배포되어야 실제 동작 확인 가능