### PR TITLE
[Refactor] 어드민 사이드바 카드형 디자인 리디자인

### DIFF
--- a/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
+++ b/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
@@ -300,17 +300,19 @@ export function BaseSidebar({
                 {/* Level 1 Menu Item */}
                 <button
                   onClick={() => handleItemClick(item.id, !!hasSubItems)}
-                  className={cn(
-                    'flex items-center gap-3 rounded-xl transition-all',
-                    isExpanded ? 'w-full px-4 py-3' : 'w-[44px] h-[44px] justify-center mx-auto'
-                  )}
+                  className="flex items-center rounded-xl transition-all duration-300 overflow-hidden"
                   style={{
+                    width: isExpanded ? '100%' : '44px',
+                    height: '44px',
+                    padding: isExpanded ? '0 16px' : '0',
+                    justifyContent: 'center',
                     backgroundColor:
                       isActive && !hasSubItems ? colors.activeBg : 'transparent',
                     color:
                       isActive && !hasSubItems
                         ? colors.activeText
                         : colors.textPrimary,
+                    margin: isExpanded ? '0' : '0 auto',
                   }}
                   onMouseEnter={(e) => {
                     if (!(isActive && !hasSubItems)) {
@@ -335,7 +337,7 @@ export function BaseSidebar({
                   />
                   {isExpanded && (
                     <>
-                      <span className="flex-1 text-left text-sm font-medium">
+                      <span className="flex-1 text-left text-sm font-medium whitespace-nowrap ml-3">
                         {item.label[language]}
                       </span>
                       {hasSubItems && (
@@ -491,11 +493,15 @@ export function BaseSidebar({
           {/* Collapse Toggle */}
           <button
             onClick={onToggle}
-            className={cn(
-              'flex items-center gap-3 rounded-xl transition-all',
-              isExpanded ? 'w-full px-4 py-3' : 'w-[44px] h-[44px] justify-center mx-auto'
-            )}
-            style={{ color: colors.textPrimary }}
+            className="flex items-center rounded-xl transition-all duration-300 overflow-hidden"
+            style={{
+              width: isExpanded ? '100%' : '44px',
+              height: '44px',
+              padding: isExpanded ? '0 16px' : '0',
+              justifyContent: 'center',
+              color: colors.textPrimary,
+              margin: isExpanded ? '0' : '0 auto',
+            }}
             onMouseEnter={(e) => {
               e.currentTarget.style.backgroundColor = colors.hover;
             }}
@@ -514,17 +520,17 @@ export function BaseSidebar({
           >
             {isExpanded ? (
               <PanelLeftClose
-                className="w-5 h-5"
+                className="w-5 h-5 flex-shrink-0"
                 style={{ color: colors.textSecondary }}
               />
             ) : (
               <PanelLeft
-                className="w-5 h-5"
+                className="w-5 h-5 flex-shrink-0"
                 style={{ color: colors.textSecondary }}
               />
             )}
             {isExpanded && (
-              <span className="flex-1 text-left text-sm font-medium">
+              <span className="flex-1 text-left text-sm font-medium whitespace-nowrap ml-3">
                 {language === 'ko' ? '접기' : 'Collapse'}
               </span>
             )}

--- a/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
+++ b/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
@@ -208,12 +208,12 @@ export function BaseSidebar({
 
   return (
     <aside
-      className={cn(
-        'flex-shrink-0 transition-all duration-300',
-        isExpanded ? 'p-4' : 'p-2',
-        isDarkMode ? 'bg-[#1e1e1e]' : 'bg-gray-50'
-      )}
-      style={{ width: isExpanded ? '280px' : '84px' }}
+      className="flex-shrink-0 transition-all duration-300"
+      style={{
+        width: isExpanded ? '280px' : '84px',
+        padding: isExpanded ? '16px' : '8px',
+        backgroundColor: isDarkMode ? '#1e1e1e' : designTokens.bg.app_default,
+      }}
     >
       {/* 카드형 사이드바 */}
       <div
@@ -356,7 +356,7 @@ export function BaseSidebar({
                 {/* Level 2 Sub-Menu Items */}
                 {hasSubItems && isExpanded && isExpandedItem && (
                   <div
-                    className="mt-1 ml-4 pl-4 border-l-2"
+                    className="mt-1 ml-4 pl-4 border-l-2 space-y-1"
                     style={{ borderColor: isDarkMode ? 'rgba(255,255,255,0.1)' : '#e5e7eb' }}
                   >
                     {item.subItems!.map((subItem) => {

--- a/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
+++ b/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
@@ -48,7 +48,7 @@ function ModeSwitcher({ currentMode, isExpanded, language, colors, onModeChange 
     return (
       <button
         onClick={() => onModeChange(currentMode === 'instructor' ? 'learner' : 'instructor')}
-        className="w-10 h-10 rounded-lg flex items-center justify-center transition-all"
+        className="w-[44px] h-[44px] rounded-xl flex items-center justify-center transition-all mx-auto"
         style={{ backgroundColor: colors.hover }}
         title={currentModeData.label[language]}
       >
@@ -61,13 +61,13 @@ function ModeSwitcher({ currentMode, isExpanded, language, colors, onModeChange 
     <div className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex items-center gap-2 px-3 py-2 rounded-lg transition-all"
+        className="w-full flex items-center gap-3 px-4 py-3 rounded-xl transition-all"
         style={{
           backgroundColor: colors.hover,
           color: colors.textPrimary,
         }}
       >
-        <CurrentIcon className="w-4 h-4" style={{ color: colors.textSecondary }} />
+        <CurrentIcon className="w-5 h-5" style={{ color: colors.textSecondary }} />
         <span className="flex-1 text-left text-sm font-medium">
           {currentModeData.label[language]}
         </span>
@@ -86,7 +86,7 @@ function ModeSwitcher({ currentMode, isExpanded, language, colors, onModeChange 
           />
           {/* Dropdown */}
           <div
-            className="absolute left-0 right-0 top-full mt-1 rounded-lg border shadow-lg z-50 py-1"
+            className="absolute left-0 right-0 top-full mt-1 rounded-xl border shadow-lg z-50 py-1"
             style={{
               backgroundColor: colors.tooltipBg,
               borderColor: colors.border,
@@ -102,7 +102,7 @@ function ModeSwitcher({ currentMode, isExpanded, language, colors, onModeChange 
                     onModeChange(mode.id);
                     setIsOpen(false);
                   }}
-                  className="w-full flex items-center gap-3 px-3 py-2 transition-all"
+                  className="w-full flex items-center gap-3 px-4 py-2.5 transition-all"
                   style={{
                     backgroundColor: isActive ? colors.activeBg : 'transparent',
                     color: isActive ? colors.activeText : colors.textPrimary,
@@ -118,7 +118,7 @@ function ModeSwitcher({ currentMode, isExpanded, language, colors, onModeChange 
                     }
                   }}
                 >
-                  <Icon className="w-4 h-4" style={{ color: isActive ? colors.activeText : colors.textSecondary }} />
+                  <Icon className="w-5 h-5" style={{ color: isActive ? colors.activeText : colors.textSecondary }} />
                   <span className="flex-1 text-left text-sm">{mode.label[language]}</span>
                   {isActive && <Check className="w-4 h-4" />}
                 </button>
@@ -207,100 +207,88 @@ export function BaseSidebar({
   };
 
   return (
-    <div
-      style={{
-        width: isExpanded ? '280px' : '72px',
-        height: '100vh',
-        backgroundColor: colors.bg,
-        borderRight: `1px solid ${colors.border}`,
-        display: 'flex',
-        flexDirection: 'column',
-        transition: 'width 300ms cubic-bezier(0.4, 0, 0.2, 1)',
-        position: 'relative',
-        overflow: 'hidden',
-      }}
-    >
-      {/* Logo Section */}
-      <div
-        style={{
-          padding: isExpanded ? '20px 16px' : '20px 12px',
-          borderBottom: showModeSwitcher ? 'none' : `1px solid ${colors.border}`,
-          display: 'flex',
-          alignItems: 'center',
-          gap: '12px',
-          minHeight: '64px',
-        }}
-      >
-        <div
-          style={{
-            width: '40px',
-            height: '40px',
-            borderRadius: '10px',
-            background: 'linear-gradient(135deg, #667EEA 0%, #764BA2 100%)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            flexShrink: 0,
-          }}
-        >
-          <GraduationCap size={24} color="#FFFFFF" />
-        </div>
-        {isExpanded && (
-          <div style={{ overflow: 'hidden' }}>
-            <h1
-              style={{
-                color: colors.textPrimary,
-                margin: 0,
-                fontSize: '18px',
-                fontWeight: 600,
-                whiteSpace: 'nowrap',
-              }}
-            >
-              Learning Hub
-            </h1>
-            {!showModeSwitcher && (
-              <p
-                style={{
-                  color: colors.textSecondary,
-                  margin: 0,
-                  fontSize: '12px',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {roleLabel[language]}
-              </p>
-            )}
-          </div>
-        )}
-      </div>
-
-      {/* Mode Switcher (TU only) */}
-      {showModeSwitcher && (
-        <div
-          style={{
-            padding: isExpanded ? '0 16px 16px' : '0 12px 16px',
-            borderBottom: `1px solid ${colors.border}`,
-          }}
-        >
-          <ModeSwitcher
-            currentMode={currentMode}
-            isExpanded={isExpanded}
-            language={language}
-            colors={colors}
-            onModeChange={handleModeChange}
-          />
-        </div>
+    <aside
+      className={cn(
+        'flex-shrink-0 transition-all duration-300',
+        isExpanded ? 'p-4' : 'p-2',
+        isDarkMode ? 'bg-[#1e1e1e]' : 'bg-gray-50'
       )}
-
-      {/* Navigation Menu */}
+      style={{ width: isExpanded ? '280px' : '84px' }}
+    >
+      {/* 카드형 사이드바 */}
       <div
         className={cn(
-          'flex-1 overflow-y-auto overflow-x-hidden p-3',
-          'sidebar-scrollbar',
-          !isDarkMode && 'sidebar-scrollbar-light'
+          'rounded-2xl h-full flex flex-col',
+          isExpanded ? 'p-4' : 'py-3 px-2',
+          isDarkMode
+            ? 'bg-white/5 border border-white/10 backdrop-blur-sm'
+            : 'bg-white border border-gray-200 shadow-sm'
         )}
       >
-        <ul className="space-y-1">
+        {/* Logo Section */}
+        <div
+          className={cn(
+            'flex items-center gap-3 mb-4',
+            !isExpanded && 'justify-center'
+          )}
+        >
+          <div
+            className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
+            style={{
+              background: 'linear-gradient(135deg, #667EEA 0%, #764BA2 100%)',
+            }}
+          >
+            <GraduationCap size={22} color="#FFFFFF" />
+          </div>
+          {isExpanded && (
+            <div className="overflow-hidden">
+              <h1
+                className="text-lg font-semibold whitespace-nowrap"
+                style={{ color: colors.textPrimary }}
+              >
+                Learning Hub
+              </h1>
+              {!showModeSwitcher && (
+                <p
+                  className="text-xs whitespace-nowrap"
+                  style={{ color: colors.textSecondary }}
+                >
+                  {roleLabel[language]}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Mode Switcher (TU only) */}
+        {showModeSwitcher && (
+          <div className={cn('mb-4', !isExpanded && 'flex justify-center')}>
+            <ModeSwitcher
+              currentMode={currentMode}
+              isExpanded={isExpanded}
+              language={language}
+              colors={colors}
+              onModeChange={handleModeChange}
+            />
+          </div>
+        )}
+
+        {/* Divider after header */}
+        <div
+          className="mb-4"
+          style={{
+            borderBottom: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.1)' : colors.border}`,
+          }}
+        />
+
+        {/* Navigation Menu */}
+        <nav
+          className={cn(
+            'flex-1 overflow-y-auto overflow-x-hidden space-y-1',
+            'sidebar-scrollbar',
+            !isDarkMode && 'sidebar-scrollbar-light'
+          )}
+        >
           {menuData.map((item) => {
             const Icon = item.icon;
             const hasSubItems = item.subItems && item.subItems.length > 0;
@@ -308,13 +296,13 @@ export function BaseSidebar({
             const isActive = activeItem === item.id;
 
             return (
-              <li key={item.id}>
+              <div key={item.id} className="mb-1">
                 {/* Level 1 Menu Item */}
                 <button
                   onClick={() => handleItemClick(item.id, !!hasSubItems)}
                   className={cn(
-                    'w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all duration-200',
-                    !isExpanded && 'justify-center'
+                    'flex items-center gap-3 rounded-xl transition-all',
+                    isExpanded ? 'w-full px-4 py-3' : 'w-[44px] h-[44px] justify-center mx-auto'
                   )}
                   style={{
                     backgroundColor:
@@ -347,7 +335,7 @@ export function BaseSidebar({
                   />
                   {isExpanded && (
                     <>
-                      <span className="flex-1 text-left text-sm">
+                      <span className="flex-1 text-left text-sm font-medium">
                         {item.label[language]}
                       </span>
                       {hasSubItems && (
@@ -365,58 +353,57 @@ export function BaseSidebar({
 
                 {/* Level 2 Sub-Menu Items */}
                 {hasSubItems && isExpanded && isExpandedItem && (
-                  <ul
-                    className="mt-1 ml-4 pl-4 border-l-2 space-y-1"
-                    style={{ borderColor: colors.border }}
+                  <div
+                    className="mt-1 ml-4 pl-4 border-l-2"
+                    style={{ borderColor: isDarkMode ? 'rgba(255,255,255,0.1)' : '#e5e7eb' }}
                   >
                     {item.subItems!.map((subItem) => {
                       const SubIcon = subItem.icon;
                       const isSubActive = activeItem === subItem.id;
 
                       return (
-                        <li key={subItem.id}>
-                          <button
-                            onClick={() =>
-                              handleSubItemClick(subItem.id, item.id)
+                        <button
+                          key={subItem.id}
+                          onClick={() =>
+                            handleSubItemClick(subItem.id, item.id)
+                          }
+                          className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all text-sm"
+                          style={{
+                            backgroundColor: isSubActive
+                              ? colors.activeBg
+                              : 'transparent',
+                            color: isSubActive
+                              ? colors.activeText
+                              : colors.textPrimary,
+                          }}
+                          onMouseEnter={(e) => {
+                            if (!isSubActive) {
+                              e.currentTarget.style.backgroundColor =
+                                colors.hover;
                             }
-                            className="w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-200 text-sm"
+                          }}
+                          onMouseLeave={(e) => {
+                            if (!isSubActive) {
+                              e.currentTarget.style.backgroundColor =
+                                'transparent';
+                            }
+                          }}
+                        >
+                          <SubIcon
+                            className="w-4 h-4 flex-shrink-0"
                             style={{
-                              backgroundColor: isSubActive
-                                ? colors.activeBg
-                                : 'transparent',
                               color: isSubActive
                                 ? colors.activeText
-                                : colors.textPrimary,
+                                : colors.textSecondary,
                             }}
-                            onMouseEnter={(e) => {
-                              if (!isSubActive) {
-                                e.currentTarget.style.backgroundColor =
-                                  colors.hover;
-                              }
-                            }}
-                            onMouseLeave={(e) => {
-                              if (!isSubActive) {
-                                e.currentTarget.style.backgroundColor =
-                                  'transparent';
-                              }
-                            }}
-                          >
-                            <SubIcon
-                              className="w-4 h-4 flex-shrink-0"
-                              style={{
-                                color: isSubActive
-                                  ? colors.activeText
-                                  : colors.textSecondary,
-                              }}
-                            />
-                            <span className="flex-1 text-left">
-                              {subItem.label[language]}
-                            </span>
-                          </button>
-                        </li>
+                          />
+                          <span className="flex-1 text-left">
+                            {subItem.label[language]}
+                          </span>
+                        </button>
                       );
                     })}
-                  </ul>
+                  </div>
                 )}
 
                 {/* Collapsed State - Tooltip */}
@@ -424,7 +411,7 @@ export function BaseSidebar({
                   <div className="relative group">
                     <div className="absolute left-full top-0 ml-2 hidden group-hover:block z-50">
                       <div
-                        className="border rounded-lg shadow-lg py-2 px-1 min-w-[200px]"
+                        className="border rounded-xl shadow-lg py-2 px-1 min-w-[200px]"
                         style={{
                           backgroundColor: colors.tooltipBg,
                           borderColor: colors.border,
@@ -434,7 +421,7 @@ export function BaseSidebar({
                           className="px-3 py-1.5 text-xs border-b mb-1"
                           style={{
                             color: colors.textSecondary,
-                            borderColor: colors.border,
+                            borderColor: isDarkMode ? 'rgba(255,255,255,0.1)' : colors.border,
                           }}
                         >
                           {item.label[language]}
@@ -449,7 +436,7 @@ export function BaseSidebar({
                               onClick={() =>
                                 handleSubItemClick(subItem.id, item.id)
                               }
-                              className="w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-200 text-sm"
+                              className="w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-all text-sm"
                               style={{
                                 backgroundColor: isSubActive
                                   ? colors.activeBg
@@ -489,58 +476,61 @@ export function BaseSidebar({
                     </div>
                   </div>
                 )}
-              </li>
+              </div>
             );
           })}
-        </ul>
-      </div>
+        </nav>
 
-      {/* Divider */}
-      <div className="border-t" style={{ borderColor: colors.border }} />
-
-      {/* Collapse Toggle */}
-      <div className="p-3">
-        <button
-          onClick={onToggle}
-          className={cn(
-            'w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all duration-200',
-            !isExpanded && 'justify-center'
-          )}
-          style={{ color: colors.textPrimary }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.backgroundColor = colors.hover;
+        {/* Divider before footer */}
+        <div
+          className="mt-4 pt-4"
+          style={{
+            borderTop: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.1)' : colors.border}`,
           }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.backgroundColor = 'transparent';
-          }}
-          title={
-            isExpanded
-              ? language === 'ko'
-                ? '사이드바 접기'
-                : 'Collapse Sidebar'
-              : language === 'ko'
-                ? '사이드바 펼치기'
-                : 'Expand Sidebar'
-          }
         >
-          {isExpanded ? (
-            <PanelLeftClose
-              className="w-5 h-5"
-              style={{ color: colors.textSecondary }}
-            />
-          ) : (
-            <PanelLeft
-              className="w-5 h-5"
-              style={{ color: colors.textSecondary }}
-            />
-          )}
-          {isExpanded && (
-            <span className="flex-1 text-left text-sm">
-              {language === 'ko' ? '접기' : 'Collapse'}
-            </span>
-          )}
-        </button>
+          {/* Collapse Toggle */}
+          <button
+            onClick={onToggle}
+            className={cn(
+              'flex items-center gap-3 rounded-xl transition-all',
+              isExpanded ? 'w-full px-4 py-3' : 'w-[44px] h-[44px] justify-center mx-auto'
+            )}
+            style={{ color: colors.textPrimary }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.backgroundColor = colors.hover;
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = 'transparent';
+            }}
+            title={
+              isExpanded
+                ? language === 'ko'
+                  ? '사이드바 접기'
+                  : 'Collapse Sidebar'
+                : language === 'ko'
+                  ? '사이드바 펼치기'
+                  : 'Expand Sidebar'
+            }
+          >
+            {isExpanded ? (
+              <PanelLeftClose
+                className="w-5 h-5"
+                style={{ color: colors.textSecondary }}
+              />
+            ) : (
+              <PanelLeft
+                className="w-5 h-5"
+                style={{ color: colors.textSecondary }}
+              />
+            )}
+            {isExpanded && (
+              <span className="flex-1 text-left text-sm font-medium">
+                {language === 'ko' ? '접기' : 'Collapse'}
+              </span>
+            )}
+          </button>
+        </div>
       </div>
-    </div>
+    </aside>
   );
 }

--- a/src/pages/tu/teaching/courses/MyCoursesPage.tsx
+++ b/src/pages/tu/teaching/courses/MyCoursesPage.tsx
@@ -99,7 +99,7 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
   const avgCompletion = Math.round(TEACHING_COURSES.reduce((acc, c) => acc + c.progress, 0) / TEACHING_COURSES.length);
 
   return (
-    <div className="p-8 bg-bg-default min-h-screen">
+    <div className="p-8 bg-bg-app_default min-h-screen">
       {/* Header */}
       <div className="mb-8 flex justify-between items-start">
         <div>


### PR DESCRIPTION
## Summary
- 어드민 사이드바(BaseSidebar)를 MyPageSidebar와 동일한 카드형 디자인으로 리디자인
- 사이드바 접기/펼치기 모션 개선 (아이콘 중심 부드러운 애니메이션)
- 2단계 메뉴 
<img width="1493" height="765" alt="스크린샷 2025-12-31 오전 10 48 39" src="https://github.com/user-attachments/assets/43abe10b-3230-4793-b7d0-7c923337481b" />
<img width="1318" height="764" alt="스크린샷 2025-12-31 오전 10 48 46" src="https://github.com/user-attachments/assets/2542b9db-54f6-4448-8289-66b1c8cb32e2" />
<img width="1235" height="767" alt="스크린샷 2025-12-31 오전 10 48 56" src="https://github.com/user-attachments/assets/81d88a19-2de1-4708-ba86-7c30a205c37e" />
아이템 간격 조정
<img width="1356" height="765" alt="스크린샷 2025-12-31 오전 10 49 03" src="https://github.com/user-attachments/assets/5f5a44e9-8472-4d63-84df-9289de5516ce" />


## Changes
- `BaseSidebar.tsx`: 카드형 디자인 적용 (rounded-2xl, border, backdrop-blur)
- `MyCoursesPage.tsx`: 배경색을 bg-bg-app_default로 변경

## Test Plan
- [ ] 사이드바 펼친 상태에서 카드형 디자인 확인
- [ ] 사이드바 접은 상태에서 아이콘 중앙 정렬 확인
- [ ] 접기/펼치기 시 스크롤 없이 부드럽게 전환되는지 확인
- [ ] 다크모드/라이트모드 전환 시 배경색 확인
- [ ] 2단계 메뉴 아이템 간격 확인

## Related Issues
Closes #152