### PR TITLE
feat: 다운로드 허용 옵션 프론트엔드 연동 (#141)

### DIFF
--- a/src/components/domain/tu/content/ContentRegistrationWizard.tsx
+++ b/src/components/domain/tu/content/ContentRegistrationWizard.tsx
@@ -141,7 +141,7 @@ export function ContentRegistrationWizard({
       case 2:
         return <Step2ContentUpload data={formData} onUpdate={handleUpdateData} />;
       case 3:
-        return <Step3Settings data={formData} onUpdate={handleUpdateData} />;
+        return <Step3Settings data={formData} onUpdate={handleUpdateData} isExternalLink={formData.loType === 'external-link'} />;
       default:
         return null;
     }

--- a/src/components/domain/tu/content/Step3Settings.tsx
+++ b/src/components/domain/tu/content/Step3Settings.tsx
@@ -6,6 +6,7 @@ import { RadioOptionCard } from '@/components/common';
 interface Step3Props {
   data: LOData;
   onUpdate: (data: Partial<LOData>) => void;
+  isExternalLink?: boolean;
 }
 
 const completionOptions: { value: CompletionCriteria; label: string; description: string }[] = [
@@ -41,7 +42,7 @@ const accessOptions: { value: AccessControl; icon: typeof Globe; label: string; 
   },
 ];
 
-export function Step3Settings({ data, onUpdate }: Readonly<Step3Props>) {
+export function Step3Settings({ data, onUpdate, isExternalLink = false }: Readonly<Step3Props>) {
   return (
     <div className="space-y-8">
       {/* 학습 정책 섹션 */}
@@ -51,27 +52,33 @@ export function Step3Settings({ data, onUpdate }: Readonly<Step3Props>) {
           <h2 className="text-text-primary font-medium text-lg">학습 정책</h2>
         </div>
 
-        {/* 다운로드 허용 */}
-        <div className="mb-6 pb-6 border-b border-border">
+        {/* 다운로드 허용 - 외부 링크일 때는 비활성화 */}
+        <div className={cn('mb-6 pb-6 border-b border-border', isExternalLink && 'opacity-50')}>
           <div className="flex items-center justify-between">
             <div>
               <p className="text-text-primary mb-1">다운로드 허용</p>
-              <p className="text-sm text-text-secondary">학습자가 콘텐츠를 다운로드할 수 있도록 허용합니다</p>
+              <p className="text-sm text-text-secondary">
+                {isExternalLink
+                  ? '외부 링크는 다운로드를 지원하지 않습니다'
+                  : '학습자가 콘텐츠를 다운로드할 수 있도록 허용합니다'}
+              </p>
             </div>
             <button
               type="button"
               role="switch"
               aria-checked={data.allowDownload}
-              onClick={() => onUpdate({ allowDownload: !data.allowDownload })}
+              onClick={() => !isExternalLink && onUpdate({ allowDownload: !data.allowDownload })}
+              disabled={isExternalLink}
               className={cn(
                 'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-                data.allowDownload ? 'bg-btn-neutral' : 'bg-border'
+                data.allowDownload && !isExternalLink ? 'bg-btn-neutral' : 'bg-border',
+                isExternalLink && 'cursor-not-allowed'
               )}
             >
               <span
                 className={cn(
                   'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
-                  data.allowDownload ? 'translate-x-6' : 'translate-x-1'
+                  data.allowDownload && !isExternalLink ? 'translate-x-6' : 'translate-x-1'
                 )}
               />
             </button>

--- a/src/hooks/tu/useContentQueries.ts
+++ b/src/hooks/tu/useContentQueries.ts
@@ -83,6 +83,7 @@ interface UploadContentParams {
   description?: string;
   tags?: string;
   thumbnail?: File;
+  downloadable?: boolean;
 }
 
 // 파일 업로드
@@ -90,8 +91,8 @@ export const useUploadContent = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ file, folderId, originalFileName, description, tags, thumbnail }: UploadContentParams) =>
-      contentService.uploadFile(file, { folderId, originalFileName, description, tags, thumbnail }),
+    mutationFn: ({ file, folderId, originalFileName, description, tags, thumbnail, downloadable }: UploadContentParams) =>
+      contentService.uploadFile(file, { folderId, originalFileName, description, tags, thumbnail, downloadable }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: contentKeys.lists() });
       queryClient.invalidateQueries({ queryKey: contentKeys.myLists() });

--- a/src/pages/tu/teaching/content/ContentCreatePage.tsx
+++ b/src/pages/tu/teaching/content/ContentCreatePage.tsx
@@ -21,13 +21,14 @@ export function ContentCreatePage() {
           name: data.title, // 콘텐츠 제목을 name으로 사용
         });
       } else if (data.uploadedFile) {
-        // 파일 업로드 (제목, 설명, 태그, 썸네일 전달)
+        // 파일 업로드 (제목, 설명, 태그, 썸네일, 다운로드 허용 전달)
         await uploadContent.mutateAsync({
           file: data.uploadedFile,
           originalFileName: data.title && data.title !== data.uploadedFile.name ? data.title : undefined,
           description: data.description || undefined,
           tags: data.tags.length > 0 ? data.tags.join(',') : undefined,
           thumbnail: data.thumbnailImage,
+          downloadable: data.allowDownload,
         });
       }
 

--- a/src/pages/tu/teaching/content/ContentDetailPage.tsx
+++ b/src/pages/tu/teaching/content/ContentDetailPage.tsx
@@ -384,15 +384,17 @@ export function ContentDetailPage({ language = 'ko' }: Readonly<ContentDetailPag
                     <Eye size={16} />
                     {getText('preview')}
                   </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="border border-border"
-                    onClick={handleDownload}
-                  >
-                    <Download size={16} />
-                    {getText('download')}
-                  </Button>
+                  {content.downloadable !== false && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="border border-border"
+                      onClick={handleDownload}
+                    >
+                      <Download size={16} />
+                      {getText('download')}
+                    </Button>
+                  )}
                 </>
               )}
               {isArchived ? (

--- a/src/pages/tu/teaching/content/ContentDetailPage.tsx
+++ b/src/pages/tu/teaching/content/ContentDetailPage.tsx
@@ -112,6 +112,8 @@ const t = {
   archiveSuccess: { ko: '보관되었습니다.', en: 'Archived successfully.' },
   restoreSuccess: { ko: '복원되었습니다.', en: 'Restored successfully.' },
   deleteSuccess: { ko: '삭제되었습니다.', en: 'Deleted successfully.' },
+  deleteFailedInUse: { ko: '이 콘텐츠는 강의에 포함되어 있어 삭제할 수 없습니다.', en: 'This content cannot be deleted because it is included in a course.' },
+  updateFailedInUse: { ko: '이 콘텐츠는 강의에 포함되어 있어 수정할 수 없습니다.', en: 'This content cannot be modified because it is included in a course.' },
   versionRestoreSuccess: { ko: '버전이 복원되었습니다.', en: 'Version restored successfully.' },
   externalUrl: { ko: '외부 URL', en: 'External URL' },
   inCourse: { ko: '과정에 포함됨', en: 'In Course' },
@@ -246,9 +248,14 @@ export function ContentDetailPage({ language = 'ko' }: Readonly<ContentDetailPag
       if (fileInputRef.current) {
         fileInputRef.current.value = '';
       }
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('Update failed:', err);
-      alert('수정에 실패했습니다.');
+      const error = err as { response?: { data?: { error?: { code?: string } } } };
+      if (error.response?.data?.error?.code === 'CT010') {
+        alert(getText('updateFailedInUse'));
+      } else {
+        alert(getText('error'));
+      }
     }
   };
 
@@ -281,8 +288,15 @@ export function ContentDetailPage({ language = 'ko' }: Readonly<ContentDetailPag
       await deleteContent.mutateAsync(contentId);
       alert(getText('deleteSuccess'));
       navigate('/tu/teaching/content');
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('Delete failed:', err);
+      // 강의에 포함된 콘텐츠 삭제 시도 시 에러 처리
+      const error = err as { response?: { data?: { error?: { code?: string } } } };
+      if (error.response?.data?.error?.code === 'CT010') {
+        alert(getText('deleteFailedInUse'));
+      } else {
+        alert(getText('error'));
+      }
     }
   };
 

--- a/src/pages/tu/teaching/content/MyContentPage.tsx
+++ b/src/pages/tu/teaching/content/MyContentPage.tsx
@@ -82,6 +82,7 @@ const t = {
   loading: { ko: '로딩 중...', en: 'Loading...' },
   error: { ko: '오류가 발생했습니다.', en: 'An error occurred.' },
   confirmDelete: { ko: '정말 삭제하시겠습니까?', en: 'Are you sure you want to delete?' },
+  deleteFailedInUse: { ko: '이 콘텐츠는 강의에 포함되어 있어 삭제할 수 없습니다.', en: 'This content cannot be deleted because it is included in a course.' },
   prev: { ko: '이전', en: 'Prev' },
   next: { ko: '다음', en: 'Next' },
   contentCount: { ko: '개의 콘텐츠', en: ' contents' },
@@ -167,8 +168,15 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
     if (!confirm(getText('confirmDelete'))) return;
     try {
       await deleteContent.mutateAsync(id);
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('Delete failed:', err);
+      // 강의에 포함된 콘텐츠 삭제 시도 시 에러 처리
+      const error = err as { response?: { data?: { error?: { code?: string } } } };
+      if (error.response?.data?.error?.code === 'CT010') {
+        alert(getText('deleteFailedInUse'));
+      } else {
+        alert(getText('error'));
+      }
     }
   };
 

--- a/src/pages/tu/teaching/courses/CourseCreatePage.tsx
+++ b/src/pages/tu/teaching/courses/CourseCreatePage.tsx
@@ -49,11 +49,11 @@ async function createCurriculumItemsRecursively(
         );
       }
     } else if (isCurriculumContent(item)) {
-      // 콘텐츠(차시) 생성
+      // 콘텐츠(차시) 생성 - contentId로 백엔드에서 LO 자동 생성
       await courseService.createItem(courseId, {
         itemName: item.name,
         parentId: parentId ?? undefined,
-        learningObjectId: item.learningObjectId,
+        contentId: item.contentId,
         displayName: item.displayName || undefined,
         description: item.description || undefined,
       });

--- a/src/pages/tu/teaching/courses/components/ExistingContentModal.tsx
+++ b/src/pages/tu/teaching/courses/components/ExistingContentModal.tsx
@@ -164,8 +164,7 @@ export function ExistingContentModal({
           </div>
 
           {/* 콘텐츠 목록 */}
-          <div className="border border-border rounded-lg overflow-hidden flex-1 min-h-0">
-            <div className="h-full overflow-y-auto">
+          <div className="border border-border rounded-lg overflow-y-auto flex-1 min-h-0">
               {isLoading ? (
                 <div className="p-8 text-center text-text-secondary">
                   {getText('processing')}
@@ -204,7 +203,6 @@ export function ExistingContentModal({
                   ))}
                 </div>
               )}
-            </div>
           </div>
         </div>
 

--- a/src/pages/tu/teaching/courses/components/ExistingContentModal.tsx
+++ b/src/pages/tu/teaching/courses/components/ExistingContentModal.tsx
@@ -126,17 +126,17 @@ export function ExistingContentModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-      <DialogContent className="max-w-2xl max-h-[80vh] bg-bg-default">
-        <DialogHeader>
+      <DialogContent className="max-w-2xl max-h-[80vh] bg-bg-default flex flex-col overflow-hidden">
+        <DialogHeader className="shrink-0">
           <DialogTitle className="flex items-center gap-2 text-text-primary">
             <FileText size={20} />
             {getText('existingContentModalTitle')}
           </DialogTitle>
         </DialogHeader>
 
-        <div className="flex flex-col gap-4 py-4">
+        <div className="flex flex-col gap-4 py-4 flex-1 min-h-0 overflow-hidden">
           {/* 검색 및 필터 */}
-          <div className="flex gap-3">
+          <div className="flex gap-3 shrink-0">
             <div className="relative flex-1">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-secondary" />
               <Input
@@ -164,8 +164,8 @@ export function ExistingContentModal({
           </div>
 
           {/* 콘텐츠 목록 */}
-          <div className="border border-border rounded-lg overflow-hidden">
-            <div className="max-h-[400px] overflow-y-auto">
+          <div className="border border-border rounded-lg overflow-hidden flex-1 min-h-0">
+            <div className="h-full overflow-y-auto">
               {isLoading ? (
                 <div className="p-8 text-center text-text-secondary">
                   {getText('processing')}
@@ -208,7 +208,7 @@ export function ExistingContentModal({
           </div>
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="shrink-0">
           <Button
             variant="ghost"
             onClick={handleClose}

--- a/src/pages/tu/teaching/courses/components/courseCreate.constants.ts
+++ b/src/pages/tu/teaching/courses/components/courseCreate.constants.ts
@@ -113,6 +113,9 @@ export const translations = {
   // 공통
   cancel: { ko: '취소', en: 'Cancel' },
   processing: { ko: '처리 중...', en: 'Processing...' },
+  // 페이지네이션
+  prev: { ko: '이전', en: 'Prev' },
+  pageInfo: { ko: '{current} / {total} 페이지', en: 'Page {current} of {total}' },
 } as const;
 
 export type TranslationKey = keyof typeof translations;

--- a/src/services/tu/contentService.ts
+++ b/src/services/tu/contentService.ts
@@ -29,6 +29,7 @@ interface UploadFileOptions {
   description?: string;
   tags?: string;
   thumbnail?: File;
+  downloadable?: boolean;
 }
 
 export const contentService = {
@@ -51,6 +52,9 @@ export const contentService = {
     }
     if (options?.thumbnail) {
       formData.append('thumbnail', options.thumbnail);
+    }
+    if (options?.downloadable !== undefined) {
+      formData.append('downloadable', String(options.downloadable));
     }
 
     const { data } = await axiosInstance.post<{ data: ContentResponse }>(

--- a/src/types/common/course.types.ts
+++ b/src/types/common/course.types.ts
@@ -119,7 +119,7 @@ export interface UpdateCourseRequest {
 export interface CreateItemRequest {
   itemName: string;
   parentId?: number | null;
-  learningObjectId: number;
+  contentId: number;
   displayName?: string;
   description?: string;
 }

--- a/src/types/tu/content.types.ts
+++ b/src/types/tu/content.types.ts
@@ -30,6 +30,7 @@ export interface ContentResponse {
   customThumbnailPath: string | null;
   description: string | null;
   tags: string | null;
+  downloadable: boolean | null;
   createdBy: number;
   currentVersion: number;
   inCourse: boolean;
@@ -50,6 +51,7 @@ export interface ContentListResponse {
   customThumbnailPath: string | null;
   description: string | null;
   tags: string | null;
+  downloadable: boolean | null;
   currentVersion: number;
   inCourse: boolean | null;
   createdAt: string;
@@ -83,6 +85,7 @@ export interface CreateExternalLinkRequest {
 // 콘텐츠 메타데이터 수정 요청
 export interface UpdateContentRequest {
   originalFileName?: string;
+  downloadable?: boolean;
 }
 
 // 버전 복원 요청

--- a/src/types/tu/curriculum.types.ts
+++ b/src/types/tu/curriculum.types.ts
@@ -39,11 +39,11 @@ export interface CurriculumFolderItem extends CurriculumItemBase {
 /** 콘텐츠(LO) 타입 커리큘럼 항목 */
 export interface CurriculumContentItem extends CurriculumItemBase {
   type: 'content';
-  /** 연결된 Learning Object ID */
-  learningObjectId: number;
-  /** LO 원본 파일명 */
+  /** 콘텐츠 ID (백엔드에서 LO 자동 생성) */
+  contentId: number;
+  /** 원본 파일명 */
   originalFileName: string;
-  /** LO 콘텐츠 타입 */
+  /** 콘텐츠 타입 */
   contentType: string;
   /** 강의 내 표시용 이름 (선택적 오버라이드) */
   displayName?: string;
@@ -96,7 +96,7 @@ export function createFolderItem(
 
 /** 새 콘텐츠 항목 생성 */
 export function createContentItem(
-  learningObjectId: number,
+  contentId: number,
   originalFileName: string,
   contentType: string,
   depth: number = 0,
@@ -108,7 +108,7 @@ export function createContentItem(
     type: 'content',
     depth,
     order,
-    learningObjectId,
+    contentId,
     originalFileName,
     contentType,
   };


### PR DESCRIPTION
## Summary

콘텐츠 다운로드 허용 옵션 UI 및 관련 버그 수정

## Related Issue

- Closes #141

## Changes

- 콘텐츠 업로드 시 다운로드 허용 토글 추가
- 외부 링크 등록 시 다운로드 허용 토글 비활성화
- 콘텐츠 상세 페이지에서 다운로드 허용 여부 표시 및 편집
- 강의 생성 시 contentId로 API 호출 (백엔드 LO 자동 생성 연동)
- CurriculumContentItem 타입 learningObjectId → contentId 변경
- ExistingContentModal 스크롤 버그 수정
- 강의 포함 콘텐츠 수정/삭제 시 에러 알럿 추가 (CT010)

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Test plan

- [x] 콘텐츠 업로드 시 다운로드 허용 토글 확인
- [x] 외부 링크 등록 시 토글 비활성화 확인
- [x] 콘텐츠 상세에서 다운로드 허용 여부 표시/편집 확인
- [x] 강의 생성 후 콘텐츠-LO 연결 확인
- [x] 강의 포함 콘텐츠 삭제 시 알럿 확인