### PR TITLE
Feat/cart integration

### DIFF
--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -115,11 +115,12 @@ export {
 export {
   cartKeys,
   useCart,
-  useCartAddItem,
+  useCartCount,
+  useCheckCartStatus,
+  useAddToCart,
   useRemoveFromCart,
-  useClearCart,
-  useApplyCoupon,
-  useRemoveCoupon,
+  useRemoveFromCartBulk,
+  useToggleCart,
 } from './useCartQueries';
 
 // Wishlist Hooks

--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -94,7 +94,6 @@ export {
   usePopularCourses,
   useRecommendedCourses,
   useRelatedCourses,
-  useAddToCart,
 } from './useCourseDetailQueries';
 
 // Roadmap Detail Hooks

--- a/src/hooks/tu/useCartQueries.ts
+++ b/src/hooks/tu/useCartQueries.ts
@@ -1,23 +1,21 @@
 /**
- * 장바구니(Cart) React Query 훅
+ * 장바구니(Cart) React Query 훅 - 백엔드 API 스펙 기반
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { cartService } from '@/services/tu/cartService';
-import type {
-  AddToCartRequest,
-  RemoveFromCartRequest,
-  ApplyCouponRequest,
-} from '@/types/tu/cart.types';
+import type { CartAddRequest, CartRemoveRequest } from '@/types/tu/cart.types';
 
 // Query Keys
 export const cartKeys = {
   all: ['cart'] as const,
   cart: () => [...cartKeys.all, 'items'] as const,
+  count: () => [...cartKeys.all, 'count'] as const,
+  check: (courseId: number) => [...cartKeys.all, 'check', courseId] as const,
 };
 
 /**
- * 장바구니 조회 훅
+ * 장바구니 목록 조회 훅
  */
 export function useCart(enabled = true) {
   return useQuery({
@@ -29,13 +27,37 @@ export function useCart(enabled = true) {
 }
 
 /**
- * 장바구니 추가 훅 (Cart 서비스용)
+ * 장바구니 개수 조회 훅
  */
-export function useCartAddItem() {
+export function useCartCount(enabled = true) {
+  return useQuery({
+    queryKey: cartKeys.count(),
+    queryFn: cartService.getCartCount,
+    enabled,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+}
+
+/**
+ * 특정 강의 장바구니 여부 확인 훅
+ */
+export function useCheckCartStatus(courseId: number, enabled = true) {
+  return useQuery({
+    queryKey: cartKeys.check(courseId),
+    queryFn: () => cartService.checkCartStatus(courseId),
+    enabled: enabled && courseId > 0,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+}
+
+/**
+ * 장바구니 추가 훅
+ */
+export function useAddToCart() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: AddToCartRequest) => cartService.addToCart(data),
+    mutationFn: (request: CartAddRequest) => cartService.addToCart(request),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: cartKeys.all });
     },
@@ -43,13 +65,13 @@ export function useCartAddItem() {
 }
 
 /**
- * 장바구니 아이템 삭제 훅
+ * 장바구니 단일 삭제 훅
  */
 export function useRemoveFromCart() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: RemoveFromCartRequest) => cartService.removeFromCart(data),
+    mutationFn: (courseId: number) => cartService.removeFromCart(courseId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: cartKeys.all });
     },
@@ -57,13 +79,13 @@ export function useRemoveFromCart() {
 }
 
 /**
- * 장바구니 비우기 훅
+ * 장바구니 일괄 삭제 훅 (선택 삭제)
  */
-export function useClearCart() {
+export function useRemoveFromCartBulk() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: () => cartService.clearCart(),
+    mutationFn: (request: CartRemoveRequest) => cartService.removeFromCartBulk(request),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: cartKeys.all });
     },
@@ -71,27 +93,21 @@ export function useClearCart() {
 }
 
 /**
- * 쿠폰 적용 훅
+ * 장바구니 토글 훅 (추가/삭제)
  */
-export function useApplyCoupon() {
+export function useToggleCart() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: ApplyCouponRequest) => cartService.applyCoupon(data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: cartKeys.all });
+    mutationFn: async ({ courseId, isInCart }: { courseId: number; isInCart: boolean }) => {
+      if (isInCart) {
+        await cartService.removeFromCart(courseId);
+        return { added: false };
+      } else {
+        await cartService.addToCart({ courseId });
+        return { added: true };
+      }
     },
-  });
-}
-
-/**
- * 쿠폰 제거 훅
- */
-export function useRemoveCoupon() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: () => cartService.removeCoupon(),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: cartKeys.all });
     },

--- a/src/pages/tu/main/CartPage.tsx
+++ b/src/pages/tu/main/CartPage.tsx
@@ -1,142 +1,97 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { Trash2, ShoppingCart, ChevronRight, Tag, Loader2 } from 'lucide-react';
+import { Trash2, ShoppingCart, ChevronRight, Loader2, Heart, Plus, Check } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
-import { useCart, useRemoveFromCart, useApplyCoupon } from '@/hooks/tu';
-import type { CartItem } from '@/types/tu';
-
-// 환경 설정: true면 API 사용, false면 더미 데이터 사용
-const USE_API = false;
-
-// 더미 장바구니 데이터
-const MOCK_CART_ITEMS: CartItem[] = [
-  {
-    id: 1,
-    courseId: 101,
-    title: '실전! Next.js 15 완벽 마스터',
-    instructor: '김개발',
-    originalPrice: 129000,
-    price: 89000,
-    image: 'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=250&fit=crop',
-    discount: 31,
-    rating: 4.9,
-    reviewCount: 1234,
-    totalHours: 32,
-    isSelected: true,
-  },
-  {
-    id: 2,
-    courseId: 102,
-    title: 'ChatGPT API 활용 실무 프로젝트',
-    instructor: '이에이아이',
-    originalPrice: 150000,
-    price: 120000,
-    image: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=400&h=250&fit=crop',
-    discount: 20,
-    rating: 4.8,
-    reviewCount: 892,
-    totalHours: 28,
-    isSelected: true,
-  },
-  {
-    id: 3,
-    courseId: 103,
-    title: 'AWS 클라우드 실무',
-    instructor: '윤클라우드',
-    originalPrice: 130000,
-    price: 110000,
-    image: 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=400&h=250&fit=crop',
-    discount: 15,
-    rating: 4.7,
-    reviewCount: 567,
-    totalHours: 24,
-    isSelected: true,
-  },
-];
+import { useCart, useRemoveFromCart, useRemoveFromCartBulk, useAddToCart, useMyWishlist } from '@/hooks/tu';
+import type { CartItemResponse } from '@/types/tu/cart.types';
+import type { WishlistItemResponse } from '@/types/tu/wishlist.types';
 
 export function CartPage() {
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
 
-  // React Query 훅 (API 모드일 때만 활성화)
-  const { data: apiCartData, isLoading, error } = useCart(USE_API);
+  // Cart React Query 훅
+  const { data: cartItems = [], isLoading: isCartLoading, error: cartError } = useCart();
   const removeFromCartMutation = useRemoveFromCart();
-  const applyCouponMutation = useApplyCoupon();
+  const removeFromCartBulkMutation = useRemoveFromCartBulk();
+  const addToCartMutation = useAddToCart();
 
-  // 로컬 상태 (Mock 모드에서 사용)
-  const [mockCartItems, setMockCartItems] = useState(MOCK_CART_ITEMS);
-  const [couponCode, setCouponCode] = useState('');
-
-  // 실제 사용할 데이터 결정
-  const cartItems = USE_API ? (apiCartData?.items || []) : mockCartItems;
+  // Wishlist React Query 훅
+  const { data: wishlistData, isLoading: isWishlistLoading } = useMyWishlist();
+  const wishlistItems = wishlistData?.content || [];
 
   // 선택 상태 관리
-  const [selectedItems, setSelectedItems] = useState<number[]>(() =>
-    cartItems.map(item => item.id)
+  const [selectedCourseIds, setSelectedCourseIds] = useState<number[]>([]);
+
+  // 장바구니에 있는 courseId Set
+  const cartCourseIds = useMemo(() => new Set(cartItems.map(item => item.courseId)), [cartItems]);
+
+  // 찜 목록 중 장바구니에 없는 아이템만 표시
+  const availableWishlistItems = useMemo(() =>
+    wishlistItems.filter(item => !cartCourseIds.has(item.courseId)),
+    [wishlistItems, cartCourseIds]
   );
 
-  // 선택된 아이템 동기화
-  useMemo(() => {
-    if (cartItems.length > 0 && selectedItems.length === 0) {
-      setSelectedItems(cartItems.map(item => item.id));
+  // 장바구니 아이템이 로드되면 전체 선택
+  useEffect(() => {
+    if (cartItems.length > 0 && selectedCourseIds.length === 0) {
+      setSelectedCourseIds(cartItems.map(item => item.courseId));
     }
-  }, [cartItems, selectedItems.length]);
+  }, [cartItems, selectedCourseIds.length]);
 
   const toggleSelectAll = () => {
-    if (selectedItems.length === cartItems.length) {
-      setSelectedItems([]);
+    if (selectedCourseIds.length === cartItems.length) {
+      setSelectedCourseIds([]);
     } else {
-      setSelectedItems(cartItems.map(item => item.id));
+      setSelectedCourseIds(cartItems.map(item => item.courseId));
     }
   };
 
-  const toggleSelectItem = (id: number) => {
-    if (selectedItems.includes(id)) {
-      setSelectedItems(selectedItems.filter(itemId => itemId !== id));
+  const toggleSelectItem = (courseId: number) => {
+    if (selectedCourseIds.includes(courseId)) {
+      setSelectedCourseIds(selectedCourseIds.filter(id => id !== courseId));
     } else {
-      setSelectedItems([...selectedItems, id]);
+      setSelectedCourseIds([...selectedCourseIds, courseId]);
     }
   };
 
-  const removeItem = (id: number) => {
-    if (USE_API) {
-      removeFromCartMutation.mutate({ itemIds: [id] });
-    } else {
-      setMockCartItems(mockCartItems.filter(item => item.id !== id));
-    }
-    setSelectedItems(selectedItems.filter(itemId => itemId !== id));
+  const removeItem = (courseId: number) => {
+    removeFromCartMutation.mutate(courseId, {
+      onSuccess: () => {
+        setSelectedCourseIds(selectedCourseIds.filter(id => id !== courseId));
+      }
+    });
   };
 
   const removeSelectedItems = () => {
-    if (USE_API) {
-      removeFromCartMutation.mutate({ itemIds: selectedItems });
-    } else {
-      setMockCartItems(mockCartItems.filter(item => !selectedItems.includes(item.id)));
-    }
-    setSelectedItems([]);
+    if (selectedCourseIds.length === 0) return;
+
+    removeFromCartBulkMutation.mutate({ courseIds: selectedCourseIds }, {
+      onSuccess: () => {
+        setSelectedCourseIds([]);
+      }
+    });
   };
 
-  const handleApplyCoupon = () => {
-    if (!couponCode.trim()) return;
-
-    if (USE_API) {
-      applyCouponMutation.mutate({ couponCode: couponCode.trim() });
-    } else {
-      // Mock 모드에서는 알림만 표시
-      alert(`쿠폰 코드 "${couponCode}" 적용 (데모)`);
-    }
+  const addFromWishlist = (courseId: number) => {
+    addToCartMutation.mutate({ courseId }, {
+      onSuccess: () => {
+        // 추가된 아이템을 자동으로 선택
+        setSelectedCourseIds(prev => [...prev, courseId]);
+      }
+    });
   };
 
-  // 가격 계산
-  const selectedCartItems = cartItems.filter(item => selectedItems.includes(item.id));
-  const totalOriginalPrice = selectedCartItems.reduce((sum, item) => sum + item.originalPrice, 0);
-  const totalPrice = selectedCartItems.reduce((sum, item) => sum + item.price, 0);
-  const totalDiscount = totalOriginalPrice - totalPrice;
+  // 선택된 아이템들
+  const selectedCartItems = useMemo(() =>
+    cartItems.filter(item => selectedCourseIds.includes(item.courseId)),
+    [cartItems, selectedCourseIds]
+  );
 
   // 로딩 상태
-  if (USE_API && isLoading) {
+  if (isCartLoading) {
     return (
       <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
         <LandingHeader />
@@ -154,7 +109,7 @@ export function CartPage() {
   }
 
   // 에러 상태
-  if (USE_API && error) {
+  if (cartError) {
     return (
       <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
         <LandingHeader />
@@ -176,6 +131,9 @@ export function CartPage() {
     );
   }
 
+  const isRemoving = removeFromCartMutation.isPending || removeFromCartBulkMutation.isPending;
+  const isAdding = addToCartMutation.isPending;
+
   return (
     <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
       <LandingHeader />
@@ -185,7 +143,7 @@ export function CartPage() {
           장바구니
         </h1>
 
-        {cartItems.length === 0 ? (
+        {cartItems.length === 0 && availableWishlistItems.length === 0 ? (
           <div className="text-center py-20">
             <ShoppingCart className={`w-20 h-20 mx-auto mb-6 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
             <h2 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
@@ -203,89 +161,217 @@ export function CartPage() {
           </div>
         ) : (
           <div className="flex flex-col lg:flex-row gap-8">
-            {/* Cart Items */}
-            <div className="flex-1">
-              {/* Select All */}
-              <div className={`flex items-center justify-between mb-4 pb-4 border-b ${
-                isDark ? 'border-white/10' : 'border-gray-200'
-              }`}>
-                <label className="flex items-center gap-3 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={selectedItems.length === cartItems.length}
-                    onChange={toggleSelectAll}
-                    className="w-5 h-5 rounded border-gray-300 text-[#6778ff] focus:ring-[#6778ff]"
-                  />
-                  <span className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                    전체 선택 ({selectedItems.length}/{cartItems.length})
-                  </span>
-                </label>
-                <button
-                  onClick={removeSelectedItems}
-                  disabled={selectedItems.length === 0 || removeFromCartMutation.isPending}
-                  className={`text-sm transition-colors disabled:opacity-50 ${
-                    isDark ? 'text-gray-400 hover:text-red-400' : 'text-gray-500 hover:text-red-500'
-                  }`}
-                >
-                  선택 삭제
-                </button>
+            {/* Left Column - Cart Items & Wishlist */}
+            <div className="flex-1 space-y-8">
+              {/* Cart Items Section */}
+              <div>
+                {cartItems.length > 0 && (
+                  <>
+                    {/* Select All */}
+                    <div className={`flex items-center justify-between mb-4 pb-4 border-b ${
+                      isDark ? 'border-white/10' : 'border-gray-200'
+                    }`}>
+                      <label className="flex items-center gap-3 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={selectedCourseIds.length === cartItems.length && cartItems.length > 0}
+                          onChange={toggleSelectAll}
+                          className="w-5 h-5 rounded border-gray-300 text-[#6778ff] focus:ring-[#6778ff]"
+                        />
+                        <span className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                          전체 선택 ({selectedCourseIds.length}/{cartItems.length})
+                        </span>
+                      </label>
+                      <button
+                        onClick={removeSelectedItems}
+                        disabled={selectedCourseIds.length === 0 || isRemoving}
+                        className={`text-sm transition-colors disabled:opacity-50 ${
+                          isDark ? 'text-gray-400 hover:text-red-400' : 'text-gray-500 hover:text-red-500'
+                        }`}
+                      >
+                        {isRemoving ? '삭제 중...' : '선택 삭제'}
+                      </button>
+                    </div>
+
+                    {/* Cart Items List */}
+                    <div className="space-y-4">
+                      {cartItems.map((item: CartItemResponse) => (
+                        <div
+                          key={item.cartItemId}
+                          className={`rounded-xl p-4 flex gap-4 border ${
+                            isDark
+                              ? 'glass border-white/10'
+                              : 'bg-white border-gray-200'
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selectedCourseIds.includes(item.courseId)}
+                            onChange={() => toggleSelectItem(item.courseId)}
+                            className="w-5 h-5 rounded border-gray-300 text-[#6778ff] focus:ring-[#6778ff] mt-1"
+                          />
+                          <img
+                            src={item.thumbnailUrl || 'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=400&h=250&fit=crop'}
+                            alt={item.courseTitle}
+                            className="w-32 h-20 object-cover rounded-lg"
+                          />
+                          <div className="flex-1 min-w-0">
+                            <Link
+                              to={`/tu/main/courses/${item.courseId}`}
+                              className={`font-semibold mb-1 line-clamp-1 hover:text-[#6778ff] transition-colors block ${isDark ? 'text-white' : 'text-gray-900'}`}
+                            >
+                              {item.courseTitle}
+                            </Link>
+                            {item.courseDescription && (
+                              <p className={`text-sm mb-2 line-clamp-1 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                                {item.courseDescription}
+                              </p>
+                            )}
+                            <div className="flex items-center gap-2 flex-wrap">
+                              {item.level && (
+                                <span className={`text-xs px-2 py-0.5 rounded ${
+                                  isDark ? 'bg-white/10 text-gray-300' : 'bg-gray-100 text-gray-600'
+                                }`}>
+                                  {item.level}
+                                </span>
+                              )}
+                              {item.type && (
+                                <span className={`text-xs px-2 py-0.5 rounded ${
+                                  isDark ? 'bg-white/10 text-gray-300' : 'bg-gray-100 text-gray-600'
+                                }`}>
+                                  {item.type}
+                                </span>
+                              )}
+                              {item.estimatedHours && (
+                                <span className={`text-xs ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                                  {item.estimatedHours}시간
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                          <button
+                            onClick={() => removeItem(item.courseId)}
+                            disabled={isRemoving}
+                            className={`p-2 transition-colors disabled:opacity-50 ${
+                              isDark ? 'text-gray-400 hover:text-red-400' : 'text-gray-400 hover:text-red-500'
+                            }`}
+                          >
+                            <Trash2 className="w-5 h-5" />
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  </>
+                )}
+
+                {cartItems.length === 0 && (
+                  <div className={`text-center py-12 rounded-xl border ${
+                    isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
+                  }`}>
+                    <ShoppingCart className={`w-12 h-12 mx-auto mb-4 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
+                    <p className={`${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                      장바구니가 비어있습니다
+                    </p>
+                    <p className={`text-sm mt-1 ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
+                      아래 찜 목록에서 강의를 추가해보세요!
+                    </p>
+                  </div>
+                )}
               </div>
 
-              {/* Items List */}
-              <div className="space-y-4">
-                {cartItems.map((item) => (
-                  <div
-                    key={item.id}
-                    className={`rounded-xl p-4 flex gap-4 border ${
-                      isDark
-                        ? 'glass border-white/10'
-                        : 'bg-white border-gray-200'
-                    }`}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={selectedItems.includes(item.id)}
-                      onChange={() => toggleSelectItem(item.id)}
-                      className="w-5 h-5 rounded border-gray-300 text-[#6778ff] focus:ring-[#6778ff] mt-1"
-                    />
-                    <img
-                      src={item.image}
-                      alt={item.title}
-                      className="w-32 h-20 object-cover rounded-lg"
-                    />
-                    <div className="flex-1 min-w-0">
-                      <h3 className={`font-semibold mb-1 line-clamp-1 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                        {item.title}
-                      </h3>
-                      <p className={`text-sm mb-2 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
-                        {item.instructor}
-                      </p>
-                      <div className="flex items-center gap-2">
-                        {item.discount > 0 && (
-                          <>
-                            <span className="text-[#6778ff] font-bold">{item.discount}%</span>
-                            <span className={`line-through text-sm ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
-                              {item.originalPrice.toLocaleString()}원
-                            </span>
-                          </>
-                        )}
-                        <span className={`font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                          {item.price.toLocaleString()}원
-                        </span>
-                      </div>
-                    </div>
-                    <button
-                      onClick={() => removeItem(item.id)}
-                      disabled={removeFromCartMutation.isPending}
-                      className={`p-2 transition-colors disabled:opacity-50 ${
-                        isDark ? 'text-gray-400 hover:text-red-400' : 'text-gray-400 hover:text-red-500'
-                      }`}
-                    >
-                      <Trash2 className="w-5 h-5" />
-                    </button>
+              {/* Wishlist Section */}
+              {availableWishlistItems.length > 0 && (
+                <div>
+                  <div className={`flex items-center gap-2 mb-4 pb-4 border-b ${
+                    isDark ? 'border-white/10' : 'border-gray-200'
+                  }`}>
+                    <Heart className={`w-5 h-5 ${isDark ? 'text-pink-400' : 'text-pink-500'}`} fill="currentColor" />
+                    <h2 className={`text-lg font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                      찜 목록에서 추가하기
+                    </h2>
+                    <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                      ({availableWishlistItems.length}개)
+                    </span>
                   </div>
-                ))}
-              </div>
+
+                  {isWishlistLoading ? (
+                    <div className="flex items-center justify-center py-8">
+                      <Loader2 className="w-6 h-6 animate-spin text-[#6778ff]" />
+                    </div>
+                  ) : (
+                    <div className="space-y-3">
+                      {availableWishlistItems.map((item: WishlistItemResponse) => (
+                        <div
+                          key={item.id}
+                          className={`rounded-xl p-4 flex gap-4 border ${
+                            isDark
+                              ? 'glass border-white/10'
+                              : 'bg-white border-gray-200'
+                          }`}
+                        >
+                          <img
+                            src={item.courseThumbnailUrl || 'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=400&h=250&fit=crop'}
+                            alt={item.courseTitle || ''}
+                            className="w-28 h-18 object-cover rounded-lg"
+                          />
+                          <div className="flex-1 min-w-0">
+                            <Link
+                              to={`/tu/main/courses/${item.courseId}`}
+                              className={`font-semibold mb-1 line-clamp-1 hover:text-[#6778ff] transition-colors block ${isDark ? 'text-white' : 'text-gray-900'}`}
+                            >
+                              {item.courseTitle}
+                            </Link>
+                            <div className="flex items-center gap-2 flex-wrap mt-1">
+                              {item.courseLevel && (
+                                <span className={`text-xs px-2 py-0.5 rounded ${
+                                  isDark ? 'bg-white/10 text-gray-300' : 'bg-gray-100 text-gray-600'
+                                }`}>
+                                  {item.courseLevel}
+                                </span>
+                              )}
+                              {item.courseType && (
+                                <span className={`text-xs px-2 py-0.5 rounded ${
+                                  isDark ? 'bg-white/10 text-gray-300' : 'bg-gray-100 text-gray-600'
+                                }`}>
+                                  {item.courseType}
+                                </span>
+                              )}
+                              {item.courseEstimatedHours && (
+                                <span className={`text-xs ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                                  {item.courseEstimatedHours}시간
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                          <button
+                            onClick={() => addFromWishlist(item.courseId)}
+                            disabled={isAdding || cartCourseIds.has(item.courseId)}
+                            className={`flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium transition-all disabled:opacity-50 ${
+                              cartCourseIds.has(item.courseId)
+                                ? isDark
+                                  ? 'bg-green-500/20 text-green-400'
+                                  : 'bg-green-100 text-green-600'
+                                : 'landing-btn-primary text-white'
+                            }`}
+                          >
+                            {cartCourseIds.has(item.courseId) ? (
+                              <>
+                                <Check className="w-4 h-4" />
+                                추가됨
+                              </>
+                            ) : (
+                              <>
+                                <Plus className="w-4 h-4" />
+                                담기
+                              </>
+                            )}
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
 
             {/* Order Summary */}
@@ -296,77 +382,39 @@ export function CartPage() {
                   : 'bg-white border-gray-200'
               }`}>
                 <h2 className={`text-xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                  결제 정보
+                  선택한 강의
                 </h2>
 
-                {/* Coupon */}
-                <div className="mb-6">
-                  <label className={`block text-sm font-medium mb-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
-                    쿠폰 코드
-                  </label>
-                  <div className="flex gap-2">
-                    <div className="flex-1 relative">
-                      <Tag className={`absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 ${
-                        isDark ? 'text-gray-500' : 'text-gray-400'
-                      }`} />
-                      <input
-                        type="text"
-                        value={couponCode}
-                        onChange={(e) => setCouponCode(e.target.value)}
-                        placeholder="쿠폰 코드 입력"
-                        className={`w-full rounded-lg pl-10 pr-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-[#6778ff] ${
-                          isDark
-                            ? 'bg-white/5 border border-white/10 text-white placeholder-gray-500'
-                            : 'bg-gray-50 border border-gray-200 text-gray-900 placeholder-gray-400'
-                        }`}
-                      />
-                    </div>
-                    <button
-                      onClick={handleApplyCoupon}
-                      disabled={applyCouponMutation.isPending}
-                      className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 ${
-                        isDark
-                          ? 'bg-white/10 text-white hover:bg-white/20'
-                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                      }`}
-                    >
-                      {applyCouponMutation.isPending ? '적용 중...' : '적용'}
-                    </button>
-                  </div>
-                </div>
-
-                {/* Price Breakdown */}
+                {/* Selected Items Summary */}
                 <div className={`space-y-3 mb-6 pb-6 border-b ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
                   <div className={`flex justify-between ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-                    <span>선택 강의 ({selectedItems.length}개)</span>
-                    <span>{totalOriginalPrice.toLocaleString()}원</span>
+                    <span>선택 강의</span>
+                    <span>{selectedCartItems.length}개</span>
                   </div>
-                  <div className="flex justify-between text-[#6778ff]">
-                    <span>할인 금액</span>
-                    <span>-{totalDiscount.toLocaleString()}원</span>
-                  </div>
-                </div>
-
-                {/* Total */}
-                <div className="flex justify-between items-center mb-6">
-                  <span className={`text-lg font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                    총 결제 금액
-                  </span>
-                  <span className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                    {totalPrice.toLocaleString()}원
-                  </span>
+                  {selectedCartItems.length > 0 && (
+                    <div className={`text-sm space-y-1 ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
+                      {selectedCartItems.slice(0, 3).map(item => (
+                        <p key={item.cartItemId} className="truncate">
+                          • {item.courseTitle}
+                        </p>
+                      ))}
+                      {selectedCartItems.length > 3 && (
+                        <p>• 외 {selectedCartItems.length - 3}개</p>
+                      )}
+                    </div>
+                  )}
                 </div>
 
                 {/* Checkout Button */}
                 <button
-                  disabled={selectedItems.length === 0}
+                  disabled={selectedCourseIds.length === 0}
                   className="w-full landing-btn-primary py-4 rounded-xl text-white font-bold text-lg disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  {selectedItems.length > 0 ? `${selectedItems.length}개 강의 결제하기` : '강의를 선택해주세요'}
+                  {selectedCourseIds.length > 0 ? `${selectedCourseIds.length}개 강의 수강신청` : '강의를 선택해주세요'}
                 </button>
 
                 <p className={`text-center text-xs mt-4 ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
-                  결제 시 이용약관 및 환불 정책에 동의하게 됩니다.
+                  수강신청 시 이용약관에 동의하게 됩니다.
                 </p>
               </div>
             </div>

--- a/src/pages/tu/main/CourseDetailPage.tsx
+++ b/src/pages/tu/main/CourseDetailPage.tsx
@@ -329,7 +329,7 @@ export function CourseDetailPage() {
   const handleAddToCart = async () => {
     if (USE_API) {
       try {
-        await addToCartMutation.mutateAsync(course.id);
+        await addToCartMutation.mutateAsync({ courseId: course.id });
         toast.success('장바구니에 추가되었습니다.');
       } catch (err) {
         console.error('장바구니 추가 실패:', err);

--- a/src/pages/tu/main/CoursesExplorePage.tsx
+++ b/src/pages/tu/main/CoursesExplorePage.tsx
@@ -4,11 +4,12 @@ import { Search, SlidersHorizontal, Star, Loader2, Heart } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
-import { useCourseExplore, useCourseCategories } from '@/hooks/tu';
+import { useCourseExplore, useCourseCategories, useToggleWishlist, useCheckWishlistStatus } from '@/hooks/tu';
+import { useAuthStore } from '@/store/common/authStore';
 import type { CourseExploreItem, ExploreCourseCategory } from '@/types/tu';
 
 // 환경 설정: true면 API 사용, false면 더미 데이터 사용
-const USE_API = false;
+const USE_API = true;
 
 // 더미 카테고리 데이터
 const MOCK_CATEGORIES: ExploreCourseCategory[] = [
@@ -233,13 +234,20 @@ interface CourseCardProps {
 }
 
 function CourseCard({ course, isDark }: CourseCardProps) {
-  const [isWishlisted, setIsWishlisted] = useState(false);
+  const { isAuthenticated } = useAuthStore();
+  const { data: wishlistStatus } = useCheckWishlistStatus(course.id, isAuthenticated);
+  const toggleWishlistMutation = useToggleWishlist();
+
+  const isWishlisted = wishlistStatus ?? false;
 
   const handleWishlistToggle = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    setIsWishlisted(!isWishlisted);
-    // TODO: API 연동 시 실제 찜 추가/삭제 로직 구현
+    if (!isAuthenticated) {
+      alert('로그인이 필요합니다.');
+      return;
+    }
+    toggleWishlistMutation.toggle(course.id, isWishlisted);
   };
 
   const tags: string[] = [];

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -218,4 +218,13 @@ export const API_ENDPOINTS = {
     COURSE_CHECK: (courseId: number) => `/wishlist/courses/${courseId}/check`,
     COURSE_COUNT: (courseId: number) => `/wishlist/courses/${courseId}/count`,
   },
+
+  // Cart (장바구니) - TU
+  CART: {
+    BASE: '/cart',
+    ITEMS: '/cart/items',
+    COUNT: '/cart/count',
+    ITEM: (courseId: number) => `/cart/items/${courseId}`,
+    ITEM_CHECK: (courseId: number) => `/cart/items/${courseId}/check`,
+  },
 } as const;

--- a/src/services/tu/cartService.ts
+++ b/src/services/tu/cartService.ts
@@ -1,60 +1,70 @@
 /**
- * 장바구니(Cart) API 서비스
+ * 장바구니(Cart) API 서비스 - 백엔드 API 스펙 기반
  */
 
 import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type { ApiResponse } from '@/types/common/api.types';
 import type {
-  CartResponse,
-  AddToCartRequest,
-  RemoveFromCartRequest,
-  ApplyCouponRequest,
-  ApplyCouponResponse,
+  CartItemResponse,
+  CartAddRequest,
+  CartRemoveRequest,
+  CartCountResponse,
 } from '@/types/tu/cart.types';
-
-const BASE_URL = '/tu/cart';
 
 export const cartService = {
   /**
    * 장바구니 목록 조회
    */
-  getCart: async (): Promise<CartResponse> => {
-    const response = await axiosInstance.get<CartResponse>(BASE_URL);
-    return response.data;
+  getCart: async (): Promise<CartItemResponse[]> => {
+    const response = await axiosInstance.get<ApiResponse<CartItemResponse[]>>(
+      API_ENDPOINTS.CART.BASE
+    );
+    return response.data.data;
   },
 
   /**
    * 장바구니에 강의 추가
    */
-  addToCart: async (data: AddToCartRequest): Promise<void> => {
-    await axiosInstance.post(`${BASE_URL}/items`, data);
+  addToCart: async (request: CartAddRequest): Promise<CartItemResponse> => {
+    const response = await axiosInstance.post<ApiResponse<CartItemResponse>>(
+      API_ENDPOINTS.CART.ITEMS,
+      request
+    );
+    return response.data.data;
   },
 
   /**
-   * 장바구니에서 아이템 삭제
+   * 장바구니에서 강의 삭제
    */
-  removeFromCart: async (data: RemoveFromCartRequest): Promise<void> => {
-    await axiosInstance.delete(`${BASE_URL}/items`, { data });
+  removeFromCart: async (courseId: number): Promise<void> => {
+    await axiosInstance.delete(API_ENDPOINTS.CART.ITEM(courseId));
   },
 
   /**
-   * 장바구니 비우기
+   * 장바구니에서 여러 강의 삭제 (선택 삭제)
    */
-  clearCart: async (): Promise<void> => {
-    await axiosInstance.delete(`${BASE_URL}/clear`);
+  removeFromCartBulk: async (request: CartRemoveRequest): Promise<void> => {
+    await axiosInstance.delete(API_ENDPOINTS.CART.ITEMS, { data: request });
   },
 
   /**
-   * 쿠폰 적용
+   * 장바구니 개수 조회
    */
-  applyCoupon: async (data: ApplyCouponRequest): Promise<ApplyCouponResponse> => {
-    const response = await axiosInstance.post<ApplyCouponResponse>(`${BASE_URL}/coupon`, data);
-    return response.data;
+  getCartCount: async (): Promise<CartCountResponse> => {
+    const response = await axiosInstance.get<ApiResponse<CartCountResponse>>(
+      API_ENDPOINTS.CART.COUNT
+    );
+    return response.data.data;
   },
 
   /**
-   * 쿠폰 제거
+   * 특정 강의 장바구니 여부 확인
    */
-  removeCoupon: async (): Promise<void> => {
-    await axiosInstance.delete(`${BASE_URL}/coupon`);
+  checkCartStatus: async (courseId: number): Promise<boolean> => {
+    const response = await axiosInstance.get<ApiResponse<boolean>>(
+      API_ENDPOINTS.CART.ITEM_CHECK(courseId)
+    );
+    return response.data.data;
   },
 };

--- a/src/services/tu/courseExploreService.ts
+++ b/src/services/tu/courseExploreService.ts
@@ -7,9 +7,46 @@ import type {
   CourseExploreResponse,
   CourseCategoryResponse,
   CourseExploreFilter,
+  CourseExploreItem,
 } from '@/types/tu/courseExplore.types';
+import type { ApiResponse, PageResponse } from '@/types/common';
 
-const BASE_URL = '/tu/courses';
+const BASE_URL = '/courses';
+
+// 백엔드 응답 타입
+interface BackendCourseResponse {
+  courseId: number;
+  title: string;
+  description: string;
+  thumbnailUrl: string | null;
+  level: 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED';
+  type: 'ONLINE' | 'OFFLINE' | 'BLENDED';
+  estimatedHours: number | null;
+  categoryId: number | null;
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+// 백엔드 응답을 프론트엔드 형식으로 변환
+const transformCourse = (course: BackendCourseResponse): CourseExploreItem => ({
+  id: course.courseId,
+  title: course.title,
+  instructor: '강사명',  // 백엔드에서 강사 정보가 없어 기본값 사용
+  originalPrice: 0,
+  price: 0,
+  image: course.thumbnailUrl || 'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=400&h=250&fit=crop',
+  discount: 0,
+  rating: 4.5,
+  reviewCount: 0,
+  studentCount: 0,
+  totalHours: course.estimatedHours || 0,
+  category: course.categoryId?.toString() || 'dev',
+  level: course.level.toLowerCase() as 'beginner' | 'intermediate' | 'advanced',
+  isNew: new Date(course.createdAt) > new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),  // 7일 이내
+  isBestseller: false,
+  tags: course.tags,
+});
 
 export const courseExploreService = {
   /**
@@ -19,71 +56,93 @@ export const courseExploreService = {
     const params = new URLSearchParams();
 
     if (filter?.search) {
-      params.append('search', filter.search);
+      params.append('keyword', filter.search);
     }
     if (filter?.category && filter.category !== 'all') {
-      params.append('category', filter.category);
-    }
-    if (filter?.level && filter.level !== 'all') {
-      params.append('level', filter.level);
-    }
-    if (filter?.rating) {
-      params.append('rating', String(filter.rating));
-    }
-    if (filter?.priceRange?.min !== undefined) {
-      params.append('minPrice', String(filter.priceRange.min));
-    }
-    if (filter?.priceRange?.max !== undefined) {
-      params.append('maxPrice', String(filter.priceRange.max));
-    }
-    if (filter?.sortBy) {
-      params.append('sortBy', filter.sortBy);
+      params.append('categoryId', filter.category);
     }
     if (filter?.page) {
       params.append('page', String(filter.page));
     }
     if (filter?.pageSize) {
-      params.append('pageSize', String(filter.pageSize));
+      params.append('size', String(filter.pageSize));
     }
 
     const query = params.toString();
     const url = query ? `${BASE_URL}?${query}` : BASE_URL;
-    const response = await axiosInstance.get<CourseExploreResponse>(url);
-    return response.data;
+    const response = await axiosInstance.get<ApiResponse<PageResponse<BackendCourseResponse>>>(url);
+
+    const pageData = response.data.data;
+    return {
+      courses: pageData.content.map(transformCourse),
+      totalCount: pageData.totalElements,
+      page: pageData.number,
+      pageSize: pageData.size,
+      totalPages: pageData.totalPages,
+    };
   },
 
   /**
    * 카테고리 목록 조회
    */
   getCategories: async (): Promise<CourseCategoryResponse> => {
-    const response = await axiosInstance.get<CourseCategoryResponse>(`${BASE_URL}/categories`);
-    return response.data;
+    // 카테고리 API가 없으므로 기본 카테고리 반환
+    return {
+      categories: [
+        { id: 'all', name: '전체', count: 0 },
+        { id: 'dev', name: '개발', count: 0 },
+        { id: 'ai', name: 'AI', count: 0 },
+        { id: 'data', name: '데이터', count: 0 },
+        { id: 'design', name: '디자인', count: 0 },
+      ],
+    };
   },
 
   /**
    * 인기 강의 조회
    */
   getPopularCourses: async (limit?: number): Promise<CourseExploreResponse> => {
-    const params = limit ? `?limit=${limit}` : '';
-    const response = await axiosInstance.get<CourseExploreResponse>(`${BASE_URL}/popular${params}`);
-    return response.data;
+    const size = limit || 10;
+    const response = await axiosInstance.get<ApiResponse<PageResponse<BackendCourseResponse>>>(`${BASE_URL}?size=${size}`);
+    const pageData = response.data.data;
+    return {
+      courses: pageData.content.map(transformCourse),
+      totalCount: pageData.totalElements,
+      page: pageData.number,
+      pageSize: pageData.size,
+      totalPages: pageData.totalPages,
+    };
   },
 
   /**
    * 신규 강의 조회
    */
   getNewCourses: async (limit?: number): Promise<CourseExploreResponse> => {
-    const params = limit ? `?limit=${limit}` : '';
-    const response = await axiosInstance.get<CourseExploreResponse>(`${BASE_URL}/new${params}`);
-    return response.data;
+    const size = limit || 10;
+    const response = await axiosInstance.get<ApiResponse<PageResponse<BackendCourseResponse>>>(`${BASE_URL}?size=${size}`);
+    const pageData = response.data.data;
+    return {
+      courses: pageData.content.map(transformCourse),
+      totalCount: pageData.totalElements,
+      page: pageData.number,
+      pageSize: pageData.size,
+      totalPages: pageData.totalPages,
+    };
   },
 
   /**
    * 추천 강의 조회
    */
   getRecommendedCourses: async (limit?: number): Promise<CourseExploreResponse> => {
-    const params = limit ? `?limit=${limit}` : '';
-    const response = await axiosInstance.get<CourseExploreResponse>(`${BASE_URL}/recommended${params}`);
-    return response.data;
+    const size = limit || 10;
+    const response = await axiosInstance.get<ApiResponse<PageResponse<BackendCourseResponse>>>(`${BASE_URL}?size=${size}`);
+    const pageData = response.data.data;
+    return {
+      courses: pageData.content.map(transformCourse),
+      totalCount: pageData.totalElements,
+      page: pageData.number,
+      pageSize: pageData.size,
+      totalPages: pageData.totalPages,
+    };
   },
 };

--- a/src/types/tu/cart.types.ts
+++ b/src/types/tu/cart.types.ts
@@ -1,64 +1,42 @@
 /**
- * 장바구니(Cart) 관련 타입 정의
+ * 장바구니(Cart) 관련 타입 정의 - 백엔드 API 스펙 기반
  */
 
-// 장바구니 아이템
-export interface CartItem {
-  id: number;
+// 장바구니 항목 응답 (백엔드 API)
+export interface CartItemResponse {
+  cartItemId: number;
   courseId: number;
-  title: string;
-  instructor: string;
-  originalPrice: number;
-  price: number;
-  image: string;
-  discount: number;
-  rating: number;
-  reviewCount: number;
-  totalHours: number;
+  courseTitle: string;
+  courseDescription: string | null;
+  thumbnailUrl: string | null;
+  level: string | null;
+  type: string | null;
+  estimatedHours: number | null;
+  addedAt: string;
+}
+
+// 장바구니 추가 요청
+export interface CartAddRequest {
+  courseId: number;
+}
+
+// 장바구니 삭제 요청 (일괄)
+export interface CartRemoveRequest {
+  courseIds: number[];
+}
+
+// 장바구니 개수 응답
+export interface CartCountResponse {
+  count: number;
+}
+
+// UI용 장바구니 아이템 (선택 상태 포함)
+export interface CartItem extends CartItemResponse {
   isSelected: boolean;
 }
 
-// 장바구니 응답
-export interface CartResponse {
-  items: CartItem[];
-  totalCount: number;
-}
-
-// 장바구니 요약
+// 장바구니 요약 (UI용)
 export interface CartSummary {
-  originalTotal: number;
-  discountTotal: number;
-  finalTotal: number;
+  totalCount: number;
   selectedCount: number;
-}
-
-// 쿠폰 정보
-export interface Coupon {
-  code: string;
-  discountType: 'PERCENTAGE' | 'FIXED';
-  discountValue: number;
-  minPurchaseAmount?: number;
-  expiresAt?: string;
-}
-
-// 쿠폰 적용 요청
-export interface ApplyCouponRequest {
-  couponCode: string;
-}
-
-// 쿠폰 적용 응답
-export interface ApplyCouponResponse {
-  success: boolean;
-  discount: number;
-  message?: string;
-}
-
-// 장바구니 아이템 추가 요청
-export interface AddToCartRequest {
-  courseId: number;
-}
-
-// 장바구니 아이템 삭제 요청
-export interface RemoveFromCartRequest {
-  itemIds: number[];
 }

--- a/src/types/tu/index.ts
+++ b/src/types/tu/index.ts
@@ -102,14 +102,12 @@ export type {
 
 // Cart (장바구니)
 export type {
+  CartItemResponse,
+  CartAddRequest,
+  CartRemoveRequest,
+  CartCountResponse,
   CartItem,
-  CartResponse,
   CartSummary,
-  Coupon,
-  ApplyCouponRequest,
-  ApplyCouponResponse,
-  AddToCartRequest,
-  RemoveFromCartRequest,
 } from './cart.types';
 
 // Wishlist (찜 목록)


### PR DESCRIPTION
## Summary

강의 탐색 페이지에서 실제 API 연동 및 찜 기능을 통합했습니다.

## Related Issue

- Closes #

## Changes

- `USE_API` 플래그를 `true`로 변경하여 실제 백엔드 API 사용
- `courseExploreService`에서 백엔드 응답 형식을 프론트엔드 형식으로 변환하는 로직 추가
- `CourseCard` 컴포넌트에 실제 찜 기능 연동 (`useToggleWishlist`, `useCheckWishlistStatus` 훅 사용)
- 로그인하지 않은 사용자가 찜 버튼 클릭 시 알림 표시

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 백엔드 `/api/courses` API 응답을 프론트엔드 `CourseExploreItem` 타입으로 변환
- 강사 정보, 가격, 평점 등은 백엔드에서 제공하지 않아 기본값 사용