### PR TITLE
feat(tu): 내 프로그램 관리 페이지 구현

### DIFF
--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -44,6 +44,7 @@ import {
   PenTool,
   CheckSquare,
   Briefcase,
+  Package,
 } from 'lucide-react';
 import type { MenuItem } from '@/types';
 
@@ -232,7 +233,8 @@ export const tenantUserMenuData: MenuItem[] = [
     label: { ko: '내 강의', en: 'My Teaching' },
     icon: Briefcase,
     subItems: [
-      { id: 'my-courses', label: { ko: '내 강좌', en: 'My Courses' }, icon: BookOpen, path: '/tu/teaching/courses' },
+      { id: 'my-courses', label: { ko: '내 강의계획', en: 'My Course Plans' }, icon: BookOpen, path: '/tu/teaching/courses' },
+      { id: 'my-programs', label: { ko: '내 프로그램', en: 'My Programs' }, icon: Package, path: '/tu/teaching/programs' },
       { id: 'my-content', label: { ko: '내 콘텐츠', en: 'My Content' }, icon: PenTool, path: '/tu/teaching/content' },
       { id: 'my-assignments', label: { ko: '내 과제', en: 'My Assignments' }, icon: CheckSquare, path: '/tu/teaching/assignments' },
     ],

--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -203,3 +203,21 @@ export {
   type CourseForApplication,
   type ApplicationResult,
 } from './useProgramApplicationQueries';
+
+// My Program Hooks (TU 내 프로그램 관리)
+export {
+  myProgramKeys,
+  useMyPrograms,
+  useMyProgram,
+  useMyProgramSnapshot,
+  useSnapshotItems,
+  useUpdateMyProgram,
+  useDeleteMyProgram,
+  useSubmitMyProgram,
+  useUpdateSnapshot,
+  useAddSnapshotItem,
+  useUpdateSnapshotItem,
+  useMoveSnapshotItem,
+  useDeleteSnapshotItem,
+  type MyProgramFilterParams,
+} from './useMyProgramQueries';

--- a/src/hooks/tu/useMyProgramQueries.ts
+++ b/src/hooks/tu/useMyProgramQueries.ts
@@ -1,0 +1,246 @@
+/**
+ * TU(Tenant User) 내 프로그램(Program) React Query Hooks
+ *
+ * TO의 programService와 snapshotService를 사용하여
+ * 현재 사용자가 생성한 프로그램을 관리합니다.
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuthStore } from '@/store/common/authStore';
+import { programService, type ProgramFilterParams } from '@/services/to/programService';
+import { snapshotService } from '@/services/to/snapshotService';
+import type {
+  UpdateProgramRequest,
+  CreateSnapshotItemRequest,
+  UpdateSnapshotItemRequest,
+  MoveSnapshotItemRequest,
+  UpdateSnapshotRequest,
+} from '@/types/common';
+
+// ============================================
+// Query Keys
+// ============================================
+
+export const myProgramKeys = {
+  all: ['my-programs'] as const,
+  lists: () => [...myProgramKeys.all, 'list'] as const,
+  list: (params?: MyProgramFilterParams) => [...myProgramKeys.lists(), params] as const,
+  details: () => [...myProgramKeys.all, 'detail'] as const,
+  detail: (id: number) => [...myProgramKeys.details(), id] as const,
+  snapshot: (snapshotId: number) => [...myProgramKeys.all, 'snapshot', snapshotId] as const,
+  snapshotItems: (snapshotId: number) =>
+    [...myProgramKeys.all, 'snapshot-items', snapshotId] as const,
+};
+
+// ============================================
+// Types
+// ============================================
+
+export interface MyProgramFilterParams {
+  status?: 'DRAFT' | 'PENDING' | 'APPROVED' | 'REJECTED' | 'CLOSED';
+  keyword?: string;
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+// ============================================
+// Query Hooks
+// ============================================
+
+/** 내 프로그램 목록 조회 (creatorId 필터) */
+export const useMyPrograms = (params?: MyProgramFilterParams) => {
+  const user = useAuthStore((state) => state.user);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  return useQuery({
+    queryKey: myProgramKeys.list(params),
+    queryFn: () =>
+      programService.getPrograms({
+        ...params,
+        creatorId: user?.id,
+      } as ProgramFilterParams),
+    enabled: isAuthenticated && !!user?.id,
+  });
+};
+
+/** 내 프로그램 상세 조회 */
+export const useMyProgram = (id: number) => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  return useQuery({
+    queryKey: myProgramKeys.detail(id),
+    queryFn: () => programService.getProgram(id),
+    enabled: isAuthenticated && !!id,
+  });
+};
+
+/** 스냅샷 상세 조회 */
+export const useMyProgramSnapshot = (snapshotId: number) => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  return useQuery({
+    queryKey: myProgramKeys.snapshot(snapshotId),
+    queryFn: () => snapshotService.getSnapshot(snapshotId),
+    enabled: isAuthenticated && !!snapshotId,
+  });
+};
+
+/** 스냅샷 아이템 계층 구조 조회 */
+export const useSnapshotItems = (snapshotId: number) => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  return useQuery({
+    queryKey: myProgramKeys.snapshotItems(snapshotId),
+    queryFn: () => snapshotService.getItems(snapshotId),
+    enabled: isAuthenticated && !!snapshotId,
+  });
+};
+
+// ============================================
+// Mutation Hooks - Program
+// ============================================
+
+/** 프로그램 수정 */
+export const useUpdateMyProgram = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: { id: number; request: UpdateProgramRequest }) =>
+      programService.updateProgram(id, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: myProgramKeys.detail(variables.id) });
+      queryClient.invalidateQueries({ queryKey: myProgramKeys.lists() });
+    },
+  });
+};
+
+/** 프로그램 삭제 */
+export const useDeleteMyProgram = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => programService.deleteProgram(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: myProgramKeys.lists() });
+    },
+  });
+};
+
+/** 프로그램 제출 (DRAFT/REJECTED → PENDING) */
+export const useSubmitMyProgram = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => programService.submitProgram(id),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: myProgramKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: myProgramKeys.lists() });
+    },
+  });
+};
+
+// ============================================
+// Mutation Hooks - Snapshot
+// ============================================
+
+/** 스냅샷 기본정보 수정 */
+export const useUpdateSnapshot = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: { id: number; request: UpdateSnapshotRequest }) =>
+      snapshotService.update(id, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: myProgramKeys.snapshot(variables.id) });
+    },
+  });
+};
+
+// ============================================
+// Mutation Hooks - Snapshot Items
+// ============================================
+
+/** 스냅샷 아이템 추가 */
+export const useAddSnapshotItem = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      snapshotId,
+      request,
+    }: {
+      snapshotId: number;
+      request: CreateSnapshotItemRequest;
+    }) => snapshotService.addItem(snapshotId, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: myProgramKeys.snapshotItems(variables.snapshotId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: myProgramKeys.snapshot(variables.snapshotId),
+      });
+    },
+  });
+};
+
+/** 스냅샷 아이템 이름 수정 */
+export const useUpdateSnapshotItem = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      snapshotId,
+      itemId,
+      request,
+    }: {
+      snapshotId: number;
+      itemId: number;
+      request: UpdateSnapshotItemRequest;
+    }) => snapshotService.updateItem(snapshotId, itemId, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: myProgramKeys.snapshotItems(variables.snapshotId),
+      });
+    },
+  });
+};
+
+/** 스냅샷 아이템 이동 */
+export const useMoveSnapshotItem = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      snapshotId,
+      itemId,
+      request,
+    }: {
+      snapshotId: number;
+      itemId: number;
+      request: MoveSnapshotItemRequest;
+    }) => snapshotService.moveItem(snapshotId, itemId, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: myProgramKeys.snapshotItems(variables.snapshotId),
+      });
+    },
+  });
+};
+
+/** 스냅샷 아이템 삭제 */
+export const useDeleteSnapshotItem = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ snapshotId, itemId }: { snapshotId: number; itemId: number }) =>
+      snapshotService.deleteItem(snapshotId, itemId),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: myProgramKeys.snapshotItems(variables.snapshotId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: myProgramKeys.snapshot(variables.snapshotId),
+      });
+    },
+  });
+};

--- a/src/pages/tu/index.ts
+++ b/src/pages/tu/index.ts
@@ -1,4 +1,17 @@
-export { MyCoursesPage, MyContentPage, CourseCreatePage, CourseEditPage, CourseDetailPage as TeachingCourseDetailPage, TuContentCreatePage, ContentDetailPage, MyAssignmentsPage, AssignmentDetailPage } from './teaching';
+export {
+  MyCoursesPage,
+  MyContentPage,
+  CourseCreatePage,
+  CourseEditPage,
+  CourseDetailPage as TeachingCourseDetailPage,
+  TuContentCreatePage,
+  ContentDetailPage,
+  MyAssignmentsPage,
+  AssignmentDetailPage,
+  MyProgramsPage,
+  TuProgramDetailPage,
+  TuProgramEditPage,
+} from './teaching';
 export { SettingsLanguagePage } from './settings';
 export { LandingPage, CoursesExplorePage, RoadmapExplorePage, RoadmapDetailPage, CommunityPage, CommunityDetailPage, CartPage, WishlistPage, NotificationsPage, NotificationDetailPage, CourseDetailPage, InstructorProfilePage } from './main';
 export { CatalogPage, CatalogDetailPage } from './catalog';

--- a/src/pages/tu/teaching/courses/components/Step3Review.tsx
+++ b/src/pages/tu/teaching/courses/components/Step3Review.tsx
@@ -3,7 +3,6 @@
  * 담당: 최종 검토 화면
  */
 import {
-  Upload,
   Plus,
   Pencil,
   CheckCircle2,
@@ -13,11 +12,95 @@ import {
   Tag,
   Globe,
   FileText,
+  Folder,
+  File,
+  ChevronRight,
+  ChevronDown,
 } from 'lucide-react';
+import { useState } from 'react';
 import { Button, Label, Card, CardHeader, CardContent, Alert, AlertDescription } from '@/components/common';
 import type { CourseFormData } from '@/types';
 import type { CategoryResponse } from '@/types/common';
+import type { CurriculumItem } from '@/types/tu';
+import { isCurriculumFolder } from '@/types/tu';
 import { translations, levelOptions, type TranslationKey } from './courseCreate.constants';
+
+/** 커리큘럼 아이템 수 계산 (폴더/콘텐츠 분리) */
+function countCurriculumItems(items: CurriculumItem[]): { folders: number; contents: number } {
+  let folders = 0;
+  let contents = 0;
+  for (const item of items) {
+    if (isCurriculumFolder(item)) {
+      folders++;
+      const childCounts = countCurriculumItems(item.children);
+      folders += childCounts.folders;
+      contents += childCounts.contents;
+    } else {
+      contents++;
+    }
+  }
+  return { folders, contents };
+}
+
+/** 트리 아이템 렌더링 컴포넌트 */
+function CurriculumTreeItem({
+  item,
+  depth = 0,
+  expandedIds,
+  onToggle,
+}: {
+  item: CurriculumItem;
+  depth?: number;
+  expandedIds: Set<string>;
+  onToggle: (id: string) => void;
+}) {
+  const isFolder = isCurriculumFolder(item);
+  const isExpanded = expandedIds.has(item.id);
+
+  return (
+    <div>
+      <div
+        className="flex items-center gap-2 py-1.5 px-2 rounded hover:bg-bg-secondary"
+        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+      >
+        {isFolder ? (
+          <button
+            type="button"
+            onClick={() => onToggle(item.id)}
+            className="p-0.5 hover:bg-bg-secondary rounded"
+          >
+            {isExpanded ? (
+              <ChevronDown size={14} className="text-text-secondary" />
+            ) : (
+              <ChevronRight size={14} className="text-text-secondary" />
+            )}
+          </button>
+        ) : (
+          <span className="w-5" />
+        )}
+        {isFolder ? (
+          <Folder size={16} className="text-yellow-500 shrink-0" />
+        ) : (
+          <File size={16} className="text-blue-500 shrink-0" />
+        )}
+        <span className="text-text-primary text-sm truncate">{item.name}</span>
+      </div>
+      {isFolder && isExpanded && item.children.length > 0 && (
+        <div>
+          {item.children.map((child) => (
+            <CurriculumTreeItem
+              key={child.id}
+              item={child}
+              depth={depth + 1}
+              expandedIds={expandedIds}
+              onToggle={onToggle}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
 
 interface Step3ReviewProps {
   language: 'ko' | 'en';
@@ -35,11 +118,41 @@ export function Step3Review({
   const getText = (key: TranslationKey) =>
     language === 'ko' ? translations[key].ko : translations[key].en;
 
+  // 폴더 확장 상태 관리 (기본: 모두 확장)
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => {
+    const ids = new Set<string>();
+    const collectFolderIds = (items: CurriculumItem[]) => {
+      for (const item of items) {
+        if (isCurriculumFolder(item)) {
+          ids.add(item.id);
+          collectFolderIds(item.children);
+        }
+      }
+    };
+    collectFolderIds(formData.curriculumItems);
+    return ids;
+  });
+
+  const handleToggleExpand = (id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  // 커리큘럼 아이템 수
+  const itemCounts = countCurriculumItems(formData.curriculumItems);
+
   // 경고 메시지 계산
   const warnings: string[] = [];
   if (!formData.title) warnings.push(getText('warningCourse'));
   if (!formData.categoryId) warnings.push(getText('warningCategory'));
-  if (formData.lessons.length === 0) warnings.push(getText('warningLesson'));
+  if (formData.curriculumItems.length === 0) warnings.push(getText('warningLesson'));
 
   return (
     <div className="flex flex-col gap-6">
@@ -206,10 +319,9 @@ export function Step3Review({
             <div className="flex items-center gap-3">
               <FileText size={20} className="text-action-primary" />
               <h3 className="text-text-primary m-0 text-base font-medium">{getText('curriculum')}</h3>
-              {formData.lessons.length > 0 && (
+              {formData.curriculumItems.length > 0 && (
                 <span className="text-text-secondary text-sm">
-                  ({getText('totalLessons')}: {formData.lessons.length}, {getText('totalContents')}:{' '}
-                  {formData.lessons.reduce((acc, lesson) => acc + lesson.contents.length, 0)})
+                  ({language === 'ko' ? '폴더' : 'Folders'}: {itemCounts.folders}, {getText('totalContents')}: {itemCounts.contents})
                 </span>
               )}
             </div>
@@ -220,33 +332,15 @@ export function Step3Review({
           </div>
         </CardHeader>
         <CardContent className="pt-0">
-          {formData.lessons.length > 0 ? (
-            <div className="flex flex-col gap-3">
-              {formData.lessons.map((lesson) => (
-                <div key={lesson.id} className="p-4 bg-bg-secondary rounded-lg flex items-start gap-3">
-                  <div className="w-7 h-7 rounded-md bg-btn-neutral text-white flex items-center justify-center font-medium text-sm shrink-0">
-                    {lesson.order}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-text-primary font-medium m-0">
-                      {lesson.title || `${getText('lessonNumber')} ${lesson.order}`}
-                    </p>
-                    {lesson.description && (
-                      <p className="text-text-secondary text-sm mt-1 mb-0 line-clamp-2">
-                        {lesson.description}
-                      </p>
-                    )}
-                    {lesson.contents.length > 0 && (
-                      <div className="flex items-center gap-2 mt-2">
-                        <Upload size={14} className="text-text-tertiary" />
-                        <span className="text-text-secondary text-sm">
-                          {lesson.contents.length}
-                          {getText('contentsCount')}
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                </div>
+          {formData.curriculumItems.length > 0 ? (
+            <div className="border border-border rounded-lg p-2 max-h-80 overflow-auto">
+              {formData.curriculumItems.map((item) => (
+                <CurriculumTreeItem
+                  key={item.id}
+                  item={item}
+                  expandedIds={expandedIds}
+                  onToggle={handleToggleExpand}
+                />
               ))}
             </div>
           ) : (

--- a/src/pages/tu/teaching/index.ts
+++ b/src/pages/tu/teaching/index.ts
@@ -1,3 +1,8 @@
 export { MyCoursesPage, CourseCreatePage, CourseEditPage, CourseDetailPage } from './courses';
 export { MyContentPage, ContentCreatePage as TuContentCreatePage, ContentDetailPage } from './content';
 export { MyAssignmentsPage, AssignmentDetailPage } from './assignments';
+export {
+  MyProgramsPage,
+  ProgramDetailPage as TuProgramDetailPage,
+  ProgramEditPage as TuProgramEditPage,
+} from './programs';

--- a/src/pages/tu/teaching/programs/MyProgramsPage.tsx
+++ b/src/pages/tu/teaching/programs/MyProgramsPage.tsx
@@ -1,0 +1,352 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Package,
+  Filter,
+  Loader2,
+  AlertCircle,
+  Eye,
+  Edit2,
+  Send,
+  Trash2,
+  Clock,
+  CheckCircle,
+  XCircle,
+  Archive,
+} from 'lucide-react';
+import { cn } from '@/utils/cn';
+import { Button, Badge, Card } from '@/components/common';
+import { useMyPrograms, useSubmitMyProgram, useDeleteMyProgram } from '@/hooks/tu';
+import type { ProgramStatus, ProgramResponse } from '@/types/common';
+import {
+  PROGRAM_STATUS_LABELS,
+  PROGRAM_LEVEL_LABELS,
+  PROGRAM_TYPE_LABELS,
+} from '@/types/common';
+
+interface MyProgramsPageProps {
+  language?: 'ko' | 'en';
+}
+
+const DEFAULT_THUMBNAIL =
+  'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=400&h=250&fit=crop';
+
+const t = {
+  title: { ko: '내 프로그램', en: 'My Programs' },
+  subtitle: {
+    ko: '신청한 프로그램의 상태를 확인하고 관리하세요',
+    en: 'Check the status and manage your submitted programs',
+  },
+  all: { ko: '전체', en: 'All' },
+  draft: { ko: '임시저장', en: 'Draft' },
+  pending: { ko: '검토중', en: 'Pending' },
+  approved: { ko: '승인됨', en: 'Approved' },
+  rejected: { ko: '반려됨', en: 'Rejected' },
+  closed: { ko: '종료', en: 'Closed' },
+  sortBy: { ko: '정렬', en: 'Sort By' },
+  recent: { ko: '최신순', en: 'Recent' },
+  titleSort: { ko: '제목순', en: 'Title' },
+  noPrograms: { ko: '신청한 프로그램이 없습니다', en: 'No programs found' },
+  noProgramsDesc: {
+    ko: '강의계획에서 프로그램을 신청하면 여기에 표시됩니다',
+    en: 'Programs submitted from course plans will appear here',
+  },
+  goToCourses: { ko: '강의계획으로 이동', en: 'Go to Course Plans' },
+  loading: { ko: '프로그램 목록을 불러오는 중...', en: 'Loading programs...' },
+  error: { ko: '프로그램 목록을 불러오는데 실패했습니다', en: 'Failed to load programs' },
+  retry: { ko: '다시 시도', en: 'Retry' },
+  view: { ko: '상세보기', en: 'View' },
+  edit: { ko: '수정', en: 'Edit' },
+  submit: { ko: '신청', en: 'Submit' },
+  delete: { ko: '삭제', en: 'Delete' },
+  notSet: { ko: '미설정', en: 'Not set' },
+  hours: { ko: '시간', en: 'hours' },
+  confirmSubmit: {
+    ko: '이 프로그램을 검토 신청하시겠습니까?',
+    en: 'Submit this program for review?',
+  },
+  confirmDelete: {
+    ko: '이 프로그램을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.',
+    en: 'Delete this program? This action cannot be undone.',
+  },
+  submitSuccess: {
+    ko: '프로그램이 검토 신청되었습니다.',
+    en: 'Program submitted for review.',
+  },
+  deleteSuccess: { ko: '프로그램이 삭제되었습니다.', en: 'Program deleted.' },
+};
+
+const statusBadgeVariant: Record<
+  ProgramStatus,
+  'default' | 'secondary' | 'success' | 'warning' | 'destructive'
+> = {
+  DRAFT: 'secondary',
+  PENDING: 'warning',
+  APPROVED: 'success',
+  REJECTED: 'destructive',
+  CLOSED: 'default',
+};
+
+const statusIcons: Record<ProgramStatus, React.ReactNode> = {
+  DRAFT: <Edit2 size={14} />,
+  PENDING: <Clock size={14} />,
+  APPROVED: <CheckCircle size={14} />,
+  REJECTED: <XCircle size={14} />,
+  CLOSED: <Archive size={14} />,
+};
+
+// 상태별 허용 액션
+const canEdit = (status: ProgramStatus) => status === 'DRAFT' || status === 'REJECTED';
+const canSubmit = (status: ProgramStatus) => status === 'DRAFT' || status === 'REJECTED';
+const canDelete = (status: ProgramStatus) => status === 'DRAFT' || status === 'REJECTED';
+
+export function MyProgramsPage({ language = 'ko' }: Readonly<MyProgramsPageProps>) {
+  const navigate = useNavigate();
+  const [filterStatus, setFilterStatus] = useState<'all' | ProgramStatus>('all');
+  const [sortBy, setSortBy] = useState<'recent' | 'title'>('recent');
+
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+
+  // API hooks
+  const {
+    data: programsData,
+    isLoading,
+    error,
+    refetch,
+  } = useMyPrograms(filterStatus === 'all' ? undefined : { status: filterStatus });
+
+  const submitMutation = useSubmitMyProgram();
+  const deleteMutation = useDeleteMyProgram();
+
+  // 신청 핸들러
+  const handleSubmit = async (program: ProgramResponse) => {
+    if (!confirm(getText('confirmSubmit'))) return;
+
+    try {
+      await submitMutation.mutateAsync(program.id);
+      alert(getText('submitSuccess'));
+    } catch (err) {
+      console.error('Submit failed:', err);
+      alert('신청에 실패했습니다.');
+    }
+  };
+
+  // 삭제 핸들러
+  const handleDelete = async (program: ProgramResponse) => {
+    if (!confirm(getText('confirmDelete'))) return;
+
+    try {
+      await deleteMutation.mutateAsync(program.id);
+      alert(getText('deleteSuccess'));
+    } catch (err) {
+      console.error('Delete failed:', err);
+      alert('삭제에 실패했습니다.');
+    }
+  };
+
+  // 로딩 상태
+  if (isLoading) {
+    return (
+      <div className="p-8 bg-bg-app_default min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <Loader2 size={32} className="animate-spin text-text-secondary mx-auto mb-4" />
+          <p className="text-text-secondary">{getText('loading')}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // 에러 상태
+  if (error) {
+    return (
+      <div className="p-8 bg-bg-app_default min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <AlertCircle size={48} className="text-status-error mx-auto mb-4" />
+          <p className="text-text-secondary mb-4">{getText('error')}</p>
+          <Button onClick={() => refetch()}>{getText('retry')}</Button>
+        </div>
+      </div>
+    );
+  }
+
+  const programs = programsData?.content || [];
+
+  // 정렬
+  const sortedPrograms = [...programs].sort((a, b) => {
+    if (sortBy === 'title') return a.title.localeCompare(b.title);
+    // recent: updatedAt 기준 내림차순
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+  });
+
+  const isActionPending = submitMutation.isPending || deleteMutation.isPending;
+
+  return (
+    <div className="p-8 bg-bg-app_default min-h-screen">
+      {/* Header */}
+      <div className="mb-8">
+        <h1 className="text-text-primary mb-2">{getText('title')}</h1>
+        <p className="text-text-secondary m-0">{getText('subtitle')}</p>
+      </div>
+
+      {/* Filters & Sort */}
+      <div className="mb-6 flex gap-4 items-center flex-wrap">
+        <div className="flex gap-2 items-center">
+          <Filter size={18} className="text-text-secondary" />
+          <div className="flex gap-1 bg-bg-secondary p-1 rounded-lg">
+            {(['all', 'DRAFT', 'PENDING', 'APPROVED', 'REJECTED', 'CLOSED'] as const).map(
+              (status) => (
+                <button
+                  key={status}
+                  onClick={() => setFilterStatus(status)}
+                  className={cn(
+                    'px-4 py-1.5 rounded-md text-sm transition-colors',
+                    filterStatus === status
+                      ? 'bg-btn-neutral text-white font-medium'
+                      : 'bg-transparent text-text-secondary hover:bg-bg-secondary'
+                  )}
+                >
+                  {status === 'all'
+                    ? getText('all')
+                    : PROGRAM_STATUS_LABELS[status as ProgramStatus]}
+                </button>
+              )
+            )}
+          </div>
+        </div>
+
+        <div className="flex gap-2 items-center ml-auto">
+          <span className="text-sm text-text-secondary">{getText('sortBy')}:</span>
+          <select
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value as 'recent' | 'title')}
+            className="px-3 py-2 bg-bg-secondary text-text-primary border border-border rounded-md text-sm cursor-pointer"
+          >
+            <option value="recent">{getText('recent')}</option>
+            <option value="title">{getText('titleSort')}</option>
+          </select>
+        </div>
+      </div>
+
+      {/* Program Grid */}
+      {sortedPrograms.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {sortedPrograms.map((program) => (
+            <Card key={program.id} className="overflow-hidden">
+              {/* Thumbnail */}
+              <div className="aspect-video relative overflow-hidden bg-bg-secondary">
+                <img
+                  src={program.thumbnailUrl || DEFAULT_THUMBNAIL}
+                  alt={program.title}
+                  className="w-full h-full object-cover"
+                />
+                <div className="absolute top-3 left-3">
+                  <Badge
+                    variant={statusBadgeVariant[program.status]}
+                    className="flex items-center gap-1"
+                  >
+                    {statusIcons[program.status]}
+                    {PROGRAM_STATUS_LABELS[program.status]}
+                  </Badge>
+                </div>
+              </div>
+
+              {/* Content */}
+              <div className="p-4">
+                <h3 className="text-text-primary font-medium mb-2 line-clamp-2">
+                  {program.title}
+                </h3>
+
+                {program.description && (
+                  <p className="text-text-secondary text-sm mb-3 line-clamp-2">
+                    {program.description}
+                  </p>
+                )}
+
+                {/* Meta Info */}
+                <div className="flex flex-wrap gap-2 text-xs text-text-secondary mb-4">
+                  {program.level && (
+                    <span className="px-2 py-1 bg-bg-secondary rounded">
+                      {PROGRAM_LEVEL_LABELS[program.level]}
+                    </span>
+                  )}
+                  {program.type && (
+                    <span className="px-2 py-1 bg-bg-secondary rounded">
+                      {PROGRAM_TYPE_LABELS[program.type]}
+                    </span>
+                  )}
+                  {program.estimatedHours && (
+                    <span className="px-2 py-1 bg-bg-secondary rounded">
+                      {program.estimatedHours} {getText('hours')}
+                    </span>
+                  )}
+                </div>
+
+                {/* Actions */}
+                <div className="flex gap-2">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="flex-1 border border-border"
+                    onClick={() => navigate(`/tu/teaching/programs/${program.id}`)}
+                  >
+                    <Eye size={14} />
+                    {getText('view')}
+                  </Button>
+
+                  {canEdit(program.status) && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="flex-1 border border-border"
+                      onClick={() => navigate(`/tu/teaching/programs/${program.id}/edit`)}
+                    >
+                      <Edit2 size={14} />
+                      {getText('edit')}
+                    </Button>
+                  )}
+
+                  {canSubmit(program.status) && (
+                    <Button
+                      size="sm"
+                      className="flex-1"
+                      onClick={() => handleSubmit(program)}
+                      disabled={isActionPending}
+                    >
+                      {submitMutation.isPending ? (
+                        <Loader2 size={14} className="animate-spin" />
+                      ) : (
+                        <Send size={14} />
+                      )}
+                      {getText('submit')}
+                    </Button>
+                  )}
+
+                  {canDelete(program.status) && (
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      onClick={() => handleDelete(program)}
+                      disabled={isActionPending}
+                    >
+                      <Trash2 size={14} />
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      ) : (
+        /* Empty State */
+        <div className="text-center py-20 px-5 bg-bg-secondary rounded-xl border border-border">
+          <Package size={64} className="text-text-secondary mb-4 opacity-30 mx-auto" />
+          <h3 className="text-text-primary mb-2">{getText('noPrograms')}</h3>
+          <p className="text-text-secondary mb-6">{getText('noProgramsDesc')}</p>
+          <Button onClick={() => navigate('/tu/teaching/courses')}>
+            {getText('goToCourses')}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/tu/teaching/programs/ProgramDetailPage.tsx
+++ b/src/pages/tu/teaching/programs/ProgramDetailPage.tsx
@@ -1,0 +1,239 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  ArrowLeft,
+  Edit2,
+  Trash2,
+  Send,
+  Loader2,
+  AlertCircle,
+  Clock,
+  CheckCircle,
+  XCircle,
+  Archive,
+} from 'lucide-react';
+import { Button, Badge } from '@/components/common';
+import {
+  useMyProgram,
+  useMyProgramSnapshot,
+  useSubmitMyProgram,
+  useDeleteMyProgram,
+} from '@/hooks/tu';
+import type { ProgramStatus } from '@/types/common';
+import { PROGRAM_STATUS_LABELS } from '@/types/common';
+import { ProgramInfoSection } from './components/ProgramInfoSection';
+import { ProgramSnapshotSection } from './components/ProgramSnapshotSection';
+
+interface ProgramDetailPageProps {
+  language?: 'ko' | 'en';
+}
+
+const t = {
+  back: { ko: '목록으로', en: 'Back to List' },
+  loading: { ko: '로딩 중...', en: 'Loading...' },
+  error: { ko: '프로그램을 불러오는데 실패했습니다.', en: 'Failed to load program.' },
+  notFound: { ko: '프로그램을 찾을 수 없습니다.', en: 'Program not found.' },
+  edit: { ko: '수정', en: 'Edit' },
+  submit: { ko: '검토 신청', en: 'Submit for Review' },
+  delete: { ko: '삭제', en: 'Delete' },
+  confirmSubmit: {
+    ko: '이 프로그램을 검토 신청하시겠습니까?',
+    en: 'Submit this program for review?',
+  },
+  confirmDelete: {
+    ko: '이 프로그램을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.',
+    en: 'Delete this program? This action cannot be undone.',
+  },
+  submitSuccess: {
+    ko: '프로그램이 검토 신청되었습니다.',
+    en: 'Program submitted for review.',
+  },
+  deleteSuccess: { ko: '프로그램이 삭제되었습니다.', en: 'Program deleted.' },
+};
+
+const statusBadgeVariant: Record<
+  ProgramStatus,
+  'default' | 'secondary' | 'success' | 'warning' | 'destructive'
+> = {
+  DRAFT: 'secondary',
+  PENDING: 'warning',
+  APPROVED: 'success',
+  REJECTED: 'destructive',
+  CLOSED: 'default',
+};
+
+const statusIcons: Record<ProgramStatus, React.ReactNode> = {
+  DRAFT: <Edit2 size={14} />,
+  PENDING: <Clock size={14} />,
+  APPROVED: <CheckCircle size={14} />,
+  REJECTED: <XCircle size={14} />,
+  CLOSED: <Archive size={14} />,
+};
+
+// 상태별 허용 액션
+const canEdit = (status: ProgramStatus) => status === 'DRAFT' || status === 'REJECTED';
+const canSubmit = (status: ProgramStatus) => status === 'DRAFT' || status === 'REJECTED';
+const canDelete = (status: ProgramStatus) => status === 'DRAFT' || status === 'REJECTED';
+
+export function ProgramDetailPage({ language = 'ko' }: Readonly<ProgramDetailPageProps>) {
+  const { programId } = useParams<{ programId: string }>();
+  const navigate = useNavigate();
+  const id = programId ? parseInt(programId, 10) : 0;
+
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+
+  // API hooks
+  const { data: program, isLoading, error } = useMyProgram(id);
+  const { data: snapshot } = useMyProgramSnapshot(program?.snapshotId || 0);
+  const submitMutation = useSubmitMyProgram();
+  const deleteMutation = useDeleteMyProgram();
+
+  // 신청 핸들러
+  const handleSubmit = async () => {
+    if (!confirm(getText('confirmSubmit'))) return;
+
+    try {
+      await submitMutation.mutateAsync(id);
+      alert(getText('submitSuccess'));
+    } catch (err) {
+      console.error('Submit failed:', err);
+      alert('신청에 실패했습니다.');
+    }
+  };
+
+  // 삭제 핸들러
+  const handleDelete = async () => {
+    if (!confirm(getText('confirmDelete'))) return;
+
+    try {
+      await deleteMutation.mutateAsync(id);
+      alert(getText('deleteSuccess'));
+      navigate('/tu/teaching/programs');
+    } catch (err) {
+      console.error('Delete failed:', err);
+      alert('삭제에 실패했습니다.');
+    }
+  };
+
+  const isActionPending = submitMutation.isPending || deleteMutation.isPending;
+
+  // 로딩 상태
+  if (isLoading) {
+    return (
+      <div className="h-full flex items-center justify-center bg-bg-app">
+        <Loader2 size={32} className="animate-spin text-text-secondary" />
+        <span className="ml-2 text-text-secondary">{getText('loading')}</span>
+      </div>
+    );
+  }
+
+  // 에러 상태
+  if (error || !program) {
+    return (
+      <div className="h-full flex items-center justify-center bg-bg-app">
+        <div className="text-center">
+          <AlertCircle size={48} className="mx-auto mb-3 text-status-error" />
+          <p className="text-text-secondary">
+            {error ? getText('error') : getText('notFound')}
+          </p>
+          <Button
+            variant="ghost"
+            className="mt-4 border border-border"
+            onClick={() => navigate('/tu/teaching/programs')}
+          >
+            <ArrowLeft size={16} />
+            {getText('back')}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col bg-bg-app">
+      {/* Header */}
+      <div className="border-b border-border bg-bg-default sticky top-0 z-10">
+        <div className="p-6 px-8">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="border border-border"
+                onClick={() => navigate('/tu/teaching/programs')}
+              >
+                <ArrowLeft size={16} />
+                {getText('back')}
+              </Button>
+              <div>
+                <div className="flex items-center gap-3">
+                  <h1 className="text-text-primary text-xl mb-0">{program.title}</h1>
+                  <Badge
+                    variant={statusBadgeVariant[program.status]}
+                    className="flex items-center gap-1"
+                  >
+                    {statusIcons[program.status]}
+                    {PROGRAM_STATUS_LABELS[program.status]}
+                  </Badge>
+                </div>
+                <p className="text-text-secondary text-sm mt-1">ID: {program.id}</p>
+              </div>
+            </div>
+
+            {/* Action Buttons */}
+            <div className="flex items-center gap-2">
+              {canSubmit(program.status) && (
+                <Button size="sm" onClick={handleSubmit} disabled={isActionPending}>
+                  {submitMutation.isPending ? (
+                    <Loader2 size={16} className="animate-spin" />
+                  ) : (
+                    <Send size={16} />
+                  )}
+                  {getText('submit')}
+                </Button>
+              )}
+
+              {canEdit(program.status) && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="border border-border"
+                  onClick={() => navigate(`/tu/teaching/programs/${id}/edit`)}
+                >
+                  <Edit2 size={16} />
+                  {getText('edit')}
+                </Button>
+              )}
+
+              {canDelete(program.status) && (
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={handleDelete}
+                  disabled={isActionPending}
+                >
+                  {deleteMutation.isPending ? (
+                    <Loader2 size={16} className="animate-spin" />
+                  ) : (
+                    <Trash2 size={16} />
+                  )}
+                  {getText('delete')}
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto">
+        <div className="p-6 px-8 max-w-5xl space-y-6">
+          {/* 기본 정보 섹션 */}
+          <ProgramInfoSection program={program} language={language} />
+
+          {/* 스냅샷 섹션 */}
+          <ProgramSnapshotSection snapshot={snapshot || null} language={language} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/teaching/programs/ProgramEditPage.tsx
+++ b/src/pages/tu/teaching/programs/ProgramEditPage.tsx
@@ -1,0 +1,243 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { ArrowLeft, Save, Loader2, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/common';
+import {
+  useMyProgram,
+  useSnapshotItems,
+  useUpdateMyProgram,
+  useUpdateSnapshot,
+} from '@/hooks/tu';
+import type { ProgramStatus } from '@/types/common';
+import { ProgramBasicInfoForm, type ProgramFormData } from './components/ProgramBasicInfoForm';
+import { SnapshotItemTree } from './components/SnapshotItemTree';
+
+interface ProgramEditPageProps {
+  language?: 'ko' | 'en';
+}
+
+const t = {
+  back: { ko: '취소', en: 'Cancel' },
+  loading: { ko: '로딩 중...', en: 'Loading...' },
+  error: { ko: '프로그램을 불러오는데 실패했습니다.', en: 'Failed to load program.' },
+  notFound: { ko: '프로그램을 찾을 수 없습니다.', en: 'Program not found.' },
+  notEditable: {
+    ko: '이 프로그램은 수정할 수 없는 상태입니다.',
+    en: 'This program cannot be edited.',
+  },
+  save: { ko: '저장', en: 'Save' },
+  saving: { ko: '저장 중...', en: 'Saving...' },
+  saveSuccess: { ko: '저장되었습니다.', en: 'Saved successfully.' },
+  saveFailed: { ko: '저장에 실패했습니다.', en: 'Failed to save.' },
+  titleRequired: { ko: '프로그램명을 입력해주세요.', en: 'Please enter a program title.' },
+  editProgram: { ko: '프로그램 수정', en: 'Edit Program' },
+};
+
+// 수정 가능한 상태
+const canEdit = (status: ProgramStatus) => status === 'DRAFT' || status === 'REJECTED';
+
+export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPageProps>) {
+  const { programId } = useParams<{ programId: string }>();
+  const navigate = useNavigate();
+  const id = programId ? parseInt(programId, 10) : 0;
+
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+
+  // Form state
+  const [formData, setFormData] = useState<ProgramFormData>({
+    title: '',
+    description: '',
+    thumbnailUrl: '',
+    level: '',
+    type: '',
+    estimatedHours: null,
+  });
+
+  // API hooks
+  const { data: program, isLoading, error, refetch: refetchProgram } = useMyProgram(id);
+  const {
+    data: snapshotItems,
+    refetch: refetchItems,
+  } = useSnapshotItems(program?.snapshotId || 0);
+
+  const updateProgramMutation = useUpdateMyProgram();
+  const updateSnapshotMutation = useUpdateSnapshot();
+
+  // 프로그램 데이터로 폼 초기화
+  useEffect(() => {
+    if (program) {
+      setFormData({
+        title: program.title || '',
+        description: program.description || '',
+        thumbnailUrl: program.thumbnailUrl || '',
+        level: program.level || '',
+        type: program.type || '',
+        estimatedHours: program.estimatedHours || null,
+      });
+    }
+  }, [program]);
+
+  // 폼 데이터 변경 핸들러
+  const handleFormDataChange = (data: Partial<ProgramFormData>) => {
+    setFormData((prev) => ({ ...prev, ...data }));
+  };
+
+  // 저장 핸들러
+  const handleSave = async () => {
+    // 유효성 검사
+    if (!formData.title.trim()) {
+      alert(getText('titleRequired'));
+      return;
+    }
+
+    try {
+      // 프로그램 기본 정보 저장
+      await updateProgramMutation.mutateAsync({
+        id,
+        request: {
+          title: formData.title.trim(),
+          description: formData.description.trim() || undefined,
+          thumbnailUrl: formData.thumbnailUrl.trim() || undefined,
+          level: formData.level || undefined,
+          type: formData.type || undefined,
+          estimatedHours: formData.estimatedHours || undefined,
+        },
+      });
+
+      // 스냅샷 기본 정보도 업데이트 (이름 동기화)
+      if (program?.snapshotId) {
+        await updateSnapshotMutation.mutateAsync({
+          id: program.snapshotId,
+          request: {
+            snapshotName: formData.title.trim(),
+            description: formData.description.trim() || undefined,
+          },
+        });
+      }
+
+      alert(getText('saveSuccess'));
+      refetchProgram();
+    } catch (err) {
+      console.error('Save failed:', err);
+      alert(getText('saveFailed'));
+    }
+  };
+
+  // 스냅샷 아이템 변경 시 리프레시
+  const handleItemsChange = () => {
+    refetchItems();
+  };
+
+  const isSaving = updateProgramMutation.isPending || updateSnapshotMutation.isPending;
+
+  // 로딩 상태
+  if (isLoading) {
+    return (
+      <div className="h-full flex items-center justify-center bg-bg-app">
+        <Loader2 size={32} className="animate-spin text-text-secondary" />
+        <span className="ml-2 text-text-secondary">{getText('loading')}</span>
+      </div>
+    );
+  }
+
+  // 에러 상태
+  if (error || !program) {
+    return (
+      <div className="h-full flex items-center justify-center bg-bg-app">
+        <div className="text-center">
+          <AlertCircle size={48} className="mx-auto mb-3 text-status-error" />
+          <p className="text-text-secondary">
+            {error ? getText('error') : getText('notFound')}
+          </p>
+          <Button
+            variant="ghost"
+            className="mt-4 border border-border"
+            onClick={() => navigate('/tu/teaching/programs')}
+          >
+            <ArrowLeft size={16} />
+            목록으로
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // 수정 불가 상태
+  if (!canEdit(program.status)) {
+    return (
+      <div className="h-full flex items-center justify-center bg-bg-app">
+        <div className="text-center">
+          <AlertCircle size={48} className="mx-auto mb-3 text-status-warning" />
+          <p className="text-text-secondary">{getText('notEditable')}</p>
+          <Button
+            variant="ghost"
+            className="mt-4 border border-border"
+            onClick={() => navigate(`/tu/teaching/programs/${id}`)}
+          >
+            <ArrowLeft size={16} />
+            상세보기로 이동
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col bg-bg-app">
+      {/* Header */}
+      <div className="border-b border-border bg-bg-default sticky top-0 z-10">
+        <div className="p-6 px-8">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="border border-border"
+                onClick={() => navigate(`/tu/teaching/programs/${id}`)}
+              >
+                <ArrowLeft size={16} />
+                {getText('back')}
+              </Button>
+              <div>
+                <h1 className="text-text-primary text-xl mb-0">{getText('editProgram')}</h1>
+                <p className="text-text-secondary text-sm mt-1">{program.title}</p>
+              </div>
+            </div>
+
+            {/* Save Button */}
+            <Button onClick={handleSave} disabled={isSaving}>
+              {isSaving ? (
+                <Loader2 size={16} className="animate-spin" />
+              ) : (
+                <Save size={16} />
+              )}
+              {isSaving ? getText('saving') : getText('save')}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto">
+        <div className="p-6 px-8 max-w-5xl space-y-6">
+          {/* 기본 정보 폼 */}
+          <ProgramBasicInfoForm
+            formData={formData}
+            onFormDataChange={handleFormDataChange}
+            language={language}
+          />
+
+          {/* 스냅샷 아이템 트리 */}
+          {program.snapshotId && (
+            <SnapshotItemTree
+              snapshotId={program.snapshotId}
+              items={snapshotItems || []}
+              onItemsChange={handleItemsChange}
+              language={language}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/teaching/programs/components/ProgramBasicInfoForm.tsx
+++ b/src/pages/tu/teaching/programs/components/ProgramBasicInfoForm.tsx
@@ -1,0 +1,169 @@
+import { Card, Label, Input, Textarea, NativeSelect } from '@/components/common';
+import { Image } from 'lucide-react';
+import type { ProgramLevel, ProgramType } from '@/types/common';
+
+export interface ProgramFormData {
+  title: string;
+  description: string;
+  thumbnailUrl: string;
+  level: ProgramLevel | '';
+  type: ProgramType | '';
+  estimatedHours: number | null;
+}
+
+interface ProgramBasicInfoFormProps {
+  formData: ProgramFormData;
+  onFormDataChange: (data: Partial<ProgramFormData>) => void;
+  language?: 'ko' | 'en';
+}
+
+const t = {
+  basicInfo: { ko: '기본 정보', en: 'Basic Information' },
+  title: { ko: '프로그램명', en: 'Program Title' },
+  titlePlaceholder: { ko: '프로그램 제목을 입력하세요', en: 'Enter program title' },
+  titleRequired: { ko: '* 필수', en: '* Required' },
+  description: { ko: '설명', en: 'Description' },
+  descriptionPlaceholder: {
+    ko: '프로그램에 대한 설명을 입력하세요',
+    en: 'Enter program description',
+  },
+  thumbnailUrl: { ko: '썸네일 URL', en: 'Thumbnail URL' },
+  thumbnailPlaceholder: { ko: 'https://example.com/image.jpg', en: 'https://example.com/image.jpg' },
+  level: { ko: '난이도', en: 'Level' },
+  selectLevel: { ko: '난이도 선택', en: 'Select level' },
+  beginner: { ko: '초급', en: 'Beginner' },
+  intermediate: { ko: '중급', en: 'Intermediate' },
+  advanced: { ko: '고급', en: 'Advanced' },
+  type: { ko: '유형', en: 'Type' },
+  selectType: { ko: '유형 선택', en: 'Select type' },
+  online: { ko: '온라인', en: 'Online' },
+  offline: { ko: '오프라인', en: 'Offline' },
+  blended: { ko: '블렌디드', en: 'Blended' },
+  estimatedHours: { ko: '예상 학습시간 (시간)', en: 'Estimated Hours' },
+  estimatedHoursPlaceholder: { ko: '예: 10', en: 'e.g., 10' },
+  preview: { ko: '미리보기', en: 'Preview' },
+};
+
+export function ProgramBasicInfoForm({
+  formData,
+  onFormDataChange,
+  language = 'ko',
+}: Readonly<ProgramBasicInfoFormProps>) {
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+
+  const handleChange = (field: keyof ProgramFormData, value: string | number | null) => {
+    onFormDataChange({ [field]: value });
+  };
+
+  return (
+    <Card>
+      <div className="p-5">
+        <h2 className="text-base font-medium text-text-primary mb-6">{getText('basicInfo')}</h2>
+
+        <div className="space-y-5">
+          {/* 프로그램명 */}
+          <div>
+            <Label className="text-text-primary mb-2 flex items-center gap-2">
+              {getText('title')}
+              <span className="text-status-error text-xs">{getText('titleRequired')}</span>
+            </Label>
+            <Input
+              value={formData.title}
+              onChange={(e) => handleChange('title', e.target.value)}
+              placeholder={getText('titlePlaceholder')}
+            />
+          </div>
+
+          {/* 설명 */}
+          <div>
+            <Label className="text-text-primary mb-2">{getText('description')}</Label>
+            <Textarea
+              value={formData.description}
+              onChange={(e) => handleChange('description', e.target.value)}
+              placeholder={getText('descriptionPlaceholder')}
+              rows={4}
+            />
+          </div>
+
+          {/* 썸네일 URL */}
+          <div>
+            <Label className="text-text-primary mb-2">{getText('thumbnailUrl')}</Label>
+            <Input
+              value={formData.thumbnailUrl}
+              onChange={(e) => handleChange('thumbnailUrl', e.target.value)}
+              placeholder={getText('thumbnailPlaceholder')}
+            />
+            {formData.thumbnailUrl && (
+              <div className="mt-3">
+                <Label className="text-text-secondary text-xs mb-1">{getText('preview')}</Label>
+                <div className="w-48 aspect-video rounded-lg overflow-hidden bg-bg-secondary">
+                  <img
+                    src={formData.thumbnailUrl}
+                    alt="Thumbnail preview"
+                    className="w-full h-full object-cover"
+                    onError={(e) => {
+                      (e.target as HTMLImageElement).style.display = 'none';
+                    }}
+                  />
+                </div>
+              </div>
+            )}
+            {!formData.thumbnailUrl && (
+              <div className="mt-3 w-48 aspect-video rounded-lg bg-bg-secondary flex items-center justify-center">
+                <Image size={24} className="text-text-placeholder" />
+              </div>
+            )}
+          </div>
+
+          {/* 난이도, 유형, 예상시간 그리드 */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {/* 난이도 */}
+            <div>
+              <Label className="text-text-primary mb-2">{getText('level')}</Label>
+              <NativeSelect
+                value={formData.level}
+                onChange={(e) => handleChange('level', e.target.value as ProgramLevel | '')}
+              >
+                <option value="">{getText('selectLevel')}</option>
+                <option value="BEGINNER">{getText('beginner')}</option>
+                <option value="INTERMEDIATE">{getText('intermediate')}</option>
+                <option value="ADVANCED">{getText('advanced')}</option>
+              </NativeSelect>
+            </div>
+
+            {/* 유형 */}
+            <div>
+              <Label className="text-text-primary mb-2">{getText('type')}</Label>
+              <NativeSelect
+                value={formData.type}
+                onChange={(e) => handleChange('type', e.target.value as ProgramType | '')}
+              >
+                <option value="">{getText('selectType')}</option>
+                <option value="ONLINE">{getText('online')}</option>
+                <option value="OFFLINE">{getText('offline')}</option>
+                <option value="BLENDED">{getText('blended')}</option>
+              </NativeSelect>
+            </div>
+
+            {/* 예상 학습시간 */}
+            <div>
+              <Label className="text-text-primary mb-2">{getText('estimatedHours')}</Label>
+              <Input
+                type="number"
+                min={0}
+                value={formData.estimatedHours ?? ''}
+                onChange={(e) =>
+                  handleChange(
+                    'estimatedHours',
+                    e.target.value ? parseInt(e.target.value, 10) : null
+                  )
+                }
+                placeholder={getText('estimatedHoursPlaceholder')}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/pages/tu/teaching/programs/components/ProgramBasicInfoForm.tsx
+++ b/src/pages/tu/teaching/programs/components/ProgramBasicInfoForm.tsx
@@ -123,12 +123,13 @@ export function ProgramBasicInfoForm({
               <NativeSelect
                 value={formData.level}
                 onChange={(e) => handleChange('level', e.target.value as ProgramLevel | '')}
-              >
-                <option value="">{getText('selectLevel')}</option>
-                <option value="BEGINNER">{getText('beginner')}</option>
-                <option value="INTERMEDIATE">{getText('intermediate')}</option>
-                <option value="ADVANCED">{getText('advanced')}</option>
-              </NativeSelect>
+                options={[
+                  { value: '', label: getText('selectLevel') },
+                  { value: 'BEGINNER', label: getText('beginner') },
+                  { value: 'INTERMEDIATE', label: getText('intermediate') },
+                  { value: 'ADVANCED', label: getText('advanced') },
+                ]}
+              />
             </div>
 
             {/* 유형 */}
@@ -137,12 +138,13 @@ export function ProgramBasicInfoForm({
               <NativeSelect
                 value={formData.type}
                 onChange={(e) => handleChange('type', e.target.value as ProgramType | '')}
-              >
-                <option value="">{getText('selectType')}</option>
-                <option value="ONLINE">{getText('online')}</option>
-                <option value="OFFLINE">{getText('offline')}</option>
-                <option value="BLENDED">{getText('blended')}</option>
-              </NativeSelect>
+                options={[
+                  { value: '', label: getText('selectType') },
+                  { value: 'ONLINE', label: getText('online') },
+                  { value: 'OFFLINE', label: getText('offline') },
+                  { value: 'BLENDED', label: getText('blended') },
+                ]}
+              />
             </div>
 
             {/* 예상 학습시간 */}

--- a/src/pages/tu/teaching/programs/components/ProgramInfoSection.tsx
+++ b/src/pages/tu/teaching/programs/components/ProgramInfoSection.tsx
@@ -1,0 +1,242 @@
+import { Card, Label } from '@/components/common';
+import { Image, Clock, User, Calendar, CheckCircle, XCircle } from 'lucide-react';
+import type { ProgramDetailResponse } from '@/types/common';
+import { PROGRAM_LEVEL_LABELS, PROGRAM_TYPE_LABELS } from '@/types/common';
+
+interface ProgramInfoSectionProps {
+  program: ProgramDetailResponse;
+  language?: 'ko' | 'en';
+}
+
+const t = {
+  basicInfo: { ko: '기본 정보', en: 'Basic Information' },
+  thumbnail: { ko: '썸네일', en: 'Thumbnail' },
+  description: { ko: '설명', en: 'Description' },
+  level: { ko: '난이도', en: 'Level' },
+  type: { ko: '유형', en: 'Type' },
+  estimatedHours: { ko: '예상 학습시간', en: 'Estimated Hours' },
+  creator: { ko: '생성자', en: 'Creator' },
+  createdAt: { ko: '생성일', en: 'Created At' },
+  updatedAt: { ko: '수정일', en: 'Updated At' },
+  submittedAt: { ko: '제출일', en: 'Submitted At' },
+  approvalInfo: { ko: '승인 정보', en: 'Approval Info' },
+  approvedBy: { ko: '승인자', en: 'Approved By' },
+  approvedAt: { ko: '승인일', en: 'Approved At' },
+  approvalComment: { ko: '승인 코멘트', en: 'Approval Comment' },
+  rejectionInfo: { ko: '반려 정보', en: 'Rejection Info' },
+  rejectedAt: { ko: '반려일', en: 'Rejected At' },
+  rejectionReason: { ko: '반려 사유', en: 'Rejection Reason' },
+  notSet: { ko: '미설정', en: 'Not set' },
+  noDescription: { ko: '설명이 없습니다.', en: 'No description.' },
+  hours: { ko: '시간', en: 'hours' },
+};
+
+export function ProgramInfoSection({
+  program,
+  language = 'ko',
+}: Readonly<ProgramInfoSectionProps>) {
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+
+  const formatDate = (dateStr: string | null) => {
+    if (!dateStr) return getText('notSet');
+    return new Date(dateStr).toLocaleDateString(language === 'ko' ? 'ko-KR' : 'en-US', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* 기본 정보 */}
+      <Card>
+        <div className="p-5">
+          <h2 className="text-base font-medium text-text-primary mb-4">
+            {getText('basicInfo')}
+          </h2>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {/* 썸네일 */}
+            <div className="md:col-span-1">
+              <Label className="text-text-secondary text-xs uppercase tracking-wide mb-2 block">
+                {getText('thumbnail')}
+              </Label>
+              {program.thumbnailUrl ? (
+                <div className="aspect-video rounded-lg overflow-hidden bg-bg-secondary">
+                  <img
+                    src={program.thumbnailUrl}
+                    alt={program.title}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+              ) : (
+                <div className="aspect-video rounded-lg bg-bg-secondary flex items-center justify-center">
+                  <Image size={32} className="text-text-placeholder" />
+                </div>
+              )}
+            </div>
+
+            {/* 상세 정보 */}
+            <div className="md:col-span-2 space-y-4">
+              {/* 설명 */}
+              <div>
+                <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                  {getText('description')}
+                </Label>
+                <p className="text-text-primary mt-1 whitespace-pre-wrap">
+                  {program.description || getText('noDescription')}
+                </p>
+              </div>
+
+              {/* 그리드 정보 */}
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <div>
+                  <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                    {getText('level')}
+                  </Label>
+                  <p className="text-text-primary mt-1 font-medium">
+                    {program.level ? PROGRAM_LEVEL_LABELS[program.level] : getText('notSet')}
+                  </p>
+                </div>
+                <div>
+                  <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                    {getText('type')}
+                  </Label>
+                  <p className="text-text-primary mt-1 font-medium">
+                    {program.type ? PROGRAM_TYPE_LABELS[program.type] : getText('notSet')}
+                  </p>
+                </div>
+                <div>
+                  <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                    {getText('estimatedHours')}
+                  </Label>
+                  <p className="text-text-primary mt-1 font-medium flex items-center gap-1">
+                    <Clock size={14} className="text-text-secondary" />
+                    {program.estimatedHours
+                      ? `${program.estimatedHours} ${getText('hours')}`
+                      : getText('notSet')}
+                  </p>
+                </div>
+                <div>
+                  <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                    {getText('creator')}
+                  </Label>
+                  <p className="text-text-primary mt-1 font-medium flex items-center gap-1">
+                    <User size={14} className="text-text-secondary" />
+                    {program.creatorName || getText('notSet')}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      {/* 일시 정보 */}
+      <Card>
+        <div className="p-5">
+          <h2 className="text-base font-medium text-text-primary mb-4 flex items-center gap-2">
+            <Calendar size={18} className="text-text-secondary" />
+            일시 정보
+          </h2>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
+            <div>
+              <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                {getText('createdAt')}
+              </Label>
+              <p className="text-text-primary mt-1 text-sm">{formatDate(program.createdAt)}</p>
+            </div>
+            <div>
+              <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                {getText('updatedAt')}
+              </Label>
+              <p className="text-text-primary mt-1 text-sm">{formatDate(program.updatedAt)}</p>
+            </div>
+            {program.submittedAt && (
+              <div>
+                <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                  {getText('submittedAt')}
+                </Label>
+                <p className="text-text-primary mt-1 text-sm">
+                  {formatDate(program.submittedAt)}
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </Card>
+
+      {/* 승인 정보 */}
+      {program.status === 'APPROVED' && program.approvedAt && (
+        <Card className="border-l-4 border-l-status-success">
+          <div className="p-5">
+            <h2 className="text-base font-medium text-text-primary mb-4 flex items-center gap-2">
+              <CheckCircle size={18} className="text-status-success" />
+              {getText('approvalInfo')}
+            </h2>
+            <div className="grid grid-cols-2 gap-6">
+              <div>
+                <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                  {getText('approvedBy')}
+                </Label>
+                <p className="text-text-primary mt-1">
+                  {program.approvedByName || getText('notSet')}
+                </p>
+              </div>
+              <div>
+                <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                  {getText('approvedAt')}
+                </Label>
+                <p className="text-text-primary mt-1 text-sm">
+                  {formatDate(program.approvedAt)}
+                </p>
+              </div>
+            </div>
+            {program.approvalComment && (
+              <div className="mt-4 pt-4 border-t border-border">
+                <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                  {getText('approvalComment')}
+                </Label>
+                <p className="text-text-primary mt-1 whitespace-pre-wrap">
+                  {program.approvalComment}
+                </p>
+              </div>
+            )}
+          </div>
+        </Card>
+      )}
+
+      {/* 반려 정보 */}
+      {program.status === 'REJECTED' && program.rejectedAt && (
+        <Card className="border-l-4 border-l-status-error">
+          <div className="p-5">
+            <h2 className="text-base font-medium text-text-primary mb-4 flex items-center gap-2">
+              <XCircle size={18} className="text-status-error" />
+              {getText('rejectionInfo')}
+            </h2>
+            <div className="mb-4">
+              <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                {getText('rejectedAt')}
+              </Label>
+              <p className="text-text-primary mt-1 text-sm">
+                {formatDate(program.rejectedAt)}
+              </p>
+            </div>
+            {program.rejectionReason && (
+              <div className="pt-4 border-t border-border">
+                <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                  {getText('rejectionReason')}
+                </Label>
+                <p className="text-text-primary mt-1 whitespace-pre-wrap">
+                  {program.rejectionReason}
+                </p>
+              </div>
+            )}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/pages/tu/teaching/programs/components/ProgramSnapshotSection.tsx
+++ b/src/pages/tu/teaching/programs/components/ProgramSnapshotSection.tsx
@@ -159,10 +159,10 @@ export function ProgramSnapshotSection({
                   {getText('hashtags')}
                 </Label>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {snapshot.hashtags.map((tag) => (
-                    <Badge key={tag} variant="secondary" className="flex items-center gap-1">
+                  {snapshot.hashtags.split(',').map((tag) => (
+                    <Badge key={tag.trim()} variant="secondary" className="flex items-center gap-1">
                       <Hash size={12} />
-                      {tag}
+                      {tag.trim()}
                     </Badge>
                   ))}
                 </div>

--- a/src/pages/tu/teaching/programs/components/ProgramSnapshotSection.tsx
+++ b/src/pages/tu/teaching/programs/components/ProgramSnapshotSection.tsx
@@ -1,0 +1,216 @@
+import { useState } from 'react';
+import { Card, Label, Badge } from '@/components/common';
+import { Layers, Folder, FileText, ChevronRight, ChevronDown, Hash, Clock } from 'lucide-react';
+import type { SnapshotDetailResponse, SnapshotItemResponse } from '@/types/common';
+
+interface ProgramSnapshotSectionProps {
+  snapshot: SnapshotDetailResponse | null;
+  language?: 'ko' | 'en';
+}
+
+const t = {
+  snapshotInfo: { ko: '스냅샷 정보', en: 'Snapshot Info' },
+  noSnapshot: { ko: '연결된 스냅샷이 없습니다.', en: 'No snapshot linked.' },
+  snapshotName: { ko: '스냅샷명', en: 'Snapshot Name' },
+  description: { ko: '설명', en: 'Description' },
+  hashtags: { ko: '해시태그', en: 'Hashtags' },
+  status: { ko: '상태', en: 'Status' },
+  itemCount: { ko: '아이템 수', en: 'Item Count' },
+  totalDuration: { ko: '총 학습시간', en: 'Total Duration' },
+  curriculum: { ko: '커리큘럼', en: 'Curriculum' },
+  noItems: { ko: '아이템이 없습니다.', en: 'No items.' },
+  minutes: { ko: '분', en: 'min' },
+  items: { ko: '개', en: 'items' },
+};
+
+const snapshotStatusLabels: Record<string, { ko: string; en: string }> = {
+  DRAFT: { ko: '초안', en: 'Draft' },
+  ACTIVE: { ko: '활성', en: 'Active' },
+  COMPLETED: { ko: '완료', en: 'Completed' },
+  ARCHIVED: { ko: '보관', en: 'Archived' },
+};
+
+interface SnapshotTreeItemProps {
+  item: SnapshotItemResponse;
+  language: 'ko' | 'en';
+}
+
+function SnapshotTreeItem({ item, language }: SnapshotTreeItemProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
+  const hasChildren = item.children && item.children.length > 0;
+
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+
+  return (
+    <div className="select-none">
+      <div
+        className="flex items-center gap-2 py-2 px-3 hover:bg-bg-secondary rounded-md cursor-pointer"
+        onClick={() => hasChildren && setIsExpanded(!isExpanded)}
+      >
+        {/* 확장/축소 아이콘 */}
+        <span className="w-5 h-5 flex items-center justify-center">
+          {hasChildren ? (
+            isExpanded ? (
+              <ChevronDown size={16} className="text-text-secondary" />
+            ) : (
+              <ChevronRight size={16} className="text-text-secondary" />
+            )
+          ) : (
+            <span className="w-4" />
+          )}
+        </span>
+
+        {/* 아이콘 */}
+        {item.isFolder ? (
+          <Folder size={16} className="text-yellow-500" />
+        ) : (
+          <FileText size={16} className="text-blue-500" />
+        )}
+
+        {/* 이름 */}
+        <span className="text-text-primary flex-1">{item.itemName}</span>
+
+        {/* Learning Object 정보 */}
+        {item.snapshotLearningObject && (
+          <span className="text-text-secondary text-xs flex items-center gap-1">
+            <Clock size={12} />
+            {item.snapshotLearningObject.duration
+              ? `${item.snapshotLearningObject.duration}${getText('minutes')}`
+              : '-'}
+          </span>
+        )}
+      </div>
+
+      {/* 자식 아이템 */}
+      {hasChildren && isExpanded && (
+        <div className="ml-6 border-l border-border pl-2">
+          {item.children!.map((child) => (
+            <SnapshotTreeItem key={child.itemId} item={child} language={language} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ProgramSnapshotSection({
+  snapshot,
+  language = 'ko',
+}: Readonly<ProgramSnapshotSectionProps>) {
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+
+  if (!snapshot) {
+    return (
+      <Card>
+        <div className="p-5">
+          <h2 className="text-base font-medium text-text-primary mb-4 flex items-center gap-2">
+            <Layers size={18} className="text-text-secondary" />
+            {getText('snapshotInfo')}
+          </h2>
+          <p className="text-text-secondary">{getText('noSnapshot')}</p>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* 스냅샷 기본 정보 */}
+      <Card>
+        <div className="p-5">
+          <h2 className="text-base font-medium text-text-primary mb-4 flex items-center gap-2">
+            <Layers size={18} className="text-text-secondary" />
+            {getText('snapshotInfo')}
+          </h2>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                {getText('snapshotName')}
+              </Label>
+              <p className="text-text-primary mt-1 font-medium">{snapshot.snapshotName}</p>
+            </div>
+
+            <div>
+              <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                {getText('status')}
+              </Label>
+              <div className="mt-1">
+                <Badge variant="secondary">
+                  {snapshotStatusLabels[snapshot.status]?.[language] || snapshot.status}
+                </Badge>
+              </div>
+            </div>
+
+            {snapshot.description && (
+              <div className="md:col-span-2">
+                <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                  {getText('description')}
+                </Label>
+                <p className="text-text-primary mt-1 whitespace-pre-wrap">
+                  {snapshot.description}
+                </p>
+              </div>
+            )}
+
+            {snapshot.hashtags && snapshot.hashtags.length > 0 && (
+              <div className="md:col-span-2">
+                <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                  {getText('hashtags')}
+                </Label>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {snapshot.hashtags.map((tag) => (
+                    <Badge key={tag} variant="secondary" className="flex items-center gap-1">
+                      <Hash size={12} />
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div>
+              <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                {getText('itemCount')}
+              </Label>
+              <p className="text-text-primary mt-1">
+                {snapshot.itemCount} {getText('items')}
+              </p>
+            </div>
+
+            {snapshot.totalDuration !== undefined && (
+              <div>
+                <Label className="text-text-secondary text-xs uppercase tracking-wide">
+                  {getText('totalDuration')}
+                </Label>
+                <p className="text-text-primary mt-1 flex items-center gap-1">
+                  <Clock size={14} className="text-text-secondary" />
+                  {snapshot.totalDuration} {getText('minutes')}
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </Card>
+
+      {/* 커리큘럼 트리 */}
+      <Card>
+        <div className="p-5">
+          <h2 className="text-base font-medium text-text-primary mb-4">
+            {getText('curriculum')} ({snapshot.itemCount} {getText('items')})
+          </h2>
+
+          {snapshot.items && snapshot.items.length > 0 ? (
+            <div className="space-y-1">
+              {snapshot.items.map((item) => (
+                <SnapshotTreeItem key={item.itemId} item={item} language={language} />
+              ))}
+            </div>
+          ) : (
+            <p className="text-text-secondary">{getText('noItems')}</p>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/tu/teaching/programs/components/SnapshotItemTree.tsx
+++ b/src/pages/tu/teaching/programs/components/SnapshotItemTree.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Card, Button, Input, Label } from '@/components/common';
+import { Card, Button, Input } from '@/components/common';
 import {
   Folder,
   FileText,

--- a/src/pages/tu/teaching/programs/components/SnapshotItemTree.tsx
+++ b/src/pages/tu/teaching/programs/components/SnapshotItemTree.tsx
@@ -1,0 +1,337 @@
+import { useState } from 'react';
+import { Card, Button, Input, Label } from '@/components/common';
+import {
+  Folder,
+  FileText,
+  ChevronRight,
+  ChevronDown,
+  Plus,
+  Trash2,
+  Edit2,
+  Check,
+  X,
+  FolderPlus,
+  Loader2,
+} from 'lucide-react';
+import {
+  useAddSnapshotItem,
+  useUpdateSnapshotItem,
+  useDeleteSnapshotItem,
+} from '@/hooks/tu';
+import type { SnapshotItemResponse } from '@/types/common';
+
+interface SnapshotItemTreeProps {
+  snapshotId: number;
+  items: SnapshotItemResponse[];
+  onItemsChange: () => void;
+  language?: 'ko' | 'en';
+}
+
+const t = {
+  curriculum: { ko: '커리큘럼 편집', en: 'Edit Curriculum' },
+  addFolder: { ko: '폴더 추가', en: 'Add Folder' },
+  addItem: { ko: '아이템 추가', en: 'Add Item' },
+  noItems: { ko: '아이템이 없습니다. 폴더를 추가해주세요.', en: 'No items. Add a folder.' },
+  newFolder: { ko: '새 폴더', en: 'New Folder' },
+  confirmDelete: {
+    ko: '이 아이템을 삭제하시겠습니까?',
+    en: 'Delete this item?',
+  },
+  items: { ko: '개', en: 'items' },
+};
+
+interface TreeItemProps {
+  item: SnapshotItemResponse;
+  snapshotId: number;
+  onItemsChange: () => void;
+  language: 'ko' | 'en';
+  depth?: number;
+}
+
+function TreeItem({
+  item,
+  snapshotId,
+  onItemsChange,
+  language,
+  depth = 0,
+}: TreeItemProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState(item.itemName);
+
+  const hasChildren = item.children && item.children.length > 0;
+
+  const updateItemMutation = useUpdateSnapshotItem();
+  const deleteItemMutation = useDeleteSnapshotItem();
+  const addItemMutation = useAddSnapshotItem();
+
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+
+  const handleSaveName = async () => {
+    if (!editName.trim() || editName === item.itemName) {
+      setIsEditing(false);
+      setEditName(item.itemName);
+      return;
+    }
+
+    try {
+      await updateItemMutation.mutateAsync({
+        snapshotId,
+        itemId: item.itemId,
+        request: { itemName: editName.trim() },
+      });
+      onItemsChange();
+      setIsEditing(false);
+    } catch (err) {
+      console.error('Update item failed:', err);
+      setEditName(item.itemName);
+      setIsEditing(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirm(getText('confirmDelete'))) return;
+
+    try {
+      await deleteItemMutation.mutateAsync({
+        snapshotId,
+        itemId: item.itemId,
+      });
+      onItemsChange();
+    } catch (err) {
+      console.error('Delete item failed:', err);
+    }
+  };
+
+  const handleAddSubFolder = async () => {
+    try {
+      await addItemMutation.mutateAsync({
+        snapshotId,
+        request: {
+          itemName: getText('newFolder'),
+          parentId: item.itemId,
+          itemType: 'FOLDER',
+        },
+      });
+      onItemsChange();
+      setIsExpanded(true);
+    } catch (err) {
+      console.error('Add subfolder failed:', err);
+    }
+  };
+
+  const isLoading =
+    updateItemMutation.isPending ||
+    deleteItemMutation.isPending ||
+    addItemMutation.isPending;
+
+  return (
+    <div className="select-none">
+      <div
+        className="flex items-center gap-2 py-2 px-3 hover:bg-bg-secondary rounded-md group"
+        style={{ paddingLeft: `${depth * 24 + 12}px` }}
+      >
+        {/* 확장/축소 버튼 */}
+        <button
+          className="w-5 h-5 flex items-center justify-center"
+          onClick={() => hasChildren && setIsExpanded(!isExpanded)}
+        >
+          {hasChildren ? (
+            isExpanded ? (
+              <ChevronDown size={16} className="text-text-secondary" />
+            ) : (
+              <ChevronRight size={16} className="text-text-secondary" />
+            )
+          ) : (
+            <span className="w-4" />
+          )}
+        </button>
+
+        {/* 아이콘 */}
+        {item.isFolder ? (
+          <Folder size={16} className="text-yellow-500 flex-shrink-0" />
+        ) : (
+          <FileText size={16} className="text-blue-500 flex-shrink-0" />
+        )}
+
+        {/* 이름 (편집 모드) */}
+        {isEditing ? (
+          <div className="flex-1 flex items-center gap-2">
+            <Input
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              className="h-7 text-sm"
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleSaveName();
+                if (e.key === 'Escape') {
+                  setIsEditing(false);
+                  setEditName(item.itemName);
+                }
+              }}
+            />
+            <button
+              onClick={handleSaveName}
+              className="p-1 hover:bg-status-success-bg rounded text-status-success"
+              disabled={isLoading}
+            >
+              <Check size={14} />
+            </button>
+            <button
+              onClick={() => {
+                setIsEditing(false);
+                setEditName(item.itemName);
+              }}
+              className="p-1 hover:bg-status-error-bg rounded text-status-error"
+            >
+              <X size={14} />
+            </button>
+          </div>
+        ) : (
+          <>
+            {/* 이름 (보기 모드) */}
+            <span className="text-text-primary flex-1 truncate">{item.itemName}</span>
+
+            {/* 액션 버튼 (호버 시 표시) */}
+            <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+              {isLoading && <Loader2 size={14} className="animate-spin text-text-secondary" />}
+
+              {/* 폴더인 경우 하위 폴더 추가 */}
+              {item.isFolder && depth < 8 && (
+                <button
+                  onClick={handleAddSubFolder}
+                  className="p-1 hover:bg-bg-secondary rounded text-text-secondary hover:text-text-primary"
+                  title={getText('addFolder')}
+                  disabled={isLoading}
+                >
+                  <FolderPlus size={14} />
+                </button>
+              )}
+
+              {/* 이름 편집 */}
+              <button
+                onClick={() => setIsEditing(true)}
+                className="p-1 hover:bg-bg-secondary rounded text-text-secondary hover:text-text-primary"
+                disabled={isLoading}
+              >
+                <Edit2 size={14} />
+              </button>
+
+              {/* 삭제 */}
+              <button
+                onClick={handleDelete}
+                className="p-1 hover:bg-status-error-bg rounded text-text-secondary hover:text-status-error"
+                disabled={isLoading}
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* 자식 아이템 */}
+      {hasChildren && isExpanded && (
+        <div>
+          {item.children!.map((child) => (
+            <TreeItem
+              key={child.itemId}
+              item={child}
+              snapshotId={snapshotId}
+              onItemsChange={onItemsChange}
+              language={language}
+              depth={depth + 1}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function SnapshotItemTree({
+  snapshotId,
+  items,
+  onItemsChange,
+  language = 'ko',
+}: Readonly<SnapshotItemTreeProps>) {
+  const addItemMutation = useAddSnapshotItem();
+
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+
+  const handleAddRootFolder = async () => {
+    try {
+      await addItemMutation.mutateAsync({
+        snapshotId,
+        request: {
+          itemName: getText('newFolder'),
+          itemType: 'FOLDER',
+        },
+      });
+      onItemsChange();
+    } catch (err) {
+      console.error('Add root folder failed:', err);
+    }
+  };
+
+  const totalItems = items.length;
+
+  return (
+    <Card>
+      <div className="p-5">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-base font-medium text-text-primary">
+            {getText('curriculum')} ({totalItems} {getText('items')})
+          </h2>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="border border-border"
+            onClick={handleAddRootFolder}
+            disabled={addItemMutation.isPending}
+          >
+            {addItemMutation.isPending ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <Plus size={14} />
+            )}
+            {getText('addFolder')}
+          </Button>
+        </div>
+
+        {items.length > 0 ? (
+          <div className="border border-border rounded-lg overflow-hidden">
+            <div className="max-h-96 overflow-auto">
+              {items.map((item) => (
+                <TreeItem
+                  key={item.itemId}
+                  item={item}
+                  snapshotId={snapshotId}
+                  onItemsChange={onItemsChange}
+                  language={language}
+                />
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="text-center py-12 border border-dashed border-border rounded-lg">
+            <Folder size={48} className="mx-auto mb-3 text-text-placeholder opacity-30" />
+            <p className="text-text-secondary mb-4">{getText('noItems')}</p>
+            <Button
+              size="sm"
+              onClick={handleAddRootFolder}
+              disabled={addItemMutation.isPending}
+            >
+              {addItemMutation.isPending ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <FolderPlus size={14} />
+              )}
+              {getText('addFolder')}
+            </Button>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/pages/tu/teaching/programs/components/index.ts
+++ b/src/pages/tu/teaching/programs/components/index.ts
@@ -1,0 +1,4 @@
+export * from './ProgramInfoSection';
+export * from './ProgramSnapshotSection';
+export * from './ProgramBasicInfoForm';
+export * from './SnapshotItemTree';

--- a/src/pages/tu/teaching/programs/index.ts
+++ b/src/pages/tu/teaching/programs/index.ts
@@ -1,0 +1,4 @@
+export * from './MyProgramsPage';
+export * from './ProgramDetailPage';
+export * from './ProgramEditPage';
+export * from './components';

--- a/src/routes/tu.courses.routes.tsx
+++ b/src/routes/tu.courses.routes.tsx
@@ -11,6 +11,9 @@ import {
   ContentDetailPage,
   MyAssignmentsPage,
   AssignmentDetailPage,
+  MyProgramsPage,
+  TuProgramDetailPage,
+  TuProgramEditPage,
 } from '@/pages/tu';
 import { DashboardPage, PlaceholderPage } from './pages';
 
@@ -29,11 +32,18 @@ export const tuCoursesRoutes = (
     <Route index element={<DashboardPage />} />
     <Route path="dashboard" element={<DashboardPage />} />
 
-    {/* 내 강의 */}
+    {/* 내 강의계획 */}
     <Route path="teaching/courses" element={<MyCoursesPage />} />
     <Route path="teaching/courses/create" element={<CourseCreatePage />} />
     <Route path="teaching/courses/:courseId" element={<TeachingCourseDetailPage />} />
     <Route path="teaching/courses/:courseId/edit" element={<CourseEditPage />} />
+
+    {/* 내 프로그램 */}
+    <Route path="teaching/programs" element={<MyProgramsPage />} />
+    <Route path="teaching/programs/:programId" element={<TuProgramDetailPage />} />
+    <Route path="teaching/programs/:programId/edit" element={<TuProgramEditPage />} />
+
+    {/* 내 콘텐츠 */}
     <Route path="teaching/content" element={<MyContentPage />} />
     <Route path="teaching/content/create" element={<TuContentCreatePage />} />
     <Route path="teaching/content/:id" element={<ContentDetailPage />} />


### PR DESCRIPTION
## Summary
- TU 영역에 "내 프로그램" 관리 기능 추가
- 사이드바 메뉴 변경: "내 강좌" → "내 강의계획", "내 프로그램" 신규 추가
- 프로그램 목록/상세/수정 페이지 및 React Query hooks 구현

## Changes
### 사이드바 & 라우트
- `sidebar-menus.ts`: 메뉴명 변경 + 새 메뉴 추가
- `tu.courses.routes.tsx`: `/tu/teaching/programs/*` 라우트 3개 추가

### React Query Hooks
- `useMyProgramQueries.ts`: 프로그램/스냅샷 조회 및 수정 hooks (14개)

### 페이지
- `MyProgramsPage`: 프로그램 목록 (상태별 필터링, 신청/삭제)
- `ProgramDetailPage`: 프로그램 상세 (기본정보 + 스냅샷 커리큘럼)
- `ProgramEditPage`: 프로그램 수정 (DRAFT/REJECTED 상태만)

### 컴포넌트
- `ProgramInfoSection`: 기본정보 읽기 전용 섹션
- `ProgramSnapshotSection`: 스냅샷 커리큘럼 트리 표시
- `ProgramBasicInfoForm`: 기본정보 수정 폼
- `SnapshotItemTree`: 스냅샷 아이템 편집 (추가/수정/삭제)

## Test plan
- [ ] TU 사이드바에서 "내 강의계획", "내 프로그램" 메뉴 확인
- [ ] `/tu/teaching/programs` 목록 페이지 렌더링 확인
- [ ] 상태별 필터링 동작 확인
- [ ] 프로그램 상세 페이지 이동 및 정보 표시 확인
- [ ] DRAFT/REJECTED 상태에서 수정 페이지 접근 가능 확인
- [ ] 스냅샷 아이템 추가/수정/삭제 동작 확인

Closes #193