### PR TITLE
feat(tu): 커리큘럼 폴더 토글 기능 추가

### DIFF
--- a/src/pages/tu/teaching/courses/components/CourseCurriculumSection.tsx
+++ b/src/pages/tu/teaching/courses/components/CourseCurriculumSection.tsx
@@ -1,4 +1,5 @@
-import { BookOpen, Folder, FileText } from 'lucide-react';
+import { useState } from 'react';
+import { BookOpen, Folder, FileText, ChevronRight, ChevronDown } from 'lucide-react';
 import type { CourseItemHierarchyResponse } from '@/types/common/course.types';
 
 interface CourseCurriculumSectionProps {
@@ -14,18 +15,35 @@ function CurriculumTreeItem({
   item: CourseItemHierarchyResponse;
   depth?: number;
 }) {
+  const [isOpen, setIsOpen] = useState(true);
   const paddingLeft = depth * 24;
   const Icon = item.isFolder ? Folder : FileText;
   const iconColor = item.isFolder ? 'text-amber-500' : 'text-text-secondary';
   // displayName이 있으면 우선 표시, 없으면 itemName 사용
   const displayName = item.displayName || item.itemName;
+  const hasChildren = item.children && item.children.length > 0;
+  const isToggleable = item.isFolder && hasChildren;
+
+  const handleToggle = () => {
+    if (isToggleable) {
+      setIsOpen((prev) => !prev);
+    }
+  };
 
   return (
     <div>
       <div
-        className="flex items-start gap-2 py-2 px-3 hover:bg-bg-secondary rounded-md transition-colors"
+        className={`flex items-start gap-2 py-2 px-3 hover:bg-bg-secondary rounded-md transition-colors ${isToggleable ? 'cursor-pointer' : ''}`}
         style={{ paddingLeft: `${paddingLeft + 12}px` }}
+        onClick={handleToggle}
       >
+        {isToggleable && (
+          isOpen ? (
+            <ChevronDown size={16} className="text-text-secondary mt-0.5 flex-shrink-0" />
+          ) : (
+            <ChevronRight size={16} className="text-text-secondary mt-0.5 flex-shrink-0" />
+          )
+        )}
         <Icon size={16} className={`${iconColor} mt-0.5 flex-shrink-0`} />
         <div className="flex-1 min-w-0">
           <span className="text-text-primary text-sm block">{displayName}</span>
@@ -41,7 +59,7 @@ function CurriculumTreeItem({
           )}
         </div>
       </div>
-      {item.children && item.children.length > 0 && (
+      {hasChildren && isOpen && (
         <div>
           {item.children.map((child) => (
             <CurriculumTreeItem key={child.itemId} item={child} depth={depth + 1} />

--- a/src/routes/tu.courses.routes.tsx
+++ b/src/routes/tu.courses.routes.tsx
@@ -6,7 +6,7 @@ import {
   MyContentPage,
   CourseCreatePage,
   CourseEditPage,
-  CourseDetailPage,
+  TeachingCourseDetailPage,
   TuContentCreatePage,
   ContentDetailPage,
   MyAssignmentsPage,
@@ -32,7 +32,7 @@ export const tuCoursesRoutes = (
     {/* 내 강의 */}
     <Route path="teaching/courses" element={<MyCoursesPage />} />
     <Route path="teaching/courses/create" element={<CourseCreatePage />} />
-    <Route path="teaching/courses/:courseId" element={<CourseDetailPage />} />
+    <Route path="teaching/courses/:courseId" element={<TeachingCourseDetailPage />} />
     <Route path="teaching/courses/:courseId/edit" element={<CourseEditPage />} />
     <Route path="teaching/content" element={<MyContentPage />} />
     <Route path="teaching/content/create" element={<TuContentCreatePage />} />


### PR DESCRIPTION
## Summary
- 커리큘럼 섹션에서 폴더 클릭 시 하위 항목 접기/펼치기 기능 구현
- ChevronRight/ChevronDown 토글 아이콘 추가
- teaching 상세 페이지 라우트 수정 (더미 페이지 → 실제 API 연동 페이지)

## Changes
- `CourseCurriculumSection.tsx`: useState로 토글 상태 관리, 클릭 핸들러 추가
- `tu.courses.routes.tsx`: CourseDetailPage → TeachingCourseDetailPage로 변경

## Test plan
- [ ] `/tu/teaching/courses/:id` 페이지 접속 확인
- [ ] 폴더 클릭 시 하위 항목 접힘/펼침 동작 확인
- [ ] 토글 아이콘(▶/▼) 정상 표시 확인

Closes #106