### PR TITLE
feat: 마이페이지 내 게시글/내 댓글 페이지 추가 및 디자인 개선

### DIFF
--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -283,8 +283,8 @@ export const myPageMenuData: MenuItem[] = [
     label: { ko: '커뮤니티 활동', en: 'Community Activity' },
     icon: MessageSquare,
     subItems: [
-      { id: 'my-posts', label: { ko: '내 게시글', en: 'My Posts' }, icon: FileEdit, path: '/mypage/community/posts' },
-      { id: 'my-comments', label: { ko: '내 댓글', en: 'My Comments' }, icon: MessageSquare, path: '/mypage/community/comments' },
+      { id: 'my-posts', label: { ko: '내 게시글', en: 'My Posts' }, icon: FileEdit, path: '/tu/b2c/mypage/posts' },
+      { id: 'my-comments', label: { ko: '내 댓글', en: 'My Comments' }, icon: MessageSquare, path: '/tu/b2c/mypage/comments' },
     ],
   },
   {

--- a/src/pages/tu/mypage/MyCommentsPage.tsx
+++ b/src/pages/tu/mypage/MyCommentsPage.tsx
@@ -13,6 +13,9 @@ import {
   ChevronRight,
   Loader2,
   User,
+  MessageCircle,
+  ArrowRight,
+  Sparkles,
 } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useCommentedPosts } from '@/hooks/tu/useCommunityQueries';
@@ -33,165 +36,371 @@ export function MyCommentsPage() {
   const totalPages = data?.totalPages || 0;
   const totalCount = data?.totalCount || 0;
 
+  // 통계 계산
+  const totalInteractions = posts.reduce(
+    (sum, post) => sum + (post.likeCount || 0) + (post.commentCount || 0),
+    0
+  );
+
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffDays === 0) {
+      const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+      if (diffHours === 0) {
+        const diffMins = Math.floor(diffMs / (1000 * 60));
+        return diffMins <= 0 ? '방금 전' : `${diffMins}분 전`;
+      }
+      return `${diffHours}시간 전`;
+    }
+    if (diffDays < 7) return `${diffDays}일 전`;
+
     return date.toLocaleDateString('ko-KR', {
-      year: 'numeric',
       month: 'short',
       day: 'numeric',
     });
   };
 
   const stripMarkdownImages = (content: string): string => {
-    return content.replace(/!\[[^\]]*\]\([^)]+\)/g, '[이미지]');
+    return content.replace(/!\[[^\]]*\]\([^)]+\)/g, '').replace(/\n/g, ' ').trim();
   };
 
   return (
-    <div className="space-y-6">
-      {/* 헤더 */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            내 댓글
-          </h1>
-          <p className={`mt-1 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-            내가 댓글을 작성한 게시글을 확인하세요
-          </p>
-        </div>
-        <Button onClick={() => navigate('/tu/community')}>커뮤니티 가기</Button>
-      </div>
-
-      {/* 댓글 통계 */}
+    <div className="space-y-6 max-w-5xl mx-auto px-4 md:px-6 lg:px-8 py-6 md:py-8">
+      {/* 헤더 카드 */}
       <div
-        className={`p-4 rounded-xl ${
-          isDark ? 'bg-white/5 border border-white/10' : 'bg-white border border-gray-200'
+        className={`relative overflow-hidden rounded-2xl p-6 ${
+          isDark
+            ? 'bg-gradient-to-br from-emerald-500/20 via-teal-600/10 to-transparent border border-white/10'
+            : 'bg-gradient-to-br from-emerald-50 via-teal-50 to-white border border-gray-100'
         }`}
       >
-        <div className="flex items-center gap-2">
-          <MessageSquare className={`w-5 h-5 ${isDark ? 'text-[#6778ff]' : 'text-blue-600'}`} />
-          <span className={isDark ? 'text-gray-300' : 'text-gray-700'}>
-            총 <strong>{totalCount}</strong>개의 게시글에 댓글 작성
-          </span>
+        <div className="relative z-10">
+          <div className="flex items-start justify-between">
+            <div>
+              <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                내 댓글
+              </h1>
+              <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                내가 댓글을 작성한 게시글을 확인하세요
+              </p>
+            </div>
+            <Button
+              onClick={() => navigate('/tu/b2c/community')}
+              className={`${
+                isDark
+                  ? 'bg-emerald-500 hover:bg-emerald-600 text-white'
+                  : 'bg-emerald-500 hover:bg-emerald-600 text-white'
+              }`}
+            >
+              <MessageCircle className="w-4 h-4 mr-2" />
+              커뮤니티 가기
+            </Button>
+          </div>
+
+          {/* 통계 카드들 */}
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mt-6">
+            <div
+              className={`p-4 rounded-xl ${
+                isDark ? 'bg-white/5 backdrop-blur-sm' : 'bg-white/80 shadow-sm'
+              }`}
+            >
+              <div className="flex items-center gap-3">
+                <div className={`p-2 rounded-lg ${isDark ? 'bg-emerald-500/20' : 'bg-emerald-100'}`}>
+                  <MessageSquare
+                    className={`w-5 h-5 ${isDark ? 'text-emerald-400' : 'text-emerald-600'}`}
+                  />
+                </div>
+                <div>
+                  <p className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                    {totalCount}
+                  </p>
+                  <p className={`text-xs ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                    참여한 게시글
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div
+              className={`p-4 rounded-xl ${
+                isDark ? 'bg-white/5 backdrop-blur-sm' : 'bg-white/80 shadow-sm'
+              }`}
+            >
+              <div className="flex items-center gap-3">
+                <div className={`p-2 rounded-lg ${isDark ? 'bg-teal-500/20' : 'bg-teal-100'}`}>
+                  <Sparkles className={`w-5 h-5 ${isDark ? 'text-teal-400' : 'text-teal-600'}`} />
+                </div>
+                <div>
+                  <p className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                    {totalInteractions}
+                  </p>
+                  <p className={`text-xs ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                    총 상호작용
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div
+              className={`p-4 rounded-xl col-span-2 md:col-span-1 ${
+                isDark ? 'bg-white/5 backdrop-blur-sm' : 'bg-white/80 shadow-sm'
+              }`}
+            >
+              <div className="flex items-center gap-3">
+                <div className={`p-2 rounded-lg ${isDark ? 'bg-cyan-500/20' : 'bg-cyan-100'}`}>
+                  <User className={`w-5 h-5 ${isDark ? 'text-cyan-400' : 'text-cyan-600'}`} />
+                </div>
+                <div>
+                  <p className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                    {posts.length > 0 ? new Set(posts.map((p) => p.author?.id)).size : 0}
+                  </p>
+                  <p className={`text-xs ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                    소통한 작성자
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
+
+        {/* 배경 장식 */}
+        <div
+          className={`absolute -right-10 -top-10 w-40 h-40 rounded-full blur-3xl ${
+            isDark ? 'bg-emerald-500/20' : 'bg-emerald-200/50'
+          }`}
+        />
+        <div
+          className={`absolute -left-10 -bottom-10 w-32 h-32 rounded-full blur-3xl ${
+            isDark ? 'bg-teal-600/20' : 'bg-teal-200/50'
+          }`}
+        />
       </div>
 
       {/* 게시글 목록 */}
       {isLoading ? (
         <div className="flex items-center justify-center py-20">
-          <Loader2 className={`w-8 h-8 animate-spin ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
+          <Loader2
+            className={`w-8 h-8 animate-spin ${isDark ? 'text-emerald-400' : 'text-emerald-600'}`}
+          />
         </div>
       ) : posts.length === 0 ? (
         <div
-          className={`text-center py-20 rounded-xl ${
+          className={`text-center py-16 rounded-2xl ${
+            isDark ? 'bg-white/5 border border-white/10' : 'bg-gray-50 border border-gray-100'
+          }`}
+        >
+          <div
+            className={`w-20 h-20 mx-auto mb-6 rounded-2xl flex items-center justify-center ${
+              isDark ? 'bg-white/10' : 'bg-gray-100'
+            }`}
+          >
+            <MessageSquare className={`w-10 h-10 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
+          </div>
+          <h3 className={`text-lg font-semibold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            아직 댓글을 작성한 게시글이 없어요
+          </h3>
+          <p className={`text-sm mb-6 max-w-sm mx-auto ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+            커뮤니티에서 다양한 글에 의견을 남겨보세요
+          </p>
+          <Button
+            onClick={() => navigate('/tu/b2c/community')}
+            className="bg-emerald-500 hover:bg-emerald-600 text-white"
+          >
+            <MessageCircle className="w-4 h-4 mr-2" />
+            커뮤니티 둘러보기
+          </Button>
+        </div>
+      ) : (
+        <div
+          className={`rounded-2xl overflow-hidden ${
             isDark ? 'bg-white/5 border border-white/10' : 'bg-white border border-gray-200'
           }`}
         >
-          <MessageSquare className={`w-12 h-12 mx-auto mb-4 ${isDark ? 'text-gray-600' : 'text-gray-400'}`} />
-          <h3 className={`font-medium mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            댓글을 작성한 게시글이 없습니다
-          </h3>
-          <p className={`text-sm mb-4 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-            커뮤니티에서 다양한 글에 의견을 남겨보세요
-          </p>
-          <Button onClick={() => navigate('/tu/community')}>커뮤니티 가기</Button>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          {posts.map((post) => (
-            <Link
-              key={post.id}
-              to={`/tu/community/${post.id}`}
-              className={`block p-4 rounded-xl transition-all ${
-                isDark
-                  ? 'bg-white/5 border border-white/10 hover:bg-white/10'
-                  : 'bg-white border border-gray-200 hover:shadow-md'
-              }`}
-            >
-              <div className="flex items-start gap-4">
-                <div className="flex-1 min-w-0">
-                  {/* 타입 & 카테고리 */}
-                  <div className="flex items-center gap-2 mb-2">
-                    <Badge variant="blue" className="text-xs">
-                      {POST_TYPE_LABELS[post.type] || post.type}
-                    </Badge>
-                    {post.category && (
-                      <Badge variant="gray" className="text-xs">
-                        {post.category}
-                      </Badge>
+          <div className={`divide-y ${isDark ? 'divide-white/5' : 'divide-gray-100'}`}>
+            {posts.map((post) => (
+              <Link
+                key={post.id}
+                to={`/tu/b2c/community/${post.id}`}
+                className={`block p-5 transition-all group ${
+                  isDark ? 'hover:bg-white/5' : 'hover:bg-gray-50'
+                }`}
+              >
+                <div className="flex items-start gap-4">
+                  {/* 작성자 아바타 */}
+                  <div
+                    className={`flex-shrink-0 w-10 h-10 rounded-full overflow-hidden ${
+                      isDark ? 'bg-white/10' : 'bg-gray-100'
+                    }`}
+                  >
+                    {post.author?.avatar ? (
+                      <img
+                        src={post.author.avatar}
+                        alt={post.author.name}
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center">
+                        <User
+                          className={`w-5 h-5 ${isDark ? 'text-gray-500' : 'text-gray-400'}`}
+                        />
+                      </div>
                     )}
                   </div>
 
-                  {/* 제목 */}
-                  <h3
-                    className={`font-medium mb-2 line-clamp-1 ${
-                      isDark ? 'text-white' : 'text-gray-900'
-                    }`}
-                  >
-                    {post.title}
-                  </h3>
+                  <div className="flex-1 min-w-0">
+                    {/* 작성자 & 타입 */}
+                    <div className="flex items-center gap-2 mb-1.5">
+                      <span
+                        className={`text-sm font-medium ${
+                          isDark ? 'text-gray-300' : 'text-gray-700'
+                        }`}
+                      >
+                        {post.author?.name || '익명'}
+                      </span>
+                      <span className={`text-xs ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
+                        ·
+                      </span>
+                      <Badge
+                        variant="blue"
+                        className={`text-xs ${isDark ? 'bg-emerald-500/20 text-emerald-400' : 'bg-emerald-100 text-emerald-700'}`}
+                      >
+                        {POST_TYPE_LABELS[post.type] || post.type}
+                      </Badge>
+                      {post.category && (
+                        <Badge
+                          variant="gray"
+                          className={`text-xs ${isDark ? 'bg-white/10 text-gray-400' : ''}`}
+                        >
+                          {post.category}
+                        </Badge>
+                      )}
+                    </div>
 
-                  {/* 내용 미리보기 */}
-                  <p
-                    className={`text-sm line-clamp-2 mb-3 ${
-                      isDark ? 'text-gray-400' : 'text-gray-600'
-                    }`}
-                  >
-                    {stripMarkdownImages(post.content)}
-                  </p>
+                    {/* 제목 */}
+                    <h3
+                      className={`font-semibold mb-1.5 line-clamp-1 transition-colors ${
+                        isDark
+                          ? 'text-white group-hover:text-emerald-400'
+                          : 'text-gray-900 group-hover:text-emerald-600'
+                      }`}
+                    >
+                      {post.title}
+                    </h3>
 
-                  {/* 메타 정보 */}
-                  <div className={`flex items-center gap-4 text-xs ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
-                    <span className="flex items-center gap-1">
-                      <User className="w-3.5 h-3.5" />
-                      {post.author?.name || '익명'}
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <Clock className="w-3.5 h-3.5" />
-                      {formatDate(post.createdAt)}
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <Eye className="w-3.5 h-3.5" />
-                      {post.viewCount}
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <Heart className="w-3.5 h-3.5" />
-                      {post.likeCount}
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <MessageSquare className="w-3.5 h-3.5" />
-                      {post.commentCount}
-                    </span>
+                    {/* 내용 미리보기 */}
+                    <p
+                      className={`text-sm line-clamp-1 mb-3 ${
+                        isDark ? 'text-gray-400' : 'text-gray-600'
+                      }`}
+                    >
+                      {stripMarkdownImages(post.content)}
+                    </p>
+
+                    {/* 메타 정보 */}
+                    <div className="flex items-center gap-4">
+                      <span
+                        className={`flex items-center gap-1.5 text-xs ${
+                          isDark ? 'text-gray-500' : 'text-gray-500'
+                        }`}
+                      >
+                        <Clock className="w-3.5 h-3.5" />
+                        {formatDate(post.createdAt)}
+                      </span>
+                      <span
+                        className={`flex items-center gap-1.5 text-xs ${
+                          isDark ? 'text-gray-500' : 'text-gray-500'
+                        }`}
+                      >
+                        <Eye className="w-3.5 h-3.5" />
+                        {post.viewCount?.toLocaleString()}
+                      </span>
+                      <span
+                        className={`flex items-center gap-1.5 text-xs ${
+                          isDark ? 'text-gray-500' : 'text-gray-500'
+                        }`}
+                      >
+                        <Heart className="w-3.5 h-3.5" />
+                        {post.likeCount}
+                      </span>
+                      <span
+                        className={`flex items-center gap-1.5 text-xs ${
+                          isDark ? 'text-emerald-400' : 'text-emerald-600'
+                        }`}
+                      >
+                        <MessageSquare className="w-3.5 h-3.5" />
+                        {post.commentCount}
+                      </span>
+                    </div>
                   </div>
+
+                  {/* 화살표 */}
+                  <ArrowRight
+                    className={`w-5 h-5 flex-shrink-0 mt-1 transition-transform group-hover:translate-x-1 ${
+                      isDark ? 'text-gray-600' : 'text-gray-400'
+                    }`}
+                  />
                 </div>
-              </div>
-            </Link>
-          ))}
+              </Link>
+            ))}
+          </div>
         </div>
       )}
 
       {/* 페이지네이션 */}
       {totalPages > 1 && (
-        <div className="flex items-center justify-center gap-2 pt-4">
+        <div className="flex items-center justify-center gap-3 pt-4">
           <Button
             variant="outline"
             size="sm"
             onClick={() => setPage((p) => Math.max(0, p - 1))}
             disabled={page === 0}
-            className={isDark ? 'border-white/20 text-white hover:bg-white/10' : ''}
+            className={`${
+              isDark
+                ? 'border-white/20 text-white hover:bg-white/10 disabled:opacity-30'
+                : 'disabled:opacity-30'
+            }`}
           >
-            <ChevronLeft className="w-4 h-4" />
+            <ChevronLeft className="w-4 h-4 mr-1" />
+            이전
           </Button>
-          <span className={`px-4 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-            {page + 1} / {totalPages}
-          </span>
+          <div className="flex items-center gap-2">
+            {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+              const pageNum = Math.max(0, Math.min(page - 2, totalPages - 5)) + i;
+              if (pageNum >= totalPages) return null;
+              return (
+                <button
+                  key={pageNum}
+                  onClick={() => setPage(pageNum)}
+                  className={`w-8 h-8 rounded-lg text-sm font-medium transition-colors ${
+                    page === pageNum
+                      ? 'bg-emerald-500 text-white'
+                      : isDark
+                        ? 'text-gray-400 hover:bg-white/10'
+                        : 'text-gray-600 hover:bg-gray-100'
+                  }`}
+                >
+                  {pageNum + 1}
+                </button>
+              );
+            })}
+          </div>
           <Button
             variant="outline"
             size="sm"
             onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
             disabled={page >= totalPages - 1}
-            className={isDark ? 'border-white/20 text-white hover:bg-white/10' : ''}
+            className={`${
+              isDark
+                ? 'border-white/20 text-white hover:bg-white/10 disabled:opacity-30'
+                : 'disabled:opacity-30'
+            }`}
           >
-            <ChevronRight className="w-4 h-4" />
+            다음
+            <ChevronRight className="w-4 h-4 ml-1" />
           </Button>
         </div>
       )}

--- a/src/pages/tu/mypage/MyPostsPage.tsx
+++ b/src/pages/tu/mypage/MyPostsPage.tsx
@@ -14,7 +14,6 @@ import {
   ChevronRight,
   Loader2,
   PenSquare,
-  TrendingUp,
   ArrowRight,
 } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';

--- a/src/pages/tu/mypage/MyPostsPage.tsx
+++ b/src/pages/tu/mypage/MyPostsPage.tsx
@@ -14,6 +14,8 @@ import {
   ChevronRight,
   Loader2,
   PenSquare,
+  TrendingUp,
+  ArrowRight,
 } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useMyPosts } from '@/hooks/tu/useCommunityQueries';
@@ -34,164 +36,359 @@ export function MyPostsPage() {
   const totalPages = data?.totalPages || 0;
   const totalCount = data?.totalCount || 0;
 
+  // 통계 계산
+  const totalViews = posts.reduce((sum, post) => sum + (post.viewCount || 0), 0);
+  const totalLikes = posts.reduce((sum, post) => sum + (post.likeCount || 0), 0);
+  const totalComments = posts.reduce((sum, post) => sum + (post.commentCount || 0), 0);
+
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffDays === 0) {
+      const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+      if (diffHours === 0) {
+        const diffMins = Math.floor(diffMs / (1000 * 60));
+        return diffMins <= 0 ? '방금 전' : `${diffMins}분 전`;
+      }
+      return `${diffHours}시간 전`;
+    }
+    if (diffDays < 7) return `${diffDays}일 전`;
+
     return date.toLocaleDateString('ko-KR', {
-      year: 'numeric',
       month: 'short',
       day: 'numeric',
     });
   };
 
   const stripMarkdownImages = (content: string): string => {
-    return content.replace(/!\[[^\]]*\]\([^)]+\)/g, '[이미지]');
+    return content.replace(/!\[[^\]]*\]\([^)]+\)/g, '').replace(/\n/g, ' ').trim();
   };
 
   return (
-    <div className="space-y-6">
-      {/* 헤더 */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            내 게시글
-          </h1>
-          <p className={`mt-1 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-            내가 작성한 커뮤니티 게시글을 확인하세요
-          </p>
-        </div>
-        <Button onClick={() => navigate('/tu/community')}>
-          <PenSquare className="w-4 h-4 mr-2" />
-          글 작성하기
-        </Button>
-      </div>
-
-      {/* 게시글 통계 */}
+    <div className="space-y-6 max-w-5xl mx-auto px-4 md:px-6 lg:px-8 py-6 md:py-8">
+      {/* 헤더 카드 */}
       <div
-        className={`p-4 rounded-xl ${
-          isDark ? 'bg-white/5 border border-white/10' : 'bg-white border border-gray-200'
+        className={`relative overflow-hidden rounded-2xl p-6 ${
+          isDark
+            ? 'bg-gradient-to-br from-[#6778ff]/20 via-purple-600/10 to-transparent border border-white/10'
+            : 'bg-gradient-to-br from-blue-50 via-indigo-50 to-white border border-gray-100'
         }`}
       >
-        <div className="flex items-center gap-2">
-          <FileText className={`w-5 h-5 ${isDark ? 'text-[#6778ff]' : 'text-blue-600'}`} />
-          <span className={isDark ? 'text-gray-300' : 'text-gray-700'}>
-            총 <strong>{totalCount}</strong>개의 게시글
-          </span>
+        <div className="relative z-10">
+          <div className="flex items-start justify-between">
+            <div>
+              <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                내 게시글
+              </h1>
+              <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                내가 작성한 커뮤니티 게시글을 관리하세요
+              </p>
+            </div>
+            <Button
+              onClick={() => navigate('/tu/b2c/community')}
+              className={`${
+                isDark
+                  ? 'bg-[#6778ff] hover:bg-[#5567ee] text-white'
+                  : 'bg-[#6778ff] hover:bg-[#5567ee] text-white'
+              }`}
+            >
+              <PenSquare className="w-4 h-4 mr-2" />
+              글 작성하기
+            </Button>
+          </div>
+
+          {/* 통계 카드들 */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-6">
+            <div
+              className={`p-4 rounded-xl ${
+                isDark ? 'bg-white/5 backdrop-blur-sm' : 'bg-white/80 shadow-sm'
+              }`}
+            >
+              <div className="flex items-center gap-3">
+                <div className={`p-2 rounded-lg ${isDark ? 'bg-blue-500/20' : 'bg-blue-100'}`}>
+                  <FileText className={`w-5 h-5 ${isDark ? 'text-blue-400' : 'text-blue-600'}`} />
+                </div>
+                <div>
+                  <p className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                    {totalCount}
+                  </p>
+                  <p className={`text-xs ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                    총 게시글
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div
+              className={`p-4 rounded-xl ${
+                isDark ? 'bg-white/5 backdrop-blur-sm' : 'bg-white/80 shadow-sm'
+              }`}
+            >
+              <div className="flex items-center gap-3">
+                <div className={`p-2 rounded-lg ${isDark ? 'bg-green-500/20' : 'bg-green-100'}`}>
+                  <Eye className={`w-5 h-5 ${isDark ? 'text-green-400' : 'text-green-600'}`} />
+                </div>
+                <div>
+                  <p className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                    {totalViews.toLocaleString()}
+                  </p>
+                  <p className={`text-xs ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                    총 조회수
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div
+              className={`p-4 rounded-xl ${
+                isDark ? 'bg-white/5 backdrop-blur-sm' : 'bg-white/80 shadow-sm'
+              }`}
+            >
+              <div className="flex items-center gap-3">
+                <div className={`p-2 rounded-lg ${isDark ? 'bg-red-500/20' : 'bg-red-100'}`}>
+                  <Heart className={`w-5 h-5 ${isDark ? 'text-red-400' : 'text-red-500'}`} />
+                </div>
+                <div>
+                  <p className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                    {totalLikes}
+                  </p>
+                  <p className={`text-xs ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                    총 좋아요
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div
+              className={`p-4 rounded-xl ${
+                isDark ? 'bg-white/5 backdrop-blur-sm' : 'bg-white/80 shadow-sm'
+              }`}
+            >
+              <div className="flex items-center gap-3">
+                <div className={`p-2 rounded-lg ${isDark ? 'bg-purple-500/20' : 'bg-purple-100'}`}>
+                  <MessageSquare
+                    className={`w-5 h-5 ${isDark ? 'text-purple-400' : 'text-purple-600'}`}
+                  />
+                </div>
+                <div>
+                  <p className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                    {totalComments}
+                  </p>
+                  <p className={`text-xs ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                    총 댓글
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
+
+        {/* 배경 장식 */}
+        <div
+          className={`absolute -right-10 -top-10 w-40 h-40 rounded-full blur-3xl ${
+            isDark ? 'bg-[#6778ff]/20' : 'bg-blue-200/50'
+          }`}
+        />
+        <div
+          className={`absolute -left-10 -bottom-10 w-32 h-32 rounded-full blur-3xl ${
+            isDark ? 'bg-purple-600/20' : 'bg-indigo-200/50'
+          }`}
+        />
       </div>
 
       {/* 게시글 목록 */}
       {isLoading ? (
         <div className="flex items-center justify-center py-20">
-          <Loader2 className={`w-8 h-8 animate-spin ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
+          <Loader2
+            className={`w-8 h-8 animate-spin ${isDark ? 'text-[#6778ff]' : 'text-blue-600'}`}
+          />
         </div>
       ) : posts.length === 0 ? (
         <div
-          className={`text-center py-20 rounded-xl ${
+          className={`text-center py-16 rounded-2xl ${
+            isDark ? 'bg-white/5 border border-white/10' : 'bg-gray-50 border border-gray-100'
+          }`}
+        >
+          <div
+            className={`w-20 h-20 mx-auto mb-6 rounded-2xl flex items-center justify-center ${
+              isDark ? 'bg-white/10' : 'bg-gray-100'
+            }`}
+          >
+            <FileText className={`w-10 h-10 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
+          </div>
+          <h3 className={`text-lg font-semibold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            아직 작성한 게시글이 없어요
+          </h3>
+          <p className={`text-sm mb-6 max-w-sm mx-auto ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+            커뮤니티에서 다른 개발자들과 지식을 나누고 소통해보세요
+          </p>
+          <Button
+            onClick={() => navigate('/tu/b2c/community')}
+            className="bg-[#6778ff] hover:bg-[#5567ee] text-white"
+          >
+            <PenSquare className="w-4 h-4 mr-2" />
+            첫 게시글 작성하기
+          </Button>
+        </div>
+      ) : (
+        <div
+          className={`rounded-2xl overflow-hidden ${
             isDark ? 'bg-white/5 border border-white/10' : 'bg-white border border-gray-200'
           }`}
         >
-          <FileText className={`w-12 h-12 mx-auto mb-4 ${isDark ? 'text-gray-600' : 'text-gray-400'}`} />
-          <h3 className={`font-medium mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            작성한 게시글이 없습니다
-          </h3>
-          <p className={`text-sm mb-4 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-            커뮤니티에서 첫 게시글을 작성해보세요
-          </p>
-          <Button onClick={() => navigate('/tu/community')}>커뮤니티 가기</Button>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          {posts.map((post) => (
-            <Link
-              key={post.id}
-              to={`/tu/community/${post.id}`}
-              className={`block p-4 rounded-xl transition-all ${
-                isDark
-                  ? 'bg-white/5 border border-white/10 hover:bg-white/10'
-                  : 'bg-white border border-gray-200 hover:shadow-md'
-              }`}
-            >
-              <div className="flex items-start gap-4">
-                <div className="flex-1 min-w-0">
-                  {/* 타입 & 카테고리 */}
-                  <div className="flex items-center gap-2 mb-2">
-                    <Badge variant="blue" className="text-xs">
-                      {POST_TYPE_LABELS[post.type] || post.type}
-                    </Badge>
-                    {post.category && (
-                      <Badge variant="gray" className="text-xs">
-                        {post.category}
+          <div className={`divide-y ${isDark ? 'divide-white/5' : 'divide-gray-100'}`}>
+            {posts.map((post) => (
+              <Link
+                key={post.id}
+                to={`/tu/b2c/community/${post.id}`}
+                className={`block p-5 transition-all group ${
+                  isDark ? 'hover:bg-white/5' : 'hover:bg-gray-50'
+                }`}
+              >
+                <div className="flex items-start gap-4">
+                  <div className="flex-1 min-w-0">
+                    {/* 타입 & 카테고리 */}
+                    <div className="flex items-center gap-2 mb-2">
+                      <Badge
+                        variant="blue"
+                        className={`text-xs ${isDark ? 'bg-[#6778ff]/20 text-[#8b9aff]' : ''}`}
+                      >
+                        {POST_TYPE_LABELS[post.type] || post.type}
                       </Badge>
-                    )}
+                      {post.category && (
+                        <Badge
+                          variant="gray"
+                          className={`text-xs ${isDark ? 'bg-white/10 text-gray-400' : ''}`}
+                        >
+                          {post.category}
+                        </Badge>
+                      )}
+                    </div>
+
+                    {/* 제목 */}
+                    <h3
+                      className={`font-semibold mb-2 line-clamp-1 transition-colors ${
+                        isDark
+                          ? 'text-white group-hover:text-[#8b9aff]'
+                          : 'text-gray-900 group-hover:text-[#6778ff]'
+                      }`}
+                    >
+                      {post.title}
+                    </h3>
+
+                    {/* 내용 미리보기 */}
+                    <p
+                      className={`text-sm line-clamp-1 mb-3 ${
+                        isDark ? 'text-gray-400' : 'text-gray-600'
+                      }`}
+                    >
+                      {stripMarkdownImages(post.content)}
+                    </p>
+
+                    {/* 메타 정보 */}
+                    <div className="flex items-center gap-4">
+                      <span
+                        className={`flex items-center gap-1.5 text-xs ${
+                          isDark ? 'text-gray-500' : 'text-gray-500'
+                        }`}
+                      >
+                        <Clock className="w-3.5 h-3.5" />
+                        {formatDate(post.createdAt)}
+                      </span>
+                      <span
+                        className={`flex items-center gap-1.5 text-xs ${
+                          isDark ? 'text-gray-500' : 'text-gray-500'
+                        }`}
+                      >
+                        <Eye className="w-3.5 h-3.5" />
+                        {post.viewCount?.toLocaleString()}
+                      </span>
+                      <span
+                        className={`flex items-center gap-1.5 text-xs ${
+                          isDark ? 'text-gray-500' : 'text-gray-500'
+                        }`}
+                      >
+                        <Heart className="w-3.5 h-3.5" />
+                        {post.likeCount}
+                      </span>
+                      <span
+                        className={`flex items-center gap-1.5 text-xs ${
+                          isDark ? 'text-gray-500' : 'text-gray-500'
+                        }`}
+                      >
+                        <MessageSquare className="w-3.5 h-3.5" />
+                        {post.commentCount}
+                      </span>
+                    </div>
                   </div>
 
-                  {/* 제목 */}
-                  <h3
-                    className={`font-medium mb-2 line-clamp-1 ${
-                      isDark ? 'text-white' : 'text-gray-900'
+                  {/* 화살표 */}
+                  <ArrowRight
+                    className={`w-5 h-5 flex-shrink-0 mt-1 transition-transform group-hover:translate-x-1 ${
+                      isDark ? 'text-gray-600' : 'text-gray-400'
                     }`}
-                  >
-                    {post.title}
-                  </h3>
-
-                  {/* 내용 미리보기 */}
-                  <p
-                    className={`text-sm line-clamp-2 mb-3 ${
-                      isDark ? 'text-gray-400' : 'text-gray-600'
-                    }`}
-                  >
-                    {stripMarkdownImages(post.content)}
-                  </p>
-
-                  {/* 메타 정보 */}
-                  <div className={`flex items-center gap-4 text-xs ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
-                    <span className="flex items-center gap-1">
-                      <Clock className="w-3.5 h-3.5" />
-                      {formatDate(post.createdAt)}
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <Eye className="w-3.5 h-3.5" />
-                      {post.viewCount}
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <Heart className="w-3.5 h-3.5" />
-                      {post.likeCount}
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <MessageSquare className="w-3.5 h-3.5" />
-                      {post.commentCount}
-                    </span>
-                  </div>
+                  />
                 </div>
-              </div>
-            </Link>
-          ))}
+              </Link>
+            ))}
+          </div>
         </div>
       )}
 
       {/* 페이지네이션 */}
       {totalPages > 1 && (
-        <div className="flex items-center justify-center gap-2 pt-4">
+        <div className="flex items-center justify-center gap-3 pt-4">
           <Button
             variant="outline"
             size="sm"
             onClick={() => setPage((p) => Math.max(0, p - 1))}
             disabled={page === 0}
-            className={isDark ? 'border-white/20 text-white hover:bg-white/10' : ''}
+            className={`${
+              isDark
+                ? 'border-white/20 text-white hover:bg-white/10 disabled:opacity-30'
+                : 'disabled:opacity-30'
+            }`}
           >
-            <ChevronLeft className="w-4 h-4" />
+            <ChevronLeft className="w-4 h-4 mr-1" />
+            이전
           </Button>
-          <span className={`px-4 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-            {page + 1} / {totalPages}
-          </span>
+          <div className="flex items-center gap-2">
+            {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+              const pageNum = Math.max(0, Math.min(page - 2, totalPages - 5)) + i;
+              if (pageNum >= totalPages) return null;
+              return (
+                <button
+                  key={pageNum}
+                  onClick={() => setPage(pageNum)}
+                  className={`w-8 h-8 rounded-lg text-sm font-medium transition-colors ${
+                    page === pageNum
+                      ? 'bg-[#6778ff] text-white'
+                      : isDark
+                        ? 'text-gray-400 hover:bg-white/10'
+                        : 'text-gray-600 hover:bg-gray-100'
+                  }`}
+                >
+                  {pageNum + 1}
+                </button>
+              );
+            })}
+          </div>
           <Button
             variant="outline"
             size="sm"
             onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
             disabled={page >= totalPages - 1}
-            className={isDark ? 'border-white/20 text-white hover:bg-white/10' : ''}
+            className={`${
+              isDark
+                ? 'border-white/20 text-white hover:bg-white/10 disabled:opacity-30'
+                : 'disabled:opacity-30'
+            }`}
           >
-            <ChevronRight className="w-4 h-4" />
+            다음
+            <ChevronRight className="w-4 h-4 ml-1" />
           </Button>
         </div>
       )}

--- a/src/routes/tu.mypage.routes.tsx
+++ b/src/routes/tu.mypage.routes.tsx
@@ -12,6 +12,8 @@ import {
   TeachingStatsPage,
   CompletedCoursesPage,
   CertificationsPage,
+  MyPostsPage,
+  MyCommentsPage,
 } from '@/pages/tu';
 import {
   SettingsPage,
@@ -52,6 +54,10 @@ export const tuMyPageRoutes = (
     {/* 내 강의 관리 */}
     <Route path="teaching" element={<MyTeachingPage />} />
     <Route path="teaching/stats" element={<TeachingStatsPage />} />
+
+    {/* 커뮤니티 */}
+    <Route path="posts" element={<MyPostsPage />} />
+    <Route path="comments" element={<MyCommentsPage />} />
 
     {/* 설정 */}
     <Route path="settings" element={<SettingsPage />} />


### PR DESCRIPTION
## Summary

마이페이지의 내 게시글 및 내 댓글 페이지의 디자인을 전면 개선하고, 라우팅 문제를 수정했습니다.

## Related Issue

- Closes #

## Changes

- MyPostsPage 디자인 개선: 그라데이션 헤더, 통계 카드 (총 게시글/조회수/좋아요/댓글)
- MyCommentsPage 디자인 개선: emerald/teal 테마, 통계 카드 (참여한 게시글/총 상호작용/소통한 작성자)
- 사이드바 메뉴 경로 수정: `/mypage/community/posts` → `/tu/b2c/mypage/posts`
- 게시글 상세 링크 경로 수정: `/tu/community/${id}` → `/tu/b2c/community/${id}`
- 반응형 여백 추가: `max-w-5xl mx-auto px-4 md:px-6 lg:px-8 py-6 md:py-8`

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)
<img width="2844" height="1495" alt="image" src="https://github.com/user-attachments/assets/4f5eb92b-6435-4556-955c-ff27cd2a139a" />

## Additional Notes

- 디자인 및 색감 수정 필요함
- 다크모드/라이트모드 모두 지원
- 페이지네이션 포함
- 빈 상태 UI 개선