### PR TITLE
fix: 내 강의 목록 API 응답 파싱 오류 수정

### DIFF
--- a/src/services/common/courseService.ts
+++ b/src/services/common/courseService.ts
@@ -54,22 +54,22 @@ export const courseService = {
   async getCourses(
     params?: CourseFilterParams
   ): Promise<PageResponse<CourseResponse>> {
-    const { data } = await axiosInstance.get<PageResponse<CourseResponse>>(
+    const { data } = await axiosInstance.get<{ data: PageResponse<CourseResponse> }>(
       API_ENDPOINTS.COURSES.BASE,
       { params }
     );
-    return data;
+    return data.data;
   },
 
   /** 내 강의 목록 조회 */
   async getMyCourses(
     params?: CourseFilterParams
   ): Promise<PageResponse<CourseResponse>> {
-    const { data } = await axiosInstance.get<PageResponse<CourseResponse>>(
+    const { data } = await axiosInstance.get<{ data: PageResponse<CourseResponse> }>(
       API_ENDPOINTS.COURSES.MY,
       { params }
     );
-    return data;
+    return data.data;
   },
 
   /** 강의 상세 조회 */


### PR DESCRIPTION
## Summary
- `courseService`의 `getMyCourses`, `getCourses` 메서드에서 API 응답 파싱 오류 수정
- 백엔드 `ApiResponse` 래퍼를 고려하여 `data.data`로 실제 Page 데이터 추출

## 변경 사항
- `return data` → `return data.data`로 수정

## 원인
백엔드 API 응답 구조:
```json
{ "data": { "content": [...], "totalElements": ... } }
```
기존 코드는 `data`를 그대로 반환하여 `content`가 `undefined`가 됨

## Test plan
- [ ] `/tu/teaching/courses` 페이지에서 내 강의 목록이 정상 표시되는지 확인
- [ ] 강의 목록 페이지에서도 정상 동작하는지 확인

Closes #178