### PR TITLE
feat(wishlist): 찜 기능 프론트엔드 구현

### DIFF
--- a/.scannerwork/report-task.txt
+++ b/.scannerwork/report-task.txt
@@ -1,0 +1,6 @@
+projectKey=mzc-lp-frontend
+serverUrl=http://localhost:9000
+serverVersion=25.12.0.117093
+dashboardUrl=http://localhost:9000/dashboard?id=mzc-lp-frontend
+ceTaskId=0e35ab36-678b-46a5-b360-d6cddf0fdf2c
+ceTaskUrl=http://localhost:9000/api/ce/task?id=0e35ab36-678b-46a5-b360-d6cddf0fdf2c

--- a/src/components/common/WishlistButton/WishlistButton.tsx
+++ b/src/components/common/WishlistButton/WishlistButton.tsx
@@ -1,0 +1,104 @@
+/**
+ * 찜 버튼 컴포넌트
+ */
+
+import { Heart } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import { useCheckWishlistStatus, useToggleWishlist } from '@/hooks/tu/useWishlistQueries';
+import { useAuthStore } from '@/store/common/authStore';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/common';
+
+interface WishlistButtonProps {
+  courseId: number;
+  className?: string;
+  size?: 'sm' | 'md' | 'lg';
+  showTooltip?: boolean;
+  onToggle?: (isWishlisted: boolean) => void;
+}
+
+const sizeClasses = {
+  sm: 'w-8 h-8',
+  md: 'w-10 h-10',
+  lg: 'w-12 h-12',
+};
+
+const iconSizeClasses = {
+  sm: 'w-4 h-4',
+  md: 'w-5 h-5',
+  lg: 'w-6 h-6',
+};
+
+export function WishlistButton({
+  courseId,
+  className,
+  size = 'md',
+  showTooltip = true,
+  onToggle,
+}: WishlistButtonProps) {
+  const { isAuthenticated } = useAuthStore();
+  const { data: isWishlisted = false, isLoading: isChecking } = useCheckWishlistStatus(
+    courseId,
+    isAuthenticated
+  );
+  const { toggle, isLoading: isToggling } = useToggleWishlist();
+
+  const handleClick = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (!isAuthenticated) {
+      return;
+    }
+
+    try {
+      await toggle(courseId, isWishlisted);
+      onToggle?.(!isWishlisted);
+    } catch (error) {
+      console.error('Failed to toggle wishlist:', error);
+    }
+  };
+
+  const isLoading = isChecking || isToggling;
+
+  const button = (
+    <button
+      onClick={handleClick}
+      disabled={isLoading || !isAuthenticated}
+      className={cn(
+        'flex items-center justify-center rounded-full transition-all duration-200',
+        'hover:scale-110 active:scale-95',
+        'focus:outline-none focus:ring-2 focus:ring-primary/50',
+        'disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100',
+        isWishlisted
+          ? 'bg-red-50 dark:bg-red-500/20 text-red-500'
+          : 'bg-gray-100 dark:bg-white/10 text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400',
+        sizeClasses[size],
+        className
+      )}
+      aria-label={isWishlisted ? '찜 해제' : '찜하기'}
+    >
+      <Heart
+        className={cn(
+          iconSizeClasses[size],
+          'transition-all duration-200',
+          isWishlisted && 'fill-current'
+        )}
+      />
+    </button>
+  );
+
+  if (!showTooltip) {
+    return button;
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipContent>
+          <p>{!isAuthenticated ? '로그인이 필요합니다' : isWishlisted ? '찜 해제' : '찜하기'}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/common/WishlistButton/index.ts
+++ b/src/components/common/WishlistButton/index.ts
@@ -1,0 +1,1 @@
+export { WishlistButton } from './WishlistButton';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -370,3 +370,8 @@ export { ToggleGroup, ToggleGroupItem } from './ToggleGroup';
 // 9. AUTH - 인증 관련
 // ═══════════════════════════════════════════════════════════════════════════════
 export { ProtectedRoute } from './ProtectedRoute';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 10. WISHLIST - 찜 기능
+// ═══════════════════════════════════════════════════════════════════════════════
+export { WishlistButton } from './WishlistButton';

--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -94,8 +94,6 @@ export {
   usePopularCourses,
   useRecommendedCourses,
   useRelatedCourses,
-  useAddToWishlist,
-  useRemoveFromWishlist,
   useAddToCart,
 } from './useCourseDetailQueries';
 
@@ -127,11 +125,14 @@ export {
 // Wishlist Hooks
 export {
   wishlistKeys,
-  useWishlist,
-  useWishlistAddItem,
-  useWishlistRemoveItem,
-  useClearWishlist,
-  useAddAllToCart,
+  useMyWishlist,
+  useMyWishlistCount,
+  useCheckWishlistStatus,
+  useCheckWishlistStatusBulk,
+  useCourseWishlistCount,
+  useAddToWishlist,
+  useRemoveFromWishlist,
+  useToggleWishlist,
 } from './useWishlistQueries';
 
 // Notification Hooks

--- a/src/hooks/tu/useWishlistQueries.ts
+++ b/src/hooks/tu/useWishlistQueries.ts
@@ -1,87 +1,133 @@
 /**
- * 찜 목록(Wishlist) React Query 훅
+ * 찜 목록(Wishlist) React Query 훅 - 백엔드 API 스펙 기반
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { wishlistService } from '@/services/tu/wishlistService';
-import type {
-  AddToWishlistRequest,
-  RemoveFromWishlistRequest,
-  AddAllToCartRequest,
-} from '@/types/tu/wishlist.types';
-import { cartKeys } from './useCartQueries';
+import type { WishlistAddRequest } from '@/types/tu/wishlist.types';
 
 // Query Keys
 export const wishlistKeys = {
   all: ['wishlist'] as const,
-  list: () => [...wishlistKeys.all, 'items'] as const,
+  list: (page?: number, size?: number) => [...wishlistKeys.all, 'list', { page, size }] as const,
+  count: () => [...wishlistKeys.all, 'count'] as const,
+  check: (courseId: number) => [...wishlistKeys.all, 'check', courseId] as const,
+  checkBulk: (courseIds: number[]) => [...wishlistKeys.all, 'checkBulk', courseIds] as const,
+  courseCount: (courseId: number) => [...wishlistKeys.all, 'courseCount', courseId] as const,
 };
 
 /**
- * 찜 목록 조회 훅
+ * 내 찜 목록 조회 훅 (페이징)
  */
-export function useWishlist(enabled = true) {
+export function useMyWishlist(page: number = 0, size: number = 20, enabled = true) {
   return useQuery({
-    queryKey: wishlistKeys.list(),
-    queryFn: wishlistService.getWishlist,
+    queryKey: wishlistKeys.list(page, size),
+    queryFn: () => wishlistService.getMyWishlist(page, size),
     enabled,
     staleTime: 1000 * 60 * 5, // 5분
   });
 }
 
 /**
- * 찜 목록 추가 훅 (Wishlist 서비스용)
+ * 내 찜 개수 조회 훅
  */
-export function useWishlistAddItem() {
+export function useMyWishlistCount(enabled = true) {
+  return useQuery({
+    queryKey: wishlistKeys.count(),
+    queryFn: wishlistService.getMyWishlistCount,
+    enabled,
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+/**
+ * 특정 강의 찜 여부 확인 훅
+ */
+export function useCheckWishlistStatus(courseId: number, enabled = true) {
+  return useQuery({
+    queryKey: wishlistKeys.check(courseId),
+    queryFn: () => wishlistService.checkWishlistStatus(courseId),
+    enabled: enabled && courseId > 0,
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+/**
+ * 여러 강의 찜 여부 일괄 확인 훅
+ */
+export function useCheckWishlistStatusBulk(courseIds: number[], enabled = true) {
+  return useQuery({
+    queryKey: wishlistKeys.checkBulk(courseIds),
+    queryFn: () => wishlistService.checkWishlistStatusBulk({ courseIds }),
+    enabled: enabled && courseIds.length > 0,
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+/**
+ * 특정 강의의 찜 개수 조회 훅
+ */
+export function useCourseWishlistCount(courseId: number, enabled = true) {
+  return useQuery({
+    queryKey: wishlistKeys.courseCount(courseId),
+    queryFn: () => wishlistService.getCourseWishlistCount(courseId),
+    enabled: enabled && courseId > 0,
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+/**
+ * 찜 추가 훅
+ */
+export function useAddToWishlist() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: AddToWishlistRequest) => wishlistService.addToWishlist(data),
-    onSuccess: () => {
+    mutationFn: (request: WishlistAddRequest) => wishlistService.addToWishlist(request),
+    onSuccess: (_, variables) => {
+      // 관련 쿼리 무효화
       queryClient.invalidateQueries({ queryKey: wishlistKeys.all });
+      // 특정 강의 찜 여부 캐시 업데이트
+      queryClient.setQueryData(wishlistKeys.check(variables.courseId), true);
     },
   });
 }
 
 /**
- * 찜 목록 삭제 훅 (Wishlist 서비스용)
+ * 찜 삭제 훅
  */
-export function useWishlistRemoveItem() {
+export function useRemoveFromWishlist() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: RemoveFromWishlistRequest) => wishlistService.removeFromWishlist(data),
-    onSuccess: () => {
+    mutationFn: (courseId: number) => wishlistService.removeFromWishlist(courseId),
+    onSuccess: (_, courseId) => {
+      // 관련 쿼리 무효화
       queryClient.invalidateQueries({ queryKey: wishlistKeys.all });
+      // 특정 강의 찜 여부 캐시 업데이트
+      queryClient.setQueryData(wishlistKeys.check(courseId), false);
     },
   });
 }
 
 /**
- * 찜 목록 비우기 훅
+ * 찜 토글 훅 (추가/삭제 통합)
  */
-export function useClearWishlist() {
-  const queryClient = useQueryClient();
+export function useToggleWishlist() {
+  const addMutation = useAddToWishlist();
+  const removeMutation = useRemoveFromWishlist();
 
-  return useMutation({
-    mutationFn: () => wishlistService.clearWishlist(),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: wishlistKeys.all });
-    },
-  });
-}
+  const toggle = async (courseId: number, isCurrentlyWishlisted: boolean) => {
+    if (isCurrentlyWishlisted) {
+      await removeMutation.mutateAsync(courseId);
+    } else {
+      await addMutation.mutateAsync({ courseId });
+    }
+  };
 
-/**
- * 찜 목록 전체를 장바구니에 담기 훅
- */
-export function useAddAllToCart() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (data: AddAllToCartRequest) => wishlistService.addAllToCart(data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: wishlistKeys.all });
-      queryClient.invalidateQueries({ queryKey: cartKeys.all });
-    },
-  });
+  return {
+    toggle,
+    isLoading: addMutation.isPending || removeMutation.isPending,
+    error: addMutation.error || removeMutation.error,
+  };
 }

--- a/src/pages/tu/main/CourseDetailPage.tsx
+++ b/src/pages/tu/main/CourseDetailPage.tsx
@@ -314,7 +314,7 @@ export function CourseDetailPage() {
         if (isWishlisted) {
           await removeFromWishlistMutation.mutateAsync(course.id);
         } else {
-          await addToWishlistMutation.mutateAsync(course.id);
+          await addToWishlistMutation.mutateAsync({ courseId: course.id });
         }
         setIsWishlisted(!isWishlisted);
       } catch (err) {

--- a/src/pages/tu/main/WishlistPage.tsx
+++ b/src/pages/tu/main/WishlistPage.tsx
@@ -1,117 +1,71 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Trash2, Heart, ChevronRight, ShoppingCart, Star, Clock, Users, Loader2 } from 'lucide-react';
+import { Trash2, Heart, ChevronRight, Clock, Loader2 } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
-import { useWishlist, useWishlistRemoveItem, useAddAllToCart, useCartAddItem } from '@/hooks/tu';
-import type { WishlistItem } from '@/types/tu';
+import { useMyWishlist, useRemoveFromWishlist } from '@/hooks/tu/useWishlistQueries';
+import { useAuthStore } from '@/store/common/authStore';
+import type { WishlistItemResponse } from '@/types/tu/wishlist.types';
 
-// 환경 설정: true면 API 사용, false면 더미 데이터 사용
-const USE_API = false;
-
-// 더미 찜 목록 데이터
-const MOCK_WISHLIST_ITEMS: WishlistItem[] = [
-  {
-    id: 1,
-    courseId: 101,
-    title: '실전! Next.js 15 완벽 마스터',
-    instructor: '김개발',
-    originalPrice: 129000,
-    price: 89000,
-    image: 'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=250&fit=crop',
-    discount: 31,
-    rating: 4.9,
-    reviewCount: 1234,
-    studentCount: 5678,
-    totalHours: 32,
-  },
-  {
-    id: 2,
-    courseId: 102,
-    title: 'ChatGPT API 활용 실무 프로젝트',
-    instructor: '이에이아이',
-    originalPrice: 150000,
-    price: 120000,
-    image: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=400&h=250&fit=crop',
-    discount: 20,
-    rating: 4.8,
-    reviewCount: 892,
-    studentCount: 3421,
-    totalHours: 28,
-  },
-  {
-    id: 3,
-    courseId: 103,
-    title: 'AWS 클라우드 실무',
-    instructor: '윤클라우드',
-    originalPrice: 130000,
-    price: 110000,
-    image: 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=400&h=250&fit=crop',
-    discount: 15,
-    rating: 4.7,
-    reviewCount: 567,
-    studentCount: 2341,
-    totalHours: 24,
-  },
-  {
-    id: 4,
-    courseId: 104,
-    title: 'React Native로 앱 개발하기',
-    instructor: '박모바일',
-    originalPrice: 99000,
-    price: 79000,
-    image: 'https://images.unsplash.com/photo-1512941937669-90a1b58e7e9c?w=400&h=250&fit=crop',
-    discount: 20,
-    rating: 4.6,
-    reviewCount: 423,
-    studentCount: 1876,
-    totalHours: 22,
-  },
-];
+// 레벨 라벨 매핑
+const LEVEL_LABELS: Record<string, string> = {
+  BEGINNER: '입문',
+  INTERMEDIATE: '초급',
+  ADVANCED: '중급',
+  EXPERT: '고급',
+};
 
 export function WishlistPage() {
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
+  const { isAuthenticated } = useAuthStore();
 
-  // React Query 훅 (API 모드일 때만 활성화)
-  const { data: apiWishlistData, isLoading, error } = useWishlist(USE_API);
-  const removeFromWishlistMutation = useWishlistRemoveItem();
-  const addAllToCartMutation = useAddAllToCart();
-  const addToCartMutation = useCartAddItem();
+  // 페이징 상태
+  const [page, setPage] = useState(0);
+  const pageSize = 12;
 
-  // 로컬 상태 (Mock 모드에서 사용)
-  const [mockWishlistItems, setMockWishlistItems] = useState(MOCK_WISHLIST_ITEMS);
+  // React Query 훅
+  const { data: wishlistData, isLoading, error } = useMyWishlist(page, pageSize, isAuthenticated);
+  const removeFromWishlistMutation = useRemoveFromWishlist();
 
-  // 실제 사용할 데이터 결정
-  const wishlistItems = USE_API ? (apiWishlistData?.items || []) : mockWishlistItems;
+  const wishlistItems = wishlistData?.content || [];
+  const totalPages = wishlistData?.totalPages || 0;
+  const totalElements = wishlistData?.totalElements || 0;
 
-  const removeItem = (id: number) => {
-    if (USE_API) {
-      removeFromWishlistMutation.mutate({ itemIds: [id] });
-    } else {
-      setMockWishlistItems(mockWishlistItems.filter(item => item.id !== id));
-    }
+  const removeItem = (courseId: number) => {
+    removeFromWishlistMutation.mutate(courseId);
   };
 
-  const addToCart = (item: WishlistItem) => {
-    if (USE_API) {
-      addToCartMutation.mutate({ courseId: item.courseId });
-    } else {
-      alert('장바구니에 추가되었습니다. (데모)');
-    }
-  };
-
-  const handleAddAllToCart = () => {
-    if (USE_API) {
-      addAllToCartMutation.mutate({ itemIds: wishlistItems.map(item => item.id) });
-    } else {
-      alert(`${wishlistItems.length}개 강의가 장바구니에 추가되었습니다. (데모)`);
-    }
-  };
+  // 비로그인 상태
+  if (!isAuthenticated) {
+    return (
+      <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
+        <LandingHeader />
+        <main className="w-full px-4 md:px-8 lg:px-16 py-12">
+          <div className="text-center py-20">
+            <Heart className={`w-20 h-20 mx-auto mb-6 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
+            <h2 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              로그인이 필요합니다
+            </h2>
+            <p className={`mb-8 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+              찜 목록을 보려면 로그인해주세요.
+            </p>
+            <Link
+              to="/login"
+              className="inline-flex items-center gap-2 landing-btn-primary px-6 py-3 rounded-full text-white font-medium"
+            >
+              로그인하기 <ChevronRight className="w-4 h-4" />
+            </Link>
+          </div>
+        </main>
+        <LandingFooter />
+      </div>
+    );
+  }
 
   // 로딩 상태
-  if (USE_API && isLoading) {
+  if (isLoading) {
     return (
       <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
         <LandingHeader />
@@ -129,7 +83,7 @@ export function WishlistPage() {
   }
 
   // 에러 상태
-  if (USE_API && error) {
+  if (error) {
     return (
       <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
         <LandingHeader />
@@ -157,23 +111,16 @@ export function WishlistPage() {
 
       <main className="w-full px-4 md:px-8 lg:px-16 py-12">
         <div className="flex items-center justify-between mb-8">
-          <h1 className={`text-3xl md:text-4xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            찜한 강의
-          </h1>
-          {wishlistItems.length > 0 && (
-            <button
-              onClick={handleAddAllToCart}
-              disabled={addAllToCartMutation.isPending}
-              className="landing-btn-primary px-6 py-2.5 rounded-full text-white font-medium text-sm flex items-center gap-2 disabled:opacity-50"
-            >
-              {addAllToCartMutation.isPending ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
-              ) : (
-                <ShoppingCart className="w-4 h-4" />
-              )}
-              전체 장바구니 담기
-            </button>
-          )}
+          <div>
+            <h1 className={`text-3xl md:text-4xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              찜한 강의
+            </h1>
+            {totalElements > 0 && (
+              <p className={`mt-2 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                총 {totalElements}개의 강의
+              </p>
+            )}
+          </div>
         </div>
 
         {wishlistItems.length === 0 ? (
@@ -186,108 +133,130 @@ export function WishlistPage() {
               관심 있는 강의에 하트를 눌러 저장해보세요!
             </p>
             <Link
-              to="/tu/main/courses"
+              to="/tu/catalog"
               className="inline-flex items-center gap-2 landing-btn-primary px-6 py-3 rounded-full text-white font-medium"
             >
               강의 둘러보기 <ChevronRight className="w-4 h-4" />
             </Link>
           </div>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {wishlistItems.map((item) => (
-              <div
-                key={item.id}
-                className={`rounded-2xl overflow-hidden border group ${
-                  isDark
-                    ? 'glass border-white/10'
-                    : 'bg-white border-gray-200'
-                }`}
-              >
-                {/* Image */}
-                <Link to={`/tu/main/courses/${item.courseId}`} className="block relative">
-                  <img
-                    src={item.image}
-                    alt={item.title}
-                    className="w-full aspect-video object-cover group-hover:scale-105 transition-transform duration-300"
-                  />
-                  {item.discount > 0 && (
-                    <span className="absolute top-3 left-3 px-2 py-1 rounded-full text-xs font-bold bg-[#6778ff] text-white">
-                      {item.discount}% 할인
-                    </span>
-                  )}
-                </Link>
-
-                {/* Content */}
-                <div className="p-4">
-                  <Link to={`/tu/main/courses/${item.courseId}`}>
-                    <h3 className={`font-semibold mb-1 line-clamp-2 group-hover:text-[#6778ff] transition-colors ${
-                      isDark ? 'text-white' : 'text-gray-900'
-                    }`}>
-                      {item.title}
-                    </h3>
-                  </Link>
-                  <p className={`text-sm mb-3 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
-                    {item.instructor}
-                  </p>
-
-                  {/* Stats */}
-                  <div className={`flex items-center gap-3 mb-3 text-xs ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
-                    <span className="flex items-center gap-1">
-                      <Star className="w-3.5 h-3.5 text-yellow-500 fill-yellow-500" />
-                      {item.rating}
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <Users className="w-3.5 h-3.5" />
-                      {item.studentCount.toLocaleString()}
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <Clock className="w-3.5 h-3.5" />
-                      {item.totalHours}시간
-                    </span>
-                  </div>
-
-                  {/* Price */}
-                  <div className="flex items-center gap-2 mb-4">
-                    {item.discount > 0 && (
-                      <span className={`line-through text-sm ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
-                        {item.originalPrice.toLocaleString()}원
+          <>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {wishlistItems.map((item: WishlistItemResponse) => (
+                <div
+                  key={item.id}
+                  className={`rounded-2xl overflow-hidden border group ${
+                    isDark
+                      ? 'glass border-white/10'
+                      : 'bg-white border-gray-200'
+                  }`}
+                >
+                  {/* Image */}
+                  <Link to={`/tu/catalog/${item.courseId}`} className="block relative">
+                    <div className="w-full aspect-video bg-gradient-to-br from-[#6778ff]/20 to-[#a855f7]/20 flex items-center justify-center">
+                      {item.courseThumbnailUrl ? (
+                        <img
+                          src={item.courseThumbnailUrl}
+                          alt={item.courseTitle || '강의 썸네일'}
+                          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                        />
+                      ) : (
+                        <Heart className={`w-12 h-12 ${isDark ? 'text-gray-600' : 'text-gray-400'}`} />
+                      )}
+                    </div>
+                    {item.courseLevel && (
+                      <span className="absolute top-3 left-3 px-2 py-1 rounded-full text-xs font-bold bg-[#6778ff] text-white">
+                        {LEVEL_LABELS[item.courseLevel] || item.courseLevel}
                       </span>
                     )}
-                    <span className={`font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                      {item.price.toLocaleString()}원
-                    </span>
-                  </div>
+                  </Link>
 
-                  {/* Actions */}
-                  <div className="flex gap-2">
-                    <button
-                      onClick={() => addToCart(item)}
-                      disabled={addToCartMutation.isPending}
-                      className="flex-1 py-2.5 rounded-lg font-medium text-sm landing-btn-primary text-white flex items-center justify-center gap-2 disabled:opacity-50"
-                    >
-                      {addToCartMutation.isPending ? (
-                        <Loader2 className="w-4 h-4 animate-spin" />
-                      ) : (
-                        <ShoppingCart className="w-4 h-4" />
+                  {/* Content */}
+                  <div className="p-4">
+                    <Link to={`/tu/catalog/${item.courseId}`}>
+                      <h3 className={`font-semibold mb-2 line-clamp-2 group-hover:text-[#6778ff] transition-colors ${
+                        isDark ? 'text-white' : 'text-gray-900'
+                      }`}>
+                        {item.courseTitle || '제목 없음'}
+                      </h3>
+                    </Link>
+
+                    {/* Stats */}
+                    <div className={`flex items-center gap-3 mb-4 text-xs ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
+                      {item.courseType && (
+                        <span className={`px-2 py-0.5 rounded ${isDark ? 'bg-white/10' : 'bg-gray-100'}`}>
+                          {item.courseType}
+                        </span>
                       )}
-                      장바구니
-                    </button>
-                    <button
-                      onClick={() => removeItem(item.id)}
-                      disabled={removeFromWishlistMutation.isPending}
-                      className={`p-2.5 rounded-lg transition-colors disabled:opacity-50 ${
-                        isDark
-                          ? 'bg-white/10 text-gray-400 hover:text-red-400 hover:bg-red-500/10'
-                          : 'bg-gray-100 text-gray-500 hover:text-red-500 hover:bg-red-50'
-                      }`}
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </button>
+                      {item.courseEstimatedHours && (
+                        <span className="flex items-center gap-1">
+                          <Clock className="w-3.5 h-3.5" />
+                          {item.courseEstimatedHours}시간
+                        </span>
+                      )}
+                    </div>
+
+                    {/* Added Date */}
+                    <p className={`text-xs mb-4 ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
+                      {new Date(item.addedAt).toLocaleDateString('ko-KR')}에 찜함
+                    </p>
+
+                    {/* Actions */}
+                    <div className="flex gap-2">
+                      <Link
+                        to={`/tu/catalog/${item.courseId}`}
+                        className="flex-1 py-2.5 rounded-lg font-medium text-sm landing-btn-primary text-white flex items-center justify-center gap-2"
+                      >
+                        상세보기
+                      </Link>
+                      <button
+                        onClick={() => removeItem(item.courseId)}
+                        disabled={removeFromWishlistMutation.isPending}
+                        className={`p-2.5 rounded-lg transition-colors disabled:opacity-50 ${
+                          isDark
+                            ? 'bg-white/10 text-gray-400 hover:text-red-400 hover:bg-red-500/10'
+                            : 'bg-gray-100 text-gray-500 hover:text-red-500 hover:bg-red-50'
+                        }`}
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </div>
                   </div>
                 </div>
+              ))}
+            </div>
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+              <div className="flex justify-center gap-2 mt-8">
+                <button
+                  onClick={() => setPage(p => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                  className={`px-4 py-2 rounded-lg font-medium text-sm transition-colors disabled:opacity-50 ${
+                    isDark
+                      ? 'bg-white/10 text-white hover:bg-white/20 disabled:hover:bg-white/10'
+                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200 disabled:hover:bg-gray-100'
+                  }`}
+                >
+                  이전
+                </button>
+                <span className={`px-4 py-2 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  {page + 1} / {totalPages}
+                </span>
+                <button
+                  onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
+                  disabled={page >= totalPages - 1}
+                  className={`px-4 py-2 rounded-lg font-medium text-sm transition-colors disabled:opacity-50 ${
+                    isDark
+                      ? 'bg-white/10 text-white hover:bg-white/20 disabled:hover:bg-white/10'
+                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200 disabled:hover:bg-gray-100'
+                  }`}
+                >
+                  다음
+                </button>
               </div>
-            ))}
-          </div>
+            )}
+          </>
         )}
 
         {/* Recommendation Section */}
@@ -303,7 +272,7 @@ export function WishlistPage() {
                 찜한 강의를 기반으로 추천 강의를 준비하고 있어요.
               </p>
               <Link
-                to="/tu/main/courses"
+                to="/tu/catalog"
                 className={`inline-flex items-center gap-2 font-medium transition-colors ${
                   isDark ? 'text-[#6778ff] hover:text-[#8b99ff]' : 'text-[#6778ff] hover:text-[#5566ee]'
                 }`}

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -206,4 +206,14 @@ export const API_ENDPOINTS = {
     ITEM_COMPLETE: (id: number, itemId: number) => `/enrollments/${id}/items/${itemId}/complete`,
     CURRICULUM: (id: number) => `/enrollments/${id}/curriculum`,
   },
+
+  // Wishlist (찜) - TU
+  WISHLIST: {
+    BASE: '/wishlist',
+    COUNT: '/wishlist/count',
+    CHECK_BULK: '/wishlist/check',
+    COURSE: (courseId: number) => `/wishlist/courses/${courseId}`,
+    COURSE_CHECK: (courseId: number) => `/wishlist/courses/${courseId}/check`,
+    COURSE_COUNT: (courseId: number) => `/wishlist/courses/${courseId}/count`,
+  },
 } as const;

--- a/src/services/tu/wishlistService.ts
+++ b/src/services/tu/wishlistService.ts
@@ -1,51 +1,89 @@
 /**
- * 찜 목록(Wishlist) API 서비스
+ * 찜 목록(Wishlist) API 서비스 - 백엔드 API 스펙 기반
  */
 
 import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type { ApiResponse, PageResponse } from '@/types/common/api.types';
 import type {
-  WishlistResponse,
-  AddToWishlistRequest,
-  RemoveFromWishlistRequest,
-  AddAllToCartRequest,
+  WishlistItemResponse,
+  WishlistAddRequest,
+  WishlistCheckRequest,
+  WishlistCheckResponse,
+  WishlistCountResponse,
 } from '@/types/tu/wishlist.types';
-
-const BASE_URL = '/tu/wishlist';
 
 export const wishlistService = {
   /**
-   * 찜 목록 조회
+   * 찜 추가
    */
-  getWishlist: async (): Promise<WishlistResponse> => {
-    const response = await axiosInstance.get<WishlistResponse>(BASE_URL);
-    return response.data;
+  addToWishlist: async (request: WishlistAddRequest): Promise<WishlistItemResponse> => {
+    const response = await axiosInstance.post<ApiResponse<WishlistItemResponse>>(
+      API_ENDPOINTS.WISHLIST.BASE,
+      request
+    );
+    return response.data.data;
   },
 
   /**
-   * 찜 목록에 강의 추가
+   * 찜 삭제
    */
-  addToWishlist: async (data: AddToWishlistRequest): Promise<void> => {
-    await axiosInstance.post(`${BASE_URL}/items`, data);
+  removeFromWishlist: async (courseId: number): Promise<void> => {
+    await axiosInstance.delete(API_ENDPOINTS.WISHLIST.COURSE(courseId));
   },
 
   /**
-   * 찜 목록에서 아이템 삭제
+   * 내 찜 목록 조회 (페이징)
    */
-  removeFromWishlist: async (data: RemoveFromWishlistRequest): Promise<void> => {
-    await axiosInstance.delete(`${BASE_URL}/items`, { data });
+  getMyWishlist: async (
+    page: number = 0,
+    size: number = 20
+  ): Promise<PageResponse<WishlistItemResponse>> => {
+    const response = await axiosInstance.get<ApiResponse<PageResponse<WishlistItemResponse>>>(
+      API_ENDPOINTS.WISHLIST.BASE,
+      { params: { page, size } }
+    );
+    return response.data.data;
   },
 
   /**
-   * 찜 목록 전체 비우기
+   * 특정 강의 찜 여부 확인
    */
-  clearWishlist: async (): Promise<void> => {
-    await axiosInstance.delete(`${BASE_URL}/clear`);
+  checkWishlistStatus: async (courseId: number): Promise<boolean> => {
+    const response = await axiosInstance.get<ApiResponse<boolean>>(
+      API_ENDPOINTS.WISHLIST.COURSE_CHECK(courseId)
+    );
+    return response.data.data;
   },
 
   /**
-   * 찜 목록 전체를 장바구니에 담기
+   * 여러 강의 찜 여부 일괄 확인
    */
-  addAllToCart: async (data: AddAllToCartRequest): Promise<void> => {
-    await axiosInstance.post(`${BASE_URL}/add-all-to-cart`, data);
+  checkWishlistStatusBulk: async (request: WishlistCheckRequest): Promise<WishlistCheckResponse> => {
+    const response = await axiosInstance.post<ApiResponse<WishlistCheckResponse>>(
+      API_ENDPOINTS.WISHLIST.CHECK_BULK,
+      request
+    );
+    return response.data.data;
+  },
+
+  /**
+   * 내 찜 개수 조회
+   */
+  getMyWishlistCount: async (): Promise<WishlistCountResponse> => {
+    const response = await axiosInstance.get<ApiResponse<WishlistCountResponse>>(
+      API_ENDPOINTS.WISHLIST.COUNT
+    );
+    return response.data.data;
+  },
+
+  /**
+   * 특정 강의의 찜 개수 조회
+   */
+  getCourseWishlistCount: async (courseId: number): Promise<WishlistCountResponse> => {
+    const response = await axiosInstance.get<ApiResponse<WishlistCountResponse>>(
+      API_ENDPOINTS.WISHLIST.COURSE_COUNT(courseId)
+    );
+    return response.data.data;
   },
 };

--- a/src/types/common/api.types.ts
+++ b/src/types/common/api.types.ts
@@ -27,3 +27,15 @@ export interface PaginationParams {
   sort?: string;
   order?: 'asc' | 'desc';
 }
+
+// Spring Page 응답 타입
+export interface PageResponse<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+  first: boolean;
+  last: boolean;
+  empty: boolean;
+}

--- a/src/types/tu/index.ts
+++ b/src/types/tu/index.ts
@@ -114,6 +114,12 @@ export type {
 
 // Wishlist (찜 목록)
 export type {
+  WishlistItemResponse,
+  WishlistAddRequest,
+  WishlistCheckRequest,
+  WishlistCheckResponse,
+  WishlistCountResponse,
+  // Legacy (하위 호환)
   WishlistItem,
   WishlistResponse,
   AddToWishlistRequest,

--- a/src/types/tu/wishlist.types.ts
+++ b/src/types/tu/wishlist.types.ts
@@ -1,8 +1,42 @@
 /**
- * 찜 목록(Wishlist) 관련 타입 정의
+ * 찜 목록(Wishlist) 관련 타입 정의 - 백엔드 API 스펙 기반
  */
 
-// 찜 목록 아이템
+// 찜 아이템 응답 (백엔드 WishlistItemResponse)
+export interface WishlistItemResponse {
+  id: number;
+  courseId: number;
+  courseTitle: string | null;
+  courseThumbnailUrl: string | null;
+  courseLevel: string | null;
+  courseType: string | null;
+  courseEstimatedHours: number | null;
+  addedAt: string;
+}
+
+// 찜 추가 요청
+export interface WishlistAddRequest {
+  courseId: number;
+}
+
+// 여러 강의 찜 여부 확인 요청
+export interface WishlistCheckRequest {
+  courseIds: number[];
+}
+
+// 여러 강의 찜 여부 확인 응답
+export interface WishlistCheckResponse {
+  wishlistStatus: Record<number, boolean>;
+}
+
+// 찜 개수 응답
+export interface WishlistCountResponse {
+  count: number;
+}
+
+// === Legacy 타입 (하위 호환용) ===
+
+/** @deprecated Use WishlistItemResponse instead */
 export interface WishlistItem {
   id: number;
   courseId: number;
@@ -19,23 +53,23 @@ export interface WishlistItem {
   addedAt?: string;
 }
 
-// 찜 목록 응답
+/** @deprecated Use Page<WishlistItemResponse> instead */
 export interface WishlistResponse {
   items: WishlistItem[];
   totalCount: number;
 }
 
-// 찜 추가 요청
+/** @deprecated Use WishlistAddRequest instead */
 export interface AddToWishlistRequest {
   courseId: number;
 }
 
-// 찜 삭제 요청
+/** @deprecated */
 export interface RemoveFromWishlistRequest {
   itemIds: number[];
 }
 
-// 찜 목록 전체 장바구니 담기 요청
+/** @deprecated */
 export interface AddAllToCartRequest {
   itemIds: number[];
 }


### PR DESCRIPTION
## Summary

찜(Wishlist) 기능 프론트엔드 구현 - 백엔드 API 연동

## Related Issue

- Closes #151

## Changes

- Wishlist API 타입 정의 (WishlistItemResponse, WishlistAddRequest 등)
- WishlistService 백엔드 API 스펙에 맞게 업데이트
- useWishlistQueries 훅 구현 (useMyWishlist, useToggleWishlist 등)
- WishlistButton 컴포넌트 구현 (찜 토글 버튼)
- WishlistPage 백엔드 API 연동으로 업데이트
- PageResponse 타입 추가 (Spring Page 응답)
- API_ENDPOINTS에 WISHLIST 엔드포인트 추가

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

주요 컴포넌트:
- WishlistButton: 강의 카드에서 사용하는 찜 토글 버튼
- WishlistPage: 찜 목록 페이지 (페이징 지원)

React Query 훅:
- useMyWishlist: 내 찜 목록 조회
- useAddToWishlist: 찜 추가
- useRemoveFromWishlist: 찜 삭제
- useToggleWishlist: 찜 토글 (추가/삭제 통합)
- useCheckWishlistStatus: 특정 강의 찜 여부 확인