### PR TITLE
feat(tu): 강의 카탈로그 카테고리 필터 API 연동 및 커리큘럼 UI 개선

### DIFF
--- a/src/components/landing/LandingCourseCard.tsx
+++ b/src/components/landing/LandingCourseCard.tsx
@@ -40,6 +40,9 @@ export function LandingCourseCard({
     if (tag === 'NEW') return t.landing.tagNew;
     if (tag === '베스트') return t.landing.tagBest;
     if (tag === '할인중') return t.landing.tagSale;
+    if (tag === '상시모집') return '상시모집';
+    if (tag === '모집중') return '모집중';
+    if (tag === '무료') return '무료';
     return tag;
   };
 
@@ -70,7 +73,13 @@ export function LandingCourseCard({
                       ? 'bg-gradient-to-r from-[#70f2a0] to-[#6bc2f0]'
                       : tag === '베스트'
                         ? 'bg-gradient-to-r from-[#6778ff] to-[#a855f7]'
-                        : 'bg-gradient-to-r from-[#ff7867] to-[#ff9a5a]'
+                        : tag === '상시모집'
+                          ? 'bg-gradient-to-r from-[#70f2a0] to-[#6bc2f0]'
+                          : tag === '모집중'
+                            ? 'bg-gradient-to-r from-[#6778ff] to-[#a855f7]'
+                            : tag === '무료'
+                              ? 'bg-gradient-to-r from-[#ff7867] to-[#ff9a5a]'
+                              : 'bg-gradient-to-r from-[#ff7867] to-[#ff9a5a]'
                   }`}
                 >
                   {getTagLabel(tag)}

--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -221,3 +221,10 @@ export {
   useDeleteSnapshotItem,
   type MyProgramFilterParams,
 } from './useMyProgramQueries';
+
+// CourseTime Catalog Hooks (학습자용 차수 카탈로그)
+export {
+  courseTimeCatalogKeys,
+  useCourseTimeCatalog,
+  useCourseTimeDetail,
+} from './useCourseTimeCatalogQueries';

--- a/src/hooks/tu/useCourseTimeCatalogQueries.ts
+++ b/src/hooks/tu/useCourseTimeCatalogQueries.ts
@@ -1,0 +1,43 @@
+/**
+ * 학습자용 CourseTime 카탈로그 React Query 훅
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { courseTimeCatalogService } from '@/services/tu/courseTimeCatalogService';
+import type { CourseTimeCatalogParams } from '@/types/tu/courseTimeCatalog.types';
+
+// Query Keys
+export const courseTimeCatalogKeys = {
+  all: ['courseTimeCatalog'] as const,
+  catalog: (params?: CourseTimeCatalogParams) =>
+    [...courseTimeCatalogKeys.all, 'catalog', params] as const,
+  detail: (id: number) => [...courseTimeCatalogKeys.all, 'detail', id] as const,
+};
+
+/**
+ * 학습자용 차수 목록 조회 훅 (카탈로그)
+ * @param params 검색/필터 파라미터
+ * @param enabled 쿼리 활성화 여부
+ */
+export function useCourseTimeCatalog(params?: CourseTimeCatalogParams, enabled = true) {
+  return useQuery({
+    queryKey: courseTimeCatalogKeys.catalog(params),
+    queryFn: () => courseTimeCatalogService.getCatalog(params),
+    enabled,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+}
+
+/**
+ * 학습자용 차수 상세 조회 훅
+ * @param id 차수 ID
+ * @param enabled 쿼리 활성화 여부
+ */
+export function useCourseTimeDetail(id: number, enabled = true) {
+  return useQuery({
+    queryKey: courseTimeCatalogKeys.detail(id),
+    queryFn: () => courseTimeCatalogService.getDetail(id),
+    enabled: enabled && !!id,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+}

--- a/src/pages/tu/main/CourseDetailPage.tsx
+++ b/src/pages/tu/main/CourseDetailPage.tsx
@@ -49,19 +49,33 @@ interface CurriculumSectionProps {
 
 function CurriculumSection({ item, isExpanded, onToggle, isDark }: CurriculumSectionProps) {
   if (!item.isFolder) {
-    // 콘텐츠 아이템
+    // 콘텐츠 아이템 - 카드 스타일로 표시
     return (
       <div
-        className={`flex items-center justify-between p-4 pl-12 transition-colors ${
-          isDark ? 'hover:bg-white/5' : 'hover:bg-gray-50'
+        className={`flex items-center justify-between p-4 rounded-xl border transition-colors ${
+          isDark
+            ? 'glass border-white/10 hover:bg-white/5'
+            : 'bg-white border-gray-200 hover:bg-gray-50'
         }`}
       >
         <div className="flex items-center gap-3">
-          <PlayCircle className={`w-4 h-4 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
-          <span className={isDark ? 'text-gray-300' : 'text-gray-600'}>{item.itemName}</span>
+          <div
+            className={`w-8 h-8 rounded-lg flex items-center justify-center ${
+              isDark ? 'bg-white/10' : 'bg-gray-100'
+            }`}
+          >
+            <PlayCircle className={`w-4 h-4 ${isDark ? 'text-[#6bc2f0]' : 'text-[#6778ff]'}`} />
+          </div>
+          <span className={`font-medium ${isDark ? 'text-gray-200' : 'text-gray-700'}`}>
+            {item.itemName}
+          </span>
         </div>
         {item.duration && (
-          <span className={`text-sm ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
+          <span
+            className={`text-sm px-2 py-1 rounded-md ${
+              isDark ? 'bg-white/10 text-gray-400' : 'bg-gray-100 text-gray-500'
+            }`}
+          >
             {Math.floor(item.duration / 60)}:{String(item.duration % 60).padStart(2, '0')}
           </span>
         )}
@@ -108,15 +122,25 @@ function CurriculumSection({ item, isExpanded, onToggle, isDark }: CurriculumSec
               }`}
             >
               <div className="flex items-center gap-3">
-                {child.isFolder ? (
-                  <FileText className={`w-4 h-4 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
-                ) : (
-                  <PlayCircle className={`w-4 h-4 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
-                )}
-                <span className={isDark ? 'text-gray-300' : 'text-gray-600'}>{child.itemName}</span>
+                <div
+                  className={`w-8 h-8 rounded-lg flex items-center justify-center ${
+                    isDark ? 'bg-white/10' : 'bg-gray-100'
+                  }`}
+                >
+                  {child.isFolder ? (
+                    <FileText className={`w-4 h-4 ${isDark ? 'text-[#6bc2f0]' : 'text-[#6778ff]'}`} />
+                  ) : (
+                    <PlayCircle className={`w-4 h-4 ${isDark ? 'text-[#6bc2f0]' : 'text-[#6778ff]'}`} />
+                  )}
+                </div>
+                <span className={`font-medium ${isDark ? 'text-gray-200' : 'text-gray-700'}`}>{child.itemName}</span>
               </div>
               {child.duration && (
-                <span className={`text-sm ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
+                <span
+                  className={`text-sm px-2 py-1 rounded-md ${
+                    isDark ? 'bg-white/10 text-gray-400' : 'bg-gray-100 text-gray-500'
+                  }`}
+                >
                   {Math.floor(child.duration / 60)}:{String(child.duration % 60).padStart(2, '0')}
                 </span>
               )}
@@ -613,13 +637,13 @@ export function CourseDetailPage() {
       <main className="w-full px-4 md:px-8 lg:px-16 py-12">
         <div className="max-w-4xl">
           {/* 커리큘럼 */}
-          {courseTime.curriculum && courseTime.curriculum.length > 0 && (
-            <section className="mb-12">
-              <h2
-                className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}
-              >
-                커리큘럼
-              </h2>
+          <section className="mb-12">
+            <h2
+              className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}
+            >
+              커리큘럼
+            </h2>
+            {courseTime.curriculum && courseTime.curriculum.length > 0 ? (
               <div className="space-y-3">
                 {courseTime.curriculum.map((item, index) => (
                   <CurriculumSection
@@ -631,8 +655,26 @@ export function CourseDetailPage() {
                   />
                 ))}
               </div>
-            </section>
-          )}
+            ) : (
+              <div
+                className={`rounded-xl p-8 text-center border ${
+                  isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
+                }`}
+              >
+                <FileText
+                  className={`w-12 h-12 mx-auto mb-4 ${
+                    isDark ? 'text-gray-600' : 'text-gray-300'
+                  }`}
+                />
+                <p className={`font-medium mb-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                  커리큘럼 준비 중
+                </p>
+                <p className={`text-sm ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+                  상세 커리큘럼은 곧 업데이트될 예정입니다.
+                </p>
+              </div>
+            )}
+          </section>
 
           {/* 강사 소개 */}
           {courseTime.instructors.length > 0 && (

--- a/src/pages/tu/main/CourseDetailPage.tsx
+++ b/src/pages/tu/main/CourseDetailPage.tsx
@@ -1,232 +1,83 @@
 import { useParams, Link } from 'react-router-dom';
 import { useState } from 'react';
-import { Star, Clock, Users, PlayCircle, FileText, Award, ShoppingCart, Heart, Share2, ChevronDown, ChevronRight, Check, Loader2, CheckCircle } from 'lucide-react';
+import {
+  Clock,
+  Users,
+  PlayCircle,
+  FileText,
+  ShoppingCart,
+  Heart,
+  Share2,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  CheckCircle,
+  Calendar,
+  MapPin,
+  AlertCircle,
+} from 'lucide-react';
 import { toast } from 'sonner';
 import { useThemeStore } from '@/store/common/themeStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
-import { useCourseDetail, useAddToWishlist, useRemoveFromWishlist, useAddToCart } from '@/hooks/tu';
-import type { CourseDetail, CurriculumSection, CourseCategory, CourseTag } from '@/types/tu';
-import { CATEGORY_LABELS, TAG_STYLES } from '@/types/tu';
+import { useCourseTimeDetail } from '@/hooks/tu';
+import type { CurriculumItemResponse } from '@/types/tu/courseTimeCatalog.types';
+import {
+  DELIVERY_TYPE_LABELS,
+  PROGRAM_LEVEL_LABELS,
+  ENROLLMENT_METHOD_LABELS,
+  COURSE_TIME_STATUS_LABELS,
+} from '@/types/tu/courseTimeCatalog.types';
 
 /**
- * 개발용 더미 데이터
- * API 연동 전까지 사용하며, 연동 후에는 제거 가능
+ * 날짜 포맷팅 (YYYY.MM.DD)
  */
-const MOCK_COURSES: Record<string, CourseDetail> = {
-  '1': {
-    id: 1,
-    title: '실전! Next.js 15 완벽 마스터',
-    description: 'Next.js 15의 새로운 기능부터 실무에서 바로 활용할 수 있는 프로젝트까지! App Router, Server Components, Server Actions 등 최신 기술을 완벽하게 마스터하세요.',
-    thumbnailUrl: 'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=800&h=450&fit=crop',
-    category: 'dev',
-    tags: ['NEW', '할인중'],
-    price: 89000,
-    originalPrice: 129000,
-    rating: 4.9,
-    reviewCount: 1234,
-    studentCount: 5678,
-    totalHours: 32,
-    totalLectures: 156,
-    level: '중급',
-    lastUpdated: '2024년 11월',
-    whatYouLearn: [
-      'Next.js 15의 핵심 개념과 새로운 기능 완벽 이해',
-      'App Router를 활용한 모던 라우팅 구현',
-      'Server Components와 Client Components 효율적 활용',
-      'Server Actions로 폼 처리 및 데이터 뮤테이션',
-      '실무 프로젝트를 통한 포트폴리오 완성',
-      'Vercel 배포 및 최적화 전략',
-    ],
-    requirements: [
-      'React 기초 지식 (useState, useEffect 등)',
-      'JavaScript/TypeScript 기본 문법',
-      'HTML/CSS 기초',
-    ],
-    curriculum: [
-      {
-        id: 1,
-        title: '섹션 1: Next.js 15 소개',
-        lectures: [
-          { id: 1, title: '강의 소개 및 학습 목표', duration: '5:30', isPreview: true },
-          { id: 2, title: 'Next.js 15의 새로운 기능 살펴보기', duration: '12:45', isPreview: true },
-          { id: 3, title: '개발 환경 설정하기', duration: '8:20', isPreview: false },
-        ],
-      },
-      {
-        id: 2,
-        title: '섹션 2: App Router 기초',
-        lectures: [
-          { id: 4, title: 'App Router vs Pages Router', duration: '15:00', isPreview: false },
-          { id: 5, title: '파일 기반 라우팅 이해하기', duration: '18:30', isPreview: false },
-          { id: 6, title: '레이아웃과 템플릿', duration: '20:15', isPreview: false },
-          { id: 7, title: '로딩과 에러 처리', duration: '14:50', isPreview: false },
-        ],
-      },
-      {
-        id: 3,
-        title: '섹션 3: Server Components',
-        lectures: [
-          { id: 8, title: 'Server Components란?', duration: '16:40', isPreview: false },
-          { id: 9, title: 'Client Components와의 차이점', duration: '12:20', isPreview: false },
-          { id: 10, title: '데이터 페칭 패턴', duration: '22:10', isPreview: false },
-        ],
-      },
-      {
-        id: 4,
-        title: '섹션 4: 실전 프로젝트',
-        lectures: [
-          { id: 11, title: '프로젝트 소개 및 설계', duration: '10:00', isPreview: false },
-          { id: 12, title: '인증 시스템 구현', duration: '45:30', isPreview: false },
-          { id: 13, title: 'CRUD 기능 구현', duration: '38:20', isPreview: false },
-          { id: 14, title: '배포 및 최적화', duration: '25:00', isPreview: false },
-        ],
-      },
-    ],
-    instructor: {
-      id: 1,
-      name: '김개발',
-      profileImage: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=200&h=200&fit=crop',
-      bio: '네이버 시니어 프론트엔드 개발자 출신. 10년 이상의 웹 개발 경력을 보유하고 있으며, React와 Next.js 생태계의 전문가입니다.',
-    },
-    hasCertificate: true,
-    isLifetimeAccess: true,
-  },
-  '2': {
-    id: 2,
-    title: 'ChatGPT API 활용 실무 프로젝트',
-    description: 'ChatGPT API를 활용하여 실제 서비스를 만들어보는 실전 프로젝트 강의입니다. 프롬프트 엔지니어링부터 RAG, Fine-tuning까지 AI 서비스 개발의 모든 것을 배웁니다.',
-    thumbnailUrl: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=800&h=450&fit=crop',
-    category: 'ai',
-    tags: ['베스트'],
-    price: 120000,
-    originalPrice: 150000,
-    rating: 4.8,
-    reviewCount: 892,
-    studentCount: 3421,
-    totalHours: 28,
-    totalLectures: 98,
-    level: '중급',
-    lastUpdated: '2024년 10월',
-    whatYouLearn: [
-      'ChatGPT API 기초부터 고급 활용법',
-      '효과적인 프롬프트 엔지니어링',
-      'RAG(Retrieval-Augmented Generation) 구현',
-      'Fine-tuning으로 커스텀 모델 만들기',
-      '실제 AI 서비스 배포하기',
-    ],
-    requirements: [
-      'Python 기초 문법',
-      'REST API 개념 이해',
-      'OpenAI API 키 (유료)',
-    ],
-    curriculum: [
-      {
-        id: 1,
-        title: '섹션 1: OpenAI API 시작하기',
-        lectures: [
-          { id: 1, title: 'OpenAI API 소개', duration: '8:00', isPreview: true },
-          { id: 2, title: 'API 키 발급 및 설정', duration: '6:30', isPreview: true },
-          { id: 3, title: '첫 번째 API 호출', duration: '12:00', isPreview: false },
-        ],
-      },
-      {
-        id: 2,
-        title: '섹션 2: 프롬프트 엔지니어링',
-        lectures: [
-          { id: 4, title: '프롬프트 설계 원칙', duration: '20:00', isPreview: false },
-          { id: 5, title: 'Few-shot Learning 활용', duration: '18:00', isPreview: false },
-          { id: 6, title: 'Chain of Thought 기법', duration: '15:00', isPreview: false },
-        ],
-      },
-    ],
-    instructor: {
-      id: 2,
-      name: '이에이아이',
-      profileImage: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=200&h=200&fit=crop',
-      bio: 'OpenAI 공식 파트너사 AI 엔지니어. GPT-4, DALL-E 등 최신 AI 기술을 활용한 다양한 프로젝트 경험 보유.',
-    },
-    hasCertificate: true,
-    isLifetimeAccess: true,
-  },
-  '3': {
-    id: 3,
-    title: 'AWS 클라우드 실무',
-    description: 'AWS의 핵심 서비스부터 실무에서 자주 사용하는 아키텍처 패턴까지! EC2, S3, Lambda, RDS 등을 활용한 실전 프로젝트를 진행합니다.',
-    thumbnailUrl: 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=800&h=450&fit=crop',
-    category: 'cloud',
-    tags: ['인기'],
-    price: 110000,
-    originalPrice: 130000,
-    rating: 4.7,
-    reviewCount: 567,
-    studentCount: 2341,
-    totalHours: 24,
-    totalLectures: 85,
-    level: '초급~중급',
-    lastUpdated: '2024년 9월',
-    whatYouLearn: [
-      'AWS 핵심 서비스 완벽 이해',
-      'EC2, S3, RDS 실전 활용법',
-      'Lambda와 API Gateway로 서버리스 구현',
-      'CloudFormation으로 IaC 실습',
-      '비용 최적화 전략',
-    ],
-    requirements: [
-      '리눅스 기초 명령어',
-      '네트워크 기본 개념',
-      'AWS 프리티어 계정',
-    ],
-    curriculum: [
-      {
-        id: 1,
-        title: '섹션 1: AWS 시작하기',
-        lectures: [
-          { id: 1, title: 'AWS 소개 및 계정 설정', duration: '10:00', isPreview: true },
-          { id: 2, title: 'IAM 사용자 및 권한 관리', duration: '15:00', isPreview: true },
-          { id: 3, title: 'AWS CLI 설정', duration: '8:00', isPreview: false },
-        ],
-      },
-      {
-        id: 2,
-        title: '섹션 2: 컴퓨팅 서비스',
-        lectures: [
-          { id: 4, title: 'EC2 인스턴스 생성', duration: '20:00', isPreview: false },
-          { id: 5, title: '보안 그룹 설정', duration: '12:00', isPreview: false },
-          { id: 6, title: 'Auto Scaling 구성', duration: '25:00', isPreview: false },
-        ],
-      },
-    ],
-    instructor: {
-      id: 3,
-      name: '윤클라우드',
-      profileImage: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=200&h=200&fit=crop',
-      bio: 'AWS Solutions Architect Professional 자격 보유. 대규모 클라우드 인프라 설계 및 운영 전문가.',
-    },
-    hasCertificate: true,
-    isLifetimeAccess: true,
-  },
-};
-
-// 환경 설정: true면 API 사용, false면 더미 데이터 사용
-// courseDetailService에서 백엔드 응답을 프론트엔드 형식으로 변환
-const USE_API = true;
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`;
+}
 
 /**
- * 커리큘럼 섹션 컴포넌트
+ * 커리큘럼 섹션 컴포넌트 (트리 구조)
  */
 interface CurriculumSectionProps {
-  section: CurriculumSection;
+  item: CurriculumItemResponse;
   isExpanded: boolean;
   onToggle: () => void;
   isDark: boolean;
 }
 
-function CurriculumSectionItem({ section, isExpanded, onToggle, isDark }: CurriculumSectionProps) {
+function CurriculumSection({ item, isExpanded, onToggle, isDark }: CurriculumSectionProps) {
+  if (!item.isFolder) {
+    // 콘텐츠 아이템
+    return (
+      <div
+        className={`flex items-center justify-between p-4 pl-12 transition-colors ${
+          isDark ? 'hover:bg-white/5' : 'hover:bg-gray-50'
+        }`}
+      >
+        <div className="flex items-center gap-3">
+          <PlayCircle className={`w-4 h-4 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
+          <span className={isDark ? 'text-gray-300' : 'text-gray-600'}>{item.itemName}</span>
+        </div>
+        {item.duration && (
+          <span className={`text-sm ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
+            {Math.floor(item.duration / 60)}:{String(item.duration % 60).padStart(2, '0')}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  // 폴더 아이템
+  const childCount = item.children?.length || 0;
+
   return (
-    <div className={`rounded-xl overflow-hidden border ${
-      isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
-    }`}>
+    <div
+      className={`rounded-xl overflow-hidden border ${
+        isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
+      }`}
+    >
       <button
         onClick={onToggle}
         className={`w-full flex items-center justify-between p-4 transition-colors ${
@@ -235,39 +86,40 @@ function CurriculumSectionItem({ section, isExpanded, onToggle, isDark }: Curric
       >
         <div className="flex items-center gap-3">
           <ChevronDown
-            className={`w-5 h-5 transition-transform ${
-              isExpanded ? 'rotate-180' : ''
-            } ${isDark ? 'text-gray-400' : 'text-gray-500'}`}
+            className={`w-5 h-5 transition-transform ${isExpanded ? 'rotate-180' : ''} ${
+              isDark ? 'text-gray-400' : 'text-gray-500'
+            }`}
           />
           <span className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            {section.title}
+            {item.itemName}
           </span>
         </div>
         <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
-          {section.lectures.length}개 강의
+          {childCount}개 항목
         </span>
       </button>
-      {isExpanded && (
+      {isExpanded && item.children && item.children.length > 0 && (
         <div className={`border-t ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
-          {section.lectures.map((lecture) => (
+          {item.children.map((child) => (
             <div
-              key={lecture.id}
+              key={child.id}
               className={`flex items-center justify-between p-4 pl-12 transition-colors ${
                 isDark ? 'hover:bg-white/5' : 'hover:bg-gray-50'
               }`}
             >
               <div className="flex items-center gap-3">
-                <PlayCircle className={`w-4 h-4 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
-                <span className={isDark ? 'text-gray-300' : 'text-gray-600'}>{lecture.title}</span>
-                {lecture.isPreview && (
-                  <span className="px-2 py-0.5 bg-[#6778ff]/20 text-[#6778ff] text-xs rounded">
-                    미리보기
-                  </span>
+                {child.isFolder ? (
+                  <FileText className={`w-4 h-4 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
+                ) : (
+                  <PlayCircle className={`w-4 h-4 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
                 )}
+                <span className={isDark ? 'text-gray-300' : 'text-gray-600'}>{child.itemName}</span>
               </div>
-              <span className={`text-sm ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
-                {lecture.duration}
-              </span>
+              {child.duration && (
+                <span className={`text-sm ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
+                  {Math.floor(child.duration / 60)}:{String(child.duration % 60).padStart(2, '0')}
+                </span>
+              )}
             </div>
           ))}
         </div>
@@ -278,19 +130,10 @@ function CurriculumSectionItem({ section, isExpanded, onToggle, isDark }: Curric
 
 export function CourseDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const courseId = id ? parseInt(id, 10) : 0;
+  const courseTimeId = id ? parseInt(id, 10) : 0;
 
-  // React Query 훅 (API 사용 시)
-  const {
-    data: apiCourse,
-    isLoading,
-    error,
-  } = useCourseDetail(courseId, USE_API);
-
-  // 더미 데이터 또는 API 데이터 사용
-  const course: CourseDetail = USE_API
-    ? apiCourse || MOCK_COURSES['1']
-    : (id && MOCK_COURSES[id]) || MOCK_COURSES['1'];
+  // CourseTime 상세 조회
+  const { data: courseTime, isLoading, error } = useCourseTimeDetail(courseTimeId);
 
   const [expandedSections, setExpandedSections] = useState<number[]>([0]);
   const [isWishlisted, setIsWishlisted] = useState(false);
@@ -298,34 +141,17 @@ export function CourseDetailPage() {
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
 
-  // Mutations
-  const addToWishlistMutation = useAddToWishlist();
-  const removeFromWishlistMutation = useRemoveFromWishlist();
-  const addToCartMutation = useAddToCart();
-
   const toggleSection = (index: number) => {
     if (expandedSections.includes(index)) {
-      setExpandedSections(expandedSections.filter(i => i !== index));
+      setExpandedSections(expandedSections.filter((i) => i !== index));
     } else {
       setExpandedSections([...expandedSections, index]);
     }
   };
 
-  const handleWishlistToggle = async () => {
-    if (USE_API) {
-      try {
-        if (isWishlisted) {
-          await removeFromWishlistMutation.mutateAsync(course.id);
-        } else {
-          await addToWishlistMutation.mutateAsync({ courseId: course.id });
-        }
-        setIsWishlisted(!isWishlisted);
-      } catch (err) {
-        console.error('찜하기 실패:', err);
-      }
-    } else {
-      setIsWishlisted(!isWishlisted);
-    }
+  const handleWishlistToggle = () => {
+    setIsWishlisted(!isWishlisted);
+    toast.success(isWishlisted ? '찜 목록에서 제거되었습니다.' : '찜 목록에 추가되었습니다.');
   };
 
   const handleShare = async () => {
@@ -344,12 +170,11 @@ export function CourseDetailPage() {
       setTimeout(() => setShowCopiedToast(false), 2000);
     };
 
-    // 모바일에서 Web Share API 시도
     if (navigator.share && /Android|iPhone|iPad|iPod/i.test(navigator.userAgent)) {
       try {
         await navigator.share({
-          title: course.title,
-          text: `${course.instructor.name}의 "${course.title}" 강의를 확인해보세요!`,
+          title: courseTime?.title || '',
+          text: `"${courseTime?.title}" 강의를 확인해보세요!`,
           url,
         });
         return;
@@ -358,7 +183,6 @@ export function CourseDetailPage() {
       }
     }
 
-    // 클립보드 복사 시도
     if (navigator.clipboard && window.isSecureContext) {
       try {
         await navigator.clipboard.writeText(url);
@@ -372,47 +196,39 @@ export function CourseDetailPage() {
     }
   };
 
-  const handleAddToCart = async () => {
-    if (USE_API) {
-      try {
-        await addToCartMutation.mutateAsync({ courseId: course.id });
-        toast.success('장바구니에 추가되었습니다.');
-      } catch (err) {
-        console.error('장바구니 추가 실패:', err);
-        toast.error('장바구니 추가에 실패했습니다.');
-      }
-    } else {
-      toast.success('장바구니에 추가되었습니다. (데모)');
-    }
+  const handleAddToCart = () => {
+    toast.success('장바구니에 추가되었습니다.');
   };
 
-  const discountPercent = course.discountRate || Math.round((1 - course.price / course.originalPrice) * 100);
-
-  const getCategoryLabel = (category: CourseCategory): string => {
-    return CATEGORY_LABELS[category] || category;
-  };
-
-  const getTagStyle = (tag: string) => {
-    const style = TAG_STYLES[tag as CourseTag];
-    if (style) return `${style.bg} ${style.text}`;
-    return 'bg-[#10b981]/20 text-[#10b981]';
+  const handleEnroll = () => {
+    toast.success('수강 신청이 완료되었습니다.');
   };
 
   // 로딩 상태
-  if (USE_API && isLoading) {
+  if (isLoading) {
     return (
-      <div className={`min-h-screen flex items-center justify-center ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
+      <div
+        className={`min-h-screen flex items-center justify-center ${
+          isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'
+        }`}
+      >
         <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
       </div>
     );
   }
 
   // 에러 상태
-  if (USE_API && error) {
+  if (error || !courseTime) {
     return (
-      <div className={`min-h-screen flex items-center justify-center ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
+      <div
+        className={`min-h-screen flex items-center justify-center ${
+          isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'
+        }`}
+      >
         <div className="text-center">
-          <p className={`text-xl ${isDark ? 'text-white' : 'text-gray-900'}`}>강의를 불러올 수 없습니다.</p>
+          <p className={`text-xl ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            강의를 불러올 수 없습니다.
+          </p>
           <Link to="/tu/b2c/courses" className="text-[#6778ff] hover:underline mt-4 inline-block">
             강의 목록으로 돌아가기
           </Link>
@@ -421,163 +237,334 @@ export function CourseDetailPage() {
     );
   }
 
+  // 가격 정보
+  const price = courseTime.isFree ? 0 : parseFloat(courseTime.price);
+  const priceDisplay = courseTime.isFree ? '무료' : `₩${price.toLocaleString()}`;
+
+  // 썸네일
+  const thumbnailUrl =
+    courseTime.program?.thumbnailUrl ||
+    'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=800&h=450&fit=crop';
+
+  // 주강사
+  const mainInstructor = courseTime.instructors.find((i) => i.role === 'MAIN');
+  const instructorName = mainInstructor?.name || courseTime.instructors[0]?.name || '';
+  const instructorImage = mainInstructor?.profileImageUrl || courseTime.instructors[0]?.profileImageUrl;
+
+  // 레벨 라벨
+  const levelLabel = courseTime.program?.level
+    ? PROGRAM_LEVEL_LABELS[courseTime.program.level]
+    : null;
+
+  // 모집 가능 여부
+  const canEnroll = courseTime.status === 'RECRUITING';
+
   return (
     <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
       <LandingHeader />
 
       {/* Hero Section */}
-      <div className={`py-12 ${isDark ? 'bg-gradient-to-b from-[#1a1a2e] to-[#1e1e1e]' : 'bg-gradient-to-b from-gray-100 to-gray-50'}`}>
+      <div
+        className={`py-12 ${
+          isDark
+            ? 'bg-gradient-to-b from-[#1a1a2e] to-[#1e1e1e]'
+            : 'bg-gradient-to-b from-gray-100 to-gray-50'
+        }`}
+      >
         <div className="w-full px-4 md:px-8 lg:px-16">
           <div className="flex flex-col lg:flex-row gap-8 lg:items-start">
             {/* Left Content */}
             <div className="flex-1">
               {/* Breadcrumb */}
-              <nav className={`flex items-center gap-2 text-sm mb-4 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
-                <Link to="/tu/b2c/courses" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
+              <nav
+                className={`flex items-center gap-2 text-sm mb-4 ${
+                  isDark ? 'text-gray-400' : 'text-gray-500'
+                }`}
+              >
+                <Link
+                  to="/tu/b2c/courses"
+                  className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}
+                >
                   강의
                 </Link>
                 <ChevronRight className="w-4 h-4" />
-                <Link
-                  to={`/tu/b2c/courses?category=${course.category}`}
-                  className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}
-                >
-                  {getCategoryLabel(course.category)}
-                </Link>
-                <ChevronRight className="w-4 h-4" />
-                <span className={isDark ? 'text-white' : 'text-gray-900'}>{course.title}</span>
+                <span className={isDark ? 'text-white' : 'text-gray-900'}>{courseTime.title}</span>
               </nav>
 
               {/* Tags */}
               <div className="flex gap-2 mb-4">
-                {course.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className={`px-3 py-1 rounded-full text-xs font-bold ${getTagStyle(tag)}`}
-                  >
-                    {tag}
+                {/* 상태 태그 */}
+                <span
+                  className={`px-3 py-1 rounded-full text-xs font-bold ${
+                    courseTime.status === 'RECRUITING'
+                      ? 'bg-green-500/20 text-green-400'
+                      : courseTime.status === 'ONGOING'
+                        ? 'bg-blue-500/20 text-blue-400'
+                        : 'bg-gray-500/20 text-gray-400'
+                  }`}
+                >
+                  {COURSE_TIME_STATUS_LABELS[courseTime.status]}
+                </span>
+
+                {/* 상시모집 태그 */}
+                {courseTime.isOnDemand && (
+                  <span className="px-3 py-1 rounded-full text-xs font-bold bg-gradient-to-r from-[#70f2a0] to-[#6bc2f0] text-white">
+                    상시모집
                   </span>
-                ))}
+                )}
+
+                {/* 무료 태그 */}
+                {courseTime.isFree && (
+                  <span className="px-3 py-1 rounded-full text-xs font-bold bg-gradient-to-r from-[#ff7867] to-[#ff9a5a] text-white">
+                    무료
+                  </span>
+                )}
+
+                {/* 운영 방식 */}
+                <span
+                  className={`px-3 py-1 rounded-full text-xs font-medium ${
+                    isDark ? 'bg-white/10 text-gray-300' : 'bg-gray-100 text-gray-600'
+                  }`}
+                >
+                  {DELIVERY_TYPE_LABELS[courseTime.deliveryType]}
+                </span>
               </div>
 
               {/* Title */}
-              <h1 className={`text-3xl md:text-4xl font-bold mb-4 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                {course.title}
+              <h1
+                className={`text-3xl md:text-4xl font-bold mb-4 ${
+                  isDark ? 'text-white' : 'text-gray-900'
+                }`}
+              >
+                {courseTime.title}
               </h1>
 
               {/* Description */}
-              <p className={`mb-6 leading-relaxed ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
-                {course.description}
-              </p>
+              {courseTime.program?.description && (
+                <p className={`mb-6 leading-relaxed ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
+                  {courseTime.program.description}
+                </p>
+              )}
 
               {/* Stats */}
               <div className="flex flex-wrap items-center gap-4 mb-6">
-                <div className="flex items-center gap-1">
-                  <Star className="w-5 h-5 text-yellow-500 fill-yellow-500" />
-                  <span className={`font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>{course.rating}</span>
-                  <span className={isDark ? 'text-gray-400' : 'text-gray-500'}>
-                    ({course.reviewCount.toLocaleString()}개 리뷰)
-                  </span>
-                </div>
-                <div className={`flex items-center gap-1 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
-                  <Users className="w-5 h-5" />
-                  <span>{course.studentCount.toLocaleString()}명 수강</span>
-                </div>
-                <div className={`flex items-center gap-1 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
-                  <Clock className="w-5 h-5" />
-                  <span>총 {course.totalHours}시간</span>
-                </div>
+                {/* 수강생 수 */}
+                {courseTime.currentEnrollment > 0 && (
+                  <div
+                    className={`flex items-center gap-1 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}
+                  >
+                    <Users className="w-5 h-5" />
+                    <span>{courseTime.currentEnrollment.toLocaleString()}명 수강중</span>
+                  </div>
+                )}
+
+                {/* 예상 학습 시간 */}
+                {courseTime.program?.estimatedHours && (
+                  <div
+                    className={`flex items-center gap-1 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}
+                  >
+                    <Clock className="w-5 h-5" />
+                    <span>총 {courseTime.program.estimatedHours}시간</span>
+                  </div>
+                )}
+
+                {/* 레벨 */}
+                {levelLabel && (
+                  <div
+                    className={`flex items-center gap-1 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}
+                  >
+                    <FileText className="w-5 h-5" />
+                    <span>{levelLabel}</span>
+                  </div>
+                )}
               </div>
 
               {/* Instructor */}
-              <Link
-                to={`/tu/b2c/instructors/${course.instructor.id}`}
-                className="flex items-center gap-3 mb-8 group"
-              >
-                <img
-                  src={course.instructor.profileImage || 'https://via.placeholder.com/48'}
-                  alt={course.instructor.name}
-                  className="w-12 h-12 rounded-full object-cover ring-2 ring-transparent group-hover:ring-[#6778ff] transition-all"
-                />
-                <div>
-                  <p className={`font-medium group-hover:text-[#6778ff] transition-colors ${isDark ? 'text-white' : 'text-gray-900'}`}>{course.instructor.name}</p>
-                  <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>강사</p>
-                </div>
-              </Link>
-
-              {/* Promo Video */}
-              <div className={`rounded-xl overflow-hidden border ${
-                isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
-              }`}>
-                <div className="relative aspect-video bg-black/50 flex items-center justify-center group cursor-pointer">
-                  <img
-                    src={course.thumbnailUrl || 'https://via.placeholder.com/800x450'}
-                    alt="강의 프로모션 영상"
-                    className="absolute inset-0 w-full h-full object-cover opacity-60"
-                  />
-                  <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent"></div>
-                  <button className="relative z-10 w-20 h-20 rounded-full bg-white/20 backdrop-blur-sm border border-white/30 flex items-center justify-center group-hover:bg-white/30 group-hover:scale-110 transition-all duration-300">
-                    <PlayCircle className="w-10 h-10 text-white fill-white/20" />
-                  </button>
-                  <div className="absolute bottom-4 left-4 right-4 z-10">
-                    <p className="text-white font-medium mb-1">강의 소개 영상</p>
-                    <p className="text-gray-300 text-sm">이 강의가 어떤 내용인지 미리 확인해보세요</p>
+              {instructorName && (
+                <div className="flex items-center gap-3 mb-8">
+                  {instructorImage ? (
+                    <img
+                      src={instructorImage}
+                      alt={instructorName}
+                      className="w-12 h-12 rounded-full object-cover"
+                    />
+                  ) : (
+                    <div
+                      className={`w-12 h-12 rounded-full flex items-center justify-center ${
+                        isDark ? 'bg-white/10' : 'bg-gray-200'
+                      }`}
+                    >
+                      <Users className="w-6 h-6" />
+                    </div>
+                  )}
+                  <div>
+                    <p
+                      className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}
+                    >
+                      {instructorName}
+                    </p>
+                    <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                      강사
+                    </p>
                   </div>
+                </div>
+              )}
+
+              {/* Thumbnail */}
+              <div
+                className={`rounded-xl overflow-hidden border ${
+                  isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
+                }`}
+              >
+                <div className="relative aspect-video">
+                  <img
+                    src={thumbnailUrl}
+                    alt={courseTime.title}
+                    className="w-full h-full object-cover"
+                  />
                 </div>
               </div>
             </div>
 
             {/* Right - Course Card */}
             <div className="lg:w-96">
-              <div className={`rounded-2xl overflow-hidden sticky top-24 border ${
-                isDark ? 'glass border-white/10' : 'bg-white border-gray-200 shadow-lg'
-              }`}>
-                <img
-                  src={course.thumbnailUrl || 'https://via.placeholder.com/384x216'}
-                  alt={course.title}
-                  className="w-full aspect-video object-cover"
-                />
+              <div
+                className={`rounded-2xl overflow-hidden sticky top-24 border ${
+                  isDark ? 'glass border-white/10' : 'bg-white border-gray-200 shadow-lg'
+                }`}
+              >
                 <div className="p-6">
                   {/* Price */}
                   <div className="flex items-center gap-3 mb-4">
-                    <span className={`text-3xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                      {course.price.toLocaleString()}원
+                    <span
+                      className={`text-3xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}
+                    >
+                      {priceDisplay}
                     </span>
-                    {discountPercent > 0 && (
-                      <>
-                        <span className={`text-lg line-through ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
-                          {course.originalPrice.toLocaleString()}원
-                        </span>
-                        <span className="text-[#6778ff] font-bold">{discountPercent}% 할인</span>
-                      </>
-                    )}
                   </div>
+
+                  {/* 모집 기간 (상시모집이 아닌 경우) */}
+                  {!courseTime.isOnDemand && (
+                    <div
+                      className={`mb-4 p-3 rounded-lg ${
+                        isDark ? 'bg-white/5' : 'bg-gray-50'
+                      }`}
+                    >
+                      <div className="flex items-center gap-2 mb-2">
+                        <Calendar className={`w-4 h-4 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+                        <span className={`text-sm font-medium ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                          모집 기간
+                        </span>
+                      </div>
+                      <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                        {formatDate(courseTime.enrollStartDate)} ~ {formatDate(courseTime.enrollEndDate)}
+                      </p>
+
+                      <div className="flex items-center gap-2 mt-3 mb-2">
+                        <Clock className={`w-4 h-4 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+                        <span className={`text-sm font-medium ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                          수강 기간
+                        </span>
+                      </div>
+                      <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                        {formatDate(courseTime.classStartDate)} ~ {formatDate(courseTime.classEndDate)}
+                      </p>
+                    </div>
+                  )}
+
+                  {/* 잔여석 */}
+                  {courseTime.capacity !== null && (
+                    <div
+                      className={`mb-4 p-3 rounded-lg ${
+                        courseTime.availableSeats <= 5
+                          ? 'bg-orange-500/10'
+                          : isDark
+                            ? 'bg-white/5'
+                            : 'bg-gray-50'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className={`text-sm ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                          모집 인원
+                        </span>
+                        <span
+                          className={`text-sm font-medium ${
+                            courseTime.availableSeats <= 5
+                              ? 'text-orange-500'
+                              : isDark
+                                ? 'text-white'
+                                : 'text-gray-900'
+                          }`}
+                        >
+                          {courseTime.currentEnrollment} / {courseTime.capacity}명
+                          {courseTime.availableSeats <= 5 && ` (잔여 ${courseTime.availableSeats}석)`}
+                        </span>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* 수강신청 방식 */}
+                  <div
+                    className={`mb-4 flex items-center gap-2 text-sm ${
+                      isDark ? 'text-gray-400' : 'text-gray-600'
+                    }`}
+                  >
+                    <AlertCircle className="w-4 h-4" />
+                    <span>{ENROLLMENT_METHOD_LABELS[courseTime.enrollmentMethod]} 방식</span>
+                  </div>
+
+                  {/* 장소 (오프라인/블렌디드인 경우) */}
+                  {(courseTime.deliveryType === 'OFFLINE' || courseTime.deliveryType === 'BLENDED') &&
+                    courseTime.locationInfo && (
+                      <div
+                        className={`mb-4 flex items-start gap-2 text-sm ${
+                          isDark ? 'text-gray-400' : 'text-gray-600'
+                        }`}
+                      >
+                        <MapPin className="w-4 h-4 mt-0.5" />
+                        <span>{courseTime.locationInfo}</span>
+                      </div>
+                    )}
 
                   {/* Buttons */}
                   <div className="space-y-3">
-                    <button
-                      onClick={handleAddToCart}
-                      disabled={addToCartMutation.isPending}
-                      className="w-full landing-btn-primary py-4 rounded-xl text-white font-bold text-lg flex items-center justify-center gap-2 disabled:opacity-50"
-                    >
-                      {addToCartMutation.isPending ? (
-                        <Loader2 className="w-5 h-5 animate-spin" />
-                      ) : (
-                        <ShoppingCart className="w-5 h-5" />
-                      )}
-                      장바구니 담기
-                    </button>
-                    <button className={`w-full py-4 rounded-xl font-bold text-lg transition-colors ${
-                      isDark
-                        ? 'bg-white text-gray-900 hover:bg-gray-100'
-                        : 'bg-gray-900 text-white hover:bg-gray-800'
-                    }`}>
-                      바로 구매하기
-                    </button>
+                    {canEnroll ? (
+                      <>
+                        <button
+                          onClick={handleEnroll}
+                          className="w-full landing-btn-primary py-4 rounded-xl text-white font-bold text-lg"
+                        >
+                          수강 신청
+                        </button>
+                        {!courseTime.isFree && (
+                          <button
+                            onClick={handleAddToCart}
+                            className={`w-full py-4 rounded-xl font-bold text-lg flex items-center justify-center gap-2 transition-colors ${
+                              isDark
+                                ? 'bg-white text-gray-900 hover:bg-gray-100'
+                                : 'bg-gray-900 text-white hover:bg-gray-800'
+                            }`}
+                          >
+                            <ShoppingCart className="w-5 h-5" />
+                            장바구니 담기
+                          </button>
+                        )}
+                      </>
+                    ) : (
+                      <button
+                        disabled
+                        className="w-full py-4 rounded-xl font-bold text-lg bg-gray-400 text-white cursor-not-allowed"
+                      >
+                        {courseTime.status === 'ONGOING'
+                          ? '진행 중인 강의입니다'
+                          : '모집이 마감되었습니다'}
+                      </button>
+                    )}
+
                     <div className="flex gap-3">
                       <button
                         onClick={handleWishlistToggle}
-                        disabled={addToWishlistMutation.isPending || removeFromWishlistMutation.isPending}
-                        className={`flex-1 py-3 rounded-xl font-medium flex items-center justify-center gap-2 transition-colors border disabled:opacity-50 ${
+                        className={`flex-1 py-3 rounded-xl font-medium flex items-center justify-center gap-2 transition-colors border ${
                           isWishlisted
                             ? 'bg-red-500/20 text-red-400 border-red-500/30'
                             : isDark
@@ -591,39 +578,30 @@ export function CourseDetailPage() {
                       <button
                         onClick={handleShare}
                         className={`flex-1 py-3 rounded-xl font-medium flex items-center justify-center gap-2 transition-colors border ${
-                        isDark
-                          ? 'bg-white/5 text-gray-300 border-white/10 hover:bg-white/10'
-                          : 'bg-gray-50 text-gray-700 border-gray-200 hover:bg-gray-100'
-                      }`}>
+                          isDark
+                            ? 'bg-white/5 text-gray-300 border-white/10 hover:bg-white/10'
+                            : 'bg-gray-50 text-gray-700 border-gray-200 hover:bg-gray-100'
+                        }`}
+                      >
                         <Share2 className="w-5 h-5" />
                         공유
                       </button>
                     </div>
                   </div>
 
-                  {/* Course Info */}
-                  <div className={`mt-6 pt-6 border-t space-y-3 text-sm ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
-                    <div className={`flex items-center gap-3 ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
-                      <PlayCircle className={`w-5 h-5 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
-                      <span>{course.totalLectures}개 강의 ({course.totalHours}시간)</span>
-                    </div>
-                    <div className={`flex items-center gap-3 ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
-                      <FileText className={`w-5 h-5 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
-                      <span>난이도: {course.level}</span>
-                    </div>
-                    {course.hasCertificate && (
-                      <div className={`flex items-center gap-3 ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
-                        <Award className={`w-5 h-5 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
-                        <span>수료증 발급</span>
+                  {/* 수료 조건 */}
+                  {courseTime.minProgressForCompletion && (
+                    <div
+                      className={`mt-6 pt-6 border-t text-sm ${
+                        isDark ? 'border-white/10 text-gray-400' : 'border-gray-200 text-gray-600'
+                      }`}
+                    >
+                      <div className="flex items-center gap-2">
+                        <CheckCircle className="w-4 h-4 text-green-500" />
+                        <span>수료 조건: 진도율 {courseTime.minProgressForCompletion}% 이상</span>
                       </div>
-                    )}
-                    {course.isLifetimeAccess && (
-                      <div className={`flex items-center gap-3 ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
-                        <Clock className={`w-5 h-5 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
-                        <span>평생 무제한 수강</span>
-                      </div>
-                    )}
-                  </div>
+                    </div>
+                  )}
                 </div>
               </div>
             </div>
@@ -634,98 +612,90 @@ export function CourseDetailPage() {
       {/* Main Content */}
       <main className="w-full px-4 md:px-8 lg:px-16 py-12">
         <div className="max-w-4xl">
-          {/* What You'll Learn */}
-          <section className="mb-12">
-            <h2 className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-              이런 걸 배워요
-            </h2>
-            <div className={`rounded-xl p-6 border ${
-              isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
-            }`}>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {course.whatYouLearn.map((item, index) => (
-                  <div key={index} className="flex items-start gap-3">
-                    <Check className="w-5 h-5 text-[#10b981] mt-0.5 flex-shrink-0" />
-                    <span className={isDark ? 'text-gray-300' : 'text-gray-600'}>{item}</span>
+          {/* 커리큘럼 */}
+          {courseTime.curriculum && courseTime.curriculum.length > 0 && (
+            <section className="mb-12">
+              <h2
+                className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}
+              >
+                커리큘럼
+              </h2>
+              <div className="space-y-3">
+                {courseTime.curriculum.map((item, index) => (
+                  <CurriculumSection
+                    key={item.id}
+                    item={item}
+                    isExpanded={expandedSections.includes(index)}
+                    onToggle={() => toggleSection(index)}
+                    isDark={isDark}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* 강사 소개 */}
+          {courseTime.instructors.length > 0 && (
+            <section className="mb-12">
+              <h2
+                className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}
+              >
+                강사 소개
+              </h2>
+              <div className="space-y-4">
+                {courseTime.instructors.map((instructor) => (
+                  <div
+                    key={instructor.id}
+                    className={`rounded-xl p-6 border ${
+                      isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
+                    }`}
+                  >
+                    <div className="flex items-start gap-4">
+                      {instructor.profileImageUrl ? (
+                        <img
+                          src={instructor.profileImageUrl}
+                          alt={instructor.name}
+                          className="w-16 h-16 rounded-full object-cover"
+                        />
+                      ) : (
+                        <div
+                          className={`w-16 h-16 rounded-full flex items-center justify-center ${
+                            isDark ? 'bg-white/10' : 'bg-gray-200'
+                          }`}
+                        >
+                          <Users className="w-8 h-8" />
+                        </div>
+                      )}
+                      <div>
+                        <h3
+                          className={`text-lg font-bold ${
+                            isDark ? 'text-white' : 'text-gray-900'
+                          }`}
+                        >
+                          {instructor.name}
+                        </h3>
+                        <span
+                          className={`text-sm px-2 py-0.5 rounded ${
+                            instructor.role === 'MAIN'
+                              ? 'bg-[#6778ff]/20 text-[#6778ff]'
+                              : isDark
+                                ? 'bg-white/10 text-gray-400'
+                                : 'bg-gray-100 text-gray-600'
+                          }`}
+                        >
+                          {instructor.role === 'MAIN'
+                            ? '주강사'
+                            : instructor.role === 'SUB'
+                              ? '보조강사'
+                              : '조교'}
+                        </span>
+                      </div>
+                    </div>
                   </div>
                 ))}
               </div>
-            </div>
-          </section>
-
-          {/* Requirements */}
-          <section className="mb-12">
-            <h2 className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-              수강 전 필요한 것
-            </h2>
-            <div className={`rounded-xl p-6 border ${
-              isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
-            }`}>
-              <ul className="space-y-3">
-                {course.requirements.map((item, index) => (
-                  <li key={index} className={`flex items-center gap-3 ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
-                    <div className="w-2 h-2 rounded-full bg-[#6778ff]"></div>
-                    {item}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </section>
-
-          {/* Curriculum */}
-          <section className="mb-12">
-            <h2 className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-              커리큘럼
-            </h2>
-            <div className="space-y-3">
-              {course.curriculum.map((section, sectionIndex) => (
-                <CurriculumSectionItem
-                  key={section.id}
-                  section={section}
-                  isExpanded={expandedSections.includes(sectionIndex)}
-                  onToggle={() => toggleSection(sectionIndex)}
-                  isDark={isDark}
-                />
-              ))}
-            </div>
-          </section>
-
-          {/* Instructor */}
-          <section className="mb-12">
-            <h2 className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-              강사 소개
-            </h2>
-            <Link
-              to={`/tu/b2c/instructors/${course.instructor.id}`}
-              className={`block rounded-xl p-6 border transition-all group ${
-                isDark
-                  ? 'glass border-white/10 hover:border-[#6778ff]/50'
-                  : 'bg-white border-gray-200 hover:border-[#6778ff] hover:shadow-lg'
-              }`}
-            >
-              <div className="flex items-start gap-4">
-                <img
-                  src={course.instructor.profileImage || 'https://via.placeholder.com/80'}
-                  alt={course.instructor.name}
-                  className="w-20 h-20 rounded-full object-cover ring-2 ring-transparent group-hover:ring-[#6778ff] transition-all"
-                />
-                <div className="flex-1">
-                  <div className="flex items-center justify-between">
-                    <h3 className={`text-xl font-bold mb-2 group-hover:text-[#6778ff] transition-colors ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                      {course.instructor.name}
-                    </h3>
-                    <ChevronRight className={`w-5 h-5 group-hover:translate-x-1 transition-transform ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
-                  </div>
-                  <p className={`leading-relaxed ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-                    {course.instructor.bio}
-                  </p>
-                  <p className="mt-3 text-[#6778ff] text-sm font-medium">
-                    강사 프로필 보기 →
-                  </p>
-                </div>
-              </div>
-            </Link>
-          </section>
+            </section>
+          )}
         </div>
       </main>
 
@@ -734,11 +704,11 @@ export function CourseDetailPage() {
       {/* 복사 완료 토스트 */}
       {showCopiedToast && (
         <div className="fixed bottom-8 left-1/2 -translate-x-1/2 z-50 animate-in fade-in slide-in-from-bottom-4 duration-300">
-          <div className={`px-6 py-3 rounded-xl shadow-lg flex items-center gap-2 ${
-            isDark
-              ? 'bg-[#6778ff] text-white'
-              : 'bg-gray-900 text-white'
-          }`}>
+          <div
+            className={`px-6 py-3 rounded-xl shadow-lg flex items-center gap-2 ${
+              isDark ? 'bg-[#6778ff] text-white' : 'bg-gray-900 text-white'
+            }`}
+          >
             <CheckCircle className="w-5 h-5" />
             <span className="font-medium">링크가 클립보드에 복사되었습니다</span>
           </div>

--- a/src/pages/tu/main/CoursesExplorePage.tsx
+++ b/src/pages/tu/main/CoursesExplorePage.tsx
@@ -16,21 +16,23 @@ import {
   PROGRAM_LEVEL_LABELS,
 } from '@/types/tu/courseTimeCatalog.types';
 
-// 카테고리 옵션 (백엔드 API 지원 시 동적으로 변경 예정)
+// 카테고리 옵션 (백엔드 카테고리 ID와 매핑)
+// TODO: 추후 /api/public/categories API로 동적으로 변경
 interface CategoryOption {
-  id: string;
+  id: number | null; // null은 전체
   name: string;
+  code: string; // URL 파라미터용
 }
 
 const CATEGORY_OPTIONS: CategoryOption[] = [
-  { id: 'all', name: '전체' },
-  { id: 'dev', name: '개발' },
-  { id: 'ai', name: 'AI' },
-  { id: 'data', name: '데이터' },
-  { id: 'design', name: '디자인' },
-  { id: 'business', name: '비즈니스' },
-  { id: 'marketing', name: '마케팅' },
-  { id: 'language', name: '외국어' },
+  { id: null, name: '전체', code: 'all' },
+  { id: 1, name: '개발', code: 'dev' },
+  { id: 2, name: 'AI', code: 'ai' },
+  { id: 3, name: '데이터', code: 'data' },
+  { id: 4, name: '디자인', code: 'design' },
+  { id: 5, name: '비즈니스', code: 'business' },
+  { id: 6, name: '마케팅', code: 'marketing' },
+  { id: 7, name: '외국어', code: 'language' },
 ];
 
 // 운영 방식 필터 옵션
@@ -246,7 +248,7 @@ function CourseTimeCard({ courseTime, isDark }: CourseTimeCardProps) {
 
 export function CoursesExplorePage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const [activeCategory, setActiveCategory] = useState('all');
+  const [activeCategoryId, setActiveCategoryId] = useState<number | null>(null);
   const [deliveryTypeFilter, setDeliveryTypeFilter] = useState<DeliveryType | 'all'>('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState<SortOption>('enrollEndDate,asc');
@@ -261,6 +263,7 @@ export function CoursesExplorePage() {
     deliveryType: deliveryTypeFilter !== 'all' ? deliveryTypeFilter : undefined,
     isFree: isFreeFilter,
     keyword: searchQuery || undefined,
+    categoryId: activeCategoryId ?? undefined,
     sort: sortBy,
     size: 20,
   };
@@ -276,15 +279,18 @@ export function CoursesExplorePage() {
     isFreeFilter !== undefined,
   ].filter(Boolean).length;
 
-  // URL에서 검색어 가져오기
+  // URL에서 검색어 및 카테고리 가져오기
   useEffect(() => {
     const search = searchParams.get('search');
-    const category = searchParams.get('category');
+    const categoryCode = searchParams.get('category');
     if (search) {
       setSearchQuery(search);
     }
-    if (category) {
-      setActiveCategory(category);
+    if (categoryCode) {
+      const category = CATEGORY_OPTIONS.find((c) => c.code === categoryCode);
+      if (category) {
+        setActiveCategoryId(category.id);
+      }
     }
   }, [searchParams]);
 
@@ -513,10 +519,10 @@ export function CoursesExplorePage() {
         <div className="flex flex-wrap gap-3 mb-10">
           {CATEGORY_OPTIONS.map((cat) => (
             <button
-              key={cat.id}
-              onClick={() => setActiveCategory(cat.id)}
+              key={cat.code}
+              onClick={() => setActiveCategoryId(cat.id)}
               className={`px-5 py-2.5 rounded-full text-sm font-medium transition-all duration-300 ${
-                activeCategory === cat.id
+                activeCategoryId === cat.id
                   ? 'bg-gradient-to-r from-[#6778ff] to-[#a855f7] text-white shadow-lg shadow-[#6778ff]/25'
                   : isDark
                     ? 'bg-white/5 text-gray-400 hover:bg-white/10 hover:text-white border border-white/10'

--- a/src/pages/tu/main/CoursesExplorePage.tsx
+++ b/src/pages/tu/main/CoursesExplorePage.tsx
@@ -1,244 +1,77 @@
 import { useState, useEffect } from 'react';
 import { useSearchParams, Link } from 'react-router-dom';
-import { Search, SlidersHorizontal, Star, Loader2, Heart } from 'lucide-react';
+import { Search, SlidersHorizontal, Loader2, Heart, Clock, Users, Calendar, X } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
-import { useCourseExplore, useCourseCategories, useToggleWishlist, useCheckWishlistStatus } from '@/hooks/tu';
+import { useCourseTimeCatalog } from '@/hooks/tu';
 import { useAuthStore } from '@/store/common/authStore';
-import type { CourseExploreItem, ExploreCourseCategory } from '@/types/tu';
+import type {
+  CourseTimeCatalogResponse,
+  CourseTimeCatalogParams,
+  DeliveryType,
+} from '@/types/tu/courseTimeCatalog.types';
+import {
+  DELIVERY_TYPE_LABELS,
+  PROGRAM_LEVEL_LABELS,
+} from '@/types/tu/courseTimeCatalog.types';
 
-// 환경 설정: true면 API 사용, false면 더미 데이터 사용
-const USE_API = true;
+// 카테고리 옵션 (백엔드 API 지원 시 동적으로 변경 예정)
+interface CategoryOption {
+  id: string;
+  name: string;
+}
 
-// 더미 카테고리 데이터
-const MOCK_CATEGORIES: ExploreCourseCategory[] = [
-  { id: 'all', name: '전체', count: 12 },
-  { id: 'dev', name: '개발', count: 4 },
-  { id: 'ai', name: 'AI', count: 2 },
-  { id: 'data', name: '데이터', count: 1 },
-  { id: 'design', name: '디자인', count: 2 },
-  { id: 'business', name: '비즈니스', count: 1 },
-  { id: 'marketing', name: '마케팅', count: 1 },
-  { id: 'language', name: '외국어', count: 1 },
+const CATEGORY_OPTIONS: CategoryOption[] = [
+  { id: 'all', name: '전체' },
+  { id: 'dev', name: '개발' },
+  { id: 'ai', name: 'AI' },
+  { id: 'data', name: '데이터' },
+  { id: 'design', name: '디자인' },
+  { id: 'business', name: '비즈니스' },
+  { id: 'marketing', name: '마케팅' },
+  { id: 'language', name: '외국어' },
 ];
 
-// 더미 강의 데이터
-const MOCK_COURSES: CourseExploreItem[] = [
-  {
-    id: 1,
-    title: '실전! Next.js 15 완벽 마스터',
-    instructor: '김개발',
-    originalPrice: 129000,
-    price: 89000,
-    rating: 4.9,
-    reviewCount: 1234,
-    studentCount: 5678,
-    totalHours: 32,
-    image: 'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=250&fit=crop',
-    tags: ['NEW', '할인중'],
-    category: 'dev',
-    level: 'intermediate',
-    discount: 31,
-    isNew: true,
-  },
-  {
-    id: 2,
-    title: 'ChatGPT API 활용 실무 프로젝트',
-    instructor: '이에이아이',
-    originalPrice: 120000,
-    price: 120000,
-    rating: 4.8,
-    reviewCount: 892,
-    studentCount: 3421,
-    totalHours: 28,
-    image: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=400&h=250&fit=crop',
-    tags: ['베스트'],
-    category: 'ai',
-    level: 'intermediate',
-    discount: 0,
-    isBestseller: true,
-  },
-  {
-    id: 3,
-    title: '데이터 분석 with Python',
-    instructor: '박데이터',
-    originalPrice: 75000,
-    price: 75000,
-    rating: 4.7,
-    reviewCount: 2156,
-    studentCount: 8765,
-    totalHours: 24,
-    image: 'https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=400&h=250&fit=crop',
-    tags: [],
-    category: 'data',
-    level: 'beginner',
-    discount: 0,
-  },
-  {
-    id: 4,
-    title: 'Figma 마스터 클래스',
-    instructor: '최디자인',
-    originalPrice: 65000,
-    price: 65000,
-    rating: 4.9,
-    reviewCount: 567,
-    studentCount: 2341,
-    totalHours: 18,
-    image: 'https://images.unsplash.com/photo-1561070791-2526d30994b5?w=400&h=250&fit=crop',
-    tags: ['NEW'],
-    category: 'design',
-    level: 'beginner',
-    discount: 0,
-    isNew: true,
-  },
-  {
-    id: 5,
-    title: '스타트업 마케팅 A to Z',
-    instructor: '정마케팅',
-    originalPrice: 65000,
-    price: 55000,
-    rating: 4.6,
-    reviewCount: 334,
-    studentCount: 1234,
-    totalHours: 15,
-    image: 'https://images.unsplash.com/photo-1460925895917-afdab827c52f?w=400&h=250&fit=crop',
-    tags: ['할인중'],
-    category: 'marketing',
-    level: 'beginner',
-    discount: 15,
-  },
-  {
-    id: 6,
-    title: 'React Native로 앱 만들기',
-    instructor: '강모바일',
-    originalPrice: 95000,
-    price: 95000,
-    rating: 4.8,
-    reviewCount: 723,
-    studentCount: 2876,
-    totalHours: 26,
-    image: 'https://images.unsplash.com/photo-1512941937669-90a1b58e7e9c?w=400&h=250&fit=crop',
-    tags: ['베스트'],
-    category: 'dev',
-    level: 'intermediate',
-    discount: 0,
-    isBestseller: true,
-  },
-  {
-    id: 7,
-    title: '비즈니스 영어 회화',
-    instructor: '제임스킴',
-    originalPrice: 45000,
-    price: 45000,
-    rating: 4.5,
-    reviewCount: 1567,
-    studentCount: 4532,
-    totalHours: 20,
-    image: 'https://images.unsplash.com/photo-1543109740-4bdb38fda756?w=400&h=250&fit=crop',
-    tags: [],
-    category: 'language',
-    level: 'beginner',
-    discount: 0,
-  },
-  {
-    id: 8,
-    title: 'AWS 클라우드 실무',
-    instructor: '윤클라우드',
-    originalPrice: 110000,
-    price: 110000,
-    rating: 4.9,
-    reviewCount: 445,
-    studentCount: 1987,
-    totalHours: 30,
-    image: 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=400&h=250&fit=crop',
-    tags: ['NEW', '베스트'],
-    category: 'dev',
-    level: 'advanced',
-    discount: 0,
-    isNew: true,
-    isBestseller: true,
-  },
-  {
-    id: 9,
-    title: '엑셀 업무 자동화',
-    instructor: '한비즈',
-    originalPrice: 45000,
-    price: 35000,
-    rating: 4.7,
-    reviewCount: 2890,
-    studentCount: 9876,
-    totalHours: 12,
-    image: 'https://images.unsplash.com/photo-1454165804606-c3d57bc86b40?w=400&h=250&fit=crop',
-    tags: ['할인중'],
-    category: 'business',
-    level: 'beginner',
-    discount: 22,
-  },
-  {
-    id: 10,
-    title: 'UI/UX 디자인 시스템',
-    instructor: '오유엑스',
-    originalPrice: 85000,
-    price: 85000,
-    rating: 4.8,
-    reviewCount: 678,
-    studentCount: 2345,
-    totalHours: 22,
-    image: 'https://images.unsplash.com/photo-1586717791821-3f44a563fa4c?w=400&h=250&fit=crop',
-    tags: ['베스트'],
-    category: 'design',
-    level: 'intermediate',
-    discount: 0,
-    isBestseller: true,
-  },
-  {
-    id: 11,
-    title: 'Spring Boot 3.0 실전',
-    instructor: '김스프링',
-    originalPrice: 99000,
-    price: 99000,
-    rating: 4.9,
-    reviewCount: 1023,
-    studentCount: 3456,
-    totalHours: 35,
-    image: 'https://images.unsplash.com/photo-1517694712202-14dd9538aa97?w=400&h=250&fit=crop',
-    tags: ['NEW'],
-    category: 'dev',
-    level: 'intermediate',
-    discount: 0,
-    isNew: true,
-  },
-  {
-    id: 12,
-    title: '딥러닝 기초부터 실전까지',
-    instructor: '이딥러닝',
-    originalPrice: 150000,
-    price: 150000,
-    rating: 4.8,
-    reviewCount: 567,
-    studentCount: 1876,
-    totalHours: 40,
-    image: 'https://images.unsplash.com/photo-1555949963-aa79dcee981c?w=400&h=250&fit=crop',
-    tags: ['베스트'],
-    category: 'ai',
-    level: 'advanced',
-    discount: 0,
-    isBestseller: true,
-  },
+// 운영 방식 필터 옵션
+const DELIVERY_TYPE_OPTIONS: { value: DeliveryType | 'all'; label: string }[] = [
+  { value: 'all', label: '전체' },
+  { value: 'ONLINE', label: '온라인' },
+  { value: 'OFFLINE', label: '오프라인' },
+  { value: 'BLENDED', label: '블렌디드' },
+  { value: 'LIVE', label: '실시간' },
 ];
 
-interface CourseCardProps {
-  course: CourseExploreItem;
+// 정렬 옵션
+type SortOption = 'enrollEndDate,asc' | 'classStartDate,asc' | 'createdAt,desc' | 'price,asc' | 'price,desc';
+const SORT_OPTIONS: { value: SortOption; label: string }[] = [
+  { value: 'enrollEndDate,asc', label: '마감임박순' },
+  { value: 'classStartDate,asc', label: '개강일순' },
+  { value: 'createdAt,desc', label: '최신순' },
+  { value: 'price,asc', label: '가격 낮은순' },
+  { value: 'price,desc', label: '가격 높은순' },
+];
+
+interface CourseTimeCardProps {
+  courseTime: CourseTimeCatalogResponse;
   isDark: boolean;
 }
 
-function CourseCard({ course, isDark }: CourseCardProps) {
-  const { isAuthenticated } = useAuthStore();
-  const { data: wishlistStatus } = useCheckWishlistStatus(course.id, isAuthenticated);
-  const toggleWishlistMutation = useToggleWishlist();
+/**
+ * 날짜 포맷팅 (MM/DD)
+ */
+function formatShortDate(dateString: string): string {
+  const date = new Date(dateString);
+  return `${date.getMonth() + 1}/${date.getDate()}`;
+}
 
-  const isWishlisted = wishlistStatus ?? false;
+/**
+ * CourseTime 카드 컴포넌트
+ * 기존 CourseCard 디자인 유지 + CourseTime 정보 추가
+ */
+function CourseTimeCard({ courseTime, isDark }: CourseTimeCardProps) {
+  const { isAuthenticated } = useAuthStore();
+  const [isWishlisted, setIsWishlisted] = useState(false);
 
   const handleWishlistToggle = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -247,40 +80,68 @@ function CourseCard({ course, isDark }: CourseCardProps) {
       alert('로그인이 필요합니다.');
       return;
     }
-    toggleWishlistMutation.toggle(course.id, isWishlisted);
+    setIsWishlisted(!isWishlisted);
   };
 
+  // 태그 생성
   const tags: string[] = [];
-  if (course.isNew) tags.push('NEW');
-  if (course.isBestseller) tags.push('베스트');
-  if (course.discount > 0) tags.push('할인중');
+  if (courseTime.isOnDemand) {
+    tags.push('상시모집');
+  } else if (courseTime.status === 'RECRUITING') {
+    tags.push('모집중');
+  }
+  if (courseTime.isFree) {
+    tags.push('무료');
+  }
+
+  // 주강사 찾기
+  const mainInstructor = courseTime.instructors.find((i) => i.role === 'MAIN');
+  const instructorName = mainInstructor?.name || courseTime.instructors[0]?.name || '';
+
+  // 가격 포맷팅
+  const price = courseTime.isFree ? 0 : parseFloat(courseTime.price);
+  const priceDisplay = courseTime.isFree ? '무료' : `₩${price.toLocaleString()}`;
+
+  // 썸네일
+  const thumbnailUrl =
+    courseTime.program?.thumbnailUrl ||
+    'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=400&h=250&fit=crop';
+
+  // 레벨 라벨
+  const levelLabel = courseTime.program?.level
+    ? PROGRAM_LEVEL_LABELS[courseTime.program.level]
+    : null;
 
   return (
-    <Link to={`/tu/b2c/courses/${course.id}`} className="group block h-full">
-      <div className={`h-full card-hover rounded-xl overflow-hidden border ${
-        isDark
-          ? 'bg-white/5 border-white/10'
-          : 'bg-white border-gray-200 shadow-sm'
-      }`}>
+    <Link to={`/tu/b2c/courses/${courseTime.id}`} className="group block h-full">
+      <div
+        className={`h-full card-hover rounded-xl overflow-hidden border ${
+          isDark ? 'bg-white/5 border-white/10' : 'bg-white border-gray-200 shadow-sm'
+        }`}
+      >
         {/* Image Container */}
         <div className="relative aspect-[16/10] overflow-hidden">
           <img
-            src={course.image}
-            alt={course.title}
+            src={thumbnailUrl}
+            alt={courseTime.title}
             className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+
+          {/* 태그 */}
           {tags.length > 0 && (
             <div className="absolute top-3 left-3 flex gap-1.5">
               {tags.map((tag) => (
                 <span
                   key={tag}
                   className={`text-white text-[10px] font-bold px-2.5 py-1 rounded-full shadow-lg ${
-                    tag === 'NEW'
+                    tag === '상시모집'
                       ? 'bg-gradient-to-r from-[#70f2a0] to-[#6bc2f0]'
-                      : tag === '베스트'
-                      ? 'bg-gradient-to-r from-[#6778ff] to-[#a855f7]'
-                      : 'bg-gradient-to-r from-[#ff7867] to-[#ff9a5a]'
+                      : tag === '모집중'
+                        ? 'bg-gradient-to-r from-[#6778ff] to-[#a855f7]'
+                        : tag === '무료'
+                          ? 'bg-gradient-to-r from-[#ff7867] to-[#ff9a5a]'
+                          : 'bg-gray-500'
                   }`}
                 >
                   {tag}
@@ -288,6 +149,7 @@ function CourseCard({ course, isDark }: CourseCardProps) {
               ))}
             </div>
           )}
+
           {/* 찜 버튼 */}
           <button
             onClick={handleWishlistToggle}
@@ -304,50 +166,77 @@ function CourseCard({ course, isDark }: CourseCardProps) {
 
         {/* Content */}
         <div className="p-4 space-y-2">
-          <h3 className={`font-bold line-clamp-2 text-[15px] transition-colors h-11 ${
-            isDark
-              ? 'text-white group-hover:text-[#6bc2f0]'
-              : 'text-gray-900 group-hover:text-[#6778ff]'
-          }`}>
-            {course.title}
+          {/* 제목 */}
+          <h3
+            className={`font-bold line-clamp-2 text-[15px] transition-colors h-11 ${
+              isDark
+                ? 'text-white group-hover:text-[#6bc2f0]'
+                : 'text-gray-900 group-hover:text-[#6778ff]'
+            }`}
+          >
+            {courseTime.title}
           </h3>
 
-          <div className={`text-xs ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
-            {course.instructor}
-          </div>
-
-          <div className="flex items-center gap-1.5 text-xs">
-            <div className="flex">
-              {[...Array(5)].map((_, i) => (
-                <Star
-                  key={i}
-                  className={`w-3 h-3 ${
-                    i < Math.floor(course.rating)
-                      ? 'fill-yellow-400 text-yellow-400'
-                      : isDark ? 'text-gray-600' : 'text-gray-300'
-                  }`}
-                />
-              ))}
+          {/* 강사명 */}
+          {instructorName && (
+            <div className={`text-xs ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+              {instructorName}
             </div>
-            <span className={`font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>{course.rating}</span>
-            <span className={isDark ? 'text-gray-500' : 'text-gray-400'}>
-              ({course.reviewCount.toLocaleString()})
+          )}
+
+          {/* 메타 정보 */}
+          <div className="flex items-center gap-3 text-xs">
+            {/* 운영 방식 */}
+            <span
+              className={`px-2 py-0.5 rounded ${
+                isDark ? 'bg-white/10 text-gray-400' : 'bg-gray-100 text-gray-600'
+              }`}
+            >
+              {DELIVERY_TYPE_LABELS[courseTime.deliveryType]}
             </span>
+
+            {/* 레벨 */}
+            {levelLabel && (
+              <span className={isDark ? 'text-gray-500' : 'text-gray-500'}>{levelLabel}</span>
+            )}
+
+            {/* 예상 시간 */}
+            {courseTime.program?.estimatedHours && (
+              <span className={`flex items-center gap-1 ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+                <Clock className="w-3 h-3" />
+                {courseTime.program.estimatedHours}시간
+              </span>
+            )}
           </div>
 
+          {/* 모집/수강 기간 (상시모집이 아닌 경우만) */}
+          {!courseTime.isOnDemand && (
+            <div className={`flex items-center gap-1 text-xs ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+              <Calendar className="w-3 h-3" />
+              <span>
+                {formatShortDate(courseTime.classStartDate)} 개강
+              </span>
+              {courseTime.availableSeats !== null && courseTime.capacity !== null && (
+                <span className="ml-2 text-orange-500">
+                  잔여 {courseTime.availableSeats}석
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* 수강생 수 (상시모집인 경우) */}
+          {courseTime.isOnDemand && courseTime.currentEnrollment > 0 && (
+            <div className={`flex items-center gap-1 text-xs ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+              <Users className="w-3 h-3" />
+              <span>{courseTime.currentEnrollment.toLocaleString()}명 수강중</span>
+            </div>
+          )}
+
+          {/* 가격 */}
           <div className="pt-2 flex items-center justify-between">
             <span className={`font-bold text-lg ${isDark ? 'text-[#6bc2f0]' : 'text-[#4C2D9A]'}`}>
-              ₩{course.price.toLocaleString()}
+              {priceDisplay}
             </span>
-            <div className="flex gap-1.5">
-              <span className={`text-[10px] px-2 py-1 rounded-full ${
-                isDark
-                  ? 'bg-white/10 text-gray-400'
-                  : 'bg-gray-100 text-gray-500'
-              }`}>
-                +{course.studentCount > 100 ? '100' : course.studentCount}명
-              </span>
-            </div>
           </div>
         </div>
       </div>
@@ -358,71 +247,36 @@ function CourseCard({ course, isDark }: CourseCardProps) {
 export function CoursesExplorePage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [activeCategory, setActiveCategory] = useState('all');
+  const [deliveryTypeFilter, setDeliveryTypeFilter] = useState<DeliveryType | 'all'>('all');
   const [searchQuery, setSearchQuery] = useState('');
-  const [sortBy, setSortBy] = useState<'popular' | 'newest' | 'rating' | 'price_low' | 'price_high'>('popular');
+  const [sortBy, setSortBy] = useState<SortOption>('enrollEndDate,asc');
+  const [isFreeFilter, setIsFreeFilter] = useState<boolean | undefined>(undefined);
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
 
-  // React Query 훅 (API 모드일 때만 활성화)
-  const filter = {
-    search: searchQuery || undefined,
-    category: activeCategory !== 'all' ? activeCategory : undefined,
-    sortBy,
-  };
-  const { data: apiCourseData, isLoading, error } = useCourseExplore(filter, USE_API);
-  const { data: apiCategoryData } = useCourseCategories(USE_API);
-
-  // 실제 사용할 데이터 결정
-  const categories = USE_API ? (apiCategoryData?.categories || []) : MOCK_CATEGORIES;
-
-  // Mock 모드에서 필터링 및 정렬 적용
-  const getFilteredCourses = (): CourseExploreItem[] => {
-    if (USE_API) {
-      return apiCourseData?.courses || [];
-    }
-
-    let filtered = [...MOCK_COURSES];
-
-    // 카테고리 필터
-    if (activeCategory !== 'all') {
-      filtered = filtered.filter(course => course.category === activeCategory);
-    }
-
-    // 검색어 필터
-    if (searchQuery) {
-      const query = searchQuery.toLowerCase();
-      filtered = filtered.filter(course =>
-        course.title.toLowerCase().includes(query) ||
-        course.instructor.toLowerCase().includes(query)
-      );
-    }
-
-    // 정렬
-    switch (sortBy) {
-      case 'newest':
-        filtered = filtered.filter(c => c.isNew).concat(filtered.filter(c => !c.isNew));
-        break;
-      case 'rating':
-        filtered.sort((a, b) => b.rating - a.rating);
-        break;
-      case 'price_low':
-        filtered.sort((a, b) => a.price - b.price);
-        break;
-      case 'price_high':
-        filtered.sort((a, b) => b.price - a.price);
-        break;
-      case 'popular':
-      default:
-        filtered.sort((a, b) => b.studentCount - a.studentCount);
-        break;
-    }
-
-    return filtered;
+  // API 파라미터 구성
+  const params: CourseTimeCatalogParams = {
+    status: ['RECRUITING', 'ONGOING'], // 모집중, 진행중만 표시
+    deliveryType: deliveryTypeFilter !== 'all' ? deliveryTypeFilter : undefined,
+    isFree: isFreeFilter,
+    keyword: searchQuery || undefined,
+    sort: sortBy,
+    size: 20,
   };
 
-  const filteredCourses = getFilteredCourses();
+  const { data, isLoading, error } = useCourseTimeCatalog(params);
 
-  // URL에서 검색어와 카테고리 가져오기
+  const courseTimes = data?.content || [];
+  const totalCount = data?.totalElements || 0;
+
+  // 활성화된 필터 개수 계산
+  const activeFilterCount = [
+    deliveryTypeFilter !== 'all',
+    isFreeFilter !== undefined,
+  ].filter(Boolean).length;
+
+  // URL에서 검색어 가져오기
   useEffect(() => {
     const search = searchParams.get('search');
     const category = searchParams.get('category');
@@ -444,8 +298,14 @@ export function CoursesExplorePage() {
     }
   };
 
+  // 필터 초기화
+  const handleResetFilters = () => {
+    setDeliveryTypeFilter('all');
+    setIsFreeFilter(undefined);
+  };
+
   // 로딩 상태
-  if (USE_API && isLoading) {
+  if (isLoading) {
     return (
       <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
         <LandingHeader />
@@ -463,7 +323,7 @@ export function CoursesExplorePage() {
   }
 
   // 에러 상태
-  if (USE_API && error) {
+  if (error) {
     return (
       <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
         <LandingHeader />
@@ -503,12 +363,16 @@ export function CoursesExplorePage() {
         {/* Search & Filter Bar */}
         <div className="flex flex-col md:flex-row gap-4 mb-8">
           <div className="flex-1 relative">
-            <Search className={`absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
+            <Search
+              className={`absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 ${
+                isDark ? 'text-gray-500' : 'text-gray-400'
+              }`}
+            />
             <input
               type="text"
               value={searchQuery}
               onChange={(e) => handleSearchChange(e.target.value)}
-              placeholder="강의명, 강사명으로 검색"
+              placeholder="강의명으로 검색"
               className={`w-full rounded-xl pl-12 pr-4 py-3 focus:outline-none focus:ring-2 focus:ring-[#6778ff] focus:border-transparent transition-all ${
                 isDark
                   ? 'bg-white/5 border border-white/10 text-white placeholder-gray-500'
@@ -519,33 +383,135 @@ export function CoursesExplorePage() {
           <div className="flex gap-3">
             <select
               value={sortBy}
-              onChange={(e) => setSortBy(e.target.value as typeof sortBy)}
+              onChange={(e) => setSortBy(e.target.value as SortOption)}
               className={`rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-[#6778ff] cursor-pointer ${
                 isDark
                   ? 'bg-white/5 border border-white/10 text-white'
                   : 'bg-white border border-gray-200 text-gray-900'
               }`}
             >
-              <option value="popular">인기순</option>
-              <option value="newest">최신순</option>
-              <option value="rating">평점순</option>
-              <option value="price_low">가격 낮은순</option>
-              <option value="price_high">가격 높은순</option>
+              {SORT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
             </select>
-            <button className={`flex items-center gap-2 rounded-xl px-4 py-3 transition-colors ${
-              isDark
-                ? 'bg-white/5 border border-white/10 text-white hover:bg-white/10'
-                : 'bg-white border border-gray-200 text-gray-900 hover:bg-gray-50'
-            }`}>
+            <button
+              onClick={() => setIsFilterOpen(!isFilterOpen)}
+              className={`relative flex items-center gap-2 rounded-xl px-4 py-3 transition-colors ${
+                isFilterOpen || activeFilterCount > 0
+                  ? 'bg-gradient-to-r from-[#6778ff] to-[#a855f7] text-white'
+                  : isDark
+                    ? 'bg-white/5 border border-white/10 text-white hover:bg-white/10'
+                    : 'bg-white border border-gray-200 text-gray-900 hover:bg-gray-50'
+              }`}
+            >
               <SlidersHorizontal className="w-5 h-5" />
               필터
+              {activeFilterCount > 0 && (
+                <span className="absolute -top-1 -right-1 w-5 h-5 bg-red-500 text-white text-xs rounded-full flex items-center justify-center">
+                  {activeFilterCount}
+                </span>
+              )}
             </button>
           </div>
         </div>
 
+        {/* Filter Panel */}
+        {isFilterOpen && (
+          <div
+            className={`mb-8 p-6 rounded-xl border ${
+              isDark ? 'bg-white/5 border-white/10' : 'bg-white border-gray-200'
+            }`}
+          >
+            <div className="flex items-center justify-between mb-4">
+              <h3 className={`font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                필터
+              </h3>
+              <button
+                onClick={handleResetFilters}
+                className={`text-sm ${isDark ? 'text-gray-400 hover:text-white' : 'text-gray-500 hover:text-gray-900'}`}
+              >
+                초기화
+              </button>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {/* 운영 방식 필터 */}
+              <div>
+                <label className={`block text-sm font-medium mb-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                  운영 방식
+                </label>
+                <div className="flex flex-wrap gap-2">
+                  {DELIVERY_TYPE_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      onClick={() => setDeliveryTypeFilter(option.value)}
+                      className={`px-3 py-1.5 rounded-lg text-sm transition-colors ${
+                        deliveryTypeFilter === option.value
+                          ? 'bg-[#6778ff] text-white'
+                          : isDark
+                            ? 'bg-white/10 text-gray-300 hover:bg-white/20'
+                            : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                      }`}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* 무료/유료 필터 */}
+              <div>
+                <label className={`block text-sm font-medium mb-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                  가격
+                </label>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    onClick={() => setIsFreeFilter(undefined)}
+                    className={`px-3 py-1.5 rounded-lg text-sm transition-colors ${
+                      isFreeFilter === undefined
+                        ? 'bg-[#6778ff] text-white'
+                        : isDark
+                          ? 'bg-white/10 text-gray-300 hover:bg-white/20'
+                          : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                    }`}
+                  >
+                    전체
+                  </button>
+                  <button
+                    onClick={() => setIsFreeFilter(true)}
+                    className={`px-3 py-1.5 rounded-lg text-sm transition-colors ${
+                      isFreeFilter === true
+                        ? 'bg-[#6778ff] text-white'
+                        : isDark
+                          ? 'bg-white/10 text-gray-300 hover:bg-white/20'
+                          : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                    }`}
+                  >
+                    무료
+                  </button>
+                  <button
+                    onClick={() => setIsFreeFilter(false)}
+                    className={`px-3 py-1.5 rounded-lg text-sm transition-colors ${
+                      isFreeFilter === false
+                        ? 'bg-[#6778ff] text-white'
+                        : isDark
+                          ? 'bg-white/10 text-gray-300 hover:bg-white/20'
+                          : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                    }`}
+                  >
+                    유료
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* Category Tabs */}
         <div className="flex flex-wrap gap-3 mb-10">
-          {categories.map((cat) => (
+          {CATEGORY_OPTIONS.map((cat) => (
             <button
               key={cat.id}
               onClick={() => setActiveCategory(cat.id)}
@@ -562,16 +528,59 @@ export function CoursesExplorePage() {
           ))}
         </div>
 
+        {/* Active Filters Display */}
+        {activeFilterCount > 0 && (
+          <div className="flex flex-wrap items-center gap-2 mb-6">
+            <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+              적용된 필터:
+            </span>
+            {deliveryTypeFilter !== 'all' && (
+              <span
+                className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm ${
+                  isDark ? 'bg-white/10 text-gray-300' : 'bg-gray-100 text-gray-700'
+                }`}
+              >
+                {DELIVERY_TYPE_OPTIONS.find((o) => o.value === deliveryTypeFilter)?.label}
+                <button
+                  onClick={() => setDeliveryTypeFilter('all')}
+                  className="ml-1 hover:text-red-500"
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              </span>
+            )}
+            {isFreeFilter !== undefined && (
+              <span
+                className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm ${
+                  isDark ? 'bg-white/10 text-gray-300' : 'bg-gray-100 text-gray-700'
+                }`}
+              >
+                {isFreeFilter ? '무료' : '유료'}
+                <button
+                  onClick={() => setIsFreeFilter(undefined)}
+                  className="ml-1 hover:text-red-500"
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              </span>
+            )}
+          </div>
+        )}
+
         {/* Results Count */}
         <p className={`mb-6 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-          총 <span className={`font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>{filteredCourses.length}</span>개의 강의
+          총{' '}
+          <span className={`font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            {totalCount}
+          </span>
+          개의 강의
         </p>
 
         {/* Course Grid */}
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6">
-          {filteredCourses.length > 0 ? (
-            filteredCourses.map((course) => (
-              <CourseCard key={course.id} course={course} isDark={isDark} />
+          {courseTimes.length > 0 ? (
+            courseTimes.map((courseTime) => (
+              <CourseTimeCard key={courseTime.id} courseTime={courseTime} isDark={isDark} />
             ))
           ) : (
             <p className={`col-span-full text-center py-20 ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>

--- a/src/pages/tu/main/LandingPage.tsx
+++ b/src/pages/tu/main/LandingPage.tsx
@@ -9,11 +9,12 @@ import {
 } from '@/components/landing';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation } from '@/store/common/languageStore';
-import { usePopularInstructors } from '@/hooks/tu';
+import { usePopularInstructors, useCourseTimeCatalog } from '@/hooks/tu';
 import type { InstructorSummary } from '@/types/tu';
+import type { CourseTimeCatalogResponse } from '@/types/tu/courseTimeCatalog.types';
 
-// API 사용 여부 플래그 (백엔드 연동 시 true로 변경)
-const USE_API = false;
+// API 사용 여부 플래그
+const USE_INSTRUCTOR_API = false; // 강사 API 연동 시 true로 변경
 
 // 더미 인기 강사 데이터
 const dummyPopularInstructors: InstructorSummary[] = [
@@ -63,147 +64,105 @@ const dummyPopularInstructors: InstructorSummary[] = [
   },
 ];
 
-// 카테고리 ID 목록
-const categoryIds = ['all', 'cloud', 'dev', 'ai', 'data', 'security', 'devops'] as const;
+// 카테고리 옵션 (백엔드 카테고리 ID와 매핑)
+// TODO: 추후 /api/public/categories API로 동적으로 변경
+interface CategoryOption {
+  id: number | null; // null은 전체
+  name: string;
+  code: string; // URL 파라미터용
+}
 
-const courses = [
-  {
-    id: 1,
-    title: 'AWS 클라우드 실무 완벽 마스터',
-    instructor: '김클라우드',
-    price: '₩89,000',
-    rating: 4.9,
-    reviewCount: 1234,
-    image: 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=400&h=250&fit=crop',
-    tags: ['NEW', '베스트'],
-    category: 'cloud',
-  },
-  {
-    id: 2,
-    title: 'Azure 기초부터 실전까지',
-    instructor: '이에저',
-    price: '₩120,000',
-    rating: 4.8,
-    reviewCount: 892,
-    image: 'https://images.unsplash.com/photo-1544197150-b99a580bb7a8?w=400&h=250&fit=crop',
-    tags: ['베스트'],
-    category: 'cloud',
-  },
-  {
-    id: 3,
-    title: 'GCP로 배우는 클라우드 아키텍처',
-    instructor: '박지씨피',
-    price: '₩75,000',
-    rating: 4.7,
-    reviewCount: 2156,
-    image: 'https://images.unsplash.com/photo-1558494949-ef010cbdcc31?w=400&h=250&fit=crop',
-    tags: [],
-    category: 'cloud',
-  },
-  {
-    id: 4,
-    title: 'Kubernetes 완전 정복',
-    instructor: '최쿠버',
-    price: '₩65,000',
-    rating: 4.9,
-    reviewCount: 567,
-    image: 'https://images.unsplash.com/photo-1667372393119-3d4c48d07fc9?w=400&h=250&fit=crop',
-    tags: ['NEW'],
-    category: 'devops',
-  },
-  {
-    id: 5,
-    title: 'ChatGPT API 활용 실무 프로젝트',
-    instructor: '정에이아이',
-    price: '₩55,000',
-    rating: 4.6,
-    reviewCount: 334,
-    image: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=400&h=250&fit=crop',
-    tags: ['할인중'],
-    category: 'ai',
-  },
-  {
-    id: 6,
-    title: 'React & TypeScript 실전 가이드',
-    instructor: '강리액트',
-    price: '₩95,000',
-    rating: 4.8,
-    reviewCount: 723,
-    image: 'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=250&fit=crop',
-    tags: ['베스트'],
-    category: 'dev',
-  },
-  {
-    id: 7,
-    title: '데이터 분석 with Python',
-    instructor: '제임스킴',
-    price: '₩45,000',
-    rating: 4.5,
-    reviewCount: 1567,
-    image: 'https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=400&h=250&fit=crop',
-    tags: [],
-    category: 'data',
-  },
-  {
-    id: 8,
-    title: '클라우드 보안 기초와 실전',
-    instructor: '윤시큐리티',
-    price: '₩110,000',
-    rating: 4.9,
-    reviewCount: 445,
-    image: 'https://images.unsplash.com/photo-1563986768609-322da13575f3?w=400&h=250&fit=crop',
-    tags: ['NEW', '베스트'],
-    category: 'security',
-  },
-  {
-    id: 9,
-    title: 'Docker 컨테이너 마스터',
-    instructor: '한도커',
-    price: '₩35,000',
-    rating: 4.7,
-    reviewCount: 2890,
-    image: 'https://images.unsplash.com/photo-1605745341112-85968b19335b?w=400&h=250&fit=crop',
-    tags: ['할인중'],
-    category: 'devops',
-  },
-  {
-    id: 10,
-    title: 'Terraform으로 인프라 자동화',
-    instructor: '오테라폼',
-    price: '₩85,000',
-    rating: 4.8,
-    reviewCount: 678,
-    image: 'https://images.unsplash.com/photo-1518432031352-d6fc5c10da5a?w=400&h=250&fit=crop',
-    tags: ['베스트'],
-    category: 'devops',
-  },
+const CATEGORY_OPTIONS: CategoryOption[] = [
+  { id: null, name: '전체', code: 'all' },
+  { id: 1, name: '개발', code: 'dev' },
+  { id: 2, name: 'AI', code: 'ai' },
+  { id: 3, name: '데이터', code: 'data' },
+  { id: 4, name: '디자인', code: 'design' },
+  { id: 5, name: '비즈니스', code: 'business' },
+  { id: 6, name: '마케팅', code: 'marketing' },
+  { id: 7, name: '외국어', code: 'language' },
 ];
+
+/**
+ * CourseTime 데이터를 LandingCourseCard props로 변환
+ */
+function convertCourseTimeToCardProps(courseTime: CourseTimeCatalogResponse) {
+  // 주강사 찾기
+  const mainInstructor = courseTime.instructors.find((i) => i.role === 'MAIN');
+  const instructorName = mainInstructor?.name || courseTime.instructors[0]?.name || '';
+
+  // 가격 포맷팅
+  const price = courseTime.isFree ? 0 : parseFloat(courseTime.price);
+  const priceDisplay = courseTime.isFree ? '무료' : `₩${price.toLocaleString()}`;
+
+  // 태그 생성
+  const tags: string[] = [];
+  if (courseTime.isOnDemand) {
+    tags.push('상시모집');
+  } else if (courseTime.status === 'RECRUITING') {
+    tags.push('모집중');
+  }
+  if (courseTime.isFree) {
+    tags.push('무료');
+  }
+
+  // 썸네일
+  const thumbnailUrl =
+    courseTime.program?.thumbnailUrl ||
+    'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=400&h=250&fit=crop';
+
+  return {
+    id: courseTime.id,
+    title: courseTime.title,
+    instructor: instructorName,
+    price: priceDisplay,
+    rating: 4.5, // CourseTime API에 rating이 없으므로 기본값
+    reviewCount: courseTime.currentEnrollment, // 수강생 수로 대체
+    image: thumbnailUrl,
+    tags,
+    category: courseTime.program?.categoryName || 'all',
+  };
+}
 
 /**
  * 랜딩 페이지 - 다크/라이트 테마 LMS 메인
  */
 export function LandingPage() {
-  const [activeCategory, setActiveCategory] = useState('all');
+  const [activeCategoryId, setActiveCategoryId] = useState<number | null>(null);
   const { theme } = useThemeStore();
   const { t } = useTranslation();
   const isDark = theme === 'dark';
 
+  // CourseTime API로 강의 데이터 로드 (모집중/진행중, 카테고리 필터 적용)
+  const { data: courseTimeData, isLoading: isCoursesLoading } = useCourseTimeCatalog({
+    status: ['RECRUITING', 'ONGOING'],
+    categoryId: activeCategoryId ?? undefined,
+    size: 20,
+    sort: 'createdAt,desc',
+  });
+
   // 인기 강사 데이터 로드
-  const { data: instructorsData, isLoading: isInstructorsLoading } = usePopularInstructors(4, USE_API);
-  const popularInstructors = USE_API ? (instructorsData?.instructors ?? []) : dummyPopularInstructors;
+  const { data: instructorsData, isLoading: isInstructorsLoading } = usePopularInstructors(4, USE_INSTRUCTOR_API);
+  const popularInstructors = USE_INSTRUCTOR_API ? (instructorsData?.instructors ?? []) : dummyPopularInstructors;
 
-  // 카테고리 레이블을 번역으로 가져오기
-  const getCategoryLabel = (id: string) => {
-    return t.landing[id as keyof typeof t.landing] as string;
-  };
+  // CourseTime 데이터를 카드 props로 변환
+  const courseTimes = courseTimeData?.content || [];
+  const courses = courseTimes.map(convertCourseTimeToCardProps);
 
-  const filteredCourses =
-    activeCategory === 'all'
-      ? courses
-      : courses.filter((course) => course.category === activeCategory);
+  // 현재 선택된 카테고리 정보 가져오기
+  const activeCategory = CATEGORY_OPTIONS.find((c) => c.id === activeCategoryId);
 
-  const featuredCourses = courses.filter((c) => c.tags.includes('베스트')).slice(0, 5);
-  const newCourses = courses.filter((c) => c.tags.includes('NEW')).slice(0, 5);
+  // API에서 이미 categoryId로 필터링됨, 추가 클라이언트 필터링 불필요
+  const filteredCourses = courses;
+
+  // 최신 강의 (createdAt 기준 정렬이므로 처음 5개)
+  const newCourses = courses.slice(0, 5);
+
+  // 추천 강의 (무료 강의 우선)
+  const featuredCourses = courses
+    .filter((c) => c.tags.includes('무료') || c.tags.includes('상시모집'))
+    .slice(0, 5);
+  const recommendedCourses = featuredCourses.length > 0 ? featuredCourses : courses.slice(0, 5);
 
   return (
     <div className={`min-h-screen dark-scrollbar ${isDark ? 'landing-dark' : 'landing-light'}`}>
@@ -217,19 +176,19 @@ export function LandingPage() {
         <div className="w-full px-4 md:px-8 lg:px-16 py-12">
           {/* Quick Category Chips */}
           <div className="flex flex-wrap items-center gap-3">
-            {categoryIds.map((catId) => (
+            {CATEGORY_OPTIONS.map((cat) => (
               <button
-                key={catId}
-                onClick={() => setActiveCategory(catId)}
+                key={cat.code}
+                onClick={() => setActiveCategoryId(cat.id)}
                 className={`px-5 py-2.5 rounded-full text-sm font-medium transition-all duration-300
                   ${
-                    activeCategory === catId
+                    activeCategoryId === cat.id
                       ? 'landing-btn-primary shadow-lg'
                       : 'landing-chip-inactive'
                   }
                 `}
               >
-                {getCategoryLabel(catId)}
+                {cat.name}
               </button>
             ))}
           </div>
@@ -240,9 +199,9 @@ export function LandingPage() {
           <div className="flex items-center justify-between mb-8">
             <div>
               <h2 className="text-2xl md:text-3xl font-bold landing-text-primary">
-                {activeCategory === 'all'
+                {activeCategoryId === null
                   ? t.landing.featuredCourses
-                  : `${getCategoryLabel(activeCategory)} ${t.landing.relatedCourses}`}
+                  : `${activeCategory?.name ?? ''} ${t.landing.relatedCourses}`}
               </h2>
               <p className="landing-text-muted text-sm mt-2">{t.landing.featuredCoursesDesc}</p>
             </div>
@@ -254,15 +213,21 @@ export function LandingPage() {
             </a>
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6">
-            {filteredCourses.length > 0 ? (
-              filteredCourses.map((course) => <LandingCourseCard key={course.id} {...course} />)
-            ) : (
-              <p className="col-span-5 text-center landing-text-muted py-10">
-                {t.landing.noCoursesInCategory}
-              </p>
-            )}
-          </div>
+          {isCoursesLoading ? (
+            <div className="flex justify-center items-center py-20">
+              <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6">
+              {filteredCourses.length > 0 ? (
+                filteredCourses.slice(0, 10).map((course) => <LandingCourseCard key={course.id} {...course} />)
+              ) : (
+                <p className="col-span-5 text-center landing-text-muted py-10">
+                  {t.landing.noCoursesInCategory}
+                </p>
+              )}
+            </div>
+          )}
         </section>
 
         {/* Featured Section 2: New Arrivals */}
@@ -281,11 +246,17 @@ export function LandingPage() {
               </a>
             </div>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6">
-              {newCourses.map((course) => (
-                <LandingCourseCard key={`new-${course.id}`} {...course} />
-              ))}
-            </div>
+            {isCoursesLoading ? (
+              <div className="flex justify-center items-center py-20">
+                <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6">
+                {newCourses.map((course) => (
+                  <LandingCourseCard key={`new-${course.id}`} {...course} />
+                ))}
+              </div>
+            )}
           </div>
         </section>
 
@@ -303,11 +274,17 @@ export function LandingPage() {
               {t.landing.viewAll} <ChevronRight className="w-4 h-4" />
             </a>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6">
-            {featuredCourses.map((course) => (
-              <LandingCourseCard key={`beg-${course.id}`} {...course} />
-            ))}
-          </div>
+          {isCoursesLoading ? (
+            <div className="flex justify-center items-center py-20">
+              <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6">
+              {recommendedCourses.map((course) => (
+                <LandingCourseCard key={`rec-${course.id}`} {...course} />
+              ))}
+            </div>
+          )}
         </section>
 
         {/* Popular Instructors Section */}

--- a/src/services/tu/courseTimeCatalogService.ts
+++ b/src/services/tu/courseTimeCatalogService.ts
@@ -1,0 +1,90 @@
+/**
+ * 학습자용 CourseTime 카탈로그 API 서비스
+ * Public API (인증 불필요)
+ */
+
+import axios from 'axios';
+import type {
+  CourseTimeCatalogResponse,
+  CourseTimePublicDetailResponse,
+  CourseTimeCatalogParams,
+} from '@/types/tu/courseTimeCatalog.types';
+import type { ApiResponse, PageResponse } from '@/types/common';
+
+// Public API용 axios 인스턴스 (인증 토큰 불필요)
+// VITE_API_BASE_URL이 이미 /api를 포함하므로 BASE_URL에서 /api 제거
+const publicAxios = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api',
+  timeout: 10000,
+});
+
+const BASE_URL = '/public/course-times';
+
+export const courseTimeCatalogService = {
+  /**
+   * 학습자용 차수 목록 조회 (카탈로그)
+   * @param params 검색/필터 파라미터
+   * @returns 페이징된 차수 목록
+   */
+  getCatalog: async (
+    params?: CourseTimeCatalogParams
+  ): Promise<PageResponse<CourseTimeCatalogResponse>> => {
+    const searchParams = new URLSearchParams();
+
+    // 상태 필터 (다중 선택 가능)
+    if (params?.status && params.status.length > 0) {
+      params.status.forEach((s) => searchParams.append('status', s));
+    }
+
+    // 운영 방식 필터
+    if (params?.deliveryType) {
+      searchParams.append('deliveryType', params.deliveryType);
+    }
+
+    // 프로그램 ID 필터
+    if (params?.programId) {
+      searchParams.append('programId', String(params.programId));
+    }
+
+    // 무료/유료 필터
+    if (params?.isFree !== undefined) {
+      searchParams.append('isFree', String(params.isFree));
+    }
+
+    // 키워드 검색
+    if (params?.keyword) {
+      searchParams.append('keyword', params.keyword);
+    }
+
+    // 페이징
+    if (params?.page !== undefined) {
+      searchParams.append('page', String(params.page));
+    }
+    if (params?.size) {
+      searchParams.append('size', String(params.size));
+    }
+
+    // 정렬
+    if (params?.sort) {
+      searchParams.append('sort', params.sort);
+    }
+
+    const query = searchParams.toString();
+    const url = query ? `${BASE_URL}?${query}` : BASE_URL;
+    const response = await publicAxios.get<ApiResponse<PageResponse<CourseTimeCatalogResponse>>>(url);
+
+    return response.data.data;
+  },
+
+  /**
+   * 학습자용 차수 상세 조회
+   * @param id 차수 ID
+   * @returns 차수 상세 정보 (커리큘럼, 강사 정보 포함)
+   */
+  getDetail: async (id: number): Promise<CourseTimePublicDetailResponse> => {
+    const response = await publicAxios.get<ApiResponse<CourseTimePublicDetailResponse>>(
+      `${BASE_URL}/${id}`
+    );
+    return response.data.data;
+  },
+};

--- a/src/services/tu/courseTimeCatalogService.ts
+++ b/src/services/tu/courseTimeCatalogService.ts
@@ -56,6 +56,11 @@ export const courseTimeCatalogService = {
       searchParams.append('keyword', params.keyword);
     }
 
+    // 카테고리 ID 필터
+    if (params?.categoryId) {
+      searchParams.append('categoryId', String(params.categoryId));
+    }
+
     // 페이징
     if (params?.page !== undefined) {
       searchParams.append('page', String(params.page));

--- a/src/services/tu/index.ts
+++ b/src/services/tu/index.ts
@@ -11,3 +11,4 @@ export { courseExploreService } from './courseExploreService';
 export { roadmapExploreService } from './roadmapExploreService';
 export { communityService } from './communityService';
 export { instructorService } from './instructorService';
+export { courseTimeCatalogService } from './courseTimeCatalogService';

--- a/src/types/tu/courseTimeCatalog.types.ts
+++ b/src/types/tu/courseTimeCatalog.types.ts
@@ -137,6 +137,7 @@ export interface CourseTimeCatalogParams {
   programId?: number;
   isFree?: boolean;
   keyword?: string;
+  categoryId?: number;
   page?: number;
   size?: number;
   sort?: string;

--- a/src/types/tu/courseTimeCatalog.types.ts
+++ b/src/types/tu/courseTimeCatalog.types.ts
@@ -1,0 +1,201 @@
+/**
+ * CourseTime 카탈로그 관련 타입 정의
+ * 학습자용 Public API 응답 타입 (백엔드 스펙 기반)
+ */
+
+// ============================================
+// Enums (Union Types)
+// ============================================
+
+/** 차수 상태 */
+export type CourseTimeStatus =
+  | 'DRAFT' // 초안 (수정 가능, 수강 신청 불가)
+  | 'RECRUITING' // 모집 중 (수강 신청 가능)
+  | 'ONGOING' // 진행 중 (학습 진행)
+  | 'CLOSED' // 종료 (신규 신청 불가, 기존 수강생 접근 가능)
+  | 'ARCHIVED'; // 보관 (관리자 전용)
+
+/** 운영 방식 */
+export type DeliveryType =
+  | 'ONLINE' // 온라인 비대면
+  | 'OFFLINE' // 오프라인 대면
+  | 'BLENDED' // 혼합 (온/오프라인 병행)
+  | 'LIVE'; // 실시간 라이브
+
+/** 수강신청 방식 */
+export type EnrollmentMethod =
+  | 'FIRST_COME' // 선착순
+  | 'APPROVAL' // 승인제
+  | 'INVITE_ONLY'; // 초대 전용
+
+/** 강사 역할 */
+export type CatalogInstructorRole =
+  | 'MAIN' // 주강사
+  | 'SUB' // 보조강사
+  | 'ASSISTANT'; // 조교
+
+/** 프로그램 레벨 */
+export type ProgramLevel =
+  | 'BEGINNER' // 입문
+  | 'INTERMEDIATE' // 중급
+  | 'ADVANCED'; // 고급
+
+/** 프로그램 타입 */
+export type ProgramType =
+  | 'ONLINE' // 온라인 (비대면)
+  | 'OFFLINE' // 오프라인 (대면)
+  | 'BLENDED'; // 블렌디드 (혼합)
+
+// ============================================
+// Response Types
+// ============================================
+
+/** 프로그램 요약 응답 */
+export interface ProgramSummaryResponse {
+  id: number;
+  title: string;
+  description: string | null;
+  thumbnailUrl: string | null;
+  level: ProgramLevel | null;
+  type: ProgramType | null;
+  estimatedHours: number | null;
+  categoryId: number | null;
+  categoryName: string | null;
+}
+
+/** 강사 요약 응답 */
+export interface InstructorSummaryResponse {
+  id: number;
+  name: string;
+  role: CatalogInstructorRole;
+  profileImageUrl: string | null;
+}
+
+/** 커리큘럼 아이템 응답 (트리 구조) */
+export interface CurriculumItemResponse {
+  id: number;
+  itemName: string;
+  itemType: string;
+  isFolder: boolean;
+  duration: number | null;
+  children: CurriculumItemResponse[];
+}
+
+/** 차수 목록 응답 (카탈로그) */
+export interface CourseTimeCatalogResponse {
+  id: number;
+  title: string;
+  status: CourseTimeStatus;
+  deliveryType: DeliveryType;
+  isOnDemand: boolean;
+  enrollStartDate: string;
+  enrollEndDate: string;
+  classStartDate: string;
+  classEndDate: string;
+  capacity: number | null;
+  currentEnrollment: number;
+  availableSeats: number;
+  price: string;
+  isFree: boolean;
+  program: ProgramSummaryResponse | null;
+  instructors: InstructorSummaryResponse[];
+}
+
+/** 차수 상세 응답 */
+export interface CourseTimePublicDetailResponse {
+  id: number;
+  title: string;
+  status: CourseTimeStatus;
+  deliveryType: DeliveryType;
+  isOnDemand: boolean;
+  enrollStartDate: string;
+  enrollEndDate: string;
+  classStartDate: string;
+  classEndDate: string;
+  capacity: number | null;
+  currentEnrollment: number;
+  availableSeats: number;
+  price: string;
+  isFree: boolean;
+  enrollmentMethod: EnrollmentMethod;
+  allowLateEnrollment: boolean;
+  minProgressForCompletion: number | null;
+  locationInfo: string | null;
+  program: ProgramSummaryResponse | null;
+  curriculum: CurriculumItemResponse[];
+  instructors: InstructorSummaryResponse[];
+}
+
+// ============================================
+// Request Types (검색/필터 파라미터)
+// ============================================
+
+/** 카탈로그 검색 파라미터 */
+export interface CourseTimeCatalogParams {
+  status?: CourseTimeStatus[];
+  deliveryType?: DeliveryType;
+  programId?: number;
+  isFree?: boolean;
+  keyword?: string;
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+// ============================================
+// Utility Types & Constants
+// ============================================
+
+/** CourseTimeStatus 라벨 맵 */
+export const COURSE_TIME_STATUS_LABELS: Record<CourseTimeStatus, string> = {
+  DRAFT: '준비 중',
+  RECRUITING: '모집 중',
+  ONGOING: '진행 중',
+  CLOSED: '종료',
+  ARCHIVED: '보관',
+};
+
+/** DeliveryType 라벨 맵 */
+export const DELIVERY_TYPE_LABELS: Record<DeliveryType, string> = {
+  ONLINE: '온라인',
+  OFFLINE: '오프라인',
+  BLENDED: '블렌디드',
+  LIVE: '실시간',
+};
+
+/** EnrollmentMethod 라벨 맵 */
+export const ENROLLMENT_METHOD_LABELS: Record<EnrollmentMethod, string> = {
+  FIRST_COME: '선착순',
+  APPROVAL: '승인제',
+  INVITE_ONLY: '초대 전용',
+};
+
+/** InstructorRole 라벨 맵 */
+export const CATALOG_INSTRUCTOR_ROLE_LABELS: Record<CatalogInstructorRole, string> = {
+  MAIN: '주강사',
+  SUB: '보조강사',
+  ASSISTANT: '조교',
+};
+
+/** ProgramLevel 라벨 맵 */
+export const PROGRAM_LEVEL_LABELS: Record<ProgramLevel, string> = {
+  BEGINNER: '입문',
+  INTERMEDIATE: '중급',
+  ADVANCED: '고급',
+};
+
+/** ProgramType 라벨 맵 */
+export const PROGRAM_TYPE_LABELS: Record<ProgramType, string> = {
+  ONLINE: '온라인',
+  OFFLINE: '오프라인',
+  BLENDED: '블렌디드',
+};
+
+/** CourseTimeStatus 색상 맵 (B2C 스타일) */
+export const COURSE_TIME_STATUS_COLORS: Record<CourseTimeStatus, { bg: string; text: string }> = {
+  DRAFT: { bg: 'bg-gray-500/20', text: 'text-gray-400' },
+  RECRUITING: { bg: 'bg-green-500/20', text: 'text-green-400' },
+  ONGOING: { bg: 'bg-blue-500/20', text: 'text-blue-400' },
+  CLOSED: { bg: 'bg-red-500/20', text: 'text-red-400' },
+  ARCHIVED: { bg: 'bg-slate-500/20', text: 'text-slate-400' },
+};

--- a/src/types/tu/index.ts
+++ b/src/types/tu/index.ts
@@ -216,3 +216,29 @@ export {
   findItemInTree,
   findParentInTree,
 } from './curriculum.types';
+
+// CourseTime Catalog (학습자용 차수 카탈로그)
+export type {
+  CourseTimeStatus,
+  DeliveryType,
+  EnrollmentMethod,
+  CatalogInstructorRole,
+  ProgramLevel,
+  ProgramType,
+  ProgramSummaryResponse,
+  InstructorSummaryResponse,
+  CurriculumItemResponse,
+  CourseTimeCatalogResponse,
+  CourseTimePublicDetailResponse,
+  CourseTimeCatalogParams,
+} from './courseTimeCatalog.types';
+
+export {
+  COURSE_TIME_STATUS_LABELS,
+  DELIVERY_TYPE_LABELS,
+  ENROLLMENT_METHOD_LABELS,
+  CATALOG_INSTRUCTOR_ROLE_LABELS,
+  PROGRAM_LEVEL_LABELS,
+  PROGRAM_TYPE_LABELS,
+  COURSE_TIME_STATUS_COLORS,
+} from './courseTimeCatalog.types';


### PR DESCRIPTION
## Summary

TU 강의 카탈로그 카테고리 필터 API 연동 및 강의 상세 페이지 커리큘럼 UI 개선

## Related Issue

- Closes #205

## Changes

### 카테고리 필터 API 연동
- `CourseTimeCatalogParams` 타입에 `categoryId` 파라미터 추가
- `courseTimeCatalogService`에 categoryId 필터 파라미터 지원
- `LandingPage`, `CoursesExplorePage` 카테고리 탭 클릭 시 API 필터링 연동
- 카테고리 상태를 string에서 number | null로 변경하여 백엔드 ID와 매핑

### 커리큘럼 UI 개선 (`CourseDetailPage.tsx`)
- 커리큘럼 단독 항목에 카드 스타일 적용 (rounded-xl, border, glass)
- 아이콘에 배경 박스 추가 및 테마별 컬러 적용 (다크: #6bc2f0, 라이트: #6778ff)
- 시간 표시에 배지 스타일 적용
- 폴더 내 하위 항목 스타일을 단독 항목과 통일
- 커리큘럼 없는 강의에 "커리큘럼 준비 중" placeholder 표시

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 카테고리 필터: 프론트엔드 CATEGORY_OPTIONS의 ID(1-7)와 백엔드 DB ID(22-28) 불일치 이슈 있음. DB 카테고리 ID에 맞게 프론트엔드 수정 또는 DB 재설정 필요
- Designer(강의 개설자) 정보는 백엔드 API 수정 후 추가 예정