### PR TITLE
fix: 미리보기 모달 다운로드 비허용 콘텐츠 제한 및 downloadable prop 추가

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,6 @@
 # API
 VITE_API_BASE_URL=http://localhost:8080/api
+VITE_STATIC_BASE_URL=http://localhost:8080
 
 # App
 VITE_APP_ENV=development

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # API
 VITE_API_BASE_URL=http://localhost:8080/api
+VITE_STATIC_BASE_URL=http://localhost:8080
 
 # App
 VITE_APP_ENV=development

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "input-otp": "^1.4.2",
         "lucide-react": "^0.487.0",
         "next-themes": "^0.4.6",
+        "pdfjs-dist": "^5.4.530",
         "react": "^19.0.0",
         "react-day-picker": "^9.13.0",
         "react-dom": "^19.0.0",
@@ -1184,6 +1185,256 @@
       "dependencies": {
         "hls.js": "~1.6.15",
         "mux-embed": "^5.8.3"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.88.tgz",
+      "integrity": "sha512-/p08f93LEbsL5mDZFQ3DBxcPv/I4QG9EDYRRq1WNlCOXVfAHBTHMSVMwxlqG/AtnSfUr9+vgfN7MKiyDo0+Weg==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.88",
+        "@napi-rs/canvas-darwin-arm64": "0.1.88",
+        "@napi-rs/canvas-darwin-x64": "0.1.88",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.88",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.88",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.88",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.88",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.88",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.88",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.88",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.88"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.88.tgz",
+      "integrity": "sha512-KEaClPnZuVxJ8smUWjV1wWFkByBO/D+vy4lN+Dm5DFH514oqwukxKGeck9xcKJhaWJGjfruGmYGiwRe//+/zQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.88.tgz",
+      "integrity": "sha512-Xgywz0dDxOKSgx3eZnK85WgGMmGrQEW7ZLA/E7raZdlEE+xXCozobgqz2ZvYigpB6DJFYkqnwHjqCOTSDGlFdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.88.tgz",
+      "integrity": "sha512-Yz4wSCIQOUgNucgk+8NFtQxQxZV5NO8VKRl9ePKE6XoNyNVC8JDqtvhh3b3TPqKK8W5p2EQpAr1rjjm0mfBxdg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.88.tgz",
+      "integrity": "sha512-9gQM2SlTo76hYhxHi2XxWTAqpTOb+JtxMPEIr+H5nAhHhyEtNmTSDRtz93SP7mGd2G3Ojf2oF5tP9OdgtgXyKg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.88.tgz",
+      "integrity": "sha512-7qgaOBMXuVRk9Fzztzr3BchQKXDxGbY+nwsovD3I/Sx81e+sX0ReEDYHTItNb0Je4NHbAl7D0MKyd4SvUc04sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.88.tgz",
+      "integrity": "sha512-kYyNrUsHLkoGHBc77u4Unh067GrfiCUMbGHC2+OTxbeWfZkPt2o32UOQkhnSswKd9Fko/wSqqGkY956bIUzruA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.88.tgz",
+      "integrity": "sha512-HVuH7QgzB0yavYdNZDRyAsn/ejoXB0hn8twwFnOqUbCCdkV+REna7RXjSR7+PdfW0qMQ2YYWsLvVBT5iL/mGpw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.88.tgz",
+      "integrity": "sha512-hvcvKIcPEQrvvJtJnwD35B3qk6umFJ8dFIr8bSymfrSMem0EQsfn1ztys8ETIFndTwdNWJKWluvxztA41ivsEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.88.tgz",
+      "integrity": "sha512-eSMpGYY2xnZSQ6UxYJ6plDboxq4KeJ4zT5HaVkUnbObNN6DlbJe0Mclh3wifAmquXfrlgTZt6zhHsUgz++AK6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.88.tgz",
+      "integrity": "sha512-qcIFfEgHrchyYqRrxsCeTQgpJZ/GqHiqPcU/Fvw/ARVlQeDX1VyFH+X+0gCR2tca6UJrq96vnW+5o7buCq+erA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.88.tgz",
+      "integrity": "sha512-ROVqbfS4QyZxYkqmaIBBpbz/BQvAR+05FXM5PAtTYVc0uyY8Y4BHJSMdGAaMf6TdIVRsQsiq+FG/dH9XhvWCFQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -6161,6 +6412,18 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.530",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.530.tgz",
+      "integrity": "sha512-r1hWsSIGGmyYUAHR26zSXkxYWLXLMd6AwqcaFYG9YUZ0GBf5GvcjJSeo512tabM4GYFhxhl5pMCmPr7Q72Rq2Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.84"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "input-otp": "^1.4.2",
     "lucide-react": "^0.487.0",
     "next-themes": "^0.4.6",
+    "pdfjs-dist": "^5.4.530",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",
     "react-dom": "^19.0.0",

--- a/src/components/domain/tu/content/ContentCard.tsx
+++ b/src/components/domain/tu/content/ContentCard.tsx
@@ -83,9 +83,10 @@ export const ContentCard = ({
   const isArchived = content.status === 'ARCHIVED';
 
   // 썸네일 URL 결정: prop > customThumbnailPath > thumbnailPath
+  const staticBaseUrl = import.meta.env.VITE_STATIC_BASE_URL || '';
   const resolvedThumbnailUrl = thumbnailUrl
-    || (content.customThumbnailPath ? `${import.meta.env.VITE_API_BASE_URL || ''}${content.customThumbnailPath}` : null)
-    || (content.thumbnailPath ? `${import.meta.env.VITE_API_BASE_URL || ''}${content.thumbnailPath}` : null);
+    || (content.customThumbnailPath ? `${staticBaseUrl}${content.customThumbnailPath}` : null)
+    || (content.thumbnailPath ? `${staticBaseUrl}${content.thumbnailPath}` : null);
 
   return (
     <div

--- a/src/components/domain/tu/content/ContentPreviewModal.tsx
+++ b/src/components/domain/tu/content/ContentPreviewModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo } from 'react';
-import { Loader2, ExternalLink, Download, AlertCircle, FileText, Eye } from 'lucide-react';
+import { Loader2, ExternalLink, Download, AlertCircle, FileText, Lock } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -16,6 +16,7 @@ interface ContentPreviewModalProps {
   contentId: number | null;
   contentType: ContentType | null;
   fileName?: string;
+  downloadable?: boolean;
 }
 
 export function ContentPreviewModal({
@@ -24,6 +25,7 @@ export function ContentPreviewModal({
   contentId,
   contentType,
   fileName,
+  downloadable = true,
 }: Readonly<ContentPreviewModalProps>) {
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
 
@@ -76,6 +78,22 @@ export function ContentPreviewModal({
 
   // 콘텐츠 타입에 따른 렌더링
   const renderContent = useMemo(() => {
+    // 다운로드 비허용 콘텐츠는 미리보기 제한
+    if (!downloadable && contentType !== 'EXTERNAL_LINK') {
+      return (
+        <div className="flex flex-col items-center justify-center py-12 space-y-4">
+          <Lock className="w-16 h-16 text-text-secondary" />
+          <p className="text-text-primary text-lg font-medium">{fileName}</p>
+          <p className="text-text-secondary text-sm text-center">
+            이 콘텐츠는 미리보기가 제한되어 있습니다.
+          </p>
+          <p className="text-text-tertiary text-xs text-center">
+            학습 페이지에서 콘텐츠를 확인하세요.
+          </p>
+        </div>
+      );
+    }
+
     if (contentType === 'EXTERNAL_LINK') {
       return (
         <div className="flex flex-col items-center justify-center py-12 space-y-4">
@@ -156,28 +174,23 @@ export function ContentPreviewModal({
         );
 
       case 'DOCUMENT':
-        // PDF인 경우 새 탭에서 열기 + 다운로드 버튼
+        // PDF인 경우 iframe으로 인라인 미리보기
         if (previewData?.contentType?.includes('pdf')) {
-          const handleOpenPdf = () => {
-            if (blobUrl) {
-              window.open(blobUrl, '_blank');
-            }
-          };
           return (
-            <div className="flex flex-col items-center justify-center py-12 space-y-4">
-              <FileText className="w-16 h-16 text-text-secondary" />
-              <p className="text-text-primary text-lg font-medium">{fileName}</p>
-              <p className="text-text-secondary text-sm">PDF 문서</p>
-              <div className="flex gap-3">
-                <Button onClick={handleOpenPdf}>
-                  <Eye size={16} />
-                  새 탭에서 보기
-                </Button>
-                <Button variant="ghost" className="border border-border" onClick={handleDownload}>
-                  <Download size={16} />
-                  다운로드
-                </Button>
-              </div>
+            <div className="flex flex-col space-y-3">
+              <iframe
+                src={blobUrl}
+                title={fileName || 'PDF 미리보기'}
+                className="w-full h-[70vh] border-0 rounded-lg"
+              />
+              {downloadable && (
+                <div className="flex justify-end gap-2">
+                  <Button variant="ghost" className="border border-border" onClick={handleDownload}>
+                    <Download size={16} />
+                    다운로드
+                  </Button>
+                </div>
+              )}
             </div>
           );
         }
@@ -189,10 +202,12 @@ export function ContentPreviewModal({
             <p className="text-text-secondary text-sm">
               이 문서 형식은 미리보기를 지원하지 않습니다.
             </p>
-            <Button onClick={handleDownload}>
-              <Download size={16} />
-              다운로드
-            </Button>
+            {downloadable && (
+              <Button onClick={handleDownload}>
+                <Download size={16} />
+                다운로드
+              </Button>
+            )}
           </div>
         );
 
@@ -204,7 +219,7 @@ export function ContentPreviewModal({
           </div>
         );
     }
-  }, [contentType, isLoading, error, blobUrl, previewData, contentDetail, fileName]);
+  }, [contentType, isLoading, error, blobUrl, previewData, contentDetail, fileName, downloadable]);
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>

--- a/src/components/domain/tu/content/Step1ContentDefinition.tsx
+++ b/src/components/domain/tu/content/Step1ContentDefinition.tsx
@@ -18,6 +18,12 @@ const loTypeCards = [
     description: '동영상 콘텐츠를 업로드합니다',
   },
   {
+    type: 'image' as LOType,
+    icon: ImageIcon,
+    title: '이미지',
+    description: 'JPG, PNG 등 이미지를 업로드합니다',
+  },
+  {
     type: 'document' as LOType,
     icon: FileText,
     title: '문서',

--- a/src/components/domain/tu/content/Step2ContentUpload.tsx
+++ b/src/components/domain/tu/content/Step2ContentUpload.tsx
@@ -102,18 +102,25 @@ export function Step2ContentUpload({ data, onUpdate }: Readonly<Step2Props>) {
     );
   }
 
-  // Video/Document Upload UI
-  if (data.loType === 'video' || data.loType === 'document') {
-    const acceptedFormats = data.loType === 'video' ? '.mp4,.mov,.avi,.mkv' : '.pdf,.txt,.doc,.docx,.ppt,.pptx';
+  // Video/Image/Document Upload UI
+  if (data.loType === 'video' || data.loType === 'image' || data.loType === 'document') {
+    const acceptedFormats =
+      data.loType === 'video'
+        ? '.mp4,.mov,.avi,.mkv'
+        : data.loType === 'image'
+          ? '.jpg,.jpeg,.png,.gif,.webp'
+          : '.pdf,.txt,.doc,.docx,.ppt,.pptx';
     const formatText =
       data.loType === 'video'
         ? 'MP4, MOV, AVI, MKV (최대 500MB)'
-        : 'PDF, TXT, DOC, DOCX, PPT, PPTX (최대 100MB)';
+        : data.loType === 'image'
+          ? 'JPG, PNG, GIF, WEBP (최대 20MB)'
+          : 'PDF, TXT, DOC, DOCX, PPT, PPTX (최대 100MB)';
 
     return (
       <div className="space-y-6">
         <h2 className="text-text-primary font-medium text-lg">
-          {data.loType === 'video' ? '비디오 파일 업로드' : '문서 파일 업로드'}
+          {data.loType === 'video' ? '비디오 파일 업로드' : data.loType === 'image' ? '이미지 파일 업로드' : '문서 파일 업로드'}
         </h2>
 
         {!data.uploadedFile && !isUploading && (
@@ -152,7 +159,7 @@ export function Step2ContentUpload({ data, onUpdate }: Readonly<Step2Props>) {
             <div className="mt-4 p-4 bg-bg-secondary rounded-lg border border-border">
               <p className="text-sm text-text-secondary">
                 <strong className="text-text-primary">백그라운드 처리 안내:</strong> 업로드 완료 후
-                {data.loType === 'video' ? ' 비디오 인코딩' : ' 문서 변환'} 작업이 자동으로 진행됩니다.
+                {data.loType === 'video' ? ' 비디오 인코딩' : data.loType === 'image' ? ' 이미지 처리' : ' 문서 변환'} 작업이 자동으로 진행됩니다.
                 처리 상태는 콘텐츠 목록에서 확인하실 수 있습니다.
               </p>
             </div>

--- a/src/components/domain/tu/content/Step3Settings.tsx
+++ b/src/components/domain/tu/content/Step3Settings.tsx
@@ -85,27 +85,27 @@ export function Step3Settings({ data, onUpdate, isExternalLink = false }: Readon
           </div>
         </div>
 
-        {/* 워터마크 적용 */}
-        <div className="mb-6 pb-6 border-b border-border">
+        {/* 워터마크 적용 - 백엔드 미구현으로 비활성화 */}
+        <div className="mb-6 pb-6 border-b border-border opacity-50">
           <div className="flex items-center justify-between">
             <div>
               <p className="text-text-primary mb-1">워터마크 적용</p>
-              <p className="text-sm text-text-secondary">콘텐츠에 학습자 정보를 워터마크로 표시합니다</p>
+              <p className="text-sm text-text-secondary">현재 지원되지 않는 기능입니다</p>
             </div>
             <button
               type="button"
               role="switch"
-              aria-checked={data.applyWatermark}
-              onClick={() => onUpdate({ applyWatermark: !data.applyWatermark })}
+              aria-checked={false}
+              disabled
               className={cn(
-                'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-                data.applyWatermark ? 'bg-btn-neutral' : 'bg-border'
+                'relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-not-allowed',
+                'bg-border'
               )}
             >
               <span
                 className={cn(
                   'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
-                  data.applyWatermark ? 'translate-x-6' : 'translate-x-1'
+                  'translate-x-1'
                 )}
               />
             </button>

--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -190,15 +190,16 @@ export const tenantOperatorMenuData: MenuItem[] = [
       { id: 'instructor-assignment', label: { ko: '강사 배정', en: 'Instructor Assignment' }, icon: UserCheck, path: '/to/instructors' },
     ],
   },
-  {
-    id: 'content-management',
-    label: { ko: '콘텐츠 관리', en: 'Content Management' },
-    icon: Database,
-    subItems: [
-      { id: 'content-pool', label: { ko: '콘텐츠 풀', en: 'Content Pool' }, icon: Database, path: '/to/content' },
-      { id: 'learning-objects', label: { ko: '학습객체', en: 'Learning Objects' }, icon: Layers, path: '/to/learning-objects' },
-    ],
-  },
+  // TODO: TO 콘텐츠 관리 기능 - 개발 예정으로 임시 숨김
+  // {
+  //   id: 'content-management',
+  //   label: { ko: '콘텐츠 관리', en: 'Content Management' },
+  //   icon: Database,
+  //   subItems: [
+  //     { id: 'content-pool', label: { ko: '콘텐츠 풀', en: 'Content Pool' }, icon: Database, path: '/to/content' },
+  //     { id: 'learning-objects', label: { ko: '학습객체', en: 'Learning Objects' }, icon: Layers, path: '/to/learning-objects' },
+  //   ],
+  // },
   {
     id: 'enrollment-instructor-data',
     label: { ko: '수강 및 강사 정보', en: 'Enrollment & Instructor Data' },

--- a/src/hooks/tu/useContentQueries.ts
+++ b/src/hooks/tu/useContentQueries.ts
@@ -82,6 +82,8 @@ interface UploadContentParams {
   originalFileName?: string;
   description?: string;
   tags?: string;
+  category?: string;
+  completionCriteria?: 'BUTTON_CLICK' | 'PERCENT_90' | 'PERCENT_100';
   thumbnail?: File;
   downloadable?: boolean;
 }
@@ -91,8 +93,8 @@ export const useUploadContent = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ file, folderId, originalFileName, description, tags, thumbnail, downloadable }: UploadContentParams) =>
-      contentService.uploadFile(file, { folderId, originalFileName, description, tags, thumbnail, downloadable }),
+    mutationFn: ({ file, folderId, originalFileName, description, tags, category, completionCriteria, thumbnail, downloadable }: UploadContentParams) =>
+      contentService.uploadFile(file, { folderId, originalFileName, description, tags, category, completionCriteria, thumbnail, downloadable }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: contentKeys.lists() });
       queryClient.invalidateQueries({ queryKey: contentKeys.myLists() });

--- a/src/pages/tu/teaching/content/ContentCreatePage.tsx
+++ b/src/pages/tu/teaching/content/ContentCreatePage.tsx
@@ -1,7 +1,21 @@
 import { useNavigate } from 'react-router-dom';
 import { ContentRegistrationWizard } from '@/components/domain/tu/content';
-import type { LOData } from '@/types';
+import type { LOData, CompletionCriteria } from '@/types';
 import { useUploadContent, useCreateExternalLink } from '@/hooks/tu';
+
+// 프론트 completionCriteria -> 백엔드 enum 변환
+const mapCompletionCriteria = (criteria: CompletionCriteria): 'BUTTON_CLICK' | 'PERCENT_90' | 'PERCENT_100' => {
+  switch (criteria) {
+    case 'button-click':
+      return 'BUTTON_CLICK';
+    case '90-percent':
+      return 'PERCENT_90';
+    case '100-percent':
+      return 'PERCENT_100';
+    default:
+      return 'PERCENT_100';
+  }
+};
 
 export function ContentCreatePage() {
   const navigate = useNavigate();
@@ -21,12 +35,14 @@ export function ContentCreatePage() {
           name: data.title, // 콘텐츠 제목을 name으로 사용
         });
       } else if (data.uploadedFile) {
-        // 파일 업로드 (제목, 설명, 태그, 썸네일, 다운로드 허용 전달)
+        // 파일 업로드 (제목, 설명, 태그, 카테고리, 완료기준, 썸네일, 다운로드 허용 전달)
         await uploadContent.mutateAsync({
           file: data.uploadedFile,
           originalFileName: data.title && data.title !== data.uploadedFile.name ? data.title : undefined,
           description: data.description || undefined,
           tags: data.tags.length > 0 ? data.tags.join(',') : undefined,
+          category: data.category || undefined,
+          completionCriteria: mapCompletionCriteria(data.completionCriteria),
           thumbnail: data.thumbnailImage,
           downloadable: data.allowDownload,
         });

--- a/src/pages/tu/teaching/content/ContentDetailPage.tsx
+++ b/src/pages/tu/teaching/content/ContentDetailPage.tsx
@@ -718,6 +718,7 @@ export function ContentDetailPage({ language = 'ko' }: Readonly<ContentDetailPag
         contentId={contentId}
         contentType={content.contentType}
         fileName={content.originalFileName}
+        downloadable={content.downloadable ?? true}
       />
     </div>
   );

--- a/src/pages/tu/teaching/content/MyContentPage.tsx
+++ b/src/pages/tu/teaching/content/MyContentPage.tsx
@@ -118,7 +118,8 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
     contentId: number | null;
     contentType: ContentType | null;
     fileName: string | null;
-  }>({ isOpen: false, contentId: null, contentType: null, fileName: null });
+    downloadable: boolean;
+  }>({ isOpen: false, contentId: null, contentType: null, fileName: null, downloadable: true });
 
   // 폴더 관리 패널 상태
   const [isFolderPanelOpen, setIsFolderPanelOpen] = useState(false);
@@ -202,11 +203,12 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
       contentId: content.id,
       contentType: content.contentType,
       fileName: content.originalFileName,
+      downloadable: content.downloadable ?? true,
     });
   };
 
   const handleClosePreview = () => {
-    setPreviewModal({ isOpen: false, contentId: null, contentType: null, fileName: null });
+    setPreviewModal({ isOpen: false, contentId: null, contentType: null, fileName: null, downloadable: true });
   };
 
   // 콘텐츠 선택 핸들러
@@ -654,6 +656,7 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
         contentId={previewModal.contentId}
         contentType={previewModal.contentType}
         fileName={previewModal.fileName ?? undefined}
+        downloadable={previewModal.downloadable}
       />
 
       {/* 폴더 관리 슬라이드 패널 */}

--- a/src/services/tu/contentService.ts
+++ b/src/services/tu/contentService.ts
@@ -22,12 +22,17 @@ interface PageResponse<T> {
   number: number;
 }
 
+// 완료 기준 타입 (백엔드 enum과 매칭)
+type CompletionCriteria = 'BUTTON_CLICK' | 'PERCENT_90' | 'PERCENT_100';
+
 // 파일 업로드 옵션
 interface UploadFileOptions {
   folderId?: number;
   originalFileName?: string;
   description?: string;
   tags?: string;
+  category?: string;
+  completionCriteria?: CompletionCriteria;
   thumbnail?: File;
   downloadable?: boolean;
 }
@@ -49,6 +54,12 @@ export const contentService = {
     }
     if (options?.tags) {
       formData.append('tags', options.tags);
+    }
+    if (options?.category) {
+      formData.append('category', options.category);
+    }
+    if (options?.completionCriteria) {
+      formData.append('completionCriteria', options.completionCriteria);
     }
     if (options?.thumbnail) {
       formData.append('thumbnail', options.thumbnail);

--- a/src/services/tu/contentService.ts
+++ b/src/services/tu/contentService.ts
@@ -64,6 +64,7 @@ export const contentService = {
         headers: {
           'Content-Type': undefined, // 브라우저가 boundary 포함하여 자동 설정
         },
+        timeout: 300000, // 5분 (대용량 파일 업로드용)
       }
     );
     return data.data;
@@ -127,6 +128,7 @@ export const contentService = {
         headers: {
           'Content-Type': undefined, // 브라우저가 boundary 포함하여 자동 설정
         },
+        timeout: 300000, // 5분 (대용량 파일 업로드용)
       }
     );
     const result = response.data;

--- a/src/types/to/content.types.ts
+++ b/src/types/to/content.types.ts
@@ -3,7 +3,7 @@
  */
 
 // LO(Learning Object) 유형
-export type LOType = 'video' | 'document' | 'external-link';
+export type LOType = 'video' | 'image' | 'document' | 'external-link';
 
 // 진도율 완료 기준
 export type CompletionCriteria = 'button-click' | '90-percent' | '100-percent';

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string;
+  readonly VITE_STATIC_BASE_URL: string;
   readonly VITE_APP_ENV: string;
   readonly VITE_APP_NAME: string;
 }


### PR DESCRIPTION
## Summary
- ContentPreviewModal에 `downloadable` prop 추가
- 다운로드 비허용 콘텐츠는 미리보기 대신 안내 문구 표시
- PDF iframe 미리보기 유지, 다운로드 버튼은 downloadable일 때만 표시

## Changes
- `ContentPreviewModal.tsx`: downloadable prop 추가, 비허용 시 Lock 아이콘 + 안내 문구
- `MyContentPage.tsx`: previewModal state에 downloadable 추가
- `ContentDetailPage.tsx`: downloadable prop 전달

## Test plan
- [x] downloadable=true 콘텐츠 미리보기 정상 동작
- [x] downloadable=false 콘텐츠 미리보기 시 안내 문구 표시
- [x] PDF 미리보기 iframe 정상 동작
- [x] 다운로드 버튼 downloadable에 따라 표시/숨김

Closes #164