### PR TITLE
refactor(tu): TU 라우팅 구조 개선 및 경로 통일

### DIFF
--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -129,7 +129,7 @@ export function HeroSection() {
 
           <div className="flex gap-4 pt-4">
             <Link
-              to="/tu/catalog"
+              to="/tu/b2c/courses"
               className="landing-btn-primary px-8 py-4 rounded-full text-white font-bold text-base flex items-center gap-2"
             >
               {t.hero.getStarted}

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -136,7 +136,7 @@ export function HeroSection() {
               <ChevronRight className="w-5 h-5" />
             </Link>
             <Link
-              to="/mypage/learning"
+              to="/tu/b2c/mypage/learning"
               className="landing-btn-outline px-8 py-4 rounded-full text-white font-medium text-base"
             >
               {t.hero.explore}

--- a/src/components/landing/LandingCourseCard.tsx
+++ b/src/components/landing/LandingCourseCard.tsx
@@ -50,7 +50,7 @@ export function LandingCourseCard({
   };
 
   return (
-    <Link to={`/tu/main/courses/${id}`} className="group block h-full">
+    <Link to={`/tu/b2c/courses/${id}`} className="group block h-full">
       <div className="h-full card-hover rounded-xl overflow-hidden landing-card-bg border landing-card-border">
         {/* Image Container */}
         <div className="relative aspect-[16/10] overflow-hidden">

--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -59,20 +59,20 @@ export function LandingHeader() {
           {/* Left: Logo & Menu */}
           <div className="flex items-center gap-8 ml-2 md:ml-4">
             {/* Logo */}
-            <Link to="/" className={`flex items-center gap-2 font-bold text-xl tracking-tight ${isDark ? '' : 'text-gray-900'}`}>
+            <Link to="/tu/b2c" className={`flex items-center gap-2 font-bold text-xl tracking-tight ${isDark ? '' : 'text-gray-900'}`}>
               <span className="text-2xl">M</span>
               <span className="gradient-text">MZC Learn</span>
             </Link>
 
             {/* Desktop Nav Links */}
             <nav className={`hidden md:flex items-center gap-8 font-medium text-[15px] ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
-              <Link to="/tu/main/courses" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
+              <Link to="/tu/b2c/courses" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
                 강의 탐색
               </Link>
-              <Link to="/tu/main/roadmaps" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
+              <Link to="/tu/b2c/roadmaps" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
                 로드맵
               </Link>
-              <Link to="/tu/main/community" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
+              <Link to="/tu/b2c/community" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
                 커뮤니티
               </Link>
             </nav>
@@ -116,7 +116,7 @@ export function LandingHeader() {
                 {isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
               </button>
               <Link
-                to="/tu/cart"
+                to="/tu/b2c/cart"
                 className={`p-2 rounded-lg transition-colors relative ${
                   isDark
                     ? 'text-gray-400 hover:text-white hover:bg-white/10'
@@ -126,7 +126,7 @@ export function LandingHeader() {
                 <ShoppingCart className="h-5 w-5" />
               </Link>
               <Link
-                to="/tu/wishlist"
+                to="/tu/b2c/wishlist"
                 className={`p-2 rounded-lg transition-colors relative ${
                   isDark
                     ? 'text-gray-400 hover:text-white hover:bg-white/10'
@@ -136,7 +136,7 @@ export function LandingHeader() {
                 <Heart className="h-5 w-5" />
               </Link>
               <Link
-                to="/tu/notifications"
+                to="/tu/b2c/notifications"
                 className={`p-2 rounded-lg transition-colors relative ${
                   isDark
                     ? 'text-gray-400 hover:text-white hover:bg-white/10'
@@ -193,7 +193,7 @@ export function LandingHeader() {
                       {/* 메뉴 항목들 */}
                       <div className="py-2 space-y-1">
                         <Link
-                          to="/mypage"
+                          to="/tu/b2c/mypage"
                           onClick={() => setShowDropdown(false)}
                           className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors text-sm ${
                             isDark
@@ -205,7 +205,7 @@ export function LandingHeader() {
                           {t.landing.mypage}
                         </Link>
                         <Link
-                          to="/mypage/teaching"
+                          to="/tu/b2c/mypage/teaching"
                           onClick={() => setShowDropdown(false)}
                           className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors text-sm ${
                             isDark
@@ -222,7 +222,7 @@ export function LandingHeader() {
                       <div className={`py-2 border-t space-y-1 ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
                         <p className={`px-3 py-1 text-xs font-medium ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>{t.landing.settings}</p>
                         <Link
-                          to="/mypage/profile"
+                          to="/tu/b2c/mypage/profile"
                           onClick={() => setShowDropdown(false)}
                           className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm ${
                             isDark
@@ -234,7 +234,7 @@ export function LandingHeader() {
                           {t.landing.profileSecurity}
                         </Link>
                         <Link
-                          to="/mypage/notifications"
+                          to="/tu/b2c/mypage/notifications"
                           onClick={() => setShowDropdown(false)}
                           className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm ${
                             isDark
@@ -246,7 +246,7 @@ export function LandingHeader() {
                           {t.landing.notifications}
                         </Link>
                         <Link
-                          to="/mypage/language"
+                          to="/tu/b2c/mypage/language"
                           onClick={() => setShowDropdown(false)}
                           className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm ${
                             isDark

--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -33,7 +33,7 @@ export function LandingHeader() {
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     if (searchQuery.trim()) {
-      navigate(`/tu/catalog?search=${encodeURIComponent(searchQuery.trim())}`);
+      navigate(`/tu/b2c/courses?search=${encodeURIComponent(searchQuery.trim())}`);
     }
   };
 

--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -252,16 +252,16 @@ export const myPageMenuData: MenuItem[] = [
     id: 'mypage-home',
     label: { ko: '마이페이지', en: 'My Page' },
     icon: Home,
-    path: '/mypage',
+    path: '/tu/b2c/mypage',
   },
   {
     id: 'my-enrollments',
     label: { ko: '내 수강 강의', en: 'My Enrollments' },
     icon: BookOpen,
     subItems: [
-      { id: 'enrolled-courses', label: { ko: '수강 중인 강의', en: 'Enrolled Courses' }, icon: BookOpen, path: '/mypage/learning' },
-      { id: 'completed-courses', label: { ko: '완료한 강의', en: 'Completed Courses' }, icon: BookCheck, path: '/mypage/completed' },
-      { id: 'certifications', label: { ko: '인증서', en: 'Certifications' }, icon: Award, path: '/mypage/certifications' },
+      { id: 'enrolled-courses', label: { ko: '수강 중인 강의', en: 'Enrolled Courses' }, icon: BookOpen, path: '/tu/b2c/mypage/learning' },
+      { id: 'completed-courses', label: { ko: '완료한 강의', en: 'Completed Courses' }, icon: BookCheck, path: '/tu/b2c/mypage/completed' },
+      { id: 'certifications', label: { ko: '인증서', en: 'Certifications' }, icon: Award, path: '/tu/b2c/mypage/certifications' },
     ],
   },
   {
@@ -269,9 +269,9 @@ export const myPageMenuData: MenuItem[] = [
     label: { ko: '내 강의 관리', en: 'My Teaching' },
     icon: Briefcase,
     subItems: [
-      { id: 'my-courses', label: { ko: '내 강의', en: 'My Courses' }, icon: BookOpen, path: '/mypage/teaching' },
+      { id: 'my-courses', label: { ko: '내 강의', en: 'My Courses' }, icon: BookOpen, path: '/tu/b2c/mypage/teaching' },
       { id: 'create-course', label: { ko: '강의 개설하기', en: 'Create Course' }, icon: FolderEdit, path: '/tu/teaching/courses/create', roles: ['USER', 'DESIGNER'] },
-      { id: 'teaching-stats', label: { ko: '내 강의 통계', en: 'Teaching Stats' }, icon: TrendingUp, path: '/mypage/teaching/stats' },
+      { id: 'teaching-stats', label: { ko: '내 강의 통계', en: 'Teaching Stats' }, icon: TrendingUp, path: '/tu/b2c/mypage/teaching/stats' },
     ],
   },
   {
@@ -279,9 +279,9 @@ export const myPageMenuData: MenuItem[] = [
     label: { ko: '설정', en: 'Settings' },
     icon: Settings,
     subItems: [
-      { id: 'profile-security', label: { ko: '프로필 및 보안', en: 'Profile & Security' }, icon: Shield, path: '/mypage/settings/security' },
-      { id: 'notifications', label: { ko: '알림', en: 'Notifications' }, icon: Megaphone, path: '/mypage/settings/notifications' },
-      { id: 'language-region', label: { ko: '언어 및 지역', en: 'Language & Region' }, icon: Globe, path: '/mypage/settings/language' },
+      { id: 'profile-security', label: { ko: '프로필 및 보안', en: 'Profile & Security' }, icon: Shield, path: '/tu/b2c/mypage/settings/security' },
+      { id: 'notifications', label: { ko: '알림', en: 'Notifications' }, icon: Megaphone, path: '/tu/b2c/mypage/settings/notifications' },
+      { id: 'language-region', label: { ko: '언어 및 지역', en: 'Language & Region' }, icon: Globe, path: '/tu/b2c/mypage/settings/language' },
     ],
   },
 ];

--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -241,7 +241,7 @@ export const tenantUserMenuData: MenuItem[] = [
     id: 'catalog',
     label: { ko: '과정 둘러보기', en: 'Course Catalog' },
     icon: Library,
-    path: '/tu/catalog',
+    path: '/tu/b2c/courses',
   },
 ];
 

--- a/src/pages/tu/catalog/CatalogDetailPage.tsx
+++ b/src/pages/tu/catalog/CatalogDetailPage.tsx
@@ -148,7 +148,7 @@ export function CatalogDetailPage() {
   const enrollMutation = useEnroll();
 
   const handleBack = () => {
-    navigate('/tu/catalog');
+    navigate('/tu/b2c/courses');
   };
 
   const handleEnroll = async (courseTimeId: number) => {

--- a/src/pages/tu/learning/LearningDetailPage.tsx
+++ b/src/pages/tu/learning/LearningDetailPage.tsx
@@ -162,7 +162,7 @@ export function LearningDetailPage() {
     try {
       await cancelEnrollment.mutateAsync(enrollment.id);
       setCancelDialogOpen(false);
-      navigate('/mypage/learning');
+      navigate('/tu/b2c/mypage/learning');
     } catch (error) {
       console.error('Failed to cancel enrollment:', error);
     }
@@ -191,7 +191,7 @@ export function LearningDetailPage() {
         <h3 className={`text-lg font-medium mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
           {t.learning.enrollmentNotFound}
         </h3>
-        <Button onClick={() => navigate('/mypage/learning')}>
+        <Button onClick={() => navigate('/tu/b2c/mypage/learning')}>
           {t.learning.backToLearning}
         </Button>
       </div>
@@ -208,7 +208,7 @@ export function LearningDetailPage() {
         <Button
           variant="ghost"
           className={`mb-6 gap-2 ${isDark ? 'text-gray-400 hover:text-white hover:bg-white/10' : ''}`}
-          onClick={() => navigate('/mypage/learning')}
+          onClick={() => navigate('/tu/b2c/mypage/learning')}
         >
           <ArrowLeft className="w-4 h-4" />
           {t.learning.backToLearning}

--- a/src/pages/tu/learning/LearningPlayerPage.tsx
+++ b/src/pages/tu/learning/LearningPlayerPage.tsx
@@ -247,7 +247,7 @@ export function LearningPlayerPage() {
     setIsCompleted(progressRecords.some((r) => r.itemId === itemId && r.completed));
 
     // URL 업데이트
-    const basePath = isDemoMode ? '/mypage/learning/demo/player' : `/mypage/learning/${enrollmentId}/player`;
+    const basePath = isDemoMode ? '/tu/b2c/mypage/learning/demo/player' : `/mypage/learning/${enrollmentId}/player`;
     navigate(`${basePath}/${itemId}`, { replace: true });
   }, [enrollmentId, navigate, progressRecords, saveProgress, isDemoMode]);
 
@@ -255,7 +255,7 @@ export function LearningPlayerPage() {
   const handleBack = useCallback(() => {
     saveProgress();
     if (isDemoMode) {
-      navigate('/mypage/learning');
+      navigate('/tu/b2c/mypage/learning');
     } else {
       navigate(`/mypage/learning/${enrollmentId}`);
     }
@@ -290,7 +290,7 @@ export function LearningPlayerPage() {
         <h3 className={`text-lg font-medium mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
           {t.learning.enrollmentNotFound}
         </h3>
-        <Button onClick={() => navigate('/mypage/learning')}>
+        <Button onClick={() => navigate('/tu/b2c/mypage/learning')}>
           {t.learning.backToLearning}
         </Button>
       </div>

--- a/src/pages/tu/learning/MyLearningPage.tsx
+++ b/src/pages/tu/learning/MyLearningPage.tsx
@@ -199,7 +199,7 @@ export function MyLearningPage() {
             </h1>
             {/* 데모 버튼 (테스트용 - 숨김) */}
             <button
-              onClick={() => navigate('/mypage/learning/demo/player')}
+              onClick={() => navigate('/tu/b2c/mypage/learning/demo/player')}
               className={`opacity-10 hover:opacity-100 transition-opacity text-xs px-2 py-1 rounded ${isDark ? 'text-gray-500' : 'text-gray-400'}`}
               title="Demo Mode"
             >

--- a/src/pages/tu/learning/MyLearningPage.tsx
+++ b/src/pages/tu/learning/MyLearningPage.tsx
@@ -316,7 +316,7 @@ export function MyLearningPage() {
             <p className={`mb-4 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
               {t.learning.noEnrollmentsDesc}
             </p>
-            <Button variant="brand" onClick={() => navigate('/tu/catalog')}>
+            <Button variant="brand" onClick={() => navigate('/tu/b2c/courses')}>
               {t.learning.browseCourses}
             </Button>
           </div>

--- a/src/pages/tu/main/CartPage.tsx
+++ b/src/pages/tu/main/CartPage.tsx
@@ -217,7 +217,7 @@ export function CartPage() {
                           />
                           <div className="flex-1 min-w-0">
                             <Link
-                              to={`/tu/main/courses/${item.courseId}`}
+                              to={`/tu/b2c/courses/${item.courseId}`}
                               className={`font-semibold mb-1 line-clamp-1 hover:text-[#6778ff] transition-colors block ${isDark ? 'text-white' : 'text-gray-900'}`}
                             >
                               {item.courseTitle}
@@ -316,7 +316,7 @@ export function CartPage() {
                           />
                           <div className="flex-1 min-w-0">
                             <Link
-                              to={`/tu/main/courses/${item.courseId}`}
+                              to={`/tu/b2c/courses/${item.courseId}`}
                               className={`font-semibold mb-1 line-clamp-1 hover:text-[#6778ff] transition-colors block ${isDark ? 'text-white' : 'text-gray-900'}`}
                             >
                               {item.courseTitle}

--- a/src/pages/tu/main/CartPage.tsx
+++ b/src/pages/tu/main/CartPage.tsx
@@ -153,7 +153,7 @@ export function CartPage() {
               관심 있는 강의를 담아보세요!
             </p>
             <Link
-              to="/tu/main/courses"
+              to="/tu/b2c/courses"
               className="inline-flex items-center gap-2 landing-btn-primary px-6 py-3 rounded-full text-white font-medium"
             >
               강의 둘러보기 <ChevronRight className="w-4 h-4" />

--- a/src/pages/tu/main/CommunityDetailPage.tsx
+++ b/src/pages/tu/main/CommunityDetailPage.tsx
@@ -504,7 +504,7 @@ export function CommunityDetailPage() {
       <div className={`min-h-screen flex items-center justify-center ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
         <div className="text-center">
           <p className={`text-xl ${isDark ? 'text-white' : 'text-gray-900'}`}>게시글을 불러올 수 없습니다.</p>
-          <Link to="/tu/main/community" className="text-[#6778ff] hover:underline mt-4 inline-block">
+          <Link to="/tu/b2c/community" className="text-[#6778ff] hover:underline mt-4 inline-block">
             커뮤니티로 돌아가기
           </Link>
         </div>

--- a/src/pages/tu/main/CommunityDetailPage.tsx
+++ b/src/pages/tu/main/CommunityDetailPage.tsx
@@ -534,7 +534,7 @@ export function CommunityDetailPage() {
     try {
       await deletePostMutation.mutateAsync(postId);
       toast.success('게시글이 삭제되었습니다.');
-      navigate('/tu/main/community');
+      navigate('/tu/b2c/community');
     } catch (err) {
       console.error('게시글 삭제 실패:', err);
       toast.error('게시글 삭제에 실패했습니다.');
@@ -1085,7 +1085,7 @@ export function CommunityDetailPage() {
                 }`}
               >
                 {/* 강의 썸네일 */}
-                <Link to={`/tu/main/courses/${post.relatedCourse.id}`}>
+                <Link to={`/tu/b2c/courses/${post.relatedCourse.id}`}>
                   <img
                     src={post.relatedCourse.thumbnailUrl || 'https://via.placeholder.com/320x180'}
                     alt={post.relatedCourse.title}
@@ -1095,7 +1095,7 @@ export function CommunityDetailPage() {
 
                 <div className="p-4">
                   {/* 강의 제목 */}
-                  <Link to={`/tu/main/courses/${post.relatedCourse.id}`}>
+                  <Link to={`/tu/b2c/courses/${post.relatedCourse.id}`}>
                     <h3
                       className={`font-semibold mb-2 line-clamp-2 hover:text-[#6778ff] transition-colors ${
                         isDark ? 'text-white' : 'text-gray-900'
@@ -1107,7 +1107,7 @@ export function CommunityDetailPage() {
 
                   {/* 강사 정보 */}
                   <Link
-                    to={`/tu/main/instructors/${post.relatedCourse.instructor.id}`}
+                    to={`/tu/b2c/instructors/${post.relatedCourse.instructor.id}`}
                     className="flex items-center gap-2 mb-3"
                   >
                     <img
@@ -1133,7 +1133,7 @@ export function CommunityDetailPage() {
                   </div>
 
                   {/* 강의 보기 버튼 */}
-                  <Link to={`/tu/main/courses/${post.relatedCourse.id}`}>
+                  <Link to={`/tu/b2c/courses/${post.relatedCourse.id}`}>
                     <Button className="w-full gap-2">
                       강의 상세보기
                       <ChevronRight className="w-4 h-4" />

--- a/src/pages/tu/main/CommunityPage.tsx
+++ b/src/pages/tu/main/CommunityPage.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { MessageSquare, Heart, Eye, Clock, TrendingUp, HelpCircle, Lightbulb, Users, Loader2, Search } from 'lucide-react';
+import { MessageSquare, Loader2, ChevronRight, ChevronLeft } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
@@ -11,135 +11,131 @@ import type { CommunityPost, CommunityCategory, CreatePostRequest } from '@/type
 // 환경 설정: true면 API 사용, false면 더미 데이터 사용
 const USE_API = false;
 
-// 카테고리 아이콘 매핑
-const getCategoryIcon = (categoryId: string) => {
-  switch (categoryId) {
-    case 'qna':
-    case 'question': return HelpCircle;
-    case 'tips':
-    case 'tip': return Lightbulb;
-    case 'review': return TrendingUp;
-    case 'study':
-    case 'discussion': return Users;
-    default: return MessageSquare;
-  }
-};
-
 // 더미 카테고리 데이터
 const MOCK_CATEGORIES: CommunityCategory[] = [
-  { id: 'all', name: '전체', count: 6 },
-  { id: 'question', name: 'Q&A', count: 2 },
-  { id: 'tip', name: '학습 팁', count: 2 },
-  { id: 'review', name: '강의 후기', count: 1 },
-  { id: 'discussion', name: '스터디 모집', count: 1 },
+  { id: 'all', name: '전체', count: 15 },
+  { id: 'talk', name: '사는 얘기', count: 5 },
+  { id: 'ai', name: 'AI', count: 3 },
+  { id: 'salary', name: '연봉·단가', count: 2 },
+  { id: 'career', name: '취준생', count: 2 },
+  { id: 'study', name: '스터디', count: 2 },
+  { id: 'project', name: '프로젝트', count: 1 },
+  { id: 'mogakco', name: '모각코·모각공', count: 1 },
+  { id: 'mentoring', name: '멘토링·튜터링', count: 1 },
+  { id: 'meetup', name: '모임·네트워킹', count: 1 },
+];
+
+// 더미 인기글 데이터
+const MOCK_POPULAR_POSTS = {
+  today: [
+    { id: 1, title: '퇴사를 마음먹었습니다.', commentCount: 7, category: '사는 얘기' },
+    { id: 2, title: '이직하고 싶은 물경력 개발자', commentCount: 15, category: '사는 얘기' },
+    { id: 3, title: '승진했습니다', commentCount: 4, category: '사는 얘기' },
+    { id: 4, title: '바이브 코딩의 도입의 문제점이 있는것 같아요', commentCount: 11, category: '사는 얘기' },
+    { id: 5, title: '4년차의 개발 방향성과 이직 고려', commentCount: 11, category: '사는 얘기' },
+  ],
+  todayRight: [
+    { id: 6, title: '조폭 말투로 AI 쓰면 빡쳐요', commentCount: 2, category: 'AI' },
+    { id: 7, title: '커밋이력 없다고 일이 없냐 + 일 하기 싫고 추가 계약...', commentCount: 4, category: '사는 얘기' },
+    { id: 8, title: '초보자 PM역할을 맡았습니다. ㅠㅠ 개발자님들 도와주...', commentCount: 4, category: '피드백' },
+    { id: 9, title: '동생의 처남 결혼식 참석하는게 맞을까요?', commentCount: 10, category: '사는 얘기' },
+    { id: 10, title: '퀀트 개발해도 망할 것 같음..', commentCount: 2, category: '사는 얘기' },
+  ],
+  week: [
+    { id: 11, title: '주니어 개발자가 알아야 할 것들 정리', commentCount: 45, category: '학습 팁' },
+    { id: 12, title: 'React vs Vue 2024 비교', commentCount: 32, category: 'AI' },
+    { id: 13, title: '면접 후기 공유합니다', commentCount: 28, category: '취준생' },
+    { id: 14, title: '재택근무 꿀팁 모음', commentCount: 24, category: '사는 얘기' },
+    { id: 15, title: '연봉 협상 성공 후기', commentCount: 67, category: '연봉·단가' },
+  ],
+  month: [
+    { id: 16, title: '비전공자 개발자 취업 성공기', commentCount: 156, category: '취준생' },
+    { id: 17, title: '개발자 번아웃 극복 방법', commentCount: 89, category: '사는 얘기' },
+    { id: 18, title: '프리랜서 vs 정규직 비교', commentCount: 134, category: '연봉·단가' },
+    { id: 19, title: '스타트업 3년차 회고', commentCount: 78, category: '사는 얘기' },
+    { id: 20, title: '개발자 커리어 로드맵', commentCount: 201, category: '학습 팁' },
+  ],
+  notice: [
+    { id: 21, title: '[공지] 커뮤니티 이용 가이드라인 업데이트', commentCount: 0, category: '공지사항' },
+    { id: 22, title: '[이벤트] 2024년 연말 회고 이벤트', commentCount: 23, category: '공지사항' },
+    { id: 23, title: '[안내] 서비스 점검 일정 안내', commentCount: 5, category: '공지사항' },
+  ],
+};
+
+// 더미 테크 뉴스 데이터
+const MOCK_TECH_NEWS = [
+  { id: 1, author: 'chancy', avatar: 'https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?w=100&h=100&fit=crop', title: 'C# 을 사용하여 Excel 문서 인쇄', excerpt: 'Excel에서 표는 각 열에 제목이 있는 구조화된 데이터를 저장합니다. 이번 글에서는 C#을 사용하여...' },
+  { id: 2, author: 'devkim', avatar: 'https://images.unsplash.com/photo-1599566150163-29194dcabd36?w=100&h=100&fit=crop', title: 'React 19의 새로운 기능 살펴보기', excerpt: 'React 19에서 추가된 새로운 기능들과 변경점을 살펴봅니다. use() 훅과 서버 컴포넌트...' },
+  { id: 3, author: 'jsmaster', avatar: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=100&h=100&fit=crop', title: 'TypeScript 5.0 완벽 가이드', excerpt: 'TypeScript 5.0의 새로운 데코레이터와 const type parameters를 알아봅니다...' },
+  { id: 4, author: 'backend', avatar: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=100&h=100&fit=crop', title: 'Spring Boot 3.2 마이그레이션', excerpt: 'Spring Boot 3.2로 마이그레이션하면서 겪은 이슈들과 해결 방법을 공유합니다...' },
 ];
 
 // 더미 게시글 데이터
 const MOCK_POSTS: CommunityPost[] = [
   {
-    id: 1,
-    type: 'question',
-    category: 'question',
-    title: 'React useEffect에서 비동기 처리 시 클린업 함수 질문드립니다',
-    content: 'useEffect 안에서 API 호출을 할 때 컴포넌트가 언마운트되면 어떻게 처리해야 하나요? AbortController를 사용해야 한다고 들었는데...',
-    author: {
-      id: 1,
-      name: '코딩초보',
-      avatar: 'https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?w=100&h=100&fit=crop',
-    },
-    tags: ['React', 'JavaScript'],
+    id: 101,
+    type: 'discussion',
+    category: 'talk',
+    title: '같이 회사 다니면 출근 좀 덜 싫을 것 같은 연예인',
+    content: '1월 2일이라 그런가 출근을 했는데 일 하나도 안잡히네요 아 심심하니 같이 회사 다니면 출근하기 행복할 것 같은 연예인 알려주세요 같은 팀이면 회사',
+    author: { id: 1, name: '코코코난', avatar: 'https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?w=100&h=100&fit=crop' },
+    tags: ['커뮤니티', '사는 얘기'],
     viewCount: 234,
     likeCount: 12,
-    commentCount: 8,
-    createdAt: '2024-12-30T08:00:00Z',
-    isSolved: true,
+    commentCount: 1,
+    createdAt: new Date(Date.now() - 7 * 60000).toISOString(),
   },
   {
-    id: 2,
+    id: 102,
+    type: 'question',
+    category: 'ai',
+    title: 'ChatGPT API 연동 시 토큰 제한 우회 방법',
+    content: 'GPT-4 API를 사용하는데 토큰 제한이 너무 빡빡합니다. 긴 문서를 처리해야 하는데 어떻게 해결하셨나요?',
+    author: { id: 2, name: 'AI개발자', avatar: 'https://images.unsplash.com/photo-1599566150163-29194dcabd36?w=100&h=100&fit=crop' },
+    tags: ['AI', 'ChatGPT'],
+    viewCount: 567,
+    likeCount: 34,
+    commentCount: 12,
+    createdAt: new Date(Date.now() - 25 * 60000).toISOString(),
+  },
+  {
+    id: 103,
     type: 'tip',
-    category: 'tip',
-    title: '개발 공부 3개월 만에 취업 성공한 방법 공유합니다',
-    content: '비전공자로 시작해서 3개월 만에 스타트업에 프론트엔드 개발자로 취업했습니다. 제가 했던 공부 방법과 포트폴리오 준비 과정을 공유드려요.',
-    author: {
-      id: 2,
-      name: '취준성공',
-      avatar: 'https://images.unsplash.com/photo-1599566150163-29194dcabd36?w=100&h=100&fit=crop',
-    },
-    tags: ['취업', '포트폴리오'],
-    viewCount: 1523,
-    likeCount: 187,
-    commentCount: 45,
-    createdAt: '2024-12-30T05:00:00Z',
-    isPinned: true,
-  },
-  {
-    id: 3,
-    type: 'review',
-    category: 'review',
-    title: '[후기] Next.js 15 완벽 마스터 강의 솔직 리뷰',
-    content: '김개발님의 Next.js 강의를 완강했습니다. App Router부터 서버 컴포넌트까지 정말 깊이있게 다뤄주셔서 실무에 바로 적용할 수 있었어요.',
-    author: {
-      id: 3,
-      name: '프론트마스터',
-      avatar: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=100&h=100&fit=crop',
-    },
-    tags: ['Next.js', '강의후기'],
-    viewCount: 892,
-    likeCount: 56,
+    category: 'salary',
+    title: '연봉 협상 시 꼭 알아야 할 5가지',
+    content: '이직하면서 연봉 협상을 여러 번 해봤는데요, 제가 느낀 핵심 포인트들을 공유합니다.',
+    author: { id: 3, name: '협상의신', avatar: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=100&h=100&fit=crop' },
+    tags: ['연봉', '이직'],
+    viewCount: 1234,
+    likeCount: 89,
     commentCount: 23,
-    createdAt: '2024-12-29T10:00:00Z',
+    createdAt: new Date(Date.now() - 2 * 3600000).toISOString(),
   },
   {
-    id: 4,
+    id: 104,
     type: 'discussion',
-    category: 'discussion',
+    category: 'study',
     title: '[모집] 알고리즘 스터디 모집합니다 (주 3회)',
-    content: '프로그래머스 Lv.2~3 수준으로 함께 알고리즘 문제를 풀 분들을 모집합니다. 디스코드로 진행하며, 주 3회 저녁 9시에 모여서 풀이 공유해요.',
-    author: {
-      id: 4,
-      name: '알고왕',
-      avatar: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=100&h=100&fit=crop',
-    },
+    content: '프로그래머스 Lv.2~3 수준으로 함께 알고리즘 문제를 풀 분들을 모집합니다.',
+    author: { id: 4, name: '알고왕', avatar: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=100&h=100&fit=crop' },
     tags: ['알고리즘', '스터디'],
     viewCount: 456,
-    likeCount: 34,
-    commentCount: 67,
-    createdAt: '2024-12-27T10:00:00Z',
-  },
-  {
-    id: 5,
-    type: 'question',
-    category: 'question',
-    title: 'Spring Boot에서 JWT 토큰 재발급 로직 구현 방법',
-    content: 'Access Token이 만료되었을 때 Refresh Token으로 재발급하는 로직을 어디서 처리해야 할까요? 필터에서 처리하는 게 맞나요?',
-    author: {
-      id: 5,
-      name: '백엔드지망',
-      avatar: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=100&h=100&fit=crop',
-    },
-    tags: ['Spring', 'JWT'],
-    viewCount: 345,
     likeCount: 21,
-    commentCount: 15,
-    createdAt: '2024-12-29T10:00:00Z',
+    commentCount: 8,
+    createdAt: new Date(Date.now() - 5 * 3600000).toISOString(),
   },
   {
-    id: 6,
-    type: 'tip',
-    category: 'tip',
-    title: 'VSCode 생산성 높이는 단축키 & 확장 프로그램 추천',
-    content: '개발할 때 유용한 VSCode 단축키와 꼭 설치해야 할 확장 프로그램들을 정리해봤습니다. 특히 Vim 모드 쓰시는 분들 참고하세요!',
-    author: {
-      id: 6,
-      name: '생산성덕후',
-      avatar: 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=100&h=100&fit=crop',
-    },
-    tags: ['VSCode', '개발도구'],
-    viewCount: 2341,
-    likeCount: 234,
-    commentCount: 56,
-    createdAt: '2024-12-28T10:00:00Z',
-    isPinned: true,
+    id: 105,
+    type: 'question',
+    category: 'career',
+    title: '비전공자 신입 포트폴리오 피드백 부탁드려요',
+    content: '국비지원 6개월 과정 수료하고 취준 중인데요, 포트폴리오 방향이 맞는지 모르겠습니다.',
+    author: { id: 5, name: '취준생123', avatar: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=100&h=100&fit=crop' },
+    tags: ['취업', '포트폴리오'],
+    viewCount: 789,
+    likeCount: 45,
+    commentCount: 31,
+    createdAt: new Date(Date.now() - 1 * 86400000).toISOString(),
   },
 ];
 
@@ -150,128 +146,21 @@ const formatRelativeTime = (dateString: string): string => {
   const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
 
   if (diffInSeconds < 60) return '방금 전';
-  if (diffInSeconds < 3600) return `${Math.floor(diffInSeconds / 60)}분 전`;
+  if (diffInSeconds < 3600) return `${Math.floor(diffInSeconds / 60)}분`;
   if (diffInSeconds < 86400) return `${Math.floor(diffInSeconds / 3600)}시간 전`;
   if (diffInSeconds < 604800) return `${Math.floor(diffInSeconds / 86400)}일 전`;
   return date.toLocaleDateString('ko-KR');
 };
 
-interface PostCardProps {
-  post: CommunityPost;
-  isDark: boolean;
-  categories: CommunityCategory[];
-}
-
-function PostCard({ post, isDark, categories }: PostCardProps) {
-  const isHot = post.likeCount > 100;
-  const isRecruiting = post.type === 'discussion' && !post.isSolved;
-
-  return (
-    <Link
-      to={`/tu/main/community/${post.id}`}
-      className={`block rounded-xl p-6 transition-all cursor-pointer border ${
-        isDark
-          ? 'glass border-white/10 hover:bg-white/5'
-          : 'bg-white border-gray-200 hover:bg-gray-50'
-      }`}
-    >
-      <div className="flex items-start gap-4">
-        {/* Author Image */}
-        {post.author.avatar && (
-          <img
-            src={post.author.avatar}
-            alt={post.author.name}
-            className="w-10 h-10 rounded-full object-cover hidden sm:block"
-          />
-        )}
-
-        {/* Content */}
-        <div className="flex-1 min-w-0">
-          {/* Header */}
-          <div className="flex items-center gap-2 mb-2 flex-wrap">
-            {isHot && (
-              <span className="px-2 py-0.5 bg-red-500/20 text-red-400 text-xs font-bold rounded">
-                HOT
-              </span>
-            )}
-            {post.isSolved && (
-              <span className="px-2 py-0.5 bg-green-500/20 text-green-400 text-xs font-bold rounded">
-                해결됨
-              </span>
-            )}
-            {isRecruiting && (
-              <span className="px-2 py-0.5 bg-blue-500/20 text-blue-400 text-xs font-bold rounded">
-                모집중
-              </span>
-            )}
-            <span className={`text-xs ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
-              {categories.find((c) => c.id === post.category)?.name || post.category}
-            </span>
-          </div>
-
-          {/* Title */}
-          <h3 className={`text-lg font-semibold mb-2 transition-colors line-clamp-1 ${
-            isDark
-              ? 'text-white hover:text-[#6778ff]'
-              : 'text-gray-900 hover:text-[#6778ff]'
-          }`}>
-            {post.title}
-          </h3>
-
-          {/* Preview */}
-          <p className={`text-sm mb-3 line-clamp-2 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-            {post.excerpt || post.content}
-          </p>
-
-          {/* Tags */}
-          {post.tags && post.tags.length > 0 && (
-            <div className="flex flex-wrap gap-2 mb-3">
-              {post.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className={`px-2 py-1 rounded text-xs ${
-                    isDark
-                      ? 'bg-white/5 text-gray-400'
-                      : 'bg-gray-100 text-gray-500'
-                  }`}
-                >
-                  #{tag}
-                </span>
-              ))}
-            </div>
-          )}
-
-          {/* Meta */}
-          <div className={`flex items-center gap-4 text-sm ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
-            <span>{post.author.name}</span>
-            <span className="flex items-center gap-1">
-              <Clock className="w-3 h-3" />
-              {formatRelativeTime(post.createdAt)}
-            </span>
-            <span className="flex items-center gap-1">
-              <Eye className="w-3 h-3" />
-              {post.viewCount}
-            </span>
-            <span className="flex items-center gap-1">
-              <Heart className="w-3 h-3" />
-              {post.likeCount}
-            </span>
-            <span className="flex items-center gap-1">
-              <MessageSquare className="w-3 h-3" />
-              {post.commentCount}
-            </span>
-          </div>
-        </div>
-      </div>
-    </Link>
-  );
-}
+// 인기글 탭 타입
+type PopularTab = 'today' | 'week' | 'month' | 'notice';
 
 export function CommunityPage() {
   const [activeCategory, setActiveCategory] = useState('all');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [sortBy, setSortBy] = useState<'latest' | 'popular' | 'most_commented' | 'most_liked'>('latest');
+  const [searchQuery] = useState('');
+  const [popularTab, setPopularTab] = useState<PopularTab>('today');
   const [isWriteModalOpen, setIsWriteModalOpen] = useState(false);
+  const [carouselIndex, setCarouselIndex] = useState(0);
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
   const navigate = useNavigate();
@@ -281,7 +170,7 @@ export function CommunityPage() {
   const filter = {
     search: searchQuery || undefined,
     category: activeCategory !== 'all' ? activeCategory : undefined,
-    sortBy,
+    sortBy: 'latest' as const,
   };
   const { data: apiPostData, isLoading, error } = useCommunityPosts(filter, USE_API);
   const { data: apiCategoryData } = useCommunityCategories(USE_API);
@@ -289,7 +178,7 @@ export function CommunityPage() {
   // 실제 사용할 데이터 결정
   const categories = USE_API ? (apiCategoryData?.categories || []) : MOCK_CATEGORIES;
 
-  // Mock 모드에서 필터링 및 정렬 적용
+  // Mock 모드에서 필터링 적용
   const getFilteredPosts = (): CommunityPost[] => {
     if (USE_API) {
       return apiPostData?.posts || [];
@@ -297,12 +186,10 @@ export function CommunityPage() {
 
     let filtered = [...MOCK_POSTS];
 
-    // 카테고리 필터
     if (activeCategory !== 'all') {
       filtered = filtered.filter(post => post.category === activeCategory);
     }
 
-    // 검색어 필터
     if (searchQuery) {
       const query = searchQuery.toLowerCase();
       filtered = filtered.filter(post =>
@@ -311,39 +198,73 @@ export function CommunityPage() {
       );
     }
 
-    // 정렬
-    switch (sortBy) {
-      case 'popular':
-        filtered.sort((a, b) => b.viewCount - a.viewCount);
-        break;
-      case 'most_commented':
-        filtered.sort((a, b) => b.commentCount - a.commentCount);
-        break;
-      case 'most_liked':
-        filtered.sort((a, b) => b.likeCount - a.likeCount);
-        break;
-      case 'latest':
-      default:
-        filtered.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-        break;
-    }
-
     return filtered;
   };
 
   const filteredPosts = getFilteredPosts();
 
+  // 인기글 데이터 가져오기
+  const getPopularPosts = (tab: PopularTab) => {
+    switch (tab) {
+      case 'today':
+        return { left: MOCK_POPULAR_POSTS.today, right: MOCK_POPULAR_POSTS.todayRight };
+      case 'week':
+        return { left: MOCK_POPULAR_POSTS.week, right: MOCK_POPULAR_POSTS.todayRight };
+      case 'month':
+        return { left: MOCK_POPULAR_POSTS.month, right: MOCK_POPULAR_POSTS.todayRight };
+      case 'notice':
+        return { left: MOCK_POPULAR_POSTS.notice, right: [] };
+      default:
+        return { left: [], right: [] };
+    }
+  };
+
+  const popularPosts = getPopularPosts(popularTab);
+
+  // 무한 순환 캐러셀
+  const totalItems = MOCK_TECH_NEWS.length;
+  const extendedNews = [...MOCK_TECH_NEWS, ...MOCK_TECH_NEWS, ...MOCK_TECH_NEWS]; // 3배로 복제
+  const carouselRef = useRef<HTMLDivElement>(null);
+  const [isTransitioning, setIsTransitioning] = useState(true);
+
+  // 무한 순환 처리
+  useEffect(() => {
+    if (carouselIndex < 0) {
+      // 왼쪽 끝 -> 오른쪽으로 점프
+      setIsTransitioning(false);
+      setCarouselIndex(totalItems + carouselIndex);
+    } else if (carouselIndex >= totalItems) {
+      // 오른쪽 끝 -> 왼쪽으로 점프
+      setIsTransitioning(false);
+      setCarouselIndex(carouselIndex - totalItems);
+    }
+  }, [carouselIndex, totalItems]);
+
+  // 트랜지션 복원
+  useEffect(() => {
+    if (!isTransitioning) {
+      const timer = setTimeout(() => setIsTransitioning(true), 50);
+      return () => clearTimeout(timer);
+    }
+  }, [isTransitioning]);
+
+  const handlePrev = useCallback(() => {
+    setCarouselIndex(prev => prev - 1);
+  }, []);
+
+  const handleNext = useCallback(() => {
+    setCarouselIndex(prev => prev + 1);
+  }, []);
+
   // 로딩 상태
   if (USE_API && isLoading) {
     return (
-      <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
+      <div className={`min-h-screen dark-scrollbar ${isDark ? 'landing-dark' : 'landing-light'}`}>
         <LandingHeader />
         <main className="w-full px-4 md:px-8 lg:px-16 py-12">
           <div className="flex items-center justify-center py-20">
             <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
-            <span className={`ml-3 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-              게시글을 불러오는 중...
-            </span>
+            <span className="ml-3 landing-text-muted">게시글을 불러오는 중...</span>
           </div>
         </main>
         <LandingFooter />
@@ -354,16 +275,15 @@ export function CommunityPage() {
   // 에러 상태
   if (USE_API && error) {
     return (
-      <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
+      <div className={`min-h-screen dark-scrollbar ${isDark ? 'landing-dark' : 'landing-light'}`}>
         <LandingHeader />
         <main className="w-full px-4 md:px-8 lg:px-16 py-12">
           <div className="text-center py-20">
-            <p className={`text-lg ${isDark ? 'text-red-400' : 'text-red-500'}`}>
-              게시글을 불러오는데 실패했습니다.
-            </p>
+            <MessageSquare className="w-16 h-16 mx-auto mb-4 landing-text-muted" />
+            <p className="text-lg landing-text-primary mb-4">게시글을 불러오는데 실패했습니다</p>
             <button
               onClick={() => window.location.reload()}
-              className="mt-4 px-6 py-2 landing-btn-primary rounded-full text-white"
+              className="landing-btn-primary px-6 py-2 rounded-xl"
             >
               다시 시도
             </button>
@@ -375,117 +295,283 @@ export function CommunityPage() {
   }
 
   return (
-    <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
+    <div className={`min-h-screen dark-scrollbar ${isDark ? 'landing-dark' : 'landing-light'}`}>
       <LandingHeader />
 
-      <main className="w-full px-4 md:px-8 lg:px-16 py-12">
-        {/* Hero Section */}
-        <div className="text-center mb-12">
-          <h1 className={`text-4xl md:text-5xl font-bold mb-4 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            <span className="gradient-text">커뮤니티</span>
-          </h1>
-          <p className={`text-lg ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-            함께 성장하는 공간, 질문하고 나누고 연결하세요.
-          </p>
-        </div>
+      <main>
+        {/* 인기글 섹션 */}
+        <section className="w-full px-4 md:px-8 lg:px-16 py-12">
+          <div className={`rounded-2xl p-6 md:p-8 border ${
+            isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
+          }`}>
+            {/* 인기글 탭 */}
+            <div className={`flex gap-6 mb-6 border-b ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
+              {[
+                { key: 'today', label: '오늘의 인기글' },
+                { key: 'week', label: '이번주 인기글' },
+                { key: 'month', label: '이달의 인기글' },
+                { key: 'notice', label: '공지사항' },
+              ].map((tab) => (
+                <button
+                  key={tab.key}
+                  onClick={() => setPopularTab(tab.key as PopularTab)}
+                  className={`pb-3 text-sm font-medium transition-colors relative ${
+                    popularTab === tab.key
+                      ? 'landing-text-primary'
+                      : 'landing-text-muted hover:landing-text-secondary'
+                  }`}
+                >
+                  {tab.label}
+                  {popularTab === tab.key && (
+                    <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-[#6778ff]" />
+                  )}
+                </button>
+              ))}
+            </div>
 
-        {/* Search & Sort */}
-        <div className="flex flex-col md:flex-row gap-4 mb-8">
-          <div className="flex-1 relative">
-            <Search className={`absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
-            <input
-              type="text"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="게시글 검색"
-              className={`w-full rounded-xl pl-12 pr-4 py-3 focus:outline-none focus:ring-2 focus:ring-[#6778ff] focus:border-transparent transition-all ${
-                isDark
-                  ? 'bg-white/5 border border-white/10 text-white placeholder-gray-500'
-                  : 'bg-white border border-gray-200 text-gray-900 placeholder-gray-400'
-              }`}
-            />
+            {/* 인기글 목록 - 2열 그리드 */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-x-12 gap-y-3">
+              {/* 왼쪽 열 */}
+              <div className="space-y-3">
+                {popularPosts.left.map((post) => (
+                  <Link
+                    key={post.id}
+                    to={`/tu/main/community/${post.id}`}
+                    className="flex items-center gap-3 group"
+                  >
+                    <span className="text-sm landing-text-primary group-hover:text-[#6778ff] transition-colors truncate flex-1">
+                      {post.title}
+                    </span>
+                    {post.commentCount > 0 && (
+                      <span className="text-xs font-medium text-red-500">
+                        N ({post.commentCount})
+                      </span>
+                    )}
+                    <span className="text-xs landing-text-muted whitespace-nowrap">
+                      {post.category}
+                    </span>
+                  </Link>
+                ))}
+              </div>
+
+              {/* 오른쪽 열 */}
+              {popularPosts.right.length > 0 && (
+                <div className="space-y-3">
+                  {popularPosts.right.map((post) => (
+                    <Link
+                      key={post.id}
+                      to={`/tu/main/community/${post.id}`}
+                      className="flex items-center gap-3 group"
+                    >
+                      <span className="text-sm landing-text-primary group-hover:text-[#6778ff] transition-colors truncate flex-1">
+                        {post.title}
+                      </span>
+                      {post.commentCount > 0 && (
+                        <span className="text-xs font-medium text-red-500">
+                          N ({post.commentCount})
+                        </span>
+                      )}
+                      <span className="text-xs landing-text-muted whitespace-nowrap">
+                        {post.category}
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
-          <select
-            value={sortBy}
-            onChange={(e) => setSortBy(e.target.value as typeof sortBy)}
-            className={`rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-[#6778ff] cursor-pointer ${
-              isDark
-                ? 'bg-white/5 border border-white/10 text-white'
-                : 'bg-white border border-gray-200 text-gray-900'
-            }`}
-          >
-            <option value="latest">최신순</option>
-            <option value="popular">조회순</option>
-            <option value="most_commented">댓글순</option>
-            <option value="most_liked">좋아요순</option>
-          </select>
-        </div>
+        </section>
 
-        {/* Category Tabs */}
-        <div className="flex flex-wrap gap-3 mb-8">
-          {categories.map((cat) => {
-            const IconComponent = getCategoryIcon(cat.id);
-            return (
+        {/* 테크 지식 / 뉴스 섹션 */}
+        <section className="landing-section-alt py-16">
+          <div className="w-full px-4 md:px-8 lg:px-16">
+            <div className="flex items-center justify-between mb-8">
+              <div>
+                <h2 className="text-2xl md:text-3xl font-bold landing-text-primary">
+                  지금 가장 뜨거운 이슈
+                </h2>
+                <p className="landing-text-muted text-sm mt-2">
+                  개발자들이 주목하는 최신 트렌드를 확인하세요
+                </p>
+              </div>
+              <Link
+                to="/tu/main/community?category=tech"
+                className="text-sm landing-text-secondary hover:opacity-80 flex items-center gap-1 transition-colors"
+              >
+                더 보기 <ChevronRight className="w-4 h-4" />
+              </Link>
+            </div>
+
+            {/* 캐러셀 */}
+            <div className="relative">
+              {/* 왼쪽 버튼 - 항상 표시 */}
+              <button
+                onClick={handlePrev}
+                className={`absolute -left-4 top-1/2 -translate-y-1/2 z-10 w-10 h-10 rounded-full flex items-center justify-center shadow-lg transition-colors ${
+                  isDark ? 'glass border border-white/10 text-white hover:bg-white/10' : 'bg-white border border-gray-200 text-gray-700 hover:bg-gray-100'
+                }`}
+              >
+                <ChevronLeft className="w-5 h-5" />
+              </button>
+
+              <div className="overflow-hidden" ref={carouselRef}>
+                <div
+                  className={`flex gap-6 ${isTransitioning ? 'transition-transform duration-500 ease-out' : ''}`}
+                  style={{ transform: `translateX(calc(-${carouselIndex + totalItems} * (33.333% + 8px)))` }}
+                >
+                  {extendedNews.map((news, index) => (
+                    <Link
+                      key={`${news.id}-${index}`}
+                      to={`/tu/main/community/${news.id}`}
+                      className={`group block rounded-2xl p-6 transition-all duration-300 border flex-shrink-0 w-[calc(33.333%-16px)] ${
+                        isDark
+                          ? 'glass border-white/10 hover:border-[#6778ff]/50'
+                          : 'bg-white border-gray-200 hover:border-[#6778ff] hover:shadow-lg'
+                      }`}
+                    >
+                      <span className={`inline-block text-xs px-2 py-1 rounded mb-3 ${
+                        isDark ? 'bg-white/10 text-gray-400' : 'bg-gray-100 text-gray-500'
+                      }`}>
+                        Tech 뉴스
+                      </span>
+                      <div className="flex items-center gap-2 mb-3">
+                        <img src={news.avatar} alt={news.author} className="w-8 h-8 rounded-full object-cover" />
+                        <span className="text-sm landing-text-secondary">{news.author}</span>
+                      </div>
+                      <h3 className="font-semibold landing-text-primary mb-2 line-clamp-1 group-hover:text-[#6778ff] transition-colors">
+                        {news.title}
+                      </h3>
+                      <p className="text-sm landing-text-muted line-clamp-2">
+                        {news.excerpt}
+                      </p>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+
+              {/* 오른쪽 버튼 - 항상 표시 */}
+              <button
+                onClick={handleNext}
+                className={`absolute -right-4 top-1/2 -translate-y-1/2 z-10 w-10 h-10 rounded-full flex items-center justify-center shadow-lg transition-colors ${
+                  isDark ? 'glass border border-white/10 text-white hover:bg-white/10' : 'bg-white border border-gray-200 text-gray-700 hover:bg-gray-100'
+                }`}
+              >
+                <ChevronRight className="w-5 h-5" />
+              </button>
+            </div>
+
+            {/* 캐러셀 인디케이터 */}
+            <div className="flex justify-center gap-2 mt-6">
+              {[...Array(totalItems)].map((_, i) => (
+                <button
+                  key={i}
+                  onClick={() => setCarouselIndex(i)}
+                  className={`w-2 h-2 rounded-full transition-colors ${
+                    (carouselIndex % totalItems + totalItems) % totalItems === i ? 'bg-[#6778ff]' : isDark ? 'bg-white/20' : 'bg-gray-300'
+                  }`}
+                />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* 카테고리 필터 & 게시글 목록 */}
+        <section className="w-full px-4 md:px-8 lg:px-16 py-16">
+          {/* 카테고리 필터 칩 */}
+          <div className="flex flex-wrap items-center gap-3 mb-8">
+            {categories.map((cat) => (
               <button
                 key={cat.id}
                 onClick={() => setActiveCategory(cat.id)}
-                className={`flex items-center gap-2 px-5 py-2.5 rounded-full text-sm font-medium transition-all duration-300 ${
+                className={`px-5 py-2.5 rounded-full text-sm font-medium transition-all duration-300 ${
                   activeCategory === cat.id
-                    ? 'bg-gradient-to-r from-[#6778ff] to-[#a855f7] text-white shadow-lg shadow-[#6778ff]/25'
-                    : isDark
-                      ? 'bg-white/5 text-gray-400 hover:bg-white/10 hover:text-white border border-white/10'
-                      : 'bg-white text-gray-600 hover:bg-gray-100 hover:text-gray-900 border border-gray-200'
+                    ? 'landing-btn-primary shadow-lg'
+                    : 'landing-chip-inactive'
                 }`}
               >
-                <IconComponent className="w-4 h-4" />
                 {cat.name}
               </button>
-            );
-          })}
-        </div>
-
-        {/* Write Button */}
-        <div className="flex justify-between items-center mb-6">
-          <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
-            총 <span className={`font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>{filteredPosts.length}</span>개의 게시글
-          </p>
-          <button
-            onClick={() => setIsWriteModalOpen(true)}
-            className="landing-btn-primary px-6 py-3 rounded-xl text-white font-medium flex items-center gap-2"
-          >
-            <MessageSquare className="w-4 h-4" />
-            글쓰기
-          </button>
-        </div>
-
-        {/* Posts List */}
-        {filteredPosts.length > 0 ? (
-          <div className="space-y-4">
-            {filteredPosts.map((post) => (
-              <PostCard key={post.id} post={post} isDark={isDark} categories={categories} />
             ))}
-          </div>
-        ) : (
-          <div className="text-center py-20">
-            <MessageSquare className={`w-16 h-16 mx-auto mb-4 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
-            <p className={isDark ? 'text-gray-500' : 'text-gray-400'}>
-              게시글이 없습니다.
-            </p>
-          </div>
-        )}
 
-        {/* Load More */}
-        {filteredPosts.length > 0 && (
-          <div className="text-center mt-10">
-            <button className={`px-8 py-3 rounded-full font-medium border transition-colors ${
-              isDark
-                ? 'border-white/30 text-white hover:bg-white/10'
-                : 'border-gray-300 text-gray-700 hover:bg-gray-100'
-            }`}>
-              더보기
+            {/* 글쓰기 버튼 */}
+            <button
+              onClick={() => setIsWriteModalOpen(true)}
+              className="ml-auto landing-btn-primary px-5 py-2.5 rounded-full text-sm font-medium flex items-center gap-2 shadow-lg"
+            >
+              <MessageSquare className="w-4 h-4" />
+              글쓰기
             </button>
           </div>
-        )}
+
+          {/* 게시글 목록 */}
+          <div className={`rounded-2xl border overflow-hidden ${
+            isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
+          }`}>
+            {filteredPosts.length > 0 ? (
+              <div className={`divide-y ${isDark ? 'divide-white/5' : 'divide-gray-100'}`}>
+                {filteredPosts.map((post) => (
+                  <Link
+                    key={post.id}
+                    to={`/tu/main/community/${post.id}`}
+                    className={`flex items-start gap-4 px-6 py-5 transition-colors ${
+                      isDark ? 'hover:bg-white/5' : 'hover:bg-gray-50'
+                    }`}
+                  >
+                    {/* 카테고리 & 작성자 */}
+                    <div className="flex items-center gap-3 min-w-[200px]">
+                      <span className={`text-xs px-2 py-1 rounded ${
+                        isDark ? 'bg-white/10 text-gray-400' : 'bg-gray-100 text-gray-500'
+                      }`}>
+                        {categories.find(c => c.id === post.category)?.name || post.category}
+                      </span>
+                      <span className="text-sm landing-text-muted">
+                        {post.author.name}
+                      </span>
+                      <span className="text-xs landing-text-muted">
+                        · {formatRelativeTime(post.createdAt)}
+                      </span>
+                    </div>
+
+                    {/* 제목 & 내용 */}
+                    <div className="flex-1 min-w-0">
+                      <h3 className="font-medium landing-text-primary mb-1 line-clamp-1">
+                        {post.title}
+                        {post.commentCount > 0 && (
+                          <span className="text-red-500 text-sm ml-2 font-normal">
+                            N ({post.commentCount})
+                          </span>
+                        )}
+                      </h3>
+                      <p className="text-sm landing-text-muted line-clamp-1">
+                        {post.content}
+                      </p>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            ) : (
+              <div className="text-center py-20">
+                <MessageSquare className="w-16 h-16 mx-auto mb-4 landing-text-muted" />
+                <p className="landing-text-muted mb-4">게시글이 없습니다</p>
+                <button
+                  onClick={() => setIsWriteModalOpen(true)}
+                  className="landing-btn-primary px-6 py-2 rounded-xl"
+                >
+                  첫 번째 글쓰기
+                </button>
+              </div>
+            )}
+
+            {/* 더보기 */}
+            {filteredPosts.length > 0 && (
+              <div className={`text-center py-4 border-t ${isDark ? 'border-white/10' : 'border-gray-100'}`}>
+                <button className="text-sm landing-text-secondary hover:landing-text-primary transition-colors">
+                  더보기
+                </button>
+              </div>
+            )}
+          </div>
+        </section>
       </main>
 
       <LandingFooter />
@@ -500,7 +586,6 @@ export function CommunityPage() {
             setIsWriteModalOpen(false);
             navigate(`/tu/main/community/${result.id}`);
           } else {
-            // Mock 모드: 새 게시글을 추가하는 시뮬레이션
             console.log('New post data:', data);
             setIsWriteModalOpen(false);
             alert('게시글이 작성되었습니다. (Mock 모드)');

--- a/src/pages/tu/main/CommunityPage.tsx
+++ b/src/pages/tu/main/CommunityPage.tsx
@@ -342,7 +342,7 @@ export function CommunityPage() {
                 {popularPosts.left.map((post) => (
                   <Link
                     key={post.id}
-                    to={`/tu/main/community/${post.id}`}
+                    to={`/tu/b2c/community/${post.id}`}
                     className="flex items-center gap-3 group"
                   >
                     <span className="text-sm landing-text-primary group-hover:text-[#6778ff] transition-colors truncate flex-1">
@@ -366,7 +366,7 @@ export function CommunityPage() {
                   {popularPosts.right.map((post) => (
                     <Link
                       key={post.id}
-                      to={`/tu/main/community/${post.id}`}
+                      to={`/tu/b2c/community/${post.id}`}
                       className="flex items-center gap-3 group"
                     >
                       <span className="text-sm landing-text-primary group-hover:text-[#6778ff] transition-colors truncate flex-1">
@@ -428,7 +428,7 @@ export function CommunityPage() {
                   {extendedNews.map((news, index) => (
                     <Link
                       key={`${news.id}-${index}`}
-                      to={`/tu/main/community/${news.id}`}
+                      to={`/tu/b2c/community/${news.id}`}
                       className={`group block rounded-2xl p-6 transition-all duration-300 border flex-shrink-0 w-[calc(33.333%-16px)] ${
                         isDark
                           ? 'glass border-white/10 hover:border-[#6778ff]/50'
@@ -518,7 +518,7 @@ export function CommunityPage() {
                 {filteredPosts.map((post) => (
                   <Link
                     key={post.id}
-                    to={`/tu/main/community/${post.id}`}
+                    to={`/tu/b2c/community/${post.id}`}
                     className={`flex items-start gap-4 px-6 py-5 transition-colors ${
                       isDark ? 'hover:bg-white/5' : 'hover:bg-gray-50'
                     }`}
@@ -590,7 +590,7 @@ export function CommunityPage() {
           if (USE_API) {
             const result = await createPostMutation.mutateAsync(data);
             setIsWriteModalOpen(false);
-            navigate(`/tu/main/community/${result.id}`);
+            navigate(`/tu/b2c/community/${result.id}`);
           } else {
             console.log('New post data:', data);
             setIsWriteModalOpen(false);

--- a/src/pages/tu/main/CommunityPage.tsx
+++ b/src/pages/tu/main/CommunityPage.tsx
@@ -395,7 +395,7 @@ export function CommunityPage() {
                 </p>
               </div>
               <Link
-                to="/tu/main/community?category=tech"
+                to="/tu/b2c/community?category=tech"
                 className="text-sm landing-text-secondary hover:opacity-80 flex items-center gap-1 transition-colors"
               >
                 더 보기 <ChevronRight className="w-4 h-4" />

--- a/src/pages/tu/main/CourseDetailPage.tsx
+++ b/src/pages/tu/main/CourseDetailPage.tsx
@@ -412,7 +412,7 @@ export function CourseDetailPage() {
       <div className={`min-h-screen flex items-center justify-center ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
         <div className="text-center">
           <p className={`text-xl ${isDark ? 'text-white' : 'text-gray-900'}`}>강의를 불러올 수 없습니다.</p>
-          <Link to="/tu/main/courses" className="text-[#6778ff] hover:underline mt-4 inline-block">
+          <Link to="/tu/b2c/courses" className="text-[#6778ff] hover:underline mt-4 inline-block">
             강의 목록으로 돌아가기
           </Link>
         </div>
@@ -432,7 +432,7 @@ export function CourseDetailPage() {
             <div className="flex-1">
               {/* Breadcrumb */}
               <nav className={`flex items-center gap-2 text-sm mb-4 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
-                <Link to="/tu/main/courses" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
+                <Link to="/tu/b2c/courses" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
                   강의
                 </Link>
                 <ChevronRight className="w-4 h-4" />

--- a/src/pages/tu/main/CourseDetailPage.tsx
+++ b/src/pages/tu/main/CourseDetailPage.tsx
@@ -437,7 +437,7 @@ export function CourseDetailPage() {
                 </Link>
                 <ChevronRight className="w-4 h-4" />
                 <Link
-                  to={`/tu/main/courses?category=${course.category}`}
+                  to={`/tu/b2c/courses?category=${course.category}`}
                   className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}
                 >
                   {getCategoryLabel(course.category)}

--- a/src/pages/tu/main/CoursesExplorePage.tsx
+++ b/src/pages/tu/main/CoursesExplorePage.tsx
@@ -256,7 +256,7 @@ function CourseCard({ course, isDark }: CourseCardProps) {
   if (course.discount > 0) tags.push('할인중');
 
   return (
-    <Link to={`/tu/main/courses/${course.id}`} className="group block h-full">
+    <Link to={`/tu/b2c/courses/${course.id}`} className="group block h-full">
       <div className={`h-full card-hover rounded-xl overflow-hidden border ${
         isDark
           ? 'bg-white/5 border-white/10'

--- a/src/pages/tu/main/InstructorProfilePage.tsx
+++ b/src/pages/tu/main/InstructorProfilePage.tsx
@@ -287,7 +287,7 @@ export function InstructorProfilePage() {
         <LandingHeader />
         <div className="flex flex-col items-center justify-center min-h-[60vh]">
           <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>강사를 찾을 수 없습니다.</p>
-          <Link to="/tu/main" className="mt-4 text-[#6778ff] hover:underline">
+          <Link to="/tu/b2c" className="mt-4 text-[#6778ff] hover:underline">
             홈으로 돌아가기
           </Link>
         </div>

--- a/src/pages/tu/main/InstructorProfilePage.tsx
+++ b/src/pages/tu/main/InstructorProfilePage.tsx
@@ -481,7 +481,7 @@ export function InstructorProfilePage() {
                   return (
                     <Link
                       key={course.id}
-                      to={`/tu/main/courses/${course.id}`}
+                      to={`/tu/b2c/courses/${course.id}`}
                       className="group block h-full"
                     >
                       <div className={`h-full card-hover rounded-xl overflow-hidden border ${
@@ -592,7 +592,7 @@ export function InstructorProfilePage() {
             {roadmaps?.map((roadmap) => (
               <Link
                 key={roadmap.id}
-                to={`/tu/main/roadmaps/${roadmap.id}`}
+                to={`/tu/b2c/roadmaps/${roadmap.id}`}
                 className={`block rounded-2xl p-6 card-hover cursor-pointer group border transition-all ${
                   isDark
                     ? 'glass border-white/10'

--- a/src/pages/tu/main/LandingPage.tsx
+++ b/src/pages/tu/main/LandingPage.tsx
@@ -247,7 +247,7 @@ export function LandingPage() {
               <p className="landing-text-muted text-sm mt-2">{t.landing.featuredCoursesDesc}</p>
             </div>
             <a
-              href="/tu/catalog"
+              href="/tu/b2c/courses"
               className="text-sm landing-text-secondary hover:opacity-80 flex items-center gap-1 transition-colors"
             >
               {t.landing.viewAll} <ChevronRight className="w-4 h-4" />
@@ -274,7 +274,7 @@ export function LandingPage() {
                 <p className="landing-text-muted text-sm mt-2">{t.landing.newCoursesDesc}</p>
               </div>
               <a
-                href="/tu/catalog"
+                href="/tu/b2c/courses"
                 className="text-sm landing-text-secondary hover:opacity-80 flex items-center gap-1 transition-colors"
               >
                 {t.landing.viewAll} <ChevronRight className="w-4 h-4" />
@@ -297,7 +297,7 @@ export function LandingPage() {
               <p className="landing-text-muted text-sm mt-2">{t.landing.beginnerCoursesDesc}</p>
             </div>
             <a
-              href="/tu/catalog"
+              href="/tu/b2c/courses"
               className="text-sm landing-text-secondary hover:opacity-80 flex items-center gap-1 transition-colors"
             >
               {t.landing.viewAll} <ChevronRight className="w-4 h-4" />

--- a/src/pages/tu/main/LandingPage.tsx
+++ b/src/pages/tu/main/LandingPage.tsx
@@ -405,7 +405,7 @@ export function LandingPage() {
                 </p>
               </div>
               <Link
-                to="/mypage/teaching"
+                to="/tu/b2c/mypage/teaching"
                 className="flex items-center gap-2 px-8 py-4 bg-white text-[#6778ff] font-semibold rounded-xl hover:bg-gray-100 transition-colors shadow-lg"
               >
                 강사 시작하기

--- a/src/pages/tu/main/NotificationDetailPage.tsx
+++ b/src/pages/tu/main/NotificationDetailPage.tsx
@@ -174,7 +174,7 @@ useEffect(() => {
     `,
     createdAt: '2024-12-28T10:00:00Z',
     isRead: true,
-    actionUrl: '/mypage/certifications',
+    actionUrl: '/tu/b2c/mypage/certifications',
     actionLabel: '수료증 확인하기',
   },
   6: {

--- a/src/pages/tu/main/NotificationDetailPage.tsx
+++ b/src/pages/tu/main/NotificationDetailPage.tsx
@@ -55,7 +55,7 @@ const MOCK_NOTIFICATIONS: Record<number, NotificationItem & { content?: string; 
     `,
     createdAt: '2024-12-30T09:50:00Z',
     isRead: false,
-    actionUrl: '/tu/main/courses',
+    actionUrl: '/tu/b2c/courses',
     actionLabel: '강의 둘러보기',
   },
   2: {
@@ -82,7 +82,7 @@ const MOCK_NOTIFICATIONS: Record<number, NotificationItem & { content?: string; 
     `,
     createdAt: '2024-12-30T09:00:00Z',
     isRead: false,
-    actionUrl: '/tu/main/courses/1',
+    actionUrl: '/tu/b2c/courses/1',
     actionLabel: '강의 바로가기',
   },
   3: {
@@ -117,7 +117,7 @@ useEffect(() => {
     `,
     createdAt: '2024-12-30T07:00:00Z',
     isRead: false,
-    actionUrl: '/tu/main/community/1',
+    actionUrl: '/tu/b2c/community/1',
     actionLabel: '답변 보러가기',
   },
   4: {
@@ -204,7 +204,7 @@ MZC Learn Platform에 가입해주셔서 감사합니다!
     `,
     createdAt: '2024-12-27T10:00:00Z',
     isRead: true,
-    actionUrl: '/tu/main/courses',
+    actionUrl: '/tu/b2c/courses',
     actionLabel: '강의 둘러보기',
   },
 };

--- a/src/pages/tu/main/NotificationDetailPage.tsx
+++ b/src/pages/tu/main/NotificationDetailPage.tsx
@@ -306,7 +306,7 @@ export function NotificationDetailPage() {
       } else {
         await new Promise((resolve) => setTimeout(resolve, 300));
       }
-      navigate('/tu/notifications');
+      navigate('/tu/b2c/notifications');
     } catch (error) {
       console.error('Failed to delete notification:', error);
     } finally {
@@ -346,7 +346,7 @@ export function NotificationDetailPage() {
             <p className={`mb-6 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
               해당 알림이 삭제되었거나 존재하지 않습니다.
             </p>
-            <Button onClick={() => navigate('/tu/notifications')}>
+            <Button onClick={() => navigate('/tu/b2c/notifications')}>
               알림 목록으로 돌아가기
             </Button>
           </div>
@@ -366,7 +366,7 @@ export function NotificationDetailPage() {
         <div className="max-w-3xl mx-auto">
           {/* Back Button */}
           <button
-            onClick={() => navigate('/tu/notifications')}
+            onClick={() => navigate('/tu/b2c/notifications')}
             className={`flex items-center gap-2 mb-6 transition-colors ${
               isDark
                 ? 'text-gray-400 hover:text-white'

--- a/src/pages/tu/main/NotificationsPage.tsx
+++ b/src/pages/tu/main/NotificationsPage.tsx
@@ -310,7 +310,7 @@ export function NotificationsPage() {
                   key={notification.id}
                   onClick={() => {
                     markAsRead(notification.id);
-                    navigate(`/tu/notifications/${notification.id}`);
+                    navigate(`/tu/b2c/notifications/${notification.id}`);
                   }}
                   className={`rounded-xl p-4 flex gap-4 cursor-pointer transition-all border ${
                     isDark

--- a/src/pages/tu/main/RoadmapDetailPage.tsx
+++ b/src/pages/tu/main/RoadmapDetailPage.tsx
@@ -273,7 +273,7 @@ export function RoadmapDetailPage() {
       <div className={`min-h-screen flex items-center justify-center ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
         <div className="text-center">
           <p className={`text-xl ${isDark ? 'text-white' : 'text-gray-900'}`}>로드맵을 불러올 수 없습니다.</p>
-          <Link to="/tu/main/roadmap" className="text-[#6778ff] hover:underline mt-4 inline-block">
+          <Link to="/tu/b2c/roadmap" className="text-[#6778ff] hover:underline mt-4 inline-block">
             로드맵 목록으로 돌아가기
           </Link>
         </div>
@@ -315,7 +315,7 @@ export function RoadmapDetailPage() {
             <div className="lg:w-1/2">
               {/* Breadcrumb */}
               <nav className={`flex items-center gap-2 text-sm mb-4 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
-                <Link to="/tu/main/roadmap" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
+                <Link to="/tu/b2c/roadmap" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
                   로드맵
                 </Link>
                 <ChevronRight className="w-4 h-4" />

--- a/src/pages/tu/main/RoadmapExplorePage.tsx
+++ b/src/pages/tu/main/RoadmapExplorePage.tsx
@@ -159,7 +159,7 @@ function RoadmapCard({ roadmap, isDark }: RoadmapCardProps) {
 
   return (
     <Link
-      to={`/tu/b2c/roadmap/${roadmap.id}`}
+      to={`/tu/b2c/roadmaps/${roadmap.id}`}
       className={`block rounded-2xl p-6 card-hover cursor-pointer group border relative ${
         isDark
           ? 'glass border-white/10'

--- a/src/pages/tu/main/RoadmapExplorePage.tsx
+++ b/src/pages/tu/main/RoadmapExplorePage.tsx
@@ -159,7 +159,7 @@ function RoadmapCard({ roadmap, isDark }: RoadmapCardProps) {
 
   return (
     <Link
-      to={`/tu/main/roadmap/${roadmap.id}`}
+      to={`/tu/b2c/roadmap/${roadmap.id}`}
       className={`block rounded-2xl p-6 card-hover cursor-pointer group border relative ${
         isDark
           ? 'glass border-white/10'

--- a/src/pages/tu/main/WishlistPage.tsx
+++ b/src/pages/tu/main/WishlistPage.tsx
@@ -152,7 +152,7 @@ export function WishlistPage() {
                   }`}
                 >
                   {/* Image */}
-                  <Link to={`/tu/catalog/${item.courseId}`} className="block relative">
+                  <Link to={`/tu/b2c/courses/${item.courseId}`} className="block relative">
                     <div className="w-full aspect-video bg-gradient-to-br from-[#6778ff]/20 to-[#a855f7]/20 flex items-center justify-center">
                       {item.courseThumbnailUrl ? (
                         <img
@@ -173,7 +173,7 @@ export function WishlistPage() {
 
                   {/* Content */}
                   <div className="p-4">
-                    <Link to={`/tu/catalog/${item.courseId}`}>
+                    <Link to={`/tu/b2c/courses/${item.courseId}`}>
                       <h3 className={`font-semibold mb-2 line-clamp-2 group-hover:text-[#6778ff] transition-colors ${
                         isDark ? 'text-white' : 'text-gray-900'
                       }`}>
@@ -204,7 +204,7 @@ export function WishlistPage() {
                     {/* Actions */}
                     <div className="flex gap-2">
                       <Link
-                        to={`/tu/catalog/${item.courseId}`}
+                        to={`/tu/b2c/courses/${item.courseId}`}
                         className="flex-1 py-2.5 rounded-lg font-medium text-sm landing-btn-primary text-white flex items-center justify-center gap-2"
                       >
                         상세보기

--- a/src/pages/tu/main/WishlistPage.tsx
+++ b/src/pages/tu/main/WishlistPage.tsx
@@ -133,7 +133,7 @@ export function WishlistPage() {
               관심 있는 강의에 하트를 눌러 저장해보세요!
             </p>
             <Link
-              to="/tu/catalog"
+              to="/tu/b2c/courses"
               className="inline-flex items-center gap-2 landing-btn-primary px-6 py-3 rounded-full text-white font-medium"
             >
               강의 둘러보기 <ChevronRight className="w-4 h-4" />
@@ -272,7 +272,7 @@ export function WishlistPage() {
                 찜한 강의를 기반으로 추천 강의를 준비하고 있어요.
               </p>
               <Link
-                to="/tu/catalog"
+                to="/tu/b2c/courses"
                 className={`inline-flex items-center gap-2 font-medium transition-colors ${
                   isDark ? 'text-[#6778ff] hover:text-[#8b99ff]' : 'text-[#6778ff] hover:text-[#5566ee]'
                 }`}

--- a/src/pages/tu/mypage/MyPage.tsx
+++ b/src/pages/tu/mypage/MyPage.tsx
@@ -157,7 +157,7 @@ export function MyPage() {
               {/* 설정 버튼 */}
               <Button
                 variant="outline"
-                onClick={() => navigate('/tu/settings')}
+                onClick={() => navigate('/tu/b2c/mypage/settings')}
                 className={isDark ? 'border-white/20 text-white hover:bg-white/10' : ''}
               >
                 <Settings className="w-4 h-4 mr-2" />
@@ -304,7 +304,7 @@ export function MyPage() {
               <p className={`text-sm mb-4 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
                 새로운 강의를 찾아 학습을 시작해보세요
               </p>
-              <Button onClick={() => navigate('/tu/catalog')}>강의 둘러보기</Button>
+              <Button onClick={() => navigate('/tu/b2c/courses')}>강의 둘러보기</Button>
             </div>
           )}
         </section>
@@ -326,35 +326,35 @@ export function MyPage() {
               icon={<Award className="w-5 h-5" />}
               title="인증서"
               description="취득한 인증서를 확인하세요"
-              onClick={() => navigate('/tu/certifications')}
+              onClick={() => navigate('/tu/b2c/mypage/certifications')}
               isDark={isDark}
             />
             <QuickMenuItem
               icon={<Shield className="w-5 h-5" />}
               title="계정 및 보안"
               description="계정 정보 및 보안 설정"
-              onClick={() => navigate('/tu/settings/security')}
+              onClick={() => navigate('/tu/b2c/mypage/settings/security')}
               isDark={isDark}
             />
             <QuickMenuItem
               icon={<Bell className="w-5 h-5" />}
               title="알림 설정"
               description="알림 설정을 관리하세요"
-              onClick={() => navigate('/tu/settings/notifications')}
+              onClick={() => navigate('/tu/b2c/mypage/settings/notifications')}
               isDark={isDark}
             />
             <QuickMenuItem
               icon={<Globe className="w-5 h-5" />}
               title="언어 및 지역"
               description="언어 및 지역 설정을 변경하세요"
-              onClick={() => navigate('/tu/settings/language')}
+              onClick={() => navigate('/tu/b2c/mypage/settings/language')}
               isDark={isDark}
             />
             <QuickMenuItem
               icon={<TrendingUp className="w-5 h-5" />}
               title="학습 진도"
               description="전체 학습 진도를 확인하세요"
-              onClick={() => navigate('/tu/progress')}
+              onClick={() => navigate('/tu/b2c/mypage/learning')}
               isDark={isDark}
             />
           </div>

--- a/src/pages/tu/mypage/MyPage.tsx
+++ b/src/pages/tu/mypage/MyPage.tsx
@@ -222,7 +222,7 @@ export function MyPage() {
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => navigate('/mypage/learning')}
+              onClick={() => navigate('/tu/b2c/mypage/learning')}
               className={isDark ? 'text-gray-400 hover:text-white' : ''}
             >
               전체보기
@@ -319,7 +319,7 @@ export function MyPage() {
               icon={<BookOpen className="w-5 h-5" />}
               title="내 학습"
               description="수강 중인 강의를 확인하세요"
-              onClick={() => navigate('/mypage/learning')}
+              onClick={() => navigate('/tu/b2c/mypage/learning')}
               isDark={isDark}
             />
             <QuickMenuItem

--- a/src/pages/tu/mypage/MyPageHome.tsx
+++ b/src/pages/tu/mypage/MyPageHome.tsx
@@ -362,7 +362,7 @@ export function MyPageHome() {
               <p className={`text-sm mb-4 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
                 {t.mypage.noEnrolledCoursesDesc}
               </p>
-              <Button onClick={() => navigate('/tu/catalog')}>{t.mypage.browseCourses}</Button>
+              <Button onClick={() => navigate('/tu/b2c/courses')}>{t.mypage.browseCourses}</Button>
             </div>
           )}
         </section>
@@ -412,7 +412,7 @@ export function MyPageHome() {
               icon={<TrendingUp className="w-5 h-5" />}
               title={t.mypage.learningProgress}
               description={t.mypage.learningProgressDesc}
-              onClick={() => navigate('/tu/progress')}
+              onClick={() => navigate('/tu/b2c/mypage/learning')}
               isDark={isDark}
             />
           </div>

--- a/src/pages/tu/mypage/MyPageHome.tsx
+++ b/src/pages/tu/mypage/MyPageHome.tsx
@@ -214,7 +214,7 @@ export function MyPageHome() {
               {/* 프로필 수정 버튼 */}
               <Button
                 variant="outline"
-                onClick={() => navigate('/mypage/profile')}
+                onClick={() => navigate('/tu/b2c/mypage/profile')}
                 className={isDark ? 'border-white/30 text-white bg-white/10 hover:bg-white/20' : ''}
               >
                 {t.mypage.editProfile}
@@ -278,7 +278,7 @@ export function MyPageHome() {
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => navigate('/mypage/learning')}
+              onClick={() => navigate('/tu/b2c/mypage/learning')}
               className={isDark ? 'text-gray-400 hover:text-white' : ''}
             >
               {t.mypage.viewAll}
@@ -377,35 +377,35 @@ export function MyPageHome() {
               icon={<BookOpen className="w-5 h-5" />}
               title={t.mypage.myLearning}
               description={t.mypage.myLearningDesc}
-              onClick={() => navigate('/mypage/learning')}
+              onClick={() => navigate('/tu/b2c/mypage/learning')}
               isDark={isDark}
             />
             <QuickMenuItem
               icon={<Award className="w-5 h-5" />}
               title={t.mypage.certificates}
               description={t.mypage.certificatesDesc}
-              onClick={() => navigate('/mypage/certifications')}
+              onClick={() => navigate('/tu/b2c/mypage/certifications')}
               isDark={isDark}
             />
             <QuickMenuItem
               icon={<Shield className="w-5 h-5" />}
               title={t.mypage.profileAndSecurity}
               description={t.mypage.profileSecurityDesc}
-              onClick={() => navigate('/mypage/profile')}
+              onClick={() => navigate('/tu/b2c/mypage/profile')}
               isDark={isDark}
             />
             <QuickMenuItem
               icon={<Bell className="w-5 h-5" />}
               title={t.mypage.notifications}
               description={t.mypage.notificationsDesc}
-              onClick={() => navigate('/mypage/notifications')}
+              onClick={() => navigate('/tu/b2c/mypage/notifications')}
               isDark={isDark}
             />
             <QuickMenuItem
               icon={<Globe className="w-5 h-5" />}
               title={t.mypage.languageRegion}
               description={t.mypage.languageRegionDesc}
-              onClick={() => navigate('/mypage/language')}
+              onClick={() => navigate('/tu/b2c/mypage/language')}
               isDark={isDark}
             />
             <QuickMenuItem

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import ComponentShowcase from '@/pages/dev/ComponentShowcase';
 import { saRoutes } from './sa.routes';
 import { taRoutes } from './ta.routes';
@@ -10,6 +10,9 @@ import { UnauthorizedPage } from './pages';
 export function AppRoutes() {
   return (
     <Routes>
+      {/* 루트 경로 리다이렉트 */}
+      <Route path="/" element={<Navigate to="/tu/b2c" replace />} />
+
       {/* 역할별 라우트 */}
       {saRoutes}
       {taRoutes}

--- a/src/routes/tu.b2c.routes.tsx
+++ b/src/routes/tu.b2c.routes.tsx
@@ -1,0 +1,51 @@
+import { Route } from 'react-router-dom';
+import {
+  LandingPage,
+  CoursesExplorePage,
+  CourseDetailPage,
+  RoadmapExplorePage,
+  RoadmapDetailPage,
+  CommunityPage,
+  CommunityDetailPage,
+  CartPage,
+  WishlistPage,
+  NotificationsPage,
+  NotificationDetailPage,
+  InstructorProfilePage,
+} from '@/pages/tu';
+
+/**
+ * TU B2C 라우트 - 메인 페이지 (사이드바 없음)
+ *
+ * 경로: /tu/b2c/*
+ * - 랜딩, 강의 탐색, 로드맵, 커뮤니티, 장바구니, 위시리스트, 알림
+ */
+export const tuB2cRoutes = (
+  <>
+    {/* 랜딩 페이지 */}
+    <Route path="/tu/b2c" element={<LandingPage />} />
+
+    {/* 강의 탐색 */}
+    <Route path="/tu/b2c/courses" element={<CoursesExplorePage />} />
+    <Route path="/tu/b2c/courses/:id" element={<CourseDetailPage />} />
+
+    {/* 로드맵 */}
+    <Route path="/tu/b2c/roadmaps" element={<RoadmapExplorePage />} />
+    <Route path="/tu/b2c/roadmaps/:id" element={<RoadmapDetailPage />} />
+
+    {/* 커뮤니티 */}
+    <Route path="/tu/b2c/community" element={<CommunityPage />} />
+    <Route path="/tu/b2c/community/:id" element={<CommunityDetailPage />} />
+
+    {/* 장바구니 & 위시리스트 */}
+    <Route path="/tu/b2c/cart" element={<CartPage />} />
+    <Route path="/tu/b2c/wishlist" element={<WishlistPage />} />
+
+    {/* 알림 */}
+    <Route path="/tu/b2c/notifications" element={<NotificationsPage />} />
+    <Route path="/tu/b2c/notifications/:id" element={<NotificationDetailPage />} />
+
+    {/* 강사 프로필 */}
+    <Route path="/tu/b2c/instructors/:instructorId" element={<InstructorProfilePage />} />
+  </>
+);

--- a/src/routes/tu.mypage.routes.tsx
+++ b/src/routes/tu.mypage.routes.tsx
@@ -1,0 +1,63 @@
+import { Route, Outlet } from 'react-router-dom';
+import { MyPageLayout } from '@/components/layout';
+import { ProtectedRoute } from '@/components/common/ProtectedRoute';
+import {
+  MyPageHome,
+  ProfilePage,
+  MyLearningPage,
+  LearningDetailPage,
+  LearningPlayerPage,
+  SettingsLanguagePage,
+  MyTeachingPage,
+  TeachingStatsPage,
+  CompletedCoursesPage,
+  CertificationsPage,
+} from '@/pages/tu';
+import {
+  SettingsPage,
+  SettingsSecurityPage,
+  SettingsNotificationsPage,
+  SettingsAppearancePage,
+} from '@/pages/common';
+
+function MyPageWrapper() {
+  return (
+    <ProtectedRoute allowedRoles={['USER', 'DESIGNER', 'OPERATOR', 'TENANT_ADMIN']}>
+      <MyPageLayout>
+        <Outlet />
+      </MyPageLayout>
+    </ProtectedRoute>
+  );
+}
+
+/**
+ * TU MyPage 라우트 - 마이페이지 (사이드바 있음, 로그인 필요)
+ *
+ * 경로: /tu/b2c/mypage/*
+ * - 내 정보, 내 수강 강의, 내 강의 관리, 설정
+ */
+export const tuMyPageRoutes = (
+  <Route path="/tu/b2c/mypage" element={<MyPageWrapper />}>
+    <Route index element={<MyPageHome />} />
+    <Route path="profile" element={<ProfilePage />} />
+
+    {/* 내 수강 강의 */}
+    <Route path="learning" element={<MyLearningPage />} />
+    <Route path="learning/:enrollmentId" element={<LearningDetailPage />} />
+    <Route path="learning/:enrollmentId/player" element={<LearningPlayerPage />} />
+    <Route path="learning/:enrollmentId/player/:itemId" element={<LearningPlayerPage />} />
+    <Route path="completed" element={<CompletedCoursesPage />} />
+    <Route path="certifications" element={<CertificationsPage />} />
+
+    {/* 내 강의 관리 */}
+    <Route path="teaching" element={<MyTeachingPage />} />
+    <Route path="teaching/stats" element={<TeachingStatsPage />} />
+
+    {/* 설정 */}
+    <Route path="settings" element={<SettingsPage />} />
+    <Route path="settings/security" element={<SettingsSecurityPage />} />
+    <Route path="settings/notifications" element={<SettingsNotificationsPage />} />
+    <Route path="settings/language" element={<SettingsLanguagePage />} />
+    <Route path="settings/appearance" element={<SettingsAppearancePage />} />
+  </Route>
+);

--- a/src/routes/tu.routes.tsx
+++ b/src/routes/tu.routes.tsx
@@ -1,96 +1,25 @@
-import { Route, Outlet, Navigate } from 'react-router-dom';
-import {
-  LandingPage,
-  CoursesExplorePage,
-  RoadmapExplorePage,
-  RoadmapDetailPage,
-  CommunityPage,
-  CommunityDetailPage,
-  CartPage,
-  WishlistPage,
-  NotificationsPage,
-  NotificationDetailPage,
-  CourseDetailPage,
-  InstructorProfilePage,
-  MyPageHome,
-  ProfilePage,
-  MyLearningPage,
-  LearningDetailPage,
-  LearningPlayerPage,
-  SettingsLanguagePage,
-  MyTeachingPage,
-  TeachingStatsPage,
-  CompletedCoursesPage,
-  CertificationsPage,
-} from '@/pages/tu';
-import { MyPageLayout } from '@/components/layout';
-import { ProtectedRoute } from '@/components/common/ProtectedRoute';
-import {
-  SettingsPage,
-  SettingsSecurityPage,
-  SettingsNotificationsPage,
-  SettingsAppearancePage,
-} from '@/pages/common';
-import { tuCoursesRoutes } from './tu.courses.routes';
+import { tuB2cRoutes } from './tu.b2c.routes';
+import { tuMyPageRoutes } from './tu.mypage.routes';
+import { tuTeachingRoutes } from './tu.teaching.routes';
 
-function MyPageWrapper() {
-  return (
-    <ProtectedRoute allowedRoles={['USER', 'DESIGNER', 'OPERATOR', 'TENANT_ADMIN']}>
-      <MyPageLayout>
-        <Outlet />
-      </MyPageLayout>
-    </ProtectedRoute>
-  );
-}
-
+/**
+ * TU (Tenant User) 라우트 통합
+ *
+ * 구조:
+ * - /                 : 랜딩 페이지
+ * - /tu/b2c/*         : B2C 메인 페이지 (사이드바 없음)
+ * - /tu/b2c/mypage/*  : 마이페이지 (사이드바 있음, 로그인 필요)
+ * - /tu/teaching/*    : 강의 관리 (사이드바 있음, 로그인 필요)
+ */
 export const tuRoutes = (
   <>
-    {/* TU 강의 관련 라우트 (사이드바 있음) */}
-    {tuCoursesRoutes}
+    {/* B2C 메인 페이지 */}
+    {tuB2cRoutes}
 
-    {/* 기본 경로 - 랜딩 페이지 */}
-    <Route path="/" element={<LandingPage />} />
+    {/* 마이페이지 */}
+    {tuMyPageRoutes}
 
-    {/* 마이페이지 (사이드바 있음, 로그인 필요) */}
-    <Route path="/mypage" element={<MyPageWrapper />}>
-      <Route index element={<MyPageHome />} />
-      <Route path="profile" element={<ProfilePage />} />
-      {/* 내 수강 강의 */}
-      <Route path="learning" element={<MyLearningPage />} />
-      <Route path="learning/:enrollmentId" element={<LearningDetailPage />} />
-      <Route path="learning/:enrollmentId/player" element={<LearningPlayerPage />} />
-      <Route path="learning/:enrollmentId/player/:itemId" element={<LearningPlayerPage />} />
-      <Route path="completed" element={<CompletedCoursesPage />} />
-      <Route path="certifications" element={<CertificationsPage />} />
-      {/* 내 강의 관리 */}
-      <Route path="teaching" element={<MyTeachingPage />} />
-      <Route path="teaching/stats" element={<TeachingStatsPage />} />
-      {/* 설정 */}
-      <Route path="settings" element={<SettingsPage />} />
-      <Route path="settings/security" element={<SettingsSecurityPage />} />
-      <Route path="settings/notifications" element={<SettingsNotificationsPage />} />
-      <Route path="settings/language" element={<SettingsLanguagePage />} />
-      <Route path="settings/appearance" element={<SettingsAppearancePage />} />
-      {/* 레거시 경로 리다이렉트 */}
-      <Route path="profile" element={<Navigate to="/mypage/settings/security" replace />} />
-      <Route path="security" element={<Navigate to="/mypage/settings/security" replace />} />
-      <Route path="notifications" element={<Navigate to="/mypage/settings/notifications" replace />} />
-      <Route path="language" element={<Navigate to="/mypage/settings/language" replace />} />
-    </Route>
-
-    {/* 메인 페이지 (사이드바 없음) */}
-    <Route path="/tu/main/courses" element={<CoursesExplorePage />} />
-    <Route path="/tu/main/courses/:id" element={<CourseDetailPage />} />
-    <Route path="/tu/main/roadmaps" element={<RoadmapExplorePage />} />
-    <Route path="/tu/main/roadmaps/:id" element={<RoadmapDetailPage />} />
-    <Route path="/tu/main/community" element={<CommunityPage />} />
-    <Route path="/tu/main/community/:id" element={<CommunityDetailPage />} />
-    <Route path="/tu/community" element={<CommunityPage />} />
-    <Route path="/tu/community/:id" element={<CommunityDetailPage />} />
-    <Route path="/tu/cart" element={<CartPage />} />
-    <Route path="/tu/wishlist" element={<WishlistPage />} />
-    <Route path="/tu/notifications" element={<NotificationsPage />} />
-    <Route path="/tu/notifications/:id" element={<NotificationDetailPage />} />
-    <Route path="/tu/instructors/:instructorId" element={<InstructorProfilePage />} />
+    {/* 강의 관리 */}
+    {tuTeachingRoutes}
   </>
 );

--- a/src/routes/tu.teaching.routes.tsx
+++ b/src/routes/tu.teaching.routes.tsx
@@ -24,7 +24,13 @@ function TenantUserWrapper() {
   );
 }
 
-export const tuCoursesRoutes = (
+/**
+ * TU Teaching 라우트 - 강의 관리 (사이드바 있음)
+ *
+ * 경로: /tu/teaching/*
+ * - 내 강의 관리, 콘텐츠 관리, 과제 관리
+ */
+export const tuTeachingRoutes = (
   <Route path="/tu" element={<TenantUserWrapper />}>
     <Route index element={<DashboardPage />} />
     <Route path="dashboard" element={<DashboardPage />} />
@@ -34,9 +40,13 @@ export const tuCoursesRoutes = (
     <Route path="teaching/courses/create" element={<CourseCreatePage />} />
     <Route path="teaching/courses/:courseId" element={<TeachingCourseDetailPage />} />
     <Route path="teaching/courses/:courseId/edit" element={<CourseEditPage />} />
+
+    {/* 내 콘텐츠 */}
     <Route path="teaching/content" element={<MyContentPage />} />
     <Route path="teaching/content/create" element={<TuContentCreatePage />} />
     <Route path="teaching/content/:id" element={<ContentDetailPage />} />
+
+    {/* 내 과제 */}
     <Route path="teaching/assignments" element={<MyAssignmentsPage />} />
     <Route path="teaching/assignments/:id" element={<AssignmentDetailPage />} />
 


### PR DESCRIPTION
## Summary
- TU 라우트 파일을 도메인별로 분리 (b2c, mypage, teaching)
- 모든 B2C 경로를 `/tu/b2c/*`로 통일
- 메인 랜딩 페이지 경로를 `/tu/b2c`로 변경
- 루트 경로(`/`)에서 `/tu/b2c`로 리다이렉트 추가

## Test plan
- [x] `/` 접속 시 `/tu/b2c`로 리다이렉트 확인
- [x] `/tu/b2c` 랜딩 페이지 정상 렌더링 확인
- [x] `/tu/b2c/courses`, `/tu/b2c/community` 등 B2C 페이지 접근 확인
- [x] `/tu/b2c/mypage` 마이페이지 접근 확인 (로그인 필요)
- [x] 헤더 내 모든 링크 정상 작동 확인
- [x] 사이드바 메뉴 링크 정상 작동 확인

Closes #191