### PR TITLE
feat: TA/SA 페이지 API 연동 (#127)

### DIFF
--- a/src/hooks/sa/index.ts
+++ b/src/hooks/sa/index.ts
@@ -7,3 +7,17 @@ export {
   useUpdateTenant,
   useDeleteTenant,
 } from './useTenantQueries';
+
+export {
+  noticeKeys,
+  useNotices,
+  useNotice,
+  useDistributedTenants,
+  useCreateNotice,
+  useUpdateNotice,
+  useDeleteNotice,
+  usePublishNotice,
+  useArchiveNotice,
+  useDistributeNotice,
+  useDistributeAllNotice,
+} from './useNoticeQueries';

--- a/src/hooks/sa/useNoticeQueries.ts
+++ b/src/hooks/sa/useNoticeQueries.ts
@@ -1,0 +1,146 @@
+/**
+ * Notice React Query Hooks (SA - Super Admin)
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { noticeService } from '@/services/sa';
+import type {
+  NoticeListParams,
+  CreateNoticeRequest,
+  UpdateNoticeRequest,
+  DistributeNoticeRequest,
+} from '@/types/admin';
+
+// Query Keys
+export const noticeKeys = {
+  all: ['notices'] as const,
+  lists: () => [...noticeKeys.all, 'list'] as const,
+  list: (params?: NoticeListParams) => [...noticeKeys.lists(), params] as const,
+  details: () => [...noticeKeys.all, 'detail'] as const,
+  detail: (id: number) => [...noticeKeys.details(), id] as const,
+  tenants: (id: number) => [...noticeKeys.all, 'tenants', id] as const,
+};
+
+// ============================================
+// Queries
+// ============================================
+
+/** 공지사항 목록 조회 */
+export const useNotices = (params?: NoticeListParams) => {
+  return useQuery({
+    queryKey: noticeKeys.list(params),
+    queryFn: () => noticeService.getNotices(params),
+  });
+};
+
+/** 공지사항 상세 조회 */
+export const useNotice = (id: number) => {
+  return useQuery({
+    queryKey: noticeKeys.detail(id),
+    queryFn: () => noticeService.getNotice(id),
+    enabled: !!id,
+  });
+};
+
+/** 배포된 테넌트 목록 조회 */
+export const useDistributedTenants = (id: number) => {
+  return useQuery({
+    queryKey: noticeKeys.tenants(id),
+    queryFn: () => noticeService.getDistributedTenants(id),
+    enabled: !!id,
+  });
+};
+
+// ============================================
+// Mutations
+// ============================================
+
+/** 공지사항 생성 */
+export const useCreateNotice = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateNoticeRequest) => noticeService.create(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: noticeKeys.lists() });
+    },
+  });
+};
+
+/** 공지사항 수정 */
+export const useUpdateNotice = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: { id: number; request: UpdateNoticeRequest }) =>
+      noticeService.update(id, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: noticeKeys.detail(variables.id) });
+      queryClient.invalidateQueries({ queryKey: noticeKeys.lists() });
+    },
+  });
+};
+
+/** 공지사항 삭제 */
+export const useDeleteNotice = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => noticeService.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: noticeKeys.lists() });
+    },
+  });
+};
+
+/** 공지사항 발행 */
+export const usePublishNotice = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => noticeService.publish(id),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: noticeKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: noticeKeys.lists() });
+    },
+  });
+};
+
+/** 공지사항 보관 */
+export const useArchiveNotice = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => noticeService.archive(id),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: noticeKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: noticeKeys.lists() });
+    },
+  });
+};
+
+/** 특정 테넌트에 배포 */
+export const useDistributeNotice = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: { id: number; request: DistributeNoticeRequest }) =>
+      noticeService.distribute(id, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: noticeKeys.detail(variables.id) });
+      queryClient.invalidateQueries({ queryKey: noticeKeys.tenants(variables.id) });
+    },
+  });
+};
+
+/** 전체 테넌트에 배포 */
+export const useDistributeAllNotice = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => noticeService.distributeAll(id),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: noticeKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: noticeKeys.tenants(id) });
+    },
+  });
+};

--- a/src/hooks/ta/index.ts
+++ b/src/hooks/ta/index.ts
@@ -8,3 +8,23 @@ export {
   useUpdateUserStatus,
   useDeleteUser,
 } from './useUserQueries';
+
+export {
+  groupKeys,
+  useGroups,
+  useActiveGroups,
+  useGroup,
+  useCreateGroup,
+  useUpdateGroup,
+  useDeleteGroup,
+  useAddGroupMember,
+  useRemoveGroupMember,
+} from './useGroupQueries';
+
+export {
+  tenantSettingsKeys,
+  useTenantSettings,
+  useUpdateTenantSettings,
+  useUpdateBranding,
+  useUpdateUserManagement,
+} from './useTenantSettingsQueries';

--- a/src/hooks/ta/useGroupQueries.ts
+++ b/src/hooks/ta/useGroupQueries.ts
@@ -1,0 +1,122 @@
+/**
+ * User Group React Query Hooks (TA - Tenant Admin)
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { groupService } from '@/services/ta';
+import type {
+  UserGroupListParams,
+  CreateUserGroupRequest,
+  UpdateUserGroupRequest,
+} from '@/types/admin';
+
+// Query Keys
+export const groupKeys = {
+  all: ['groups'] as const,
+  lists: () => [...groupKeys.all, 'list'] as const,
+  list: (params?: UserGroupListParams) => [...groupKeys.lists(), params] as const,
+  active: () => [...groupKeys.all, 'active'] as const,
+  details: () => [...groupKeys.all, 'detail'] as const,
+  detail: (id: number) => [...groupKeys.details(), id] as const,
+};
+
+// ============================================
+// Queries
+// ============================================
+
+/** 그룹 목록 조회 */
+export const useGroups = (params?: UserGroupListParams) => {
+  return useQuery({
+    queryKey: groupKeys.list(params),
+    queryFn: () => groupService.getGroups(params),
+  });
+};
+
+/** 활성 그룹 목록 조회 */
+export const useActiveGroups = () => {
+  return useQuery({
+    queryKey: groupKeys.active(),
+    queryFn: () => groupService.getActiveGroups(),
+  });
+};
+
+/** 그룹 상세 조회 */
+export const useGroup = (id: number) => {
+  return useQuery({
+    queryKey: groupKeys.detail(id),
+    queryFn: () => groupService.getGroup(id),
+    enabled: !!id,
+  });
+};
+
+// ============================================
+// Mutations
+// ============================================
+
+/** 그룹 생성 */
+export const useCreateGroup = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateUserGroupRequest) => groupService.create(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: groupKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: groupKeys.active() });
+    },
+  });
+};
+
+/** 그룹 수정 */
+export const useUpdateGroup = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: { id: number; request: UpdateUserGroupRequest }) =>
+      groupService.update(id, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: groupKeys.detail(variables.id) });
+      queryClient.invalidateQueries({ queryKey: groupKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: groupKeys.active() });
+    },
+  });
+};
+
+/** 그룹 삭제 */
+export const useDeleteGroup = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => groupService.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: groupKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: groupKeys.active() });
+    },
+  });
+};
+
+/** 그룹에 멤버 추가 */
+export const useAddGroupMember = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ groupId, userId }: { groupId: number; userId: number }) =>
+      groupService.addMember(groupId, userId),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: groupKeys.detail(variables.groupId) });
+      queryClient.invalidateQueries({ queryKey: groupKeys.lists() });
+    },
+  });
+};
+
+/** 그룹에서 멤버 제거 */
+export const useRemoveGroupMember = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ groupId, userId }: { groupId: number; userId: number }) =>
+      groupService.removeMember(groupId, userId),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: groupKeys.detail(variables.groupId) });
+      queryClient.invalidateQueries({ queryKey: groupKeys.lists() });
+    },
+  });
+};

--- a/src/hooks/ta/useTenantSettingsQueries.ts
+++ b/src/hooks/ta/useTenantSettingsQueries.ts
@@ -1,0 +1,71 @@
+/**
+ * Tenant Settings React Query Hooks (TA - Tenant Admin)
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { tenantSettingsService } from '@/services/ta';
+import type {
+  UpdateTenantSettingsRequest,
+  UpdateBrandingRequest,
+  UpdateUserManagementRequest,
+} from '@/types/admin';
+
+// Query Keys
+export const tenantSettingsKeys = {
+  all: ['tenantSettings'] as const,
+  detail: () => [...tenantSettingsKeys.all, 'detail'] as const,
+};
+
+// ============================================
+// Queries
+// ============================================
+
+/** 테넌트 설정 조회 */
+export const useTenantSettings = () => {
+  return useQuery({
+    queryKey: tenantSettingsKeys.detail(),
+    queryFn: () => tenantSettingsService.getSettings(),
+  });
+};
+
+// ============================================
+// Mutations
+// ============================================
+
+/** 테넌트 설정 전체 수정 */
+export const useUpdateTenantSettings = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: UpdateTenantSettingsRequest) =>
+      tenantSettingsService.update(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantSettingsKeys.detail() });
+    },
+  });
+};
+
+/** 브랜딩 설정 수정 */
+export const useUpdateBranding = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: UpdateBrandingRequest) =>
+      tenantSettingsService.updateBranding(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantSettingsKeys.detail() });
+    },
+  });
+};
+
+/** 사용자 관리 설정 수정 */
+export const useUpdateUserManagement = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: UpdateUserManagementRequest) =>
+      tenantSettingsService.updateUserManagement(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantSettingsKeys.detail() });
+    },
+  });
+};

--- a/src/pages/sa/notices/NoticesPage.tsx
+++ b/src/pages/sa/notices/NoticesPage.tsx
@@ -4,54 +4,153 @@ import {
   Search,
   Edit,
   Trash2,
-  Eye,
   Pin,
   Calendar,
+  Send,
+  Archive,
 } from 'lucide-react';
 import { AdminPageHeader } from '@/components/domain/admin';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
 import { Button } from '@/components/common/Button';
 import { Input } from '@/components/common/Input';
 import { Badge } from '@/components/common/Badge';
+import { Label } from '@/components/common/Label';
+import { Textarea } from '@/components/common/Textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/common/Dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/common/Select';
+import { Switch } from '@/components/common/Switch';
+import {
+  useNotices,
+  useCreateNotice,
+  useUpdateNotice,
+  useDeleteNotice,
+  usePublishNotice,
+  useArchiveNotice,
+} from '@/hooks/sa';
+import type {
+  Notice,
+  NoticeType,
+  NoticeStatus,
+  CreateNoticeRequest,
+  UpdateNoticeRequest,
+} from '@/types/admin';
 
-// Mock 데이터
-const mockNotices: {
-  id: number;
-  title: string;
-  content: string;
-  category: 'GENERAL' | 'UPDATE' | 'MAINTENANCE' | 'EVENT';
-  status: 'DRAFT' | 'PUBLISHED' | 'SCHEDULED';
-  isPinned: boolean;
-  views: number;
-  publishedAt: string | null;
-  createdAt: string;
-}[] = [
-  { id: 1, title: '2025년 1월 시스템 업데이트 안내', content: '새로운 기능이 추가됩니다...', category: 'UPDATE', status: 'PUBLISHED', isPinned: true, views: 1250, publishedAt: '2025-12-28', createdAt: '2025-12-27' },
-  { id: 2, title: '연말 시스템 점검 안내', content: '12월 31일 시스템 점검...', category: 'MAINTENANCE', status: 'PUBLISHED', isPinned: true, views: 890, publishedAt: '2025-12-25', createdAt: '2025-12-24' },
-  { id: 3, title: '신규 강좌 오픈 이벤트', content: '신규 강좌 50% 할인...', category: 'EVENT', status: 'PUBLISHED', isPinned: false, views: 2340, publishedAt: '2025-12-20', createdAt: '2025-12-19' },
-  { id: 4, title: '이용약관 변경 안내', content: '이용약관이 변경됩니다...', category: 'GENERAL', status: 'SCHEDULED', isPinned: false, views: 0, publishedAt: null, createdAt: '2025-12-29' },
-  { id: 5, title: '새해 맞이 특별 프로모션 (초안)', content: '2026년을 맞아...', category: 'EVENT', status: 'DRAFT', isPinned: false, views: 0, publishedAt: null, createdAt: '2025-12-30' },
-];
-
-const categoryConfig = {
+const typeConfig: Record<NoticeType, { label: string; color: string }> = {
   GENERAL: { label: '일반', color: 'bg-gray-100 text-gray-700' },
   UPDATE: { label: '업데이트', color: 'bg-blue-100 text-blue-700' },
-  MAINTENANCE: { label: '점검', color: 'bg-yellow-100 text-yellow-700' },
+  SYSTEM: { label: '시스템', color: 'bg-yellow-100 text-yellow-700' },
   EVENT: { label: '이벤트', color: 'bg-purple-100 text-purple-700' },
 };
 
-const statusConfig = {
+const statusConfig: Record<NoticeStatus, { label: string; color: string }> = {
   DRAFT: { label: '초안', color: 'bg-gray-100 text-gray-600' },
   PUBLISHED: { label: '게시됨', color: 'bg-green-100 text-green-700' },
-  SCHEDULED: { label: '예약됨', color: 'bg-blue-100 text-blue-700' },
+  ARCHIVED: { label: '보관됨', color: 'bg-orange-100 text-orange-700' },
 };
 
 export function NoticesPage() {
   const [searchKeyword, setSearchKeyword] = useState('');
+  const [statusFilter, setStatusFilter] = useState<NoticeStatus | 'ALL'>('ALL');
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [editingNotice, setEditingNotice] = useState<Notice | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Notice | null>(null);
 
-  const filteredNotices = mockNotices.filter((notice) =>
-    notice.title.toLowerCase().includes(searchKeyword.toLowerCase())
-  );
+  // Form state
+  const [formData, setFormData] = useState<CreateNoticeRequest>({
+    title: '',
+    content: '',
+    type: 'GENERAL',
+    isPinned: false,
+  });
+
+  // API Hooks
+  const { data: noticesData, isLoading } = useNotices({
+    keyword: searchKeyword || undefined,
+    status: statusFilter !== 'ALL' ? statusFilter : undefined,
+  });
+  const createMutation = useCreateNotice();
+  const updateMutation = useUpdateNotice();
+  const deleteMutation = useDeleteNotice();
+  const publishMutation = usePublishNotice();
+  const archiveMutation = useArchiveNotice();
+
+  const notices = noticesData?.content || [];
+  const totalNotices = noticesData?.totalElements || 0;
+
+  const handleCreateOpen = () => {
+    setFormData({
+      title: '',
+      content: '',
+      type: 'GENERAL',
+      isPinned: false,
+    });
+    setIsCreateOpen(true);
+  };
+
+  const handleEditOpen = (notice: Notice) => {
+    setFormData({
+      title: notice.title,
+      content: notice.content,
+      type: notice.type,
+      isPinned: notice.isPinned,
+    });
+    setEditingNotice(notice);
+  };
+
+  const handleCreate = async () => {
+    if (!formData.title.trim() || !formData.content.trim()) return;
+    await createMutation.mutateAsync(formData);
+    setIsCreateOpen(false);
+  };
+
+  const handleUpdate = async () => {
+    if (!editingNotice || !formData.title.trim() || !formData.content.trim()) return;
+    const request: UpdateNoticeRequest = {
+      title: formData.title,
+      content: formData.content,
+      type: formData.type,
+      isPinned: formData.isPinned,
+    };
+    await updateMutation.mutateAsync({ id: editingNotice.id, request });
+    setEditingNotice(null);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    await deleteMutation.mutateAsync(deleteTarget.id);
+    setDeleteTarget(null);
+  };
+
+  const handlePublish = async (id: number) => {
+    await publishMutation.mutateAsync(id);
+  };
+
+  const handleArchive = async (id: number) => {
+    await archiveMutation.mutateAsync(id);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+          <div className="h-64 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="p-6">
@@ -59,7 +158,7 @@ export function NoticesPage() {
         title="공지사항 관리"
         description="전체 테넌트에 공지사항을 관리합니다"
         actions={
-          <Button>
+          <Button onClick={handleCreateOpen}>
             <Plus className="mr-2 h-4 w-4" />
             공지 작성
           </Button>
@@ -71,59 +170,277 @@ export function NoticesPage() {
           <div className="flex items-center justify-between">
             <div>
               <CardTitle>공지사항 목록</CardTitle>
-              <CardDescription>전체 {mockNotices.length}개의 공지사항</CardDescription>
+              <CardDescription>전체 {totalNotices}개의 공지사항</CardDescription>
             </div>
-            <div className="relative w-64">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-secondary" />
-              <Input
-                placeholder="공지 검색..."
-                value={searchKeyword}
-                onChange={(e) => setSearchKeyword(e.target.value)}
-                className="pl-9"
-              />
+            <div className="flex items-center gap-3">
+              <Select
+                value={statusFilter}
+                onValueChange={(v) => setStatusFilter(v as NoticeStatus | 'ALL')}
+              >
+                <SelectTrigger className="w-32">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ALL">전체</SelectItem>
+                  <SelectItem value="DRAFT">초안</SelectItem>
+                  <SelectItem value="PUBLISHED">게시됨</SelectItem>
+                  <SelectItem value="ARCHIVED">보관됨</SelectItem>
+                </SelectContent>
+              </Select>
+              <div className="relative w-64">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-secondary" />
+                <Input
+                  placeholder="공지 검색..."
+                  value={searchKeyword}
+                  onChange={(e) => setSearchKeyword(e.target.value)}
+                  className="pl-9"
+                />
+              </div>
             </div>
           </div>
         </CardHeader>
         <CardContent>
           <div className="space-y-3">
-            {filteredNotices.map((notice) => (
-              <div key={notice.id} className="flex items-center justify-between p-4 border rounded-lg hover:bg-bg-secondary">
-                <div className="flex items-start gap-3">
-                  {notice.isPinned && <Pin className="h-4 w-4 text-brand-primary mt-1" />}
-                  <div>
-                    <div className="flex items-center gap-2">
-                      <h3 className="font-medium">{notice.title}</h3>
-                      <Badge className={categoryConfig[notice.category].color}>
-                        {categoryConfig[notice.category].label}
-                      </Badge>
-                      <Badge className={statusConfig[notice.status].color}>
-                        {statusConfig[notice.status].label}
-                      </Badge>
-                    </div>
-                    <div className="flex items-center gap-4 mt-1 text-sm text-text-secondary">
-                      <span className="flex items-center gap-1">
-                        <Calendar className="h-3 w-3" />
-                        {notice.publishedAt || notice.createdAt}
-                      </span>
-                      {notice.status === 'PUBLISHED' && (
+            {notices.length === 0 ? (
+              <div className="text-center py-8 text-text-secondary">
+                {searchKeyword ? '검색 결과가 없습니다' : '등록된 공지사항이 없습니다'}
+              </div>
+            ) : (
+              notices.map((notice) => (
+                <div
+                  key={notice.id}
+                  className="flex items-center justify-between p-4 border rounded-lg hover:bg-bg-secondary"
+                >
+                  <div className="flex items-start gap-3">
+                    {notice.isPinned && <Pin className="h-4 w-4 text-brand-primary mt-1" />}
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <h3 className="font-medium">{notice.title}</h3>
+                        <Badge className={typeConfig[notice.type].color}>
+                          {typeConfig[notice.type].label}
+                        </Badge>
+                        <Badge className={statusConfig[notice.status].color}>
+                          {statusConfig[notice.status].label}
+                        </Badge>
+                      </div>
+                      <div className="flex items-center gap-4 mt-1 text-sm text-text-secondary">
                         <span className="flex items-center gap-1">
-                          <Eye className="h-3 w-3" />
-                          {notice.views.toLocaleString()} 조회
+                          <Calendar className="h-3 w-3" />
+                          {notice.publishedAt || notice.createdAt}
                         </span>
-                      )}
+                        {notice.status === 'PUBLISHED' && (
+                          <span className="flex items-center gap-1">
+                            배포: {notice.distributionCount}개 테넌트
+                          </span>
+                        )}
+                      </div>
                     </div>
                   </div>
+                  <div className="flex items-center gap-1">
+                    {notice.status === 'DRAFT' && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handlePublish(notice.id)}
+                        disabled={publishMutation.isPending}
+                        title="발행"
+                      >
+                        <Send className="h-4 w-4 text-green-600" />
+                      </Button>
+                    )}
+                    {notice.status === 'PUBLISHED' && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleArchive(notice.id)}
+                        disabled={archiveMutation.isPending}
+                        title="보관"
+                      >
+                        <Archive className="h-4 w-4 text-orange-600" />
+                      </Button>
+                    )}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleEditOpen(notice)}
+                    >
+                      <Edit className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-red-500"
+                      onClick={() => setDeleteTarget(notice)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
                 </div>
-                <div className="flex items-center gap-1">
-                  <Button variant="ghost" size="sm"><Eye className="h-4 w-4" /></Button>
-                  <Button variant="ghost" size="sm"><Edit className="h-4 w-4" /></Button>
-                  <Button variant="ghost" size="sm" className="text-red-500"><Trash2 className="h-4 w-4" /></Button>
-                </div>
-              </div>
-            ))}
+              ))
+            )}
           </div>
         </CardContent>
       </Card>
+
+      {/* Create Dialog */}
+      <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>새 공지사항 작성</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label>제목 *</Label>
+              <Input
+                value={formData.title}
+                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                placeholder="공지사항 제목을 입력하세요"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>유형</Label>
+                <Select
+                  value={formData.type}
+                  onValueChange={(v) => setFormData({ ...formData, type: v as NoticeType })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="GENERAL">일반</SelectItem>
+                    <SelectItem value="UPDATE">업데이트</SelectItem>
+                    <SelectItem value="SYSTEM">시스템</SelectItem>
+                    <SelectItem value="EVENT">이벤트</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-center gap-2 pt-6">
+                <Switch
+                  id="isPinned"
+                  checked={formData.isPinned}
+                  onCheckedChange={(v) => setFormData({ ...formData, isPinned: v })}
+                />
+                <Label htmlFor="isPinned">상단 고정</Label>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>내용 *</Label>
+              <Textarea
+                value={formData.content}
+                onChange={(e) => setFormData({ ...formData, content: e.target.value })}
+                placeholder="공지사항 내용을 입력하세요"
+                rows={8}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsCreateOpen(false)}>
+              취소
+            </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={!formData.title.trim() || !formData.content.trim() || createMutation.isPending}
+            >
+              {createMutation.isPending ? '생성 중...' : '생성'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Dialog */}
+      <Dialog open={!!editingNotice} onOpenChange={() => setEditingNotice(null)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>공지사항 수정</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label>제목 *</Label>
+              <Input
+                value={formData.title}
+                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                placeholder="공지사항 제목을 입력하세요"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>유형</Label>
+                <Select
+                  value={formData.type}
+                  onValueChange={(v) => setFormData({ ...formData, type: v as NoticeType })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="GENERAL">일반</SelectItem>
+                    <SelectItem value="UPDATE">업데이트</SelectItem>
+                    <SelectItem value="SYSTEM">시스템</SelectItem>
+                    <SelectItem value="EVENT">이벤트</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-center gap-2 pt-6">
+                <Switch
+                  id="isPinnedEdit"
+                  checked={formData.isPinned}
+                  onCheckedChange={(v) => setFormData({ ...formData, isPinned: v })}
+                />
+                <Label htmlFor="isPinnedEdit">상단 고정</Label>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>내용 *</Label>
+              <Textarea
+                value={formData.content}
+                onChange={(e) => setFormData({ ...formData, content: e.target.value })}
+                placeholder="공지사항 내용을 입력하세요"
+                rows={8}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditingNotice(null)}>
+              취소
+            </Button>
+            <Button
+              onClick={handleUpdate}
+              disabled={!formData.title.trim() || !formData.content.trim() || updateMutation.isPending}
+            >
+              {updateMutation.isPending ? '저장 중...' : '저장'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirm Dialog */}
+      <Dialog open={!!deleteTarget} onOpenChange={() => setDeleteTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>공지사항 삭제</DialogTitle>
+          </DialogHeader>
+          <p className="py-4">
+            "{deleteTarget?.title}" 공지사항을 삭제하시겠습니까?
+            <br />
+            <span className="text-sm text-text-secondary">
+              이 작업은 되돌릴 수 없습니다.
+            </span>
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)}>
+              취소
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? '삭제 중...' : '삭제'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/pages/ta/settings/TenantSettingsPage.tsx
+++ b/src/pages/ta/settings/TenantSettingsPage.tsx
@@ -1,12 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
-  Building2,
   Save,
   RotateCcw,
-  Globe,
-  Clock,
-  Bell,
-  Shield,
+  Palette,
+  Users,
+  Settings2,
+  Gauge,
 } from 'lucide-react';
 import { AdminPageHeader } from '@/components/domain/admin';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
@@ -14,7 +13,6 @@ import { Button } from '@/components/common/Button';
 import { Input } from '@/components/common/Input';
 import { Label } from '@/components/common/Label';
 import { Switch } from '@/components/common/Switch';
-import { Textarea } from '@/components/common/Textarea';
 import {
   Select,
   SelectContent,
@@ -22,43 +20,86 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/common/Select';
-
-// Mock 데이터
-const mockTenantSettings = {
-  general: {
-    name: '메가존클라우드',
-    description: '클라우드 전문 교육 플랫폼',
-    contactEmail: 'support@megazone.com',
-    timezone: 'Asia/Seoul',
-    language: 'ko',
-  },
-  features: {
-    allowSelfRegistration: true,
-    requireEmailVerification: true,
-    enableSocialLogin: false,
-    enableCertificates: true,
-    enableDiscussions: true,
-  },
-  notifications: {
-    emailNotifications: true,
-    browserNotifications: true,
-    courseReminders: true,
-    marketingEmails: false,
-  },
-  security: {
-    sessionTimeout: 30,
-    maxLoginAttempts: 5,
-    requireStrongPassword: true,
-    enable2FA: false,
-  },
-};
+import {
+  useTenantSettings,
+  useUpdateTenantSettings,
+} from '@/hooks/ta';
+import type { UpdateTenantSettingsRequest } from '@/types/admin';
 
 export function TenantSettingsPage() {
-  const [settings, setSettings] = useState(mockTenantSettings);
+  const { data: settings, isLoading } = useTenantSettings();
+  const updateMutation = useUpdateTenantSettings();
+
+  const [formData, setFormData] = useState<UpdateTenantSettingsRequest>({
+    logoUrl: null,
+    faviconUrl: null,
+    primaryColor: null,
+    secondaryColor: null,
+    allowSelfRegistration: true,
+    requireEmailVerification: true,
+    defaultUserRole: 'USER',
+    maxUsers: null,
+    maxStorage: null,
+    maxCourses: null,
+    enableDiscussions: true,
+    enableCertificates: true,
+    enableAnalytics: true,
+  });
+
+  useEffect(() => {
+    if (settings) {
+      setFormData({
+        logoUrl: settings.logoUrl,
+        faviconUrl: settings.faviconUrl,
+        primaryColor: settings.primaryColor,
+        secondaryColor: settings.secondaryColor,
+        allowSelfRegistration: settings.allowSelfRegistration,
+        requireEmailVerification: settings.requireEmailVerification,
+        defaultUserRole: settings.defaultUserRole,
+        maxUsers: settings.maxUsers,
+        maxStorage: settings.maxStorage,
+        maxCourses: settings.maxCourses,
+        enableDiscussions: settings.enableDiscussions,
+        enableCertificates: settings.enableCertificates,
+        enableAnalytics: settings.enableAnalytics,
+      });
+    }
+  }, [settings]);
+
+  const handleSave = async () => {
+    await updateMutation.mutateAsync(formData);
+  };
 
   const handleReset = () => {
-    setSettings(mockTenantSettings);
+    if (settings) {
+      setFormData({
+        logoUrl: settings.logoUrl,
+        faviconUrl: settings.faviconUrl,
+        primaryColor: settings.primaryColor,
+        secondaryColor: settings.secondaryColor,
+        allowSelfRegistration: settings.allowSelfRegistration,
+        requireEmailVerification: settings.requireEmailVerification,
+        defaultUserRole: settings.defaultUserRole,
+        maxUsers: settings.maxUsers,
+        maxStorage: settings.maxStorage,
+        maxCourses: settings.maxCourses,
+        enableDiscussions: settings.enableDiscussions,
+        enableCertificates: settings.enableCertificates,
+        enableAnalytics: settings.enableAnalytics,
+      });
+    }
   };
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+          <div className="h-64 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="p-6">
@@ -71,113 +112,108 @@ export function TenantSettingsPage() {
               <RotateCcw className="mr-2 h-4 w-4" />
               초기화
             </Button>
-            <Button>
+            <Button onClick={handleSave} disabled={updateMutation.isPending}>
               <Save className="mr-2 h-4 w-4" />
-              저장
+              {updateMutation.isPending ? '저장 중...' : '저장'}
             </Button>
           </div>
         }
       />
 
       <div className="space-y-6">
-        {/* General Settings */}
+        {/* Branding Settings */}
         <Card>
           <CardHeader>
             <div className="flex items-center gap-2">
-              <Building2 className="h-5 w-5 text-brand-primary" />
-              <CardTitle>기본 정보</CardTitle>
+              <Palette className="h-5 w-5 text-brand-primary" />
+              <CardTitle>브랜딩 설정</CardTitle>
             </div>
-            <CardDescription>테넌트 기본 정보를 설정합니다</CardDescription>
+            <CardDescription>로고와 색상을 설정합니다</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
-                <Label>테넌트 이름</Label>
+                <Label>로고 URL</Label>
                 <Input
-                  value={settings.general.name}
-                  onChange={(e) => setSettings({
-                    ...settings,
-                    general: { ...settings.general, name: e.target.value },
+                  value={formData.logoUrl || ''}
+                  onChange={(e) => setFormData({
+                    ...formData,
+                    logoUrl: e.target.value || null,
                   })}
+                  placeholder="https://example.com/logo.png"
                 />
               </div>
               <div className="space-y-2">
-                <Label>연락처 이메일</Label>
+                <Label>파비콘 URL</Label>
                 <Input
-                  type="email"
-                  value={settings.general.contactEmail}
-                  onChange={(e) => setSettings({
-                    ...settings,
-                    general: { ...settings.general, contactEmail: e.target.value },
+                  value={formData.faviconUrl || ''}
+                  onChange={(e) => setFormData({
+                    ...formData,
+                    faviconUrl: e.target.value || null,
                   })}
+                  placeholder="https://example.com/favicon.ico"
                 />
               </div>
-            </div>
-            <div className="space-y-2">
-              <Label>설명</Label>
-              <Textarea
-                value={settings.general.description}
-                onChange={(e) => setSettings({
-                  ...settings,
-                  general: { ...settings.general, description: e.target.value },
-                })}
-                rows={3}
-              />
             </div>
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
-                <Label className="flex items-center gap-2">
-                  <Clock className="h-4 w-4" />
-                  타임존
-                </Label>
-                <Select
-                  value={settings.general.timezone}
-                  onValueChange={(v) => setSettings({
-                    ...settings,
-                    general: { ...settings.general, timezone: v },
-                  })}
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="Asia/Seoul">Asia/Seoul (KST)</SelectItem>
-                    <SelectItem value="America/New_York">America/New_York (EST)</SelectItem>
-                    <SelectItem value="Europe/London">Europe/London (GMT)</SelectItem>
-                  </SelectContent>
-                </Select>
+                <Label>기본 색상</Label>
+                <div className="flex gap-2">
+                  <Input
+                    type="color"
+                    value={formData.primaryColor || '#3B82F6'}
+                    onChange={(e) => setFormData({
+                      ...formData,
+                      primaryColor: e.target.value,
+                    })}
+                    className="w-12 h-10 p-1"
+                  />
+                  <Input
+                    value={formData.primaryColor || ''}
+                    onChange={(e) => setFormData({
+                      ...formData,
+                      primaryColor: e.target.value || null,
+                    })}
+                    placeholder="#3B82F6"
+                    className="flex-1"
+                  />
+                </div>
               </div>
               <div className="space-y-2">
-                <Label className="flex items-center gap-2">
-                  <Globe className="h-4 w-4" />
-                  기본 언어
-                </Label>
-                <Select
-                  value={settings.general.language}
-                  onValueChange={(v) => setSettings({
-                    ...settings,
-                    general: { ...settings.general, language: v },
-                  })}
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="ko">한국어</SelectItem>
-                    <SelectItem value="en">English</SelectItem>
-                    <SelectItem value="ja">日本語</SelectItem>
-                  </SelectContent>
-                </Select>
+                <Label>보조 색상</Label>
+                <div className="flex gap-2">
+                  <Input
+                    type="color"
+                    value={formData.secondaryColor || '#10B981'}
+                    onChange={(e) => setFormData({
+                      ...formData,
+                      secondaryColor: e.target.value,
+                    })}
+                    className="w-12 h-10 p-1"
+                  />
+                  <Input
+                    value={formData.secondaryColor || ''}
+                    onChange={(e) => setFormData({
+                      ...formData,
+                      secondaryColor: e.target.value || null,
+                    })}
+                    placeholder="#10B981"
+                    className="flex-1"
+                  />
+                </div>
               </div>
             </div>
           </CardContent>
         </Card>
 
-        {/* Features */}
+        {/* User Management Settings */}
         <Card>
           <CardHeader>
-            <CardTitle>기능 설정</CardTitle>
-            <CardDescription>테넌트에서 사용할 기능을 설정합니다</CardDescription>
+            <div className="flex items-center gap-2">
+              <Users className="h-5 w-5 text-brand-primary" />
+              <CardTitle>사용자 관리</CardTitle>
+            </div>
+            <CardDescription>사용자 등록 및 인증 설정을 관리합니다</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="flex items-center justify-between">
@@ -186,10 +222,10 @@ export function TenantSettingsPage() {
                 <p className="text-sm text-text-secondary">사용자가 직접 계정을 생성할 수 있습니다</p>
               </div>
               <Switch
-                checked={settings.features.allowSelfRegistration}
-                onCheckedChange={(v) => setSettings({
-                  ...settings,
-                  features: { ...settings.features, allowSelfRegistration: v },
+                checked={formData.allowSelfRegistration}
+                onCheckedChange={(v) => setFormData({
+                  ...formData,
+                  allowSelfRegistration: v,
                 })}
               />
             </div>
@@ -199,156 +235,119 @@ export function TenantSettingsPage() {
                 <p className="text-sm text-text-secondary">가입 시 이메일 인증을 요구합니다</p>
               </div>
               <Switch
-                checked={settings.features.requireEmailVerification}
-                onCheckedChange={(v) => setSettings({
-                  ...settings,
-                  features: { ...settings.features, requireEmailVerification: v },
+                checked={formData.requireEmailVerification}
+                onCheckedChange={(v) => setFormData({
+                  ...formData,
+                  requireEmailVerification: v,
                 })}
               />
             </div>
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-medium">소셜 로그인</p>
-                <p className="text-sm text-text-secondary">Google, Kakao 등 소셜 로그인 허용</p>
-              </div>
-              <Switch
-                checked={settings.features.enableSocialLogin}
-                onCheckedChange={(v) => setSettings({
-                  ...settings,
-                  features: { ...settings.features, enableSocialLogin: v },
+            <div className="space-y-2">
+              <Label>기본 사용자 역할</Label>
+              <Select
+                value={formData.defaultUserRole}
+                onValueChange={(v) => setFormData({
+                  ...formData,
+                  defaultUserRole: v,
                 })}
-              />
-            </div>
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-medium">수료증 발급</p>
-                <p className="text-sm text-text-secondary">강좌 완료 시 수료증을 발급합니다</p>
-              </div>
-              <Switch
-                checked={settings.features.enableCertificates}
-                onCheckedChange={(v) => setSettings({
-                  ...settings,
-                  features: { ...settings.features, enableCertificates: v },
-                })}
-              />
-            </div>
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-medium">토론 기능</p>
-                <p className="text-sm text-text-secondary">강좌 내 토론 게시판을 사용합니다</p>
-              </div>
-              <Switch
-                checked={settings.features.enableDiscussions}
-                onCheckedChange={(v) => setSettings({
-                  ...settings,
-                  features: { ...settings.features, enableDiscussions: v },
-                })}
-              />
+              >
+                <SelectTrigger className="w-48">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="USER">일반 사용자</SelectItem>
+                  <SelectItem value="OPERATOR">운영자</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
           </CardContent>
         </Card>
 
         <div className="grid grid-cols-2 gap-6">
-          {/* Notifications */}
+          {/* Limits */}
           <Card>
             <CardHeader>
               <div className="flex items-center gap-2">
-                <Bell className="h-5 w-5 text-brand-primary" />
-                <CardTitle>알림 설정</CardTitle>
+                <Gauge className="h-5 w-5 text-brand-primary" />
+                <CardTitle>제한 설정</CardTitle>
               </div>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="flex items-center justify-between">
-                <span className="text-sm">이메일 알림</span>
-                <Switch
-                  checked={settings.notifications.emailNotifications}
-                  onCheckedChange={(v) => setSettings({
-                    ...settings,
-                    notifications: { ...settings.notifications, emailNotifications: v },
+              <div className="space-y-2">
+                <Label>최대 사용자 수</Label>
+                <Input
+                  type="number"
+                  value={formData.maxUsers || ''}
+                  onChange={(e) => setFormData({
+                    ...formData,
+                    maxUsers: e.target.value ? Number(e.target.value) : null,
                   })}
+                  placeholder="무제한"
                 />
               </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm">브라우저 알림</span>
-                <Switch
-                  checked={settings.notifications.browserNotifications}
-                  onCheckedChange={(v) => setSettings({
-                    ...settings,
-                    notifications: { ...settings.notifications, browserNotifications: v },
+              <div className="space-y-2">
+                <Label>최대 저장 용량 (GB)</Label>
+                <Input
+                  type="number"
+                  value={formData.maxStorage || ''}
+                  onChange={(e) => setFormData({
+                    ...formData,
+                    maxStorage: e.target.value ? Number(e.target.value) : null,
                   })}
+                  placeholder="무제한"
                 />
               </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm">강좌 리마인더</span>
-                <Switch
-                  checked={settings.notifications.courseReminders}
-                  onCheckedChange={(v) => setSettings({
-                    ...settings,
-                    notifications: { ...settings.notifications, courseReminders: v },
+              <div className="space-y-2">
+                <Label>최대 강좌 수</Label>
+                <Input
+                  type="number"
+                  value={formData.maxCourses || ''}
+                  onChange={(e) => setFormData({
+                    ...formData,
+                    maxCourses: e.target.value ? Number(e.target.value) : null,
                   })}
-                />
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm">마케팅 이메일</span>
-                <Switch
-                  checked={settings.notifications.marketingEmails}
-                  onCheckedChange={(v) => setSettings({
-                    ...settings,
-                    notifications: { ...settings.notifications, marketingEmails: v },
-                  })}
+                  placeholder="무제한"
                 />
               </div>
             </CardContent>
           </Card>
 
-          {/* Security */}
+          {/* Features */}
           <Card>
             <CardHeader>
               <div className="flex items-center gap-2">
-                <Shield className="h-5 w-5 text-brand-primary" />
-                <CardTitle>보안 설정</CardTitle>
+                <Settings2 className="h-5 w-5 text-brand-primary" />
+                <CardTitle>기능 설정</CardTitle>
               </div>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label>세션 타임아웃 (분)</Label>
-                <Input
-                  type="number"
-                  value={settings.security.sessionTimeout}
-                  onChange={(e) => setSettings({
-                    ...settings,
-                    security: { ...settings.security, sessionTimeout: Number(e.target.value) },
-                  })}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label>최대 로그인 시도</Label>
-                <Input
-                  type="number"
-                  value={settings.security.maxLoginAttempts}
-                  onChange={(e) => setSettings({
-                    ...settings,
-                    security: { ...settings.security, maxLoginAttempts: Number(e.target.value) },
+              <div className="flex items-center justify-between">
+                <span className="text-sm">토론 기능</span>
+                <Switch
+                  checked={formData.enableDiscussions}
+                  onCheckedChange={(v) => setFormData({
+                    ...formData,
+                    enableDiscussions: v,
                   })}
                 />
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-sm">강력한 비밀번호 필수</span>
+                <span className="text-sm">수료증 발급</span>
                 <Switch
-                  checked={settings.security.requireStrongPassword}
-                  onCheckedChange={(v) => setSettings({
-                    ...settings,
-                    security: { ...settings.security, requireStrongPassword: v },
+                  checked={formData.enableCertificates}
+                  onCheckedChange={(v) => setFormData({
+                    ...formData,
+                    enableCertificates: v,
                   })}
                 />
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-sm">2단계 인증 (2FA)</span>
+                <span className="text-sm">분석 기능</span>
                 <Switch
-                  checked={settings.security.enable2FA}
-                  onCheckedChange={(v) => setSettings({
-                    ...settings,
-                    security: { ...settings.security, enable2FA: v },
+                  checked={formData.enableAnalytics}
+                  onCheckedChange={(v) => setFormData({
+                    ...formData,
+                    enableAnalytics: v,
                   })}
                 />
               </div>

--- a/src/pages/ta/users/GroupsPage.tsx
+++ b/src/pages/ta/users/GroupsPage.tsx
@@ -6,112 +6,104 @@ import {
   Edit,
   Trash2,
   FolderTree,
-  ChevronRight,
 } from 'lucide-react';
 import { AdminPageHeader } from '@/components/domain/admin';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
 import { Button } from '@/components/common/Button';
 import { Input } from '@/components/common/Input';
 import { Badge } from '@/components/common/Badge';
-
-// Mock 데이터
-const mockGroups: {
-  id: number;
-  name: string;
-  description: string;
-  memberCount: number;
-  parentId: number | null;
-  children?: number[];
-  createdAt: string;
-}[] = [
-  { id: 1, name: '전체 사용자', description: '모든 테넌트 사용자', memberCount: 2500, parentId: null, children: [2, 3, 4], createdAt: '2024-01-01' },
-  { id: 2, name: '개발팀', description: '개발 부서 소속 사용자', memberCount: 450, parentId: 1, children: [5, 6], createdAt: '2024-01-15' },
-  { id: 3, name: '마케팅팀', description: '마케팅 부서 소속 사용자', memberCount: 120, parentId: 1, createdAt: '2024-01-15' },
-  { id: 4, name: '영업팀', description: '영업 부서 소속 사용자', memberCount: 280, parentId: 1, createdAt: '2024-01-15' },
-  { id: 5, name: '프론트엔드팀', description: '프론트엔드 개발자', memberCount: 150, parentId: 2, createdAt: '2024-02-01' },
-  { id: 6, name: '백엔드팀', description: '백엔드 개발자', memberCount: 200, parentId: 2, createdAt: '2024-02-01' },
-];
+import { Label } from '@/components/common/Label';
+import { Textarea } from '@/components/common/Textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/common/Dialog';
+import {
+  useGroups,
+  useCreateGroup,
+  useUpdateGroup,
+  useDeleteGroup,
+} from '@/hooks/ta';
+import type { UserGroup, CreateUserGroupRequest, UpdateUserGroupRequest } from '@/types/admin';
 
 export function GroupsPage() {
   const [searchKeyword, setSearchKeyword] = useState('');
-  const [expandedGroups, setExpandedGroups] = useState<number[]>([1]);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [editingGroup, setEditingGroup] = useState<UserGroup | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<UserGroup | null>(null);
 
-  const toggleExpand = (id: number) => {
-    setExpandedGroups(prev =>
-      prev.includes(id) ? prev.filter(gId => gId !== id) : [...prev, id]
-    );
+  // Form state
+  const [formData, setFormData] = useState<CreateUserGroupRequest>({
+    name: '',
+    description: '',
+  });
+
+  // API Hooks
+  const { data: groupsData, isLoading } = useGroups({ keyword: searchKeyword || undefined });
+  const createMutation = useCreateGroup();
+  const updateMutation = useUpdateGroup();
+  const deleteMutation = useDeleteGroup();
+
+  const groups = groupsData?.content || [];
+  const totalGroups = groupsData?.totalElements || 0;
+  const activeGroups = groups.filter(g => g.isActive).length;
+  const totalMembers = groups.reduce((sum, g) => sum + g.memberCount, 0);
+
+  const handleCreateOpen = () => {
+    setFormData({ name: '', description: '' });
+    setIsCreateOpen(true);
   };
 
-  const rootGroups = mockGroups.filter(g => g.parentId === null);
+  const handleEditOpen = (group: UserGroup) => {
+    setFormData({ name: group.name, description: group.description || '' });
+    setEditingGroup(group);
+  };
 
-  const renderGroupTree = (groups: typeof mockGroups, level = 0) => {
-    return groups.map((group) => {
-      const children = mockGroups.filter(g => g.parentId === group.id);
-      const hasChildren = children.length > 0;
-      const isExpanded = expandedGroups.includes(group.id);
+  const handleCreate = async () => {
+    if (!formData.name.trim()) return;
+    await createMutation.mutateAsync(formData);
+    setIsCreateOpen(false);
+    setFormData({ name: '', description: '' });
+  };
 
-      if (searchKeyword && !group.name.toLowerCase().includes(searchKeyword.toLowerCase())) {
-        return null;
-      }
+  const handleUpdate = async () => {
+    if (!editingGroup || !formData.name.trim()) return;
+    const request: UpdateUserGroupRequest = {
+      name: formData.name,
+      description: formData.description,
+    };
+    await updateMutation.mutateAsync({ id: editingGroup.id, request });
+    setEditingGroup(null);
+    setFormData({ name: '', description: '' });
+  };
 
-      return (
-        <div key={group.id}>
-          <div
-            className={`flex items-center justify-between p-3 border rounded-lg hover:bg-bg-secondary ${
-              level > 0 ? 'ml-' + (level * 6) : ''
-            }`}
-            style={{ marginLeft: level * 24 }}
-          >
-            <div className="flex items-center gap-3">
-              {hasChildren ? (
-                <button
-                  onClick={() => toggleExpand(group.id)}
-                  className="p-1 hover:bg-gray-200 rounded"
-                >
-                  <ChevronRight className={`h-4 w-4 transition-transform ${isExpanded ? 'rotate-90' : ''}`} />
-                </button>
-              ) : (
-                <div className="w-6" />
-              )}
-              <div className="p-2 bg-brand-primary/10 rounded-lg">
-                <FolderTree className="h-4 w-4 text-brand-primary" />
-              </div>
-              <div>
-                <p className="font-medium">{group.name}</p>
-                <p className="text-xs text-text-secondary">{group.description}</p>
-              </div>
-            </div>
-            <div className="flex items-center gap-4">
-              <Badge variant="outline">{group.memberCount}명</Badge>
-              <div className="flex items-center gap-1">
-                <Button variant="ghost" size="sm">
-                  <Edit className="h-4 w-4" />
-                </Button>
-                {group.parentId !== null && (
-                  <Button variant="ghost" size="sm" className="text-red-500">
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                )}
-              </div>
-            </div>
-          </div>
-          {hasChildren && isExpanded && (
-            <div className="mt-2 space-y-2">
-              {renderGroupTree(children, level + 1)}
-            </div>
-          )}
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    await deleteMutation.mutateAsync(deleteTarget.id);
+    setDeleteTarget(null);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+          <div className="h-64 bg-gray-200 rounded"></div>
         </div>
-      );
-    });
-  };
+      </div>
+    );
+  }
 
   return (
     <div className="p-6">
       <AdminPageHeader
-        title="사용자 그룹 및 역할 관리"
-        description="사용자 그룹을 계층 구조로 관리합니다"
+        title="사용자 그룹 관리"
+        description="사용자 그룹을 생성하고 관리합니다"
         actions={
-          <Button>
+          <Button onClick={handleCreateOpen}>
             <Plus className="mr-2 h-4 w-4" />
             그룹 추가
           </Button>
@@ -127,23 +119,8 @@ export function GroupsPage() {
                 <FolderTree className="h-5 w-5 text-brand-primary" />
               </div>
               <div>
-                <p className="text-2xl font-bold">{mockGroups.length}</p>
+                <p className="text-2xl font-bold">{totalGroups}</p>
                 <p className="text-sm text-text-secondary">전체 그룹</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-blue-100 rounded-lg">
-                <Users className="h-5 w-5 text-blue-600" />
-              </div>
-              <div>
-                <p className="text-2xl font-bold">
-                  {mockGroups.find(g => g.parentId === null)?.memberCount.toLocaleString() || 0}
-                </p>
-                <p className="text-sm text-text-secondary">전체 사용자</p>
               </div>
             </div>
           </CardContent>
@@ -155,21 +132,34 @@ export function GroupsPage() {
                 <FolderTree className="h-5 w-5 text-green-600" />
               </div>
               <div>
-                <p className="text-2xl font-bold">{mockGroups.filter(g => g.parentId !== null).length}</p>
-                <p className="text-sm text-text-secondary">하위 그룹</p>
+                <p className="text-2xl font-bold">{activeGroups}</p>
+                <p className="text-sm text-text-secondary">활성 그룹</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-blue-100 rounded-lg">
+                <Users className="h-5 w-5 text-blue-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{totalMembers.toLocaleString()}</p>
+                <p className="text-sm text-text-secondary">총 멤버 수</p>
               </div>
             </div>
           </CardContent>
         </Card>
       </div>
 
-      {/* Group Tree */}
+      {/* Group List */}
       <Card>
         <CardHeader>
           <div className="flex items-center justify-between">
             <div>
-              <CardTitle>그룹 구조</CardTitle>
-              <CardDescription>그룹을 클릭하여 하위 그룹을 확인하세요</CardDescription>
+              <CardTitle>그룹 목록</CardTitle>
+              <CardDescription>전체 {totalGroups}개의 그룹</CardDescription>
             </div>
             <div className="relative w-64">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-secondary" />
@@ -184,10 +174,164 @@ export function GroupsPage() {
         </CardHeader>
         <CardContent>
           <div className="space-y-2">
-            {renderGroupTree(rootGroups)}
+            {groups.length === 0 ? (
+              <div className="text-center py-8 text-text-secondary">
+                {searchKeyword ? '검색 결과가 없습니다' : '등록된 그룹이 없습니다'}
+              </div>
+            ) : (
+              groups.map((group) => (
+                <div
+                  key={group.id}
+                  className="flex items-center justify-between p-4 border rounded-lg hover:bg-bg-secondary"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-brand-primary/10 rounded-lg">
+                      <FolderTree className="h-4 w-4 text-brand-primary" />
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <p className="font-medium">{group.name}</p>
+                        <Badge variant={group.isActive ? 'default' : 'secondary'}>
+                          {group.isActive ? '활성' : '비활성'}
+                        </Badge>
+                      </div>
+                      <p className="text-sm text-text-secondary">
+                        {group.description || '설명 없음'}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-4">
+                    <Badge variant="outline">{group.memberCount}명</Badge>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleEditOpen(group)}
+                      >
+                        <Edit className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-red-500"
+                        onClick={() => setDeleteTarget(group)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              ))
+            )}
           </div>
         </CardContent>
       </Card>
+
+      {/* Create Dialog */}
+      <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>새 그룹 추가</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label>그룹 이름 *</Label>
+              <Input
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                placeholder="그룹 이름을 입력하세요"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>설명</Label>
+              <Textarea
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                placeholder="그룹에 대한 설명을 입력하세요"
+                rows={3}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsCreateOpen(false)}>
+              취소
+            </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={!formData.name.trim() || createMutation.isPending}
+            >
+              {createMutation.isPending ? '생성 중...' : '생성'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Dialog */}
+      <Dialog open={!!editingGroup} onOpenChange={() => setEditingGroup(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>그룹 수정</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label>그룹 이름 *</Label>
+              <Input
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                placeholder="그룹 이름을 입력하세요"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>설명</Label>
+              <Textarea
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                placeholder="그룹에 대한 설명을 입력하세요"
+                rows={3}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditingGroup(null)}>
+              취소
+            </Button>
+            <Button
+              onClick={handleUpdate}
+              disabled={!formData.name.trim() || updateMutation.isPending}
+            >
+              {updateMutation.isPending ? '저장 중...' : '저장'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirm Dialog */}
+      <Dialog open={!!deleteTarget} onOpenChange={() => setDeleteTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>그룹 삭제</DialogTitle>
+          </DialogHeader>
+          <p className="py-4">
+            "{deleteTarget?.name}" 그룹을 삭제하시겠습니까?
+            <br />
+            <span className="text-sm text-text-secondary">
+              이 작업은 되돌릴 수 없습니다.
+            </span>
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)}>
+              취소
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? '삭제 중...' : '삭제'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -31,6 +31,32 @@ export const API_ENDPOINTS = {
     BY_ID: (id: number) => `/tenants/${id}`,
   },
 
+  // Tenant Settings (TA)
+  TENANT_SETTINGS: {
+    BASE: '/tenant/settings',
+    BRANDING: '/tenant/settings/branding',
+    USER_MANAGEMENT: '/tenant/settings/user-management',
+  },
+
+  // User Groups (TA)
+  GROUPS: {
+    BASE: '/groups',
+    ACTIVE: '/groups/active',
+    BY_ID: (id: number) => `/groups/${id}`,
+    MEMBERS: (groupId: number, userId: number) => `/groups/${groupId}/members/${userId}`,
+  },
+
+  // Notices (SA)
+  NOTICES: {
+    BASE: '/sa/notices',
+    BY_ID: (id: number) => `/sa/notices/${id}`,
+    PUBLISH: (id: number) => `/sa/notices/${id}/publish`,
+    ARCHIVE: (id: number) => `/sa/notices/${id}/archive`,
+    DISTRIBUTE: (id: number) => `/sa/notices/${id}/distribute`,
+    DISTRIBUTE_ALL: (id: number) => `/sa/notices/${id}/distribute-all`,
+    TENANTS: (id: number) => `/sa/notices/${id}/tenants`,
+  },
+
   // Categories (TO)
   CATEGORIES: {
     BASE: '/categories',

--- a/src/services/sa/index.ts
+++ b/src/services/sa/index.ts
@@ -1,2 +1,3 @@
 export { tenantService } from './tenantService';
 export type { TenantFilterParams } from './tenantService';
+export { noticeService } from './noticeService';

--- a/src/services/sa/noticeService.ts
+++ b/src/services/sa/noticeService.ts
@@ -1,0 +1,89 @@
+/**
+ * Notice API 서비스 (SA - Super Admin)
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type {
+  Notice,
+  NoticeListResponse,
+  NoticeListParams,
+  CreateNoticeRequest,
+  UpdateNoticeRequest,
+  DistributeNoticeRequest,
+} from '@/types/admin';
+
+export const noticeService = {
+  /** 공지사항 목록 조회 */
+  async getNotices(params?: NoticeListParams): Promise<NoticeListResponse> {
+    const { data } = await axiosInstance.get<{ data: NoticeListResponse }>(
+      API_ENDPOINTS.NOTICES.BASE,
+      { params }
+    );
+    return data.data;
+  },
+
+  /** 공지사항 상세 조회 */
+  async getNotice(id: number): Promise<Notice> {
+    const { data } = await axiosInstance.get<{ data: Notice }>(
+      API_ENDPOINTS.NOTICES.BY_ID(id)
+    );
+    return data.data;
+  },
+
+  /** 공지사항 생성 */
+  async create(request: CreateNoticeRequest): Promise<Notice> {
+    const { data } = await axiosInstance.post<{ data: Notice }>(
+      API_ENDPOINTS.NOTICES.BASE,
+      request
+    );
+    return data.data;
+  },
+
+  /** 공지사항 수정 */
+  async update(id: number, request: UpdateNoticeRequest): Promise<Notice> {
+    const { data } = await axiosInstance.put<{ data: Notice }>(
+      API_ENDPOINTS.NOTICES.BY_ID(id),
+      request
+    );
+    return data.data;
+  },
+
+  /** 공지사항 삭제 */
+  async delete(id: number): Promise<void> {
+    await axiosInstance.delete(API_ENDPOINTS.NOTICES.BY_ID(id));
+  },
+
+  /** 공지사항 발행 */
+  async publish(id: number): Promise<Notice> {
+    const { data } = await axiosInstance.post<{ data: Notice }>(
+      API_ENDPOINTS.NOTICES.PUBLISH(id)
+    );
+    return data.data;
+  },
+
+  /** 공지사항 보관 */
+  async archive(id: number): Promise<Notice> {
+    const { data } = await axiosInstance.post<{ data: Notice }>(
+      API_ENDPOINTS.NOTICES.ARCHIVE(id)
+    );
+    return data.data;
+  },
+
+  /** 특정 테넌트에 배포 */
+  async distribute(id: number, request: DistributeNoticeRequest): Promise<void> {
+    await axiosInstance.post(API_ENDPOINTS.NOTICES.DISTRIBUTE(id), request);
+  },
+
+  /** 전체 테넌트에 배포 */
+  async distributeAll(id: number): Promise<void> {
+    await axiosInstance.post(API_ENDPOINTS.NOTICES.DISTRIBUTE_ALL(id));
+  },
+
+  /** 배포된 테넌트 ID 목록 조회 */
+  async getDistributedTenants(id: number): Promise<number[]> {
+    const { data } = await axiosInstance.get<{ data: number[] }>(
+      API_ENDPOINTS.NOTICES.TENANTS(id)
+    );
+    return data.data;
+  },
+};

--- a/src/services/ta/groupService.ts
+++ b/src/services/ta/groupService.ts
@@ -1,0 +1,72 @@
+/**
+ * User Group API 서비스 (TA - Tenant Admin)
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type {
+  UserGroup,
+  UserGroupListResponse,
+  UserGroupListParams,
+  CreateUserGroupRequest,
+  UpdateUserGroupRequest,
+} from '@/types/admin';
+
+export const groupService = {
+  /** 그룹 목록 조회 */
+  async getGroups(params?: UserGroupListParams): Promise<UserGroupListResponse> {
+    const { data } = await axiosInstance.get<{ data: UserGroupListResponse }>(
+      API_ENDPOINTS.GROUPS.BASE,
+      { params }
+    );
+    return data.data;
+  },
+
+  /** 활성 그룹 목록 조회 */
+  async getActiveGroups(): Promise<UserGroup[]> {
+    const { data } = await axiosInstance.get<{ data: UserGroup[] }>(
+      API_ENDPOINTS.GROUPS.ACTIVE
+    );
+    return data.data;
+  },
+
+  /** 그룹 상세 조회 */
+  async getGroup(id: number): Promise<UserGroup> {
+    const { data } = await axiosInstance.get<{ data: UserGroup }>(
+      API_ENDPOINTS.GROUPS.BY_ID(id)
+    );
+    return data.data;
+  },
+
+  /** 그룹 생성 */
+  async create(request: CreateUserGroupRequest): Promise<UserGroup> {
+    const { data } = await axiosInstance.post<{ data: UserGroup }>(
+      API_ENDPOINTS.GROUPS.BASE,
+      request
+    );
+    return data.data;
+  },
+
+  /** 그룹 수정 */
+  async update(id: number, request: UpdateUserGroupRequest): Promise<UserGroup> {
+    const { data } = await axiosInstance.put<{ data: UserGroup }>(
+      API_ENDPOINTS.GROUPS.BY_ID(id),
+      request
+    );
+    return data.data;
+  },
+
+  /** 그룹 삭제 */
+  async delete(id: number): Promise<void> {
+    await axiosInstance.delete(API_ENDPOINTS.GROUPS.BY_ID(id));
+  },
+
+  /** 그룹에 멤버 추가 */
+  async addMember(groupId: number, userId: number): Promise<void> {
+    await axiosInstance.post(API_ENDPOINTS.GROUPS.MEMBERS(groupId, userId));
+  },
+
+  /** 그룹에서 멤버 제거 */
+  async removeMember(groupId: number, userId: number): Promise<void> {
+    await axiosInstance.delete(API_ENDPOINTS.GROUPS.MEMBERS(groupId, userId));
+  },
+};

--- a/src/services/ta/index.ts
+++ b/src/services/ta/index.ts
@@ -1,1 +1,3 @@
 export { userService } from './userService';
+export { groupService } from './groupService';
+export { tenantSettingsService } from './tenantSettingsService';

--- a/src/services/ta/tenantSettingsService.ts
+++ b/src/services/ta/tenantSettingsService.ts
@@ -1,0 +1,48 @@
+/**
+ * Tenant Settings API 서비스 (TA - Tenant Admin)
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type {
+  TenantSettingsDetail,
+  UpdateTenantSettingsRequest,
+  UpdateBrandingRequest,
+  UpdateUserManagementRequest,
+} from '@/types/admin';
+
+export const tenantSettingsService = {
+  /** 테넌트 설정 조회 */
+  async getSettings(): Promise<TenantSettingsDetail> {
+    const { data } = await axiosInstance.get<{ data: TenantSettingsDetail }>(
+      API_ENDPOINTS.TENANT_SETTINGS.BASE
+    );
+    return data.data;
+  },
+
+  /** 테넌트 설정 전체 수정 */
+  async update(request: UpdateTenantSettingsRequest): Promise<TenantSettingsDetail> {
+    const { data } = await axiosInstance.put<{ data: TenantSettingsDetail }>(
+      API_ENDPOINTS.TENANT_SETTINGS.BASE,
+      request
+    );
+    return data.data;
+  },
+
+  /** 브랜딩 설정 수정 */
+  async updateBranding(request: UpdateBrandingRequest): Promise<TenantSettingsDetail> {
+    const { data } = await axiosInstance.patch<{ data: TenantSettingsDetail }>(
+      API_ENDPOINTS.TENANT_SETTINGS.BRANDING,
+      request
+    );
+    return data.data;
+  },
+
+  /** 사용자 관리 설정 수정 */
+  async updateUserManagement(request: UpdateUserManagementRequest): Promise<TenantSettingsDetail> {
+    const { data } = await axiosInstance.patch<{ data: TenantSettingsDetail }>(
+      API_ENDPOINTS.TENANT_SETTINGS.USER_MANAGEMENT,
+      request
+    );
+    return data.data;
+  },
+};

--- a/src/types/admin/group.types.ts
+++ b/src/types/admin/group.types.ts
@@ -1,0 +1,38 @@
+/**
+ * User Group 타입 정의 (TA)
+ */
+
+export interface UserGroup {
+  id: number;
+  name: string;
+  description: string | null;
+  isActive: boolean;
+  memberCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UserGroupListResponse {
+  content: UserGroup[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+}
+
+export interface UserGroupListParams {
+  keyword?: string;
+  page?: number;
+  size?: number;
+}
+
+export interface CreateUserGroupRequest {
+  name: string;
+  description?: string;
+}
+
+export interface UpdateUserGroupRequest {
+  name?: string;
+  description?: string;
+  isActive?: boolean;
+}

--- a/src/types/admin/index.ts
+++ b/src/types/admin/index.ts
@@ -2,3 +2,6 @@
 export * from './tenant.types';
 export * from './user.types';
 export * from './dashboard.types';
+export * from './group.types';
+export * from './tenantSettings.types';
+export * from './notice.types';

--- a/src/types/admin/notice.types.ts
+++ b/src/types/admin/notice.types.ts
@@ -1,0 +1,57 @@
+/**
+ * Notice 타입 정의 (SA)
+ */
+
+export type NoticeType = 'SYSTEM' | 'UPDATE' | 'EVENT' | 'GENERAL';
+export type NoticeStatus = 'DRAFT' | 'PUBLISHED' | 'ARCHIVED';
+
+export interface Notice {
+  id: number;
+  title: string;
+  content: string;
+  type: NoticeType;
+  status: NoticeStatus;
+  isPinned: boolean;
+  publishedAt: string | null;
+  expiredAt: string | null;
+  createdBy: number;
+  distributionCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface NoticeListResponse {
+  content: Notice[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+}
+
+export interface NoticeListParams {
+  keyword?: string;
+  status?: NoticeStatus;
+  type?: NoticeType;
+  page?: number;
+  size?: number;
+}
+
+export interface CreateNoticeRequest {
+  title: string;
+  content: string;
+  type: NoticeType;
+  isPinned?: boolean;
+  expiredAt?: string;
+}
+
+export interface UpdateNoticeRequest {
+  title?: string;
+  content?: string;
+  type?: NoticeType;
+  isPinned?: boolean;
+  expiredAt?: string;
+}
+
+export interface DistributeNoticeRequest {
+  tenantIds: number[];
+}

--- a/src/types/admin/tenantSettings.types.ts
+++ b/src/types/admin/tenantSettings.types.ts
@@ -1,0 +1,68 @@
+/**
+ * Tenant Settings 타입 정의 (TA)
+ */
+
+export interface TenantSettingsDetail {
+  id: number;
+  tenantId: number;
+
+  // Branding
+  logoUrl: string | null;
+  faviconUrl: string | null;
+  primaryColor: string | null;
+  secondaryColor: string | null;
+
+  // User Management
+  allowSelfRegistration: boolean;
+  requireEmailVerification: boolean;
+  defaultUserRole: string;
+
+  // Limits
+  maxUsers: number | null;
+  maxStorage: number | null;
+  maxCourses: number | null;
+
+  // Features
+  enableDiscussions: boolean;
+  enableCertificates: boolean;
+  enableAnalytics: boolean;
+
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdateTenantSettingsRequest {
+  // Branding
+  logoUrl?: string | null;
+  faviconUrl?: string | null;
+  primaryColor?: string | null;
+  secondaryColor?: string | null;
+
+  // User Management
+  allowSelfRegistration?: boolean;
+  requireEmailVerification?: boolean;
+  defaultUserRole?: string;
+
+  // Limits
+  maxUsers?: number | null;
+  maxStorage?: number | null;
+  maxCourses?: number | null;
+
+  // Features
+  enableDiscussions?: boolean;
+  enableCertificates?: boolean;
+  enableAnalytics?: boolean;
+}
+
+export interface UpdateBrandingRequest {
+  logoUrl?: string | null;
+  faviconUrl?: string | null;
+  primaryColor?: string | null;
+  secondaryColor?: string | null;
+}
+
+export interface UpdateUserManagementRequest {
+  allowSelfRegistration?: boolean;
+  requireEmailVerification?: boolean;
+  defaultUserRole?: string;
+}


### PR DESCRIPTION
## Summary

TA/SA 관리 페이지에 실제 API를 연동하여 목업 데이터를 대체합니다.

## Related Issue

- Closes #127

## Changes

- TA Groups 페이지 UserGroup API 연동 (CRUD)
- TA Settings 페이지 TenantSettings API 연동 (조회/수정)
- SA Notices 페이지 Notice API 연동 (CRUD + 발행/보관)
- API 타입 정의 추가 (`group.types.ts`, `tenantSettings.types.ts`, `notice.types.ts`)
- API 서비스 레이어 추가 (`groupService.ts`, `tenantSettingsService.ts`, `noticeService.ts`)
- React Query 훅 추가 (`useGroupQueries.ts`, `useTenantSettingsQueries.ts`, `useNoticeQueries.ts`)
- 엔드포인트 정의 추가 (`endpoints.ts`)

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 백엔드 API가 구현되어 있어야 정상 동작합니다
- 기존 목업 데이터 로직 제거 및 실제 API 호출로 대체