### PR TITLE
feat: 프로그램 페이지 사용자 이름 표시 (#113)

### DIFF
--- a/src/pages/to/program/ProgramDetailPage.tsx
+++ b/src/pages/to/program/ProgramDetailPage.tsx
@@ -74,7 +74,7 @@ const t = {
   confirm: { ko: '확인', en: 'Confirm' },
   notSet: { ko: '미설정', en: 'Not set' },
   hours: { ko: '시간', en: 'hours' },
-  creatorId: { ko: '생성자 ID', en: 'Creator ID' },
+  creator: { ko: '생성자', en: 'Creator' },
   noSnapshot: { ko: '연결된 스냅샷이 없습니다.', en: 'No snapshot linked.' },
   courseDetails: { ko: '과정 세부 정보', en: 'Course Details' },
   metadata: { ko: '메타데이터', en: 'Metadata' },
@@ -299,11 +299,11 @@ export function ProgramDetailPage({ language = 'ko' }: Readonly<ProgramDetailPag
                 </div>
                 <div>
                   <Label className="text-text-secondary text-xs uppercase tracking-wide">
-                    {getText('creatorId')}
+                    {getText('creator')}
                   </Label>
                   <p className="text-text-primary mt-1 font-medium flex items-center gap-1">
                     <User size={14} className="text-text-secondary" />
-                    {program.creatorId}
+                    {program.creatorName || (program.creatorId ? `ID: ${program.creatorId}` : '-')}
                   </p>
                 </div>
               </div>
@@ -392,7 +392,7 @@ export function ProgramDetailPage({ language = 'ko' }: Readonly<ProgramDetailPag
                       {getText('approvedBy')}
                     </Label>
                     <p className="text-text-primary mt-1">
-                      {program.approvedBy || getText('notSet')}
+                      {program.approvedByName || (program.approvedBy ? `ID: ${program.approvedBy}` : getText('notSet'))}
                     </p>
                   </div>
                   <div>

--- a/src/pages/to/program/ProgramListPage.tsx
+++ b/src/pages/to/program/ProgramListPage.tsx
@@ -76,6 +76,7 @@ const t = {
   columnStatus: { ko: '상태', en: 'Status' },
   columnLevel: { ko: '레벨', en: 'Level' },
   columnType: { ko: '타입', en: 'Type' },
+  columnCreator: { ko: '생성자', en: 'Creator' },
   columnCreatedAt: { ko: '생성일', en: 'Created' },
   columnActions: { ko: '액션', en: 'Actions' },
   view: { ko: '상세보기', en: 'View Details' },
@@ -346,6 +347,17 @@ export function ProgramListPage({ language = 'ko' }: Readonly<ProgramListPagePro
         cell: ({ row }) => (
           <span className="text-sm text-text-secondary whitespace-nowrap">
             {row.original.type ? PROGRAM_TYPE_LABELS[row.original.type] : getText('notSet')}
+          </span>
+        ),
+      },
+      {
+        accessorKey: 'creatorName',
+        header: ({ column }) => (
+          <DataTableColumnHeader column={column} title={getText('columnCreator')} />
+        ),
+        cell: ({ row }) => (
+          <span className="text-sm text-text-secondary whitespace-nowrap">
+            {row.original.creatorName || (row.original.creatorId ? `ID: ${row.original.creatorId}` : '-')}
           </span>
         ),
       },

--- a/src/pages/to/program/ProgramPendingPage.tsx
+++ b/src/pages/to/program/ProgramPendingPage.tsx
@@ -56,6 +56,7 @@ const t = {
   columnTitle: { ko: '과정명', en: 'Title' },
   columnLevel: { ko: '레벨', en: 'Level' },
   columnType: { ko: '타입', en: 'Type' },
+  columnCreator: { ko: '생성자', en: 'Creator' },
   columnSubmittedAt: { ko: '신청일', en: 'Submitted' },
   columnActions: { ko: '액션', en: 'Actions' },
   view: { ko: '상세보기', en: 'View Details' },
@@ -245,6 +246,17 @@ export function ProgramPendingPage({ language = 'ko' }: Readonly<ProgramPendingP
         cell: ({ row }) => (
           <span className="text-sm text-text-secondary whitespace-nowrap">
             {row.original.type ? PROGRAM_TYPE_LABELS[row.original.type] : getText('notSet')}
+          </span>
+        ),
+      },
+      {
+        accessorKey: 'creatorName',
+        header: ({ column }) => (
+          <DataTableColumnHeader column={column} title={getText('columnCreator')} />
+        ),
+        cell: ({ row }) => (
+          <span className="text-sm text-text-secondary whitespace-nowrap">
+            {row.original.creatorName || (row.original.creatorId ? `ID: ${row.original.creatorId}` : '-')}
           </span>
         ),
       },

--- a/src/types/common/program.types.ts
+++ b/src/types/common/program.types.ts
@@ -42,6 +42,10 @@ export interface ProgramResponse {
   estimatedHours: number | null;
   status: ProgramStatus;
   creatorId: number;
+  creatorName: string | null;
+  ownerId: number | null;
+  ownerName: string | null;
+  ownerEmail: string | null;
   snapshotId: number | null;
   createdAt: string;
   updatedAt: string;
@@ -58,10 +62,15 @@ export interface ProgramDetailResponse {
   estimatedHours: number | null;
   status: ProgramStatus;
   creatorId: number;
+  creatorName: string | null;
+  ownerId: number | null;
+  ownerName: string | null;
+  ownerEmail: string | null;
   snapshotId: number | null;
   snapshotName: string | null;
   // 승인 정보
   approvedBy: number | null;
+  approvedByName: string | null;
   approvedAt: string | null;
   approvalComment: string | null;
   // 반려 정보
@@ -81,6 +90,7 @@ export interface PendingProgramResponse {
   level: ProgramLevel | null;
   type: ProgramType | null;
   creatorId: number;
+  creatorName: string | null;
   submittedAt: string;
   snapshotId: number | null;
 }


### PR DESCRIPTION
## Summary

프로그램 관리 페이지에서 ID 대신 사용자 이름을 표시하도록 개선했습니다.

## Related Issue

- Closes #113

## Changes

- `program.types.ts`: 백엔드 PR #225에서 추가된 필드 반영
  - `ProgramResponse`: `creatorName`, `ownerId`, `ownerName`, `ownerEmail` 추가
  - `ProgramDetailResponse`: 위 필드 + `approvedByName` 추가
  - `PendingProgramResponse`: `creatorName` 추가
- `ProgramDetailPage.tsx`: 생성자/승인자 이름 표시 (ID 폴백 지원)
- `ProgramListPage.tsx`: 과정 목록에 "생성자" 컬럼 추가
- `ProgramPendingPage.tsx`: 검토 대기 목록에 "생성자" 컬럼 추가

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 백엔드 PR #225, #226 배포 후 정상 동작합니다
- 백엔드에서 이름이 null인 경우 `ID: {id}` 형태로 폴백 표시