### PR TITLE
fix(tu): 모달 긴 파일명 overflow 문제 수정

### DIFF
--- a/src/pages/tu/teaching/courses/components/ExistingContentModal.tsx
+++ b/src/pages/tu/teaching/courses/components/ExistingContentModal.tsx
@@ -126,7 +126,7 @@ export function ExistingContentModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-      <DialogContent className="max-w-2xl max-h-[80vh] bg-bg-default">
+      <DialogContent className="max-w-2xl sm:max-w-2xl max-h-[80vh] bg-bg-default">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-text-primary">
             <FileText size={20} />
@@ -188,7 +188,7 @@ export function ExistingContentModal({
                       <div className="flex h-10 w-10 items-center justify-center rounded-md bg-bg-secondary text-text-secondary shrink-0">
                         {getContentIcon(content.contentType)}
                       </div>
-                      <div className="flex-1 min-w-0">
+                      <div className="flex-1 min-w-0 w-0">
                         <p className="text-sm font-medium text-text-primary truncate">
                           {content.originalFileName}
                         </p>

--- a/src/pages/tu/teaching/courses/components/FileUploadModal.tsx
+++ b/src/pages/tu/teaching/courses/components/FileUploadModal.tsx
@@ -134,7 +134,7 @@ export function FileUploadModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-      <DialogContent className="max-w-md bg-bg-default">
+      <DialogContent className="max-w-md sm:max-w-md bg-bg-default">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-text-primary">
             <Upload size={20} />
@@ -177,7 +177,7 @@ export function FileUploadModal({
                 <div className="flex h-10 w-10 items-center justify-center rounded-md bg-bg-secondary text-text-secondary">
                   {getFileIcon(selectedFile)}
                 </div>
-                <div className="flex-1 min-w-0">
+                <div className="flex-1 min-w-0 w-0">
                   <p className="text-sm font-medium text-text-primary truncate">
                     {selectedFile.name}
                   </p>


### PR DESCRIPTION
## Summary
- ExistingContentModal, FileUploadModal에서 긴 파일명이 모달 영역을 넘어가는 overflow 문제 수정
- DialogContent의 기본 `sm:max-w-lg` 스타일과 충돌 해결
- flex 컨테이너에서 truncate가 정상 작동하도록 `w-0` 트릭 적용

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| ExistingContentModal.tsx | `sm:max-w-2xl` 추가, 파일명 컨테이너에 `w-0` 추가 |
| FileUploadModal.tsx | `sm:max-w-md` 추가, 파일명 컨테이너에 `w-0` 추가 |

## Root Cause
Dialog 컴포넌트의 기본 스타일에 `sm:max-w-lg`가 있어서, 모달에서 `max-w-2xl`만 추가하면 sm breakpoint 이상에서 여전히 512px로 제한됨. 또한 `flex-1 min-w-0`만으로는 깊게 중첩된 flex 컨테이너에서 truncate가 작동하지 않는 경우가 있음.

## Test Plan
- [ ] ExistingContentModal에서 긴 파일명 선택 시 truncate 확인
- [ ] FileUploadModal에서 긴 파일명 업로드 시 truncate 확인

Closes #154