### PR TITLE
refactor: Button/Calendar 디자인 토큰 적용 및 스타일 수정

### DIFF
--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -11,8 +11,8 @@ export const buttonVariants = cva(
         default: 'bg-primary text-primary-foreground hover:bg-primary-hover',
         destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline: 'border border-border bg-white text-text-primary hover:bg-bg-secondary',
-        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-white/10 dark:text-gray-200',
+        secondary: 'border border-border bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground text-text-primary',
         link: 'text-primary underline-offset-4 hover:underline',
         // 디자인 토큰 기반 버튼 variants
         neutral: 'bg-btn-neutral text-white hover:bg-btn-neutral-hover',

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -10,7 +10,7 @@ export const buttonVariants = cva(
       variant: {
         default: 'bg-primary text-primary-foreground hover:bg-primary-hover',
         destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-        outline: 'border border-gray-200 dark:border-white/20 bg-white dark:bg-transparent text-gray-900 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-white/10',
+        outline: 'border border-border bg-white text-text-primary hover:bg-bg-secondary',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-white/10 dark:text-gray-200',
         link: 'text-primary underline-offset-4 hover:underline',

--- a/src/components/common/Calendar/Calendar.tsx
+++ b/src/components/common/Calendar/Calendar.tsx
@@ -49,7 +49,7 @@ function Calendar({
           "day-range-end aria-selected:bg-primary aria-selected:text-primary-foreground",
         selected:
           "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
-        today: "bg-accent text-accent-foreground",
+        today: "bg-bg-secondary text-text-primary font-semibold",
         outside:
           "day-outside text-muted-foreground aria-selected:text-muted-foreground",
         disabled: "text-muted-foreground opacity-50",

--- a/src/components/common/Calendar/Calendar.tsx
+++ b/src/components/common/Calendar/Calendar.tsx
@@ -39,17 +39,15 @@ function Calendar({
           "text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]",
         week: "flex w-full mt-2",
         day: "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected])]:rounded-md",
-        day_button: cn(
-          buttonVariants({ variant: "ghost" }),
-          "size-8 p-0 font-normal aria-selected:opacity-100"
-        ),
+        day_button:
+          "size-8 p-0 font-normal rounded-md hover:bg-accent hover:text-accent-foreground transition-colors aria-selected:bg-primary aria-selected:text-primary-foreground aria-selected:hover:bg-primary aria-selected:hover:text-primary-foreground",
         range_start:
           "day-range-start aria-selected:bg-primary aria-selected:text-primary-foreground",
         range_end:
           "day-range-end aria-selected:bg-primary aria-selected:text-primary-foreground",
         selected:
-          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
-        today: "bg-bg-secondary text-text-primary font-semibold",
+          "bg-primary text-primary-foreground rounded-md hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+        today: "bg-bg-secondary text-text-primary font-semibold rounded-md aria-selected:bg-primary aria-selected:text-primary-foreground",
         outside:
           "day-outside text-muted-foreground aria-selected:text-muted-foreground",
         disabled: "text-muted-foreground opacity-50",


### PR DESCRIPTION
## Summary
Button과 Calendar 컴포넌트에 디자인 토큰을 적용하고 스타일을 개선합니다.

## Related Issue
- Closes #180

## Changes
- Button outline variant: dark mode 제거, 디자인 토큰 적용 (border-border, text-text-primary, bg-bg-secondary)
- Button ghost variant: dark mode 제거, text-text-primary 적용
- Button secondary variant: bo
<img width="1501" height="754" alt="스크린샷 2026-01-02 오후 3 50 00" src="https://github.com/user-attachments/assets/69576f69-ffd7-45e3-8771-349b7a6db095" />
rder-border 추가
- Calendar today: bg-bg-secondary, text-text-primary, font-semibold 적용
- Calendar selected: aria-selected 상태에 bg-primary, text-primary-foreground, rounded-md 적용
- Calendar day_button: buttonVariants(ghost) 제거, 직접 스타일 정의
<img width="313" height="310" alt="스크린샷 2026-01-02 오후 3 49 18" src="https://github.com/user-attachments/assets/db20bdb7-b3d6-44a7-9158-ff2e0d1fa939" />

## Type of Change
- [x] Refactor: 리팩토링

## Checklist
- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요시)