### PR TITLE
Feat/course detail api integration

### DIFF
--- a/src/pages/tu/main/CourseDetailPage.tsx
+++ b/src/pages/tu/main/CourseDetailPage.tsx
@@ -209,6 +209,7 @@ const MOCK_COURSES: Record<string, CourseDetail> = {
 };
 
 // 환경 설정: true면 API 사용, false면 더미 데이터 사용
+// courseDetailService에서 백엔드 응답을 프론트엔드 형식으로 변환
 const USE_API = true;
 
 /**

--- a/src/services/tu/courseDetailService.ts
+++ b/src/services/tu/courseDetailService.ts
@@ -3,6 +3,8 @@ import type {
   CourseDetail,
   CourseCard,
   CourseFilterParams,
+  CurriculumSection,
+  CourseCategory,
 } from '@/types/tu';
 import type { PageResponse } from '@/services/tu/catalogService';
 
@@ -21,6 +23,152 @@ interface ApiResponse<T> {
   };
 }
 
+// 백엔드 CourseItem 응답 타입
+interface BackendCourseItemResponse {
+  itemId: number;
+  itemName: string;
+  depth: number;
+  parentId: number | null;
+  learningObjectId: number | null;
+  isFolder: boolean;
+  displayName: string;
+  description: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// 백엔드 강의 상세 응답 타입
+interface BackendCourseDetailResponse {
+  courseId: number;
+  title: string;
+  description: string;
+  thumbnailUrl: string | null;
+  level: 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED';
+  type: 'ONLINE' | 'OFFLINE' | 'BLENDED';
+  estimatedHours: number | null;
+  categoryId: number | null;
+  startDate: string | null;
+  endDate: string | null;
+  tags: string[];
+  items: BackendCourseItemResponse[];
+  itemCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// 레벨 변환 매핑
+const LEVEL_MAP: Record<string, string> = {
+  BEGINNER: '입문',
+  INTERMEDIATE: '중급',
+  ADVANCED: '고급',
+};
+
+// 카테고리 변환 (categoryId → CourseCategory)
+const getCategoryFromId = (categoryId: number | null): CourseCategory => {
+  const categoryMap: Record<number, CourseCategory> = {
+    1: 'dev',
+    2: 'ai',
+    3: 'cloud',
+    4: 'data',
+    5: 'design',
+    6: 'business',
+  };
+  return categoryMap[categoryId || 0] || 'other';
+};
+
+// 백엔드 items를 커리큘럼 섹션으로 변환
+const transformItemsToCurriculum = (items: BackendCourseItemResponse[]): CurriculumSection[] => {
+  // 폴더(섹션)와 강의 아이템 분리
+  const folders = items.filter(item => item.isFolder);
+  const lectures = items.filter(item => !item.isFolder);
+
+  // 폴더가 없으면 기본 섹션 하나 생성
+  if (folders.length === 0) {
+    return [{
+      id: 1,
+      title: '강의 목록',
+      lectures: lectures.map((item, index) => ({
+        id: item.itemId,
+        title: item.displayName || item.itemName,
+        duration: '00:00',
+        isPreview: index === 0,
+      })),
+    }];
+  }
+
+  // 폴더별로 강의 그룹화
+  return folders.map((folder, index) => ({
+    id: folder.itemId,
+    title: folder.displayName || folder.itemName,
+    lectures: lectures
+      .filter(lecture => lecture.parentId === folder.itemId)
+      .map((lecture, lectureIndex) => ({
+        id: lecture.itemId,
+        title: lecture.displayName || lecture.itemName,
+        duration: '00:00',
+        isPreview: index === 0 && lectureIndex === 0,
+      })),
+  }));
+};
+
+// 백엔드 응답을 프론트엔드 CourseDetail로 변환
+const transformCourseDetail = (backend: BackendCourseDetailResponse): CourseDetail => ({
+  id: backend.courseId,
+  title: backend.title,
+  description: backend.description,
+  thumbnailUrl: backend.thumbnailUrl || undefined,
+  promoVideoUrl: undefined,
+  category: getCategoryFromId(backend.categoryId),
+  tags: backend.tags?.length > 0 ? backend.tags as CourseDetail['tags'] : [],
+
+  // 가격 정보 (백엔드에 없으므로 기본값)
+  price: 0,
+  originalPrice: 0,
+  discountRate: 0,
+
+  // 통계 정보 (백엔드에 없으므로 기본값)
+  rating: 4.5,
+  reviewCount: 0,
+  studentCount: 0,
+
+  // 강의 정보
+  totalHours: backend.estimatedHours || 0,
+  totalLectures: backend.itemCount,
+  level: LEVEL_MAP[backend.level] || backend.level,
+  lastUpdated: backend.updatedAt,
+
+  // 상세 내용 (백엔드에 없으므로 기본값)
+  whatYouLearn: [
+    '이 강의의 핵심 개념을 이해합니다',
+    '실무에 바로 적용할 수 있는 기술을 습득합니다',
+    '프로젝트를 통해 실전 경험을 쌓습니다',
+  ],
+  requirements: [
+    '기본적인 프로그래밍 지식',
+    '학습에 대한 열정',
+  ],
+
+  // 커리큘럼
+  curriculum: transformItemsToCurriculum(backend.items || []),
+
+  // 강사 정보 (백엔드에 없으므로 기본값)
+  instructor: {
+    id: 1,
+    name: '강사',
+    bio: '전문 강사입니다.',
+    profileImage: undefined,
+    courseCount: 1,
+    studentCount: 0,
+    rating: 4.5,
+  },
+
+  // 메타 정보
+  hasCertificate: true,
+  isLifetimeAccess: true,
+  createdAt: backend.createdAt,
+  updatedAt: backend.updatedAt,
+});
+
 /**
  * 강의 상세 서비스
  */
@@ -30,10 +178,10 @@ export const courseDetailService = {
    * @param id 강의 ID
    */
   getCourseDetail: async (id: number): Promise<CourseDetail> => {
-    const response = await axiosInstance.get<ApiResponse<CourseDetail>>(
-      `/courses/${id}/detail`
+    const response = await axiosInstance.get<ApiResponse<BackendCourseDetailResponse>>(
+      `/courses/${id}`
     );
-    return response.data.data;
+    return transformCourseDetail(response.data.data);
   },
 
   /**


### PR DESCRIPTION
## Summary

강의 상세 페이지(`/tu/main/courses/:id`)에서 백엔드 API 연동을 구현했습니다. 백엔드 응답 형식과 프론트엔드 타입이 다르므로, 변환 로직을 추가하여 API 데이터를 사용할 수 있도록 했습니다.

## Changes

- `courseDetailService.ts`에 백엔드 응답 변환 로직 추가
  - `BackendCourseDetailResponse`, `BackendCourseItemResponse` 타입 정의
  - `transformCourseDetail` 함수로 백엔드 → 프론트엔드 타입 변환
  - `transformItemsToCurriculum` 함수로 CourseItem → CurriculumSection 변환
  - 레벨(`BEGINNER`→`입문`), 카테고리(`categoryId`→`CourseCategory`) 매핑
- `CourseDetailPage.tsx`의 `USE_API` 플래그 활성화
- 백엔드에 없는 필드는 기본값 제공 (가격, 강사 정보, 통계 등)

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

- 백엔드 `CourseDetailResponse`에 가격, 강사, 리뷰 등의 정보가 없어 기본값으로 처리됨
- 추후 백엔드 API 확장 시 변환 로직 수정 필요
- `cm_courses` 테이블에 더미 데이터 필요 (백엔드 `data.sql`에 추가됨)
