### PR TITLE
[Feat] TO 강사 배정 정보 확인 페이지 구현

### DIFF
--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -205,7 +205,7 @@ export const tenantOperatorMenuData: MenuItem[] = [
     icon: ClipboardList,
     subItems: [
       { id: 'sis-lookup', label: { ko: '학생 수강 정보 확인', en: 'SIS Lookup' }, icon: BookOpen, path: '/to/sis' },
-      { id: 'iis-lookup', label: { ko: '강사 배정 정보 확인', en: 'IIS Lookup' }, icon: BookCheck, path: '/to/iis' },
+      { id: 'iis-lookup', label: { ko: '강사 배정 정보 확인', en: 'IIS Lookup' }, icon: BookCheck, path: '/to/instructor-assignments' },
     ],
   },
   {

--- a/src/hooks/to/useInstructorAssignmentQueries.ts
+++ b/src/hooks/to/useInstructorAssignmentQueries.ts
@@ -18,8 +18,11 @@ import type {
 
 export const instructorAssignmentKeys = {
   all: ['instructorAssignments'] as const,
+  lists: () => [...instructorAssignmentKeys.all, 'list'] as const,
+  list: (params?: InstructorAssignmentFilterParams) =>
+    [...instructorAssignmentKeys.lists(), params] as const,
   byTime: (timeId: number) => [...instructorAssignmentKeys.all, 'time', timeId] as const,
-  list: (timeId: number, params?: InstructorAssignmentFilterParams) =>
+  timeList: (timeId: number, params?: InstructorAssignmentFilterParams) =>
     [...instructorAssignmentKeys.byTime(timeId), params] as const,
 };
 
@@ -27,13 +30,21 @@ export const instructorAssignmentKeys = {
 // Query Hooks
 // ============================================
 
+/** 전체 강사 배정 목록 조회 (TO 전용) */
+export const useInstructorAssignments = (params?: InstructorAssignmentFilterParams) => {
+  return useQuery({
+    queryKey: instructorAssignmentKeys.list(params),
+    queryFn: () => instructorAssignmentService.getAssignments(params),
+  });
+};
+
 /** 차수별 강사 목록 조회 */
 export const useTimeInstructors = (
   timeId: number,
   params?: InstructorAssignmentFilterParams
 ) => {
   return useQuery({
-    queryKey: instructorAssignmentKeys.list(timeId, params),
+    queryKey: instructorAssignmentKeys.timeList(timeId, params),
     queryFn: () => instructorAssignmentService.getInstructors(timeId, params),
     enabled: !!timeId,
   });

--- a/src/pages/to/instructor/InstructorAssignmentsPage.tsx
+++ b/src/pages/to/instructor/InstructorAssignmentsPage.tsx
@@ -17,7 +17,6 @@ import {
 import { cn } from '@/utils/cn';
 import {
   Button,
-  Badge,
   DataTable,
   DataTableColumnHeader,
   IconStatCard,
@@ -90,16 +89,17 @@ const t = {
   goToCourseTime: { ko: '차수 상세 페이지로 이동', en: 'Go to Course Time' },
 };
 
-const roleBadgeVariant: Record<InstructorRole, 'default' | 'secondary' | 'outline'> = {
-  MAIN: 'default',
-  SUB: 'secondary',
-  ASSISTANT: 'outline',
+// Badge 색상 스타일 (디자인 토큰 기반)
+const roleBadgeStyles: Record<InstructorRole, string> = {
+  MAIN: 'bg-badge-indigo-bg text-badge-indigo border-transparent',
+  SUB: 'bg-badge-blue-bg text-badge-blue border-transparent',
+  ASSISTANT: 'bg-badge-gray-bg text-badge-gray border-transparent',
 };
 
-const statusBadgeVariant: Record<AssignmentStatus, 'default' | 'secondary' | 'destructive'> = {
-  ACTIVE: 'default',
-  REPLACED: 'secondary',
-  CANCELLED: 'destructive',
+const statusBadgeStyles: Record<AssignmentStatus, string> = {
+  ACTIVE: 'bg-badge-green-bg text-badge-green border-transparent',
+  REPLACED: 'bg-badge-yellow-bg text-badge-yellow border-transparent',
+  CANCELLED: 'bg-badge-red-bg text-badge-red border-transparent',
 };
 
 export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<InstructorAssignmentsPageProps>) {
@@ -250,9 +250,9 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
           <DataTableColumnHeader column={column} title={getText('columnRole')} />
         ),
         cell: ({ row }) => (
-          <Badge variant={roleBadgeVariant[row.original.role]}>
+          <span className={cn('inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium', roleBadgeStyles[row.original.role])}>
             {getRoleLabel(row.original.role)}
-          </Badge>
+          </span>
         ),
       },
       {
@@ -261,9 +261,9 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
           <DataTableColumnHeader column={column} title={getText('columnStatus')} />
         ),
         cell: ({ row }) => (
-          <Badge variant={statusBadgeVariant[row.original.status]}>
+          <span className={cn('inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium', statusBadgeStyles[row.original.status])}>
             {getStatusLabel(row.original.status)}
-          </Badge>
+          </span>
         ),
       },
       {
@@ -534,15 +534,15 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
                   </div>
                   <div>
                     <p className="text-xs text-text-secondary">{getText('columnRole')}</p>
-                    <Badge variant={roleBadgeVariant[selectedAssignment.role]} className="mt-1">
+                    <span className={cn('inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium mt-1', roleBadgeStyles[selectedAssignment.role])}>
                       {getRoleLabel(selectedAssignment.role)}
-                    </Badge>
+                    </span>
                   </div>
                   <div>
                     <p className="text-xs text-text-secondary">{getText('columnStatus')}</p>
-                    <Badge variant={statusBadgeVariant[selectedAssignment.status]} className="mt-1">
+                    <span className={cn('inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium mt-1', statusBadgeStyles[selectedAssignment.status])}>
                       {getStatusLabel(selectedAssignment.status)}
-                    </Badge>
+                    </span>
                   </div>
                   <div>
                     <p className="text-xs text-text-secondary">{getText('assignedAt')}</p>

--- a/src/pages/to/instructor/InstructorAssignmentsPage.tsx
+++ b/src/pages/to/instructor/InstructorAssignmentsPage.tsx
@@ -11,6 +11,8 @@ import {
   MoreHorizontal,
   UserCheck,
   Calendar,
+  Mail,
+  ExternalLink,
 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import {
@@ -24,6 +26,10 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   NativeSelect,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
 } from '@/components/common';
 import { useInstructorAssignments } from '@/hooks/to/useInstructorAssignmentQueries';
 import type {
@@ -56,8 +62,8 @@ const t = {
   activeAssignments: { ko: '활동 중', en: 'Active' },
   // 테이블 컬럼
   columnInstructor: { ko: '강사명', en: 'Instructor' },
-  columnCourseTime: { ko: '차수', en: 'Course Time' },
-  columnProgram: { ko: '프로그램', en: 'Program' },
+  columnCourseTime: { ko: '차수명', en: 'Course Time' },
+  columnProgram: { ko: '과정명', en: 'Course' },
   columnRole: { ko: '역할', en: 'Role' },
   columnStatus: { ko: '상태', en: 'Status' },
   columnPeriod: { ko: '학습 기간', en: 'Period' },
@@ -73,6 +79,15 @@ const t = {
   prev: { ko: '이전', en: 'Prev' },
   next: { ko: '다음', en: 'Next' },
   assignmentCount: { ko: '개의 배정', en: ' assignments' },
+  // 사이드 패널
+  panelTitle: { ko: '배정 상세 정보', en: 'Assignment Details' },
+  instructorInfo: { ko: '강사 정보', en: 'Instructor Info' },
+  courseTimeInfo: { ko: '차수 정보', en: 'Course Time Info' },
+  email: { ko: '이메일', en: 'Email' },
+  assignedAt: { ko: '배정일', en: 'Assigned At' },
+  programName: { ko: '과정명', en: 'Course Name' },
+  learningPeriod: { ko: '학습 기간', en: 'Learning Period' },
+  goToCourseTime: { ko: '차수 상세 페이지로 이동', en: 'Go to Course Time' },
 };
 
 const roleBadgeVariant: Record<InstructorRole, 'default' | 'secondary' | 'outline'> = {
@@ -94,6 +109,7 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
   const [statusFilter, setStatusFilter] = useState<AssignmentStatus | 'all'>('all');
   const [showFilters, setShowFilters] = useState(false);
   const [page, setPage] = useState(0);
+  const [selectedAssignment, setSelectedAssignment] = useState<InstructorAssignmentListResponse | null>(null);
 
   const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
   const getRoleLabel = (role: InstructorRole) =>
@@ -121,9 +137,9 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
     const query = searchQuery.toLowerCase();
     return assignments.filter(
       (item) =>
-        item.instructor.name.toLowerCase().includes(query) ||
-        item.courseTime.title.toLowerCase().includes(query) ||
-        item.program.title.toLowerCase().includes(query)
+        (item.instructor?.name?.toLowerCase().includes(query) ?? false) ||
+        (item.courseTime?.title?.toLowerCase().includes(query) ?? false) ||
+        (item.program?.title?.toLowerCase().includes(query) ?? false)
     );
   }, [assignments, searchQuery]);
 
@@ -171,7 +187,10 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-40">
-          <DropdownMenuItem onClick={() => navigate(`/to/times/${item.courseTime.id}`)}>
+          <DropdownMenuItem
+            onClick={() => item.courseTime?.id && navigate(`/to/times/${item.courseTime.id}`)}
+            disabled={!item.courseTime?.id}
+          >
             <Eye size={14} />
             {getText('viewCourseTime')}
           </DropdownMenuItem>
@@ -191,10 +210,10 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
         cell: ({ row }) => (
           <div className="max-w-[180px]">
             <p className="text-sm font-medium text-text-primary truncate">
-              {row.original.instructor.name}
+              {row.original.instructor?.name ?? '-'}
             </p>
             <p className="text-xs text-text-secondary truncate">
-              {row.original.instructor.email}
+              {row.original.instructor?.email ?? '-'}
             </p>
           </div>
         ),
@@ -207,7 +226,7 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
         cell: ({ row }) => (
           <div className="max-w-[150px]">
             <p className="text-sm text-text-primary truncate">
-              {row.original.courseTime.title}
+              {row.original.courseTime?.title ?? '-'}
             </p>
           </div>
         ),
@@ -220,7 +239,7 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
         cell: ({ row }) => (
           <div className="max-w-[180px]">
             <p className="text-sm text-text-secondary truncate">
-              {row.original.program.title}
+              {row.original.program?.title ?? '-'}
             </p>
           </div>
         ),
@@ -252,7 +271,9 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
         header: getText('columnPeriod'),
         cell: ({ row }) => (
           <span className="text-sm text-text-secondary">
-            {formatPeriod(row.original.courseTime.startDate, row.original.courseTime.endDate)}
+            {row.original.courseTime?.startDate && row.original.courseTime?.endDate
+              ? formatPeriod(row.original.courseTime.startDate, row.original.courseTime.endDate)
+              : '-'}
           </span>
         ),
       },
@@ -446,7 +467,7 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
               data={filteredAssignments}
               showColumnToggle={false}
               showPagination={true}
-              onRowClick={(item) => navigate(`/to/times/${item.courseTime.id}`)}
+              onRowClick={(item) => setSelectedAssignment(item)}
               labels={{
                 noResults: getText('noResults'),
               }}
@@ -479,6 +500,107 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
           )}
         </div>
       </div>
+
+      {/* Detail Modal */}
+      <Dialog open={!!selectedAssignment} onOpenChange={(open: boolean) => !open && setSelectedAssignment(null)}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>{getText('panelTitle')}</DialogTitle>
+          </DialogHeader>
+
+          {selectedAssignment && (
+            <div className="space-y-6">
+              {/* 강사 정보 */}
+              <div className="space-y-3">
+                <h3 className="text-sm font-semibold text-text-primary flex items-center gap-2">
+                  <UserCheck size={16} />
+                  {getText('instructorInfo')}
+                </h3>
+                <div className="bg-bg-secondary rounded-lg p-4 space-y-3">
+                  <div>
+                    <p className="text-xs text-text-secondary">{getText('columnInstructor')}</p>
+                    <p className="text-sm font-medium text-text-primary">
+                      {selectedAssignment.instructor?.name ?? '-'}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-text-secondary flex items-center gap-1">
+                      <Mail size={12} />
+                      {getText('email')}
+                    </p>
+                    <p className="text-sm text-text-primary">
+                      {selectedAssignment.instructor?.email ?? '-'}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-text-secondary">{getText('columnRole')}</p>
+                    <Badge variant={roleBadgeVariant[selectedAssignment.role]} className="mt-1">
+                      {getRoleLabel(selectedAssignment.role)}
+                    </Badge>
+                  </div>
+                  <div>
+                    <p className="text-xs text-text-secondary">{getText('columnStatus')}</p>
+                    <Badge variant={statusBadgeVariant[selectedAssignment.status]} className="mt-1">
+                      {getStatusLabel(selectedAssignment.status)}
+                    </Badge>
+                  </div>
+                  <div>
+                    <p className="text-xs text-text-secondary">{getText('assignedAt')}</p>
+                    <p className="text-sm text-text-primary">
+                      {formatDate(selectedAssignment.assignedAt)}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* 차수 정보 */}
+              <div className="space-y-3">
+                <h3 className="text-sm font-semibold text-text-primary flex items-center gap-2">
+                  <Calendar size={16} />
+                  {getText('courseTimeInfo')}
+                </h3>
+                <div className="bg-bg-secondary rounded-lg p-4 space-y-3">
+                  <div>
+                    <p className="text-xs text-text-secondary">{getText('columnCourseTime')}</p>
+                    <p className="text-sm font-medium text-text-primary">
+                      {selectedAssignment.courseTime?.title ?? '-'}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-text-secondary">{getText('programName')}</p>
+                    <p className="text-sm text-text-primary">
+                      {selectedAssignment.program?.title ?? '-'}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-text-secondary">{getText('learningPeriod')}</p>
+                    <p className="text-sm text-text-primary">
+                      {selectedAssignment.courseTime?.startDate && selectedAssignment.courseTime?.endDate
+                        ? `${formatDate(selectedAssignment.courseTime.startDate)} ~ ${formatDate(selectedAssignment.courseTime.endDate)}`
+                        : '-'}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* 차수 상세 페이지 이동 버튼 */}
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={() => {
+                  if (selectedAssignment.courseTime?.id) {
+                    navigate(`/to/times/${selectedAssignment.courseTime.id}`);
+                  }
+                }}
+                disabled={!selectedAssignment.courseTime?.id}
+              >
+                <ExternalLink size={16} />
+                {getText('goToCourseTime')}
+              </Button>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/pages/to/instructor/InstructorAssignmentsPage.tsx
+++ b/src/pages/to/instructor/InstructorAssignmentsPage.tsx
@@ -1,0 +1,484 @@
+import { useState, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { ColumnDef } from '@tanstack/react-table';
+import {
+  Search,
+  Filter,
+  ChevronDown,
+  Loader2,
+  Users,
+  Eye,
+  MoreHorizontal,
+  UserCheck,
+  Calendar,
+} from 'lucide-react';
+import { cn } from '@/utils/cn';
+import {
+  Button,
+  Badge,
+  DataTable,
+  DataTableColumnHeader,
+  IconStatCard,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  NativeSelect,
+} from '@/components/common';
+import { useInstructorAssignments } from '@/hooks/to/useInstructorAssignmentQueries';
+import type {
+  InstructorAssignmentListResponse,
+  InstructorAssignmentFilterParams,
+  InstructorRole,
+  AssignmentStatus,
+} from '@/types/to/instructorAssignment.types';
+import {
+  INSTRUCTOR_ROLE_LABELS,
+  ASSIGNMENT_STATUS_LABELS,
+} from '@/types/to/instructorAssignment.types';
+
+interface InstructorAssignmentsPageProps {
+  language?: 'ko' | 'en';
+}
+
+const t = {
+  title: { ko: '강사 배정 정보', en: 'Instructor Assignments' },
+  subtitle: { ko: '전체 강사 배정 현황을 확인합니다.', en: 'View all instructor assignments.' },
+  searchPlaceholder: { ko: '강사명, 차수명, 프로그램명 검색...', en: 'Search instructor, course time, program...' },
+  filter: { ko: '필터', en: 'Filter' },
+  role: { ko: '역할', en: 'Role' },
+  status: { ko: '상태', en: 'Status' },
+  all: { ko: '전체', en: 'All' },
+  // 통계 라벨
+  totalAssignments: { ko: '전체 배정', en: 'Total Assignments' },
+  mainInstructors: { ko: '주강사', en: 'Main Instructors' },
+  subInstructors: { ko: '보조강사', en: 'Sub Instructors' },
+  activeAssignments: { ko: '활동 중', en: 'Active' },
+  // 테이블 컬럼
+  columnInstructor: { ko: '강사명', en: 'Instructor' },
+  columnCourseTime: { ko: '차수', en: 'Course Time' },
+  columnProgram: { ko: '프로그램', en: 'Program' },
+  columnRole: { ko: '역할', en: 'Role' },
+  columnStatus: { ko: '상태', en: 'Status' },
+  columnPeriod: { ko: '학습 기간', en: 'Period' },
+  columnAssignedAt: { ko: '배정일', en: 'Assigned At' },
+  // 액션
+  viewCourseTime: { ko: '차수 상세보기', en: 'View Course Time' },
+  // 상태
+  noResults: { ko: '검색 결과가 없습니다.', en: 'No results found.' },
+  noAssignments: { ko: '강사 배정 정보가 없습니다.', en: 'No instructor assignments.' },
+  noAssignmentsDescription: { ko: '차수에 강사를 배정하면 여기에 표시됩니다.', en: 'Assign instructors to course times to see them here.' },
+  loading: { ko: '로딩 중...', en: 'Loading...' },
+  error: { ko: '오류가 발생했습니다.', en: 'An error occurred.' },
+  prev: { ko: '이전', en: 'Prev' },
+  next: { ko: '다음', en: 'Next' },
+  assignmentCount: { ko: '개의 배정', en: ' assignments' },
+};
+
+const roleBadgeVariant: Record<InstructorRole, 'default' | 'secondary' | 'outline'> = {
+  MAIN: 'default',
+  SUB: 'secondary',
+  ASSISTANT: 'outline',
+};
+
+const statusBadgeVariant: Record<AssignmentStatus, 'default' | 'secondary' | 'destructive'> = {
+  ACTIVE: 'default',
+  REPLACED: 'secondary',
+  CANCELLED: 'destructive',
+};
+
+export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<InstructorAssignmentsPageProps>) {
+  const navigate = useNavigate();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [roleFilter, setRoleFilter] = useState<InstructorRole | 'all'>('all');
+  const [statusFilter, setStatusFilter] = useState<AssignmentStatus | 'all'>('all');
+  const [showFilters, setShowFilters] = useState(false);
+  const [page, setPage] = useState(0);
+
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+  const getRoleLabel = (role: InstructorRole) =>
+    language === 'ko' ? INSTRUCTOR_ROLE_LABELS[role].ko : INSTRUCTOR_ROLE_LABELS[role].en;
+  const getStatusLabel = (status: AssignmentStatus) =>
+    language === 'ko' ? ASSIGNMENT_STATUS_LABELS[status].ko : ASSIGNMENT_STATUS_LABELS[status].en;
+
+  // API 파라미터 구성
+  const params: InstructorAssignmentFilterParams = {
+    page,
+    size: 20,
+    ...(roleFilter !== 'all' && { role: roleFilter }),
+    ...(statusFilter !== 'all' && { status: statusFilter }),
+  };
+
+  // React Query 훅 사용
+  const { data, isLoading, error } = useInstructorAssignments(params);
+
+  const assignments = data?.content ?? [];
+  const totalElements = data?.totalElements ?? 0;
+
+  // 클라이언트 사이드 검색 필터링
+  const filteredAssignments = useMemo(() => {
+    if (!searchQuery) return assignments;
+    const query = searchQuery.toLowerCase();
+    return assignments.filter(
+      (item) =>
+        item.instructor.name.toLowerCase().includes(query) ||
+        item.courseTime.title.toLowerCase().includes(query) ||
+        item.program.title.toLowerCase().includes(query)
+    );
+  }, [assignments, searchQuery]);
+
+  // 통계 계산
+  const stats = useMemo(() => ({
+    total: totalElements,
+    main: assignments.filter((a) => a.role === 'MAIN').length,
+    sub: assignments.filter((a) => a.role === 'SUB').length,
+    active: assignments.filter((a) => a.status === 'ACTIVE').length,
+  }), [assignments, totalElements]);
+
+  const formatDate = (dateStr: string | null | undefined) => {
+    if (!dateStr) return '-';
+    const date = new Date(dateStr);
+    if (isNaN(date.getTime())) return '-';
+    return date.toLocaleDateString(language === 'ko' ? 'ko-KR' : 'en-US', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+  };
+
+  const formatPeriod = (startDate: string, endDate: string) => {
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) return '-';
+    const format = (d: Date) =>
+      d.toLocaleDateString(language === 'ko' ? 'ko-KR' : 'en-US', {
+        month: '2-digit',
+        day: '2-digit',
+      });
+    return `${format(start)} ~ ${format(end)}`;
+  };
+
+  // 더보기 메뉴 렌더링
+  const renderMoreMenu = (item: InstructorAssignmentListResponse) => {
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            onClick={(e) => e.stopPropagation()}
+            className="inline-flex items-center justify-center w-8 h-8 rounded-lg hover:bg-bg-secondary transition-colors"
+          >
+            <MoreHorizontal size={16} className="text-text-secondary" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-40">
+          <DropdownMenuItem onClick={() => navigate(`/to/times/${item.courseTime.id}`)}>
+            <Eye size={14} />
+            {getText('viewCourseTime')}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  };
+
+  // 테이블 컬럼 정의
+  const columns: ColumnDef<InstructorAssignmentListResponse>[] = useMemo(
+    () => [
+      {
+        accessorKey: 'instructor',
+        header: ({ column }) => (
+          <DataTableColumnHeader column={column} title={getText('columnInstructor')} />
+        ),
+        cell: ({ row }) => (
+          <div className="max-w-[180px]">
+            <p className="text-sm font-medium text-text-primary truncate">
+              {row.original.instructor.name}
+            </p>
+            <p className="text-xs text-text-secondary truncate">
+              {row.original.instructor.email}
+            </p>
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'courseTime',
+        header: ({ column }) => (
+          <DataTableColumnHeader column={column} title={getText('columnCourseTime')} />
+        ),
+        cell: ({ row }) => (
+          <div className="max-w-[150px]">
+            <p className="text-sm text-text-primary truncate">
+              {row.original.courseTime.title}
+            </p>
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'program',
+        header: ({ column }) => (
+          <DataTableColumnHeader column={column} title={getText('columnProgram')} />
+        ),
+        cell: ({ row }) => (
+          <div className="max-w-[180px]">
+            <p className="text-sm text-text-secondary truncate">
+              {row.original.program.title}
+            </p>
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'role',
+        header: ({ column }) => (
+          <DataTableColumnHeader column={column} title={getText('columnRole')} />
+        ),
+        cell: ({ row }) => (
+          <Badge variant={roleBadgeVariant[row.original.role]}>
+            {getRoleLabel(row.original.role)}
+          </Badge>
+        ),
+      },
+      {
+        accessorKey: 'status',
+        header: ({ column }) => (
+          <DataTableColumnHeader column={column} title={getText('columnStatus')} />
+        ),
+        cell: ({ row }) => (
+          <Badge variant={statusBadgeVariant[row.original.status]}>
+            {getStatusLabel(row.original.status)}
+          </Badge>
+        ),
+      },
+      {
+        id: 'period',
+        header: getText('columnPeriod'),
+        cell: ({ row }) => (
+          <span className="text-sm text-text-secondary">
+            {formatPeriod(row.original.courseTime.startDate, row.original.courseTime.endDate)}
+          </span>
+        ),
+      },
+      {
+        accessorKey: 'assignedAt',
+        header: getText('columnAssignedAt'),
+        cell: ({ row }) => (
+          <span className="text-sm text-text-secondary">
+            {formatDate(row.original.assignedAt)}
+          </span>
+        ),
+      },
+      {
+        id: 'actions',
+        header: () => <span className="sr-only">Actions</span>,
+        cell: ({ row }) => (
+          <div
+            className="flex items-center justify-end"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {renderMoreMenu(row.original)}
+          </div>
+        ),
+      },
+    ],
+    [language, navigate]
+  );
+
+  if (error) {
+    return (
+      <div className="h-full flex items-center justify-center bg-bg-app">
+        <div className="text-center">
+          <Users size={48} className="mx-auto mb-3 text-text-placeholder" />
+          <p className="text-text-secondary">{getText('error')}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col bg-bg-app">
+      {/* Top Bar */}
+      <div className="sticky top-0 z-10 bg-bg-app">
+        <div className="p-6 px-8">
+          <div className="flex items-center justify-between mb-6">
+            <div>
+              <h1 className="text-text-primary mb-1">{getText('title')}</h1>
+              <p className="text-text-secondary text-sm m-0">{getText('subtitle')}</p>
+            </div>
+          </div>
+
+          {/* Search and Filter Bar */}
+          <div className="flex items-center gap-3">
+            <div className="flex-1 relative">
+              <Search
+                size={20}
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary"
+              />
+              <input
+                type="text"
+                placeholder={getText('searchPlaceholder')}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full pl-10 pr-4 py-2.5 bg-bg-default border border-border rounded-lg text-text-primary text-sm outline-none focus:ring-2 focus:ring-btn-neutral"
+              />
+            </div>
+            <Button
+              variant="ghost"
+              onClick={() => setShowFilters(!showFilters)}
+              className="border border-border"
+            >
+              <Filter size={20} />
+              <span>{getText('filter')}</span>
+              <ChevronDown
+                size={16}
+                className={cn('transition-transform', showFilters && 'rotate-180')}
+              />
+            </Button>
+          </div>
+
+          {/* Filter Options */}
+          {showFilters && (
+            <div className="mt-4 p-4 border border-border rounded-lg bg-bg-secondary">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm text-text-primary mb-2">
+                    {getText('role')}
+                  </label>
+                  <NativeSelect
+                    value={roleFilter}
+                    onChange={(e) => {
+                      setRoleFilter(e.target.value as InstructorRole | 'all');
+                      setPage(0);
+                    }}
+                    options={[
+                      { value: 'all', label: getText('all') },
+                      { value: 'MAIN', label: getRoleLabel('MAIN') },
+                      { value: 'SUB', label: getRoleLabel('SUB') },
+                      { value: 'ASSISTANT', label: getRoleLabel('ASSISTANT') },
+                    ]}
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm text-text-primary mb-2">
+                    {getText('status')}
+                  </label>
+                  <NativeSelect
+                    value={statusFilter}
+                    onChange={(e) => {
+                      setStatusFilter(e.target.value as AssignmentStatus | 'all');
+                      setPage(0);
+                    }}
+                    options={[
+                      { value: 'all', label: getText('all') },
+                      { value: 'ACTIVE', label: getStatusLabel('ACTIVE') },
+                      { value: 'REPLACED', label: getStatusLabel('REPLACED') },
+                      { value: 'CANCELLED', label: getStatusLabel('CANCELLED') },
+                    ]}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Content List */}
+      <div className="flex-1 overflow-auto">
+        <div className="p-6 px-8 pt-0">
+          {/* Statistics Cards */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+            <IconStatCard
+              icon={<Users size={20} />}
+              label={getText('totalAssignments')}
+              value={stats.total}
+            />
+            <IconStatCard
+              icon={<UserCheck size={20} />}
+              label={getText('mainInstructors')}
+              value={stats.main}
+            />
+            <IconStatCard
+              icon={<Users size={20} />}
+              label={getText('subInstructors')}
+              value={stats.sub}
+            />
+            <IconStatCard
+              icon={<Calendar size={20} />}
+              label={getText('activeAssignments')}
+              value={stats.active}
+            />
+          </div>
+
+          {/* Count */}
+          <div className="flex items-center justify-between mb-4">
+            <p className="text-sm text-text-secondary">
+              {filteredAssignments.length}
+              {getText('assignmentCount')}
+            </p>
+          </div>
+
+          {/* Loading State */}
+          {isLoading && (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 size={32} className="animate-spin text-text-secondary" />
+              <span className="ml-2 text-text-secondary">{getText('loading')}</span>
+            </div>
+          )}
+
+          {/* Empty State */}
+          {!isLoading && totalElements === 0 && !searchQuery && roleFilter === 'all' && statusFilter === 'all' && (
+            <div className="text-center py-12 text-text-secondary">
+              <Users size={48} className="mx-auto mb-3 text-text-placeholder" />
+              <p className="mb-1">{getText('noAssignments')}</p>
+              <p className="text-sm">{getText('noAssignmentsDescription')}</p>
+            </div>
+          )}
+
+          {/* Empty Search Results */}
+          {!isLoading && filteredAssignments.length === 0 && (searchQuery || roleFilter !== 'all' || statusFilter !== 'all') && (
+            <div className="text-center py-12 text-text-secondary">
+              <Search size={48} className="mx-auto mb-3 text-text-placeholder" />
+              <p>{getText('noResults')}</p>
+            </div>
+          )}
+
+          {/* Data Table */}
+          {!isLoading && filteredAssignments.length > 0 && (
+            <DataTable
+              columns={columns}
+              data={filteredAssignments}
+              showColumnToggle={false}
+              showPagination={true}
+              onRowClick={(item) => navigate(`/to/times/${item.courseTime.id}`)}
+              labels={{
+                noResults: getText('noResults'),
+              }}
+            />
+          )}
+
+          {/* Pagination */}
+          {data && data.totalPages > 1 && (
+            <div className="flex justify-center gap-2 mt-6">
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={page === 0}
+                onClick={() => setPage((p) => p - 1)}
+              >
+                {getText('prev')}
+              </Button>
+              <span className="px-4 py-2 text-sm text-text-secondary">
+                {page + 1} / {data.totalPages}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={page >= data.totalPages - 1}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                {getText('next')}
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/to/instructor/InstructorAssignmentsPage.tsx
+++ b/src/pages/to/instructor/InstructorAssignmentsPage.tsx
@@ -9,17 +9,19 @@ import {
   Users,
   Eye,
   MoreHorizontal,
+  User,
   UserCheck,
   Calendar,
   Mail,
   ExternalLink,
+  Clock,
+  CheckCircle2,
 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import {
   Button,
   DataTable,
   DataTableColumnHeader,
-  IconStatCard,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -91,16 +93,51 @@ const t = {
 
 // Badge 색상 스타일 (디자인 토큰 기반)
 const roleBadgeStyles: Record<InstructorRole, string> = {
-  MAIN: 'bg-badge-indigo-bg text-badge-indigo border-transparent',
-  SUB: 'bg-badge-blue-bg text-badge-blue border-transparent',
-  ASSISTANT: 'bg-badge-gray-bg text-badge-gray border-transparent',
+  MAIN: 'bg-badge-indigo-bg text-badge-indigo',
+  SUB: 'bg-badge-blue-bg text-badge-blue',
+  ASSISTANT: 'bg-badge-gray-bg text-badge-gray',
 };
 
 const statusBadgeStyles: Record<AssignmentStatus, string> = {
-  ACTIVE: 'bg-badge-green-bg text-badge-green border-transparent',
-  REPLACED: 'bg-badge-yellow-bg text-badge-yellow border-transparent',
-  CANCELLED: 'bg-badge-red-bg text-badge-red border-transparent',
+  ACTIVE: 'bg-badge-green-bg text-badge-green',
+  REPLACED: 'bg-badge-yellow-bg text-badge-yellow',
+  CANCELLED: 'bg-badge-red-bg text-badge-red',
 };
+
+// 아이콘 색상별 스타일 (디자인 토큰 기반)
+const iconColorStyles = {
+  blue: 'bg-badge-blue-bg text-badge-blue',
+  indigo: 'bg-badge-indigo-bg text-badge-indigo',
+  green: 'bg-badge-green-bg text-badge-green',
+  gray: 'bg-badge-gray-bg text-badge-gray',
+} as const;
+
+type IconColor = keyof typeof iconColorStyles;
+
+// 통계 카드 컴포넌트 (White Surface + Colored Icon)
+function StatCard({
+  icon,
+  label,
+  value,
+  iconColor
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string | number;
+  iconColor: IconColor;
+}) {
+  return (
+    <div className="flex items-center gap-4 rounded-xl border border-border bg-bg-default p-5 shadow-sm transition-all hover:shadow-md">
+      <div className={cn('flex h-12 w-12 items-center justify-center rounded-lg', iconColorStyles[iconColor])}>
+        {icon}
+      </div>
+      <div>
+        <p className="text-sm font-medium text-text-secondary">{label}</p>
+        <p className="text-2xl font-bold text-text-primary">{value}</p>
+      </div>
+    </div>
+  );
+}
 
 export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<InstructorAssignmentsPageProps>) {
   const navigate = useNavigate();
@@ -403,37 +440,39 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
       {/* Content List */}
       <div className="flex-1 overflow-auto">
         <div className="p-6 px-8 pt-0">
-          {/* Statistics Cards */}
+          {/* Statistics Cards - White Surface + Colored Icons */}
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-            <IconStatCard
+            <StatCard
               icon={<Users size={20} />}
               label={getText('totalAssignments')}
               value={stats.total}
+              iconColor="blue"
             />
-            <IconStatCard
+            <StatCard
               icon={<UserCheck size={20} />}
               label={getText('mainInstructors')}
               value={stats.main}
+              iconColor="indigo"
             />
-            <IconStatCard
+            <StatCard
               icon={<Users size={20} />}
               label={getText('subInstructors')}
               value={stats.sub}
+              iconColor="gray"
             />
-            <IconStatCard
+            <StatCard
               icon={<Calendar size={20} />}
               label={getText('activeAssignments')}
               value={stats.active}
+              iconColor="green"
             />
           </div>
 
           {/* Count */}
-          <div className="flex items-center justify-between mb-4">
-            <p className="text-sm text-text-secondary">
-              {filteredAssignments.length}
-              {getText('assignmentCount')}
-            </p>
-          </div>
+          <p className="text-sm text-text-secondary mb-4">
+            {filteredAssignments.length}
+            {getText('assignmentCount')}
+          </p>
 
           {/* Loading State */}
           {isLoading && (
@@ -466,7 +505,7 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
               columns={columns}
               data={filteredAssignments}
               showColumnToggle={false}
-              showPagination={true}
+              showPagination={false}
               onRowClick={(item) => setSelectedAssignment(item)}
               labels={{
                 noResults: getText('noResults'),
@@ -476,26 +515,28 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
 
           {/* Pagination */}
           {data && data.totalPages > 1 && (
-            <div className="flex justify-center gap-2 mt-6">
-              <Button
-                variant="ghost"
-                size="sm"
-                disabled={page === 0}
-                onClick={() => setPage((p) => p - 1)}
-              >
-                {getText('prev')}
-              </Button>
-              <span className="px-4 py-2 text-sm text-text-secondary">
-                {page + 1} / {data.totalPages}
+            <div className="flex items-center justify-between mt-4">
+              <span className="text-xs text-text-secondary">
+                {page * 20 + 1} - {Math.min((page + 1) * 20, totalElements)} / {totalElements}
               </span>
-              <Button
-                variant="ghost"
-                size="sm"
-                disabled={page >= data.totalPages - 1}
-                onClick={() => setPage((p) => p + 1)}
-              >
-                {getText('next')}
-              </Button>
+              <div className="flex gap-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={page === 0}
+                  onClick={() => setPage((p) => p - 1)}
+                >
+                  {getText('prev')}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={page >= data.totalPages - 1}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  {getText('next')}
+                </Button>
+              </div>
             </div>
           )}
         </div>
@@ -503,101 +544,155 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
 
       {/* Detail Modal */}
       <Dialog open={!!selectedAssignment} onOpenChange={(open: boolean) => !open && setSelectedAssignment(null)}>
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>{getText('panelTitle')}</DialogTitle>
+        <DialogContent className="max-w-lg p-0 overflow-hidden">
+          {/* Header */}
+          <DialogHeader className="px-6 py-5 border-b border-border">
+            <DialogTitle className="text-lg font-bold text-text-primary tracking-tight">
+              {getText('panelTitle')}
+            </DialogTitle>
           </DialogHeader>
 
           {selectedAssignment && (
-            <div className="space-y-6">
-              {/* 강사 정보 */}
-              <div className="space-y-3">
-                <h3 className="text-sm font-semibold text-text-primary flex items-center gap-2">
-                  <UserCheck size={16} />
-                  {getText('instructorInfo')}
-                </h3>
-                <div className="bg-bg-secondary rounded-lg p-4 space-y-3">
-                  <div>
-                    <p className="text-xs text-text-secondary">{getText('columnInstructor')}</p>
-                    <p className="text-sm font-medium text-text-primary">
-                      {selectedAssignment.instructor?.name ?? '-'}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-text-secondary flex items-center gap-1">
-                      <Mail size={12} />
-                      {getText('email')}
-                    </p>
-                    <p className="text-sm text-text-primary">
-                      {selectedAssignment.instructor?.email ?? '-'}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-text-secondary">{getText('columnRole')}</p>
-                    <span className={cn('inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium mt-1', roleBadgeStyles[selectedAssignment.role])}>
-                      {getRoleLabel(selectedAssignment.role)}
+            <>
+              {/* Body */}
+              <div className="px-6 py-6 max-h-[70vh] overflow-y-auto">
+                {/* Section 1: 강사 정보 */}
+                <section className="mb-8">
+                  {/* Section Title with Icon Badge */}
+                  <h3 className="flex items-center gap-2 text-sm font-bold text-text-primary mb-5">
+                    <span className="flex h-6 w-6 items-center justify-center rounded-md bg-badge-indigo-bg text-badge-indigo">
+                      <User size={14} />
                     </span>
+                    {getText('instructorInfo')}
+                  </h3>
+
+                  {/* Grid Layout */}
+                  <div className="grid grid-cols-2 gap-x-4 gap-y-5">
+                    {/* 강사명 */}
+                    <div>
+                      <dt className="text-xs font-medium text-text-secondary mb-1.5 uppercase tracking-wide">
+                        {getText('columnInstructor')}
+                      </dt>
+                      <dd className="text-sm font-medium text-text-primary">
+                        {selectedAssignment.instructor?.name ?? '-'}
+                      </dd>
+                    </div>
+
+                    {/* 이메일 */}
+                    <div className="col-span-2 sm:col-span-1">
+                      <dt className="text-xs font-medium text-text-secondary mb-1.5 uppercase tracking-wide">
+                        {getText('email')}
+                      </dt>
+                      <dd className="flex items-center gap-1.5 text-sm font-medium text-text-primary">
+                        <Mail size={14} className="text-text-placeholder" />
+                        {selectedAssignment.instructor?.email ?? '-'}
+                      </dd>
+                    </div>
+
+                    {/* 역할 */}
+                    <div>
+                      <dt className="text-xs font-medium text-text-secondary mb-1.5 uppercase tracking-wide">
+                        {getText('columnRole')}
+                      </dt>
+                      <dd>
+                        <span className={cn('inline-flex items-center gap-1 rounded-md px-2.5 py-1 text-xs font-semibold', roleBadgeStyles[selectedAssignment.role])}>
+                          {getRoleLabel(selectedAssignment.role)}
+                        </span>
+                      </dd>
+                    </div>
+
+                    {/* 상태 */}
+                    <div>
+                      <dt className="text-xs font-medium text-text-secondary mb-1.5 uppercase tracking-wide">
+                        {getText('columnStatus')}
+                      </dt>
+                      <dd>
+                        <span className={cn('inline-flex items-center gap-1 rounded-md px-2.5 py-1 text-xs font-semibold', statusBadgeStyles[selectedAssignment.status])}>
+                          {selectedAssignment.status === 'ACTIVE' && <CheckCircle2 size={12} />}
+                          {getStatusLabel(selectedAssignment.status)}
+                        </span>
+                      </dd>
+                    </div>
+
+                    {/* 배정일 */}
+                    <div>
+                      <dt className="text-xs font-medium text-text-secondary mb-1.5 uppercase tracking-wide">
+                        {getText('assignedAt')}
+                      </dt>
+                      <dd className="text-sm font-medium text-text-primary">
+                        {formatDate(selectedAssignment.assignedAt)}
+                      </dd>
+                    </div>
                   </div>
-                  <div>
-                    <p className="text-xs text-text-secondary">{getText('columnStatus')}</p>
-                    <span className={cn('inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium mt-1', statusBadgeStyles[selectedAssignment.status])}>
-                      {getStatusLabel(selectedAssignment.status)}
+                </section>
+
+                {/* Divider */}
+                <div className="my-6 border-t border-dashed border-border" />
+
+                {/* Section 2: 차수 정보 */}
+                <section>
+                  <h3 className="flex items-center gap-2 text-sm font-bold text-text-primary mb-5">
+                    <span className="flex h-6 w-6 items-center justify-center rounded-md bg-badge-indigo-bg text-badge-indigo">
+                      <Calendar size={14} />
                     </span>
+                    {getText('courseTimeInfo')}
+                  </h3>
+
+                  <div className="space-y-5">
+                    <div className="grid grid-cols-2 gap-4">
+                      {/* 차수명 */}
+                      <div>
+                        <dt className="text-xs font-medium text-text-secondary mb-1.5 uppercase tracking-wide">
+                          {getText('columnCourseTime')}
+                        </dt>
+                        <dd className="text-sm font-medium text-text-primary">
+                          {selectedAssignment.courseTime?.title ?? '-'}
+                        </dd>
+                      </div>
+
+                      {/* 과정명 */}
+                      <div>
+                        <dt className="text-xs font-medium text-text-secondary mb-1.5 uppercase tracking-wide">
+                          {getText('programName')}
+                        </dt>
+                        <dd className="text-sm font-medium text-text-primary">
+                          {selectedAssignment.program?.title ?? '-'}
+                        </dd>
+                      </div>
+                    </div>
+
+                    {/* 학습 기간 */}
+                    <div>
+                      <dt className="text-xs font-medium text-text-secondary mb-1.5 uppercase tracking-wide">
+                        {getText('learningPeriod')}
+                      </dt>
+                      <dd className="flex items-center gap-2 text-sm font-medium text-text-primary">
+                        <Clock size={14} className="text-text-placeholder" />
+                        {selectedAssignment.courseTime?.startDate && selectedAssignment.courseTime?.endDate
+                          ? `${formatDate(selectedAssignment.courseTime.startDate)} ~ ${formatDate(selectedAssignment.courseTime.endDate)}`
+                          : '-'}
+                      </dd>
+                    </div>
                   </div>
-                  <div>
-                    <p className="text-xs text-text-secondary">{getText('assignedAt')}</p>
-                    <p className="text-sm text-text-primary">
-                      {formatDate(selectedAssignment.assignedAt)}
-                    </p>
-                  </div>
-                </div>
+                </section>
               </div>
 
-              {/* 차수 정보 */}
-              <div className="space-y-3">
-                <h3 className="text-sm font-semibold text-text-primary flex items-center gap-2">
-                  <Calendar size={16} />
-                  {getText('courseTimeInfo')}
-                </h3>
-                <div className="bg-bg-secondary rounded-lg p-4 space-y-3">
-                  <div>
-                    <p className="text-xs text-text-secondary">{getText('columnCourseTime')}</p>
-                    <p className="text-sm font-medium text-text-primary">
-                      {selectedAssignment.courseTime?.title ?? '-'}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-text-secondary">{getText('programName')}</p>
-                    <p className="text-sm text-text-primary">
-                      {selectedAssignment.program?.title ?? '-'}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-text-secondary">{getText('learningPeriod')}</p>
-                    <p className="text-sm text-text-primary">
-                      {selectedAssignment.courseTime?.startDate && selectedAssignment.courseTime?.endDate
-                        ? `${formatDate(selectedAssignment.courseTime.startDate)} ~ ${formatDate(selectedAssignment.courseTime.endDate)}`
-                        : '-'}
-                    </p>
-                  </div>
-                </div>
+              {/* Footer */}
+              <div className="bg-bg-secondary px-6 py-4 flex justify-end border-t border-border">
+                <button
+                  onClick={() => {
+                    if (selectedAssignment.courseTime?.id) {
+                      navigate(`/to/times/${selectedAssignment.courseTime.id}`);
+                    }
+                  }}
+                  disabled={!selectedAssignment.courseTime?.id}
+                  className="group flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold text-text-secondary hover:text-badge-indigo hover:bg-badge-indigo-bg transition-all disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-secondary"
+                >
+                  {getText('goToCourseTime')}
+                  <ExternalLink size={16} className="transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+                </button>
               </div>
-
-              {/* 차수 상세 페이지 이동 버튼 */}
-              <Button
-                variant="outline"
-                className="w-full"
-                onClick={() => {
-                  if (selectedAssignment.courseTime?.id) {
-                    navigate(`/to/times/${selectedAssignment.courseTime.id}`);
-                  }
-                }}
-                disabled={!selectedAssignment.courseTime?.id}
-              >
-                <ExternalLink size={16} />
-                {getText('goToCourseTime')}
-              </Button>
-            </div>
+            </>
           )}
         </DialogContent>
       </Dialog>

--- a/src/pages/to/instructor/index.ts
+++ b/src/pages/to/instructor/index.ts
@@ -1,0 +1,1 @@
+export { InstructorAssignmentsPage } from './InstructorAssignmentsPage';

--- a/src/routes/to.routes.tsx
+++ b/src/routes/to.routes.tsx
@@ -17,6 +17,7 @@ import {
   ProgramPendingPage,
   ProgramDetailPage,
 } from '@/pages/to/program';
+import { InstructorAssignmentsPage } from '@/pages/to/instructor';
 import { DashboardPage, PlaceholderPage } from './pages';
 
 function TenantOperatorWrapper() {
@@ -49,7 +50,7 @@ export const toRoutes = (
     <Route path="learning-objects" element={<PlaceholderPage title="학습 객체 관리" />} />
     {/* 수강 및 강사 정보 */}
     <Route path="sis" element={<PlaceholderPage title="학생 수강 정보 확인" />} />
-    <Route path="iis" element={<PlaceholderPage title="강사 배정 정보 확인" />} />
+    <Route path="instructor-assignments" element={<InstructorAssignmentsPage />} />
     {/* 설정 */}
     <Route path="settings" element={<SettingsPage />} />
     <Route path="settings/security" element={<SettingsSecurityPage />} />

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -140,8 +140,10 @@ export const API_ENDPOINTS = {
     SNAPSHOT: (id: number) => `/programs/${id}/snapshot`,
   },
 
-  // Instructor Assignments (TU - 내 배정)
+  // Instructor Assignments (TU - 내 배정, TO - 전체 관리)
   INSTRUCTOR_ASSIGNMENTS: {
+    BASE: '/instructor-assignments',
+    BY_ID: (id: number) => `/instructor-assignments/${id}`,
     MY: '/users/me/instructor-assignments',
     MY_STATISTICS: '/users/me/instructor-statistics',
   },

--- a/src/services/to/instructorAssignmentService.ts
+++ b/src/services/to/instructorAssignmentService.ts
@@ -10,11 +10,28 @@ import type {
   ReplaceInstructorRequest,
   CancelAssignmentRequest,
   InstructorAssignmentFilterParams,
+  InstructorAssignmentListResponse,
 } from '@/types/to/instructorAssignment.types';
+import type { PageResponse } from '@/types/common/api.types';
 
 export const instructorAssignmentService = {
   // ============================================
-  // 강사 배정 CRUD
+  // 전체 강사 배정 목록 조회 (TO용)
+  // ============================================
+
+  /** 전체 강사 배정 목록 조회 */
+  async getAssignments(
+    params?: InstructorAssignmentFilterParams
+  ): Promise<PageResponse<InstructorAssignmentListResponse>> {
+    const { data } = await axiosInstance.get<{ data: PageResponse<InstructorAssignmentListResponse> }>(
+      API_ENDPOINTS.INSTRUCTOR_ASSIGNMENTS.BASE,
+      { params }
+    );
+    return data.data;
+  },
+
+  // ============================================
+  // 강사 배정 CRUD (차수 기준)
   // ============================================
 
   /** 강사 배정 */

--- a/src/types/to/instructorAssignment.types.ts
+++ b/src/types/to/instructorAssignment.types.ts
@@ -50,5 +50,47 @@ export interface CancelAssignmentRequest {
 
 /** 강사 배정 목록 필터 */
 export interface InstructorAssignmentFilterParams {
+  instructorId?: number;
+  courseTimeId?: number;
+  role?: import('@/types/tu/instructorAssignment.types').InstructorRole;
   status?: import('@/types/tu/instructorAssignment.types').AssignmentStatus;
+  page?: number;
+  size?: number;
+}
+
+// ============================================
+// TO 전용 Response Types (목록 조회용)
+// ============================================
+
+/** 강사 정보 (목록용) */
+export interface InstructorInfo {
+  id: number;
+  name: string;
+  email: string;
+}
+
+/** 차수 정보 (목록용) */
+export interface CourseTimeInfo {
+  id: number;
+  title: string;
+  startDate: string;
+  endDate: string;
+}
+
+/** 프로그램 정보 (목록용) */
+export interface ProgramInfo {
+  id: number;
+  title: string;
+}
+
+/** 강사 배정 목록 아이템 응답 */
+export interface InstructorAssignmentListResponse {
+  id: number;
+  instructor: InstructorInfo;
+  courseTime: CourseTimeInfo;
+  program: ProgramInfo;
+  role: import('@/types/tu/instructorAssignment.types').InstructorRole;
+  status: import('@/types/tu/instructorAssignment.types').AssignmentStatus;
+  assignedAt: string;
+  createdAt: string;
 }


### PR DESCRIPTION
## Summary

TO 강사 배정 정보 확인 페이지 구현. 전체 강사 배정 목록 조회, 필터링, 검색 기능과 행 클릭 시 상세 정보 모달 표시 기능 제공.

## Related Issue

- Closes #158

## Changes

- `InstructorAssignmentsPage.tsx`: 상세 모달 추가, null-safe 처리, 컬럼명 변경 (차수→차수명, 프로그램→과정명)
- `instructorAssignment.types.ts`: 목록 조회용 타입 추가 (InstructorAssignmentListResponse, InstructorInfo, CourseTimeInfo, ProgramInfo)
- `instructorAssignmentService.ts`: `getAssignments()` 함수 추가
- `useInstructorAssignmentQueries.ts`: `useInstructorAssignments()` 훅 추가
- `to.routes.tsx`: `/to/instructor-assignments` 라우트 등록
- `sidebar-menus.ts`: IIS Lookup 경로 업데이트 (`/to/iis` → `/to/instructor-assignments`)
- `endpoints.ts`: `INSTRUCTOR_ASSIGNMENTS.BASE`, `BY_ID` 엔드포인트 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 백엔드 API에서 orphaned 데이터(삭제된 강사/차수/프로그램 참조)가 반환될 수 있어 null-safe 처리 적용
- 행 클릭 시 직접 페이지 이동이 아닌 모달로 상세 정보 표시 후 차수 상세 페이지 이동 버튼 제공