### PR TITLE
feat(enrollment): 백엔드 API 응답 불일치 수정 및 UX 개선

### DIFF
--- a/src/pages/tu/catalog/CatalogDetailPage.tsx
+++ b/src/pages/tu/catalog/CatalogDetailPage.tsx
@@ -10,6 +10,7 @@ import {
   Loader2,
   AlertCircle,
 } from 'lucide-react';
+import { toast } from 'sonner';
 import { designTokens } from '@/styles/admin-design-tokens';
 import {
   Button,
@@ -152,10 +153,12 @@ export function CatalogDetailPage() {
 
   const handleEnroll = async (courseTimeId: number) => {
     try {
-      await enrollMutation.mutateAsync(courseTimeId);
-      alert(t.catalog.enrollSuccess);
+      const enrollment = await enrollMutation.mutateAsync(courseTimeId);
+      toast.success(t.catalog.enrollSuccess);
+      // 수강 신청 성공 후 학습 페이지로 이동
+      navigate(`/mypage/learning/${enrollment.id}`);
     } catch {
-      alert(t.catalog.enrollFail);
+      toast.error(t.catalog.enrollFail);
     }
   };
 

--- a/src/pages/tu/main/CourseDetailPage.tsx
+++ b/src/pages/tu/main/CourseDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useParams, Link } from 'react-router-dom';
 import { useState } from 'react';
 import { Star, Clock, Users, PlayCircle, FileText, Award, ShoppingCart, Heart, Share2, ChevronDown, ChevronRight, Check, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
 import { useThemeStore } from '@/store/common/themeStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
@@ -208,7 +209,7 @@ const MOCK_COURSES: Record<string, CourseDetail> = {
 };
 
 // 환경 설정: true면 API 사용, false면 더미 데이터 사용
-const USE_API = false;
+const USE_API = true;
 
 /**
  * 커리큘럼 섹션 컴포넌트
@@ -329,12 +330,13 @@ export function CourseDetailPage() {
     if (USE_API) {
       try {
         await addToCartMutation.mutateAsync(course.id);
-        alert('장바구니에 추가되었습니다.');
+        toast.success('장바구니에 추가되었습니다.');
       } catch (err) {
         console.error('장바구니 추가 실패:', err);
+        toast.error('장바구니 추가에 실패했습니다.');
       }
     } else {
-      alert('장바구니에 추가되었습니다. (데모)');
+      toast.success('장바구니에 추가되었습니다. (데모)');
     }
   };
 

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -199,7 +199,7 @@ export const API_ENDPOINTS = {
   // Enrollments (수강 신청) - TU
   ENROLLMENTS: {
     BASE: '/enrollments',
-    MY: '/enrollments/my',
+    MY: '/users/me/enrollments',
     BY_ID: (id: number) => `/enrollments/${id}`,
     CANCEL: (id: number) => `/enrollments/${id}/cancel`,
     PROGRESS: (id: number) => `/enrollments/${id}/progress`,

--- a/src/services/tu/enrollmentService.ts
+++ b/src/services/tu/enrollmentService.ts
@@ -11,7 +11,34 @@ import type {
 export type EnrollmentStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'CANCELLED' | 'COMPLETED';
 
 /**
- * 수강 신청 타입
+ * 백엔드 EnrollmentResponse 타입 (실제 API 응답)
+ */
+interface BackendEnrollmentResponse {
+  id: number;
+  userId: number;
+  courseTimeId: number;
+  enrolledAt: string;
+  type: string;
+  status: string;
+  progressPercent: number | null;
+  score: number | null;
+  completedAt: string | null;
+}
+
+/**
+ * 백엔드 CourseTime 응답 타입 (차수 정보)
+ */
+interface BackendCourseTimeResponse {
+  id: number;
+  title: string;
+  programId: number;
+  programName: string;
+  classStartDate: string;
+  classEndDate: string;
+}
+
+/**
+ * 수강 신청 타입 (프론트엔드용)
  */
 export interface Enrollment {
   id: number;
@@ -63,6 +90,41 @@ interface ApiResponse<T> {
 }
 
 /**
+ * 백엔드 상태를 프론트엔드 상태로 매핑
+ */
+const mapEnrollmentStatus = (status: string): EnrollmentStatus => {
+  const statusMap: Record<string, EnrollmentStatus> = {
+    ENROLLED: 'APPROVED',
+    IN_PROGRESS: 'APPROVED',
+    COMPLETED: 'COMPLETED',
+    CANCELLED: 'CANCELLED',
+    DROPPED: 'CANCELLED',
+  };
+  return statusMap[status] || 'PENDING';
+};
+
+/**
+ * 백엔드 응답을 프론트엔드 Enrollment로 변환
+ */
+const transformEnrollment = (
+  backend: BackendEnrollmentResponse,
+  courseTimeInfo?: BackendCourseTimeResponse
+): Enrollment => ({
+  id: backend.id,
+  userId: backend.userId,
+  courseTimeId: backend.courseTimeId,
+  programId: courseTimeInfo?.programId ?? 0,
+  programTitle: courseTimeInfo?.programName ?? '',
+  courseTimeName: courseTimeInfo?.title ?? '',
+  status: mapEnrollmentStatus(backend.status),
+  enrolledAt: backend.enrolledAt,
+  completedAt: backend.completedAt ?? undefined,
+  progress: backend.progressPercent ?? 0,
+  startDate: courseTimeInfo?.classStartDate ?? '',
+  endDate: courseTimeInfo?.classEndDate ?? '',
+});
+
+/**
  * 수강 신청 서비스
  */
 export const enrollmentService = {
@@ -78,13 +140,46 @@ export const enrollmentService = {
 
   /**
    * 내 수강 신청 목록 조회
+   * - 백엔드 응답을 프론트엔드 형식으로 변환
+   * - 차수(courseTime) 정보를 추가로 조회하여 programTitle, courseTimeName 등 보완
    */
   getMyEnrollments: async (params?: EnrollmentFilterParams): Promise<PageResponse<Enrollment>> => {
-    const response = await axiosInstance.get<ApiResponse<PageResponse<Enrollment>>>(
+    // 1. 수강 목록 조회
+    const response = await axiosInstance.get<ApiResponse<PageResponse<BackendEnrollmentResponse>>>(
       API_ENDPOINTS.ENROLLMENTS.MY,
       { params }
     );
-    return response.data.data;
+    const pageData = response.data.data;
+
+    // 2. 고유한 courseTimeId 목록 추출
+    const courseTimeIds = [...new Set(pageData.content.map((e) => e.courseTimeId))];
+
+    // 3. 각 차수 정보 조회 (병렬)
+    const courseTimeMap = new Map<number, BackendCourseTimeResponse>();
+    if (courseTimeIds.length > 0) {
+      const courseTimePromises = courseTimeIds.map(async (id) => {
+        try {
+          const res = await axiosInstance.get<ApiResponse<BackendCourseTimeResponse>>(
+            API_ENDPOINTS.TIMES.BY_ID(id)
+          );
+          return { id, data: res.data.data };
+        } catch {
+          return { id, data: null };
+        }
+      });
+      const results = await Promise.all(courseTimePromises);
+      results.forEach(({ id, data }) => {
+        if (data) courseTimeMap.set(id, data);
+      });
+    }
+
+    // 4. 변환하여 반환
+    return {
+      ...pageData,
+      content: pageData.content.map((e) =>
+        transformEnrollment(e, courseTimeMap.get(e.courseTimeId))
+      ),
+    };
   },
 
   /**


### PR DESCRIPTION
## Summary

백엔드 Enrollment API 응답과 프론트엔드 인터페이스 간 불일치를 수정하고, 사용자 경험을 개선했습니다.

## Related Issue

- Closes #157

## Changes

- Enrollment API 엔드포인트 수정 (`/enrollments/my` → `/users/me/enrollments`)
- 백엔드 응답 변환 레이어 추가 (`progressPercent` → `progress`, status 매핑)
- 차수(courseTime) 정보 병렬 조회로 누락 필드 보완 (`programTitle`, `courseTimeName`, `startDate`, `endDate`)
- 수강 신청 성공 시 학습 페이지로 리다이렉트 추가
- `alert()` → `toast()` 변경으로 UX 개선
- CourseDetailPage API 모드 활성화 (`USE_API = true`)

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

### 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `src/services/common/api/endpoints.ts` | 엔드포인트 경로 수정 |
| `src/services/tu/enrollmentService.ts` | 백엔드 응답 변환 로직 추가 |
| `src/pages/tu/catalog/CatalogDetailPage.tsx` | toast 알림 + 리다이렉트 |
| `src/pages/tu/main/CourseDetailPage.tsx` | toast 알림 + API 활성화 |

### 알려진 이슈
- 백엔드 `/api/times/{id}` 응답에 `programId`, `programName` 필드가 없어 기본값 처리됨
- 수강 신청 생성 시 백엔드 Hibernate 버전 관리 버그 존재 (별도 이슈)