### PR TITLE
fix: 리스트뷰에서 보관된 콘텐츠 시각적 구분 추가

### DIFF
--- a/src/components/common/DataTable/DataTable.tsx
+++ b/src/components/common/DataTable/DataTable.tsx
@@ -71,6 +71,7 @@ function DataTable<TData, TValue>({
   pageSize = 10,
   labels: customLabels,
   onRowClick,
+  rowClassName,
 }: DataTableProps<TData, TValue>) {
   const labels = { ...defaultLabels, ...customLabels };
   const [sorting, setSorting] = React.useState<SortingState>([]);
@@ -182,7 +183,10 @@ function DataTable<TData, TValue>({
                   key={row.id}
                   data-state={row.getIsSelected() && "selected"}
                   onClick={() => onRowClick?.(row.original)}
-                  className={onRowClick ? "cursor-pointer hover:bg-muted/50" : ""}
+                  className={cn(
+                    onRowClick ? "cursor-pointer hover:bg-muted/50" : "",
+                    rowClassName?.(row.original)
+                  )}
                 >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell key={cell.id}>

--- a/src/components/common/DataTable/DataTable.types.ts
+++ b/src/components/common/DataTable/DataTable.types.ts
@@ -23,6 +23,8 @@ export interface DataTableProps<TData, TValue> {
   labels?: DataTableLabels;
   /** 행 클릭 핸들러 */
   onRowClick?: (row: TData) => void;
+  /** 행별 클래스명 반환 함수 */
+  rowClassName?: (row: TData) => string;
 }
 
 export interface DataTableColumnHeaderProps

--- a/src/pages/tu/teaching/content/MyContentPage.tsx
+++ b/src/pages/tu/teaching/content/MyContentPage.tsx
@@ -616,6 +616,7 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
               showColumnToggle={false}
               showPagination={false}
               onRowClick={(item) => navigate(`/tu/teaching/content/${item.id}`)}
+              rowClassName={(item) => item.status === 'ARCHIVED' ? 'opacity-60' : ''}
               labels={{
                 noResults: getText('noResults'),
               }}


### PR DESCRIPTION
## Summary
- DataTable 컴포넌트에 `rowClassName` prop 추가
- 보관된 콘텐츠 행에 `opacity-60` 스타일 적용
- 카드뷰와 동일한 시각적 구분 제공

## 변경 파일
- `src/components/common/DataTable/DataTable.tsx`
- `src/components/common/DataTable/DataTable.types.ts`
- `src/pages/tu/teaching/content/MyContentPage.tsx`

## Test plan
- [x] 내 콘텐츠 페이지 리스트뷰에서 보관된 콘텐츠가 흐리게 표시되는지 확인
- [x] 카드뷰와 동일한 수준의 시각적 구분인지 확인

Closes #195