### PR TITLE
Feat/notification api integration

### DIFF
--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/hooks/common/auth';
 import { useMyProfile } from '@/hooks/common';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation } from '@/store/common/languageStore';
+import { useUnreadNotificationCount } from '@/hooks/tu';
 
 export function LandingHeader() {
   const [showBanner, setShowBanner] = useState(true);
@@ -16,6 +17,8 @@ export function LandingHeader() {
   const { theme, toggleTheme } = useThemeStore();
   const { t } = useTranslation();
   const isDark = theme === 'dark';
+  const { data: unreadCountData } = useUnreadNotificationCount(isAuthenticated);
+  const unreadCount = unreadCountData?.count || 0;
 
   // 프로필 이미지 URL 생성
   const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api').replace('/api', '');
@@ -144,6 +147,11 @@ export function LandingHeader() {
                 }`}
               >
                 <Bell className="h-5 w-5" />
+                {unreadCount > 0 && (
+                  <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] flex items-center justify-center px-1 text-[10px] font-bold text-white bg-gradient-to-r from-[#6778ff] to-[#a855f7] rounded-full">
+                    {unreadCount > 99 ? '99+' : unreadCount}
+                  </span>
+                )}
               </Link>
               {isAuthenticated && user ? (
                 /* Logged in state */

--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -139,10 +139,11 @@ export {
 export {
   notificationKeys,
   useNotifications,
+  useNotification,
   useUnreadNotificationCount,
   useMarkAsRead,
   useMarkAllAsRead,
-  useDeleteNotifications,
+  useDeleteNotification,
   useDeleteReadNotifications,
 } from './useNotificationQueries';
 

--- a/src/hooks/tu/useNotificationQueries.ts
+++ b/src/hooks/tu/useNotificationQueries.ts
@@ -4,16 +4,13 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { notificationService } from '@/services/tu/notificationService';
-import type {
-  NotificationFilter,
-  MarkAsReadRequest,
-  DeleteNotificationRequest,
-} from '@/types/tu/notification.types';
+import type { NotificationFilter } from '@/types/tu/notification.types';
 
 // Query Keys
 export const notificationKeys = {
   all: ['notifications'] as const,
   list: (filter?: NotificationFilter) => [...notificationKeys.all, 'list', filter] as const,
+  detail: (id: number) => [...notificationKeys.all, 'detail', id] as const,
   unreadCount: () => [...notificationKeys.all, 'unreadCount'] as const,
 };
 
@@ -25,6 +22,18 @@ export function useNotifications(filter?: NotificationFilter, enabled = true) {
     queryKey: notificationKeys.list(filter),
     queryFn: () => notificationService.getNotifications(filter),
     enabled,
+    staleTime: 1000 * 60, // 1분
+  });
+}
+
+/**
+ * 알림 상세 조회 훅
+ */
+export function useNotification(notificationId: number, enabled = true) {
+  return useQuery({
+    queryKey: notificationKeys.detail(notificationId),
+    queryFn: () => notificationService.getNotification(notificationId),
+    enabled: enabled && !!notificationId,
     staleTime: 1000 * 60, // 1분
   });
 }
@@ -49,7 +58,7 @@ export function useMarkAsRead() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: MarkAsReadRequest) => notificationService.markAsRead(data),
+    mutationFn: (notificationId: number) => notificationService.markAsRead(notificationId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: notificationKeys.all });
     },
@@ -73,11 +82,11 @@ export function useMarkAllAsRead() {
 /**
  * 알림 삭제 훅
  */
-export function useDeleteNotifications() {
+export function useDeleteNotification() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: DeleteNotificationRequest) => notificationService.deleteNotifications(data),
+    mutationFn: (notificationId: number) => notificationService.deleteNotification(notificationId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: notificationKeys.all });
     },

--- a/src/pages/tu/main/NotificationDetailPage.tsx
+++ b/src/pages/tu/main/NotificationDetailPage.tsx
@@ -1,9 +1,8 @@
-import { useState, useEffect } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import {
   ArrowLeft,
   Bell,
-  Gift,
+  Heart,
   MessageSquare,
   BookOpen,
   Megaphone,
@@ -19,204 +18,17 @@ import { useThemeStore } from '@/store/common/themeStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
 import { Button } from '@/components/common';
-import type { NotificationItem, NotificationType } from '@/types/tu';
-
-// 환경 설정: true면 API 사용, false면 더미 데이터 사용
-const USE_API = false;
-
-// 더미 알림 상세 데이터
-const MOCK_NOTIFICATIONS: Record<number, NotificationItem & { content?: string; actionUrl?: string; actionLabel?: string }> = {
-  1: {
-    id: 1,
-    type: 'promotion',
-    title: '블랙위크 특별 할인!',
-    message: '모든 강의 25% 할인 + 100% 환급 이벤트가 시작되었습니다. 지금 바로 확인해보세요!',
-    content: `
-## 🎉 블랙위크 특별 할인 이벤트
-
-안녕하세요, MZC Learn Platform입니다.
-
-블랙위크를 맞아 **모든 강의 25% 할인** + **100% 환급 이벤트**를 진행합니다!
-
-### 이벤트 기간
-2024년 12월 1일 ~ 12월 31일
-
-### 이벤트 내용
-- **전 강의 25% 할인**: 모든 강의가 25% 할인된 가격으로 제공됩니다.
-- **100% 환급 챌린지**: 수강 완료 시 결제 금액의 100%를 포인트로 환급해드립니다.
-- **추가 쿠폰 증정**: 3개 이상 강의 구매 시 10% 추가 할인 쿠폰 증정
-
-### 참여 방법
-1. 원하는 강의를 선택하세요
-2. 결제 시 자동으로 25% 할인이 적용됩니다
-3. 수강 완료 후 환급 신청을 진행해주세요
-
-놓치지 마세요! 🚀
-    `,
-    createdAt: '2024-12-30T09:50:00Z',
-    isRead: false,
-    actionUrl: '/tu/b2c/courses',
-    actionLabel: '강의 둘러보기',
-  },
-  2: {
-    id: 2,
-    type: 'course',
-    title: '새 강의가 업데이트되었습니다',
-    message: '"실전! Next.js 15 완벽 마스터" 강의에 새로운 섹션이 추가되었습니다.',
-    content: `
-## 📚 강의 업데이트 알림
-
-**"실전! Next.js 15 완벽 마스터"** 강의에 새로운 콘텐츠가 추가되었습니다.
-
-### 추가된 섹션
-- **섹션 12: Server Actions 심화**
-  - 12-1. Server Actions의 동작 원리
-  - 12-2. Form 처리와 Server Actions
-  - 12-3. 에러 핸들링 패턴
-  - 12-4. 실전 프로젝트: 댓글 시스템 구현
-
-### 업데이트 내용
-총 4개의 새로운 강의가 추가되었으며, 약 2시간 분량입니다.
-
-지금 바로 확인해보세요!
-    `,
-    createdAt: '2024-12-30T09:00:00Z',
-    isRead: false,
-    actionUrl: '/tu/b2c/courses/1',
-    actionLabel: '강의 바로가기',
-  },
-  3: {
-    id: 3,
-    type: 'comment',
-    title: '질문에 답변이 달렸습니다',
-    message: '김개발 강사님이 회원님의 질문에 답변을 남겼습니다.',
-    content: `
-## 💬 새로운 답변 알림
-
-**김개발** 강사님이 회원님의 질문에 답변을 남겼습니다.
-
-### 원본 질문
-> useEffect에서 async/await를 직접 사용하면 안 되는 이유가 무엇인가요?
-
-### 강사님 답변
-좋은 질문이네요! useEffect의 콜백 함수는 cleanup 함수를 반환해야 하는데, async 함수는 항상 Promise를 반환하기 때문입니다.
-
-대신 다음과 같이 내부에 async 함수를 정의해서 사용하세요:
-
-\`\`\`javascript
-useEffect(() => {
-  const fetchData = async () => {
-    const result = await api.getData();
-    setData(result);
-  };
-  fetchData();
-}, []);
-\`\`\`
-
-추가 질문 있으시면 편하게 남겨주세요!
-    `,
-    createdAt: '2024-12-30T07:00:00Z',
-    isRead: false,
-    actionUrl: '/tu/b2c/community/1',
-    actionLabel: '답변 보러가기',
-  },
-  4: {
-    id: 4,
-    type: 'system',
-    title: '서비스 점검 안내',
-    message: '12월 5일 오전 2시~4시 서비스 점검이 예정되어 있습니다.',
-    content: `
-## 🔧 서비스 정기 점검 안내
-
-안녕하세요, MZC Learn Platform입니다.
-
-서비스 안정화 및 성능 개선을 위한 정기 점검을 진행합니다.
-
-### 점검 일시
-**2024년 12월 5일 (목) 오전 02:00 ~ 04:00** (약 2시간)
-
-### 점검 내용
-- 서버 인프라 업그레이드
-- 데이터베이스 최적화
-- 보안 패치 적용
-
-### 주의사항
-- 점검 시간 동안 서비스 이용이 불가합니다
-- 강의 시청, 결제 등 모든 기능이 일시 중단됩니다
-- 점검 종료 후 자동으로 정상화됩니다
-
-이용에 불편을 드려 죄송합니다.
-더 나은 서비스로 보답하겠습니다.
-    `,
-    createdAt: '2024-12-29T10:00:00Z',
-    isRead: true,
-  },
-  5: {
-    id: 5,
-    type: 'course',
-    title: '수강 완료를 축하합니다!',
-    message: '"React 기초부터 실전까지" 강의를 완료하셨습니다. 수료증을 다운로드해보세요!',
-    content: `
-## 🎊 수강 완료를 축하합니다!
-
-회원님께서 **"React 기초부터 실전까지"** 강의를 성공적으로 완료하셨습니다!
-
-### 수강 정보
-- **강의명**: React 기초부터 실전까지
-- **수강 기간**: 2024.11.15 ~ 2024.12.28
-- **총 학습 시간**: 24시간 32분
-- **진도율**: 100%
-
-### 수료증 안내
-수료증이 발급되었습니다. 마이페이지에서 다운로드하실 수 있습니다.
-
-앞으로도 MZC Learn Platform과 함께 성장해주세요! 🚀
-    `,
-    createdAt: '2024-12-28T10:00:00Z',
-    isRead: true,
-    actionUrl: '/tu/b2c/mypage/certifications',
-    actionLabel: '수료증 확인하기',
-  },
-  6: {
-    id: 6,
-    type: 'promotion',
-    title: '첫 구매 할인 쿠폰 도착',
-    message: '첫 강의 구매 시 사용할 수 있는 20% 할인 쿠폰이 발급되었습니다.',
-    content: `
-## 🎁 첫 구매 할인 쿠폰 발급
-
-MZC Learn Platform에 가입해주셔서 감사합니다!
-
-첫 강의 구매 시 사용하실 수 있는 **20% 할인 쿠폰**이 발급되었습니다.
-
-### 쿠폰 정보
-- **할인율**: 20%
-- **최대 할인 금액**: 30,000원
-- **사용 기한**: 2025년 1월 27일까지
-- **적용 대상**: 모든 강의
-
-### 사용 방법
-1. 원하는 강의를 장바구니에 담으세요
-2. 결제 페이지에서 쿠폰을 선택하세요
-3. 할인된 금액으로 결제하세요
-
-지금 바로 강의를 둘러보세요! 📚
-    `,
-    createdAt: '2024-12-27T10:00:00Z',
-    isRead: true,
-    actionUrl: '/tu/b2c/courses',
-    actionLabel: '강의 둘러보기',
-  },
-};
+import { useNotification, useMarkAsRead, useDeleteNotification } from '@/hooks/tu';
+import type { NotificationType } from '@/types/tu';
 
 // 알림 타입별 아이콘 매핑
 const getNotificationIcon = (type: NotificationType) => {
   switch (type) {
-    case 'promotion': return Gift;
-    case 'course': return BookOpen;
-    case 'comment': return MessageSquare;
-    case 'system': return Megaphone;
-    case 'assignment': return FileText;
+    case 'COMMENT': return MessageSquare;
+    case 'LIKE': return Heart;
+    case 'COURSE': return BookOpen;
+    case 'SYSTEM': return Megaphone;
+    case 'ASSIGNMENT': return FileText;
     default: return AlertCircle;
   }
 };
@@ -224,11 +36,11 @@ const getNotificationIcon = (type: NotificationType) => {
 // 알림 타입별 색상 매핑
 const getIconColor = (type: NotificationType) => {
   switch (type) {
-    case 'promotion': return 'text-[#f59e0b] bg-[#f59e0b]/20';
-    case 'course': return 'text-[#6778ff] bg-[#6778ff]/20';
-    case 'comment': return 'text-[#10b981] bg-[#10b981]/20';
-    case 'system': return 'text-[#ec4899] bg-[#ec4899]/20';
-    case 'assignment': return 'text-[#8b5cf6] bg-[#8b5cf6]/20';
+    case 'COMMENT': return 'text-[#10b981] bg-[#10b981]/20';
+    case 'LIKE': return 'text-[#f43f5e] bg-[#f43f5e]/20';
+    case 'COURSE': return 'text-[#6778ff] bg-[#6778ff]/20';
+    case 'SYSTEM': return 'text-[#f59e0b] bg-[#f59e0b]/20';
+    case 'ASSIGNMENT': return 'text-[#8b5cf6] bg-[#8b5cf6]/20';
     default: return 'text-gray-400 bg-gray-400/20';
   }
 };
@@ -236,11 +48,11 @@ const getIconColor = (type: NotificationType) => {
 // 알림 타입 레이블
 const getTypeLabel = (type: NotificationType) => {
   switch (type) {
-    case 'promotion': return '이벤트';
-    case 'course': return '강의';
-    case 'comment': return '댓글';
-    case 'system': return '공지';
-    case 'assignment': return '과제';
+    case 'COMMENT': return '댓글';
+    case 'LIKE': return '좋아요';
+    case 'COURSE': return '강의';
+    case 'SYSTEM': return '시스템';
+    case 'ASSIGNMENT': return '과제';
     default: return '알림';
   }
 };
@@ -263,55 +75,25 @@ export function NotificationDetailPage() {
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
 
-  const [notification, setNotification] = useState<(NotificationItem & { content?: string; actionUrl?: string; actionLabel?: string }) | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isDeleting, setIsDeleting] = useState(false);
+  // React Query 훅
+  const notificationId = Number(id);
+  const { data: notification, isLoading } = useNotification(notificationId, !!id);
+  const markAsReadMutation = useMarkAsRead();
+  const deleteNotificationMutation = useDeleteNotification();
 
-  useEffect(() => {
-    const loadNotification = async () => {
-      setIsLoading(true);
-      try {
-        if (USE_API) {
-          // API 호출 (구현 필요)
-          // const data = await notificationService.getNotification(Number(id));
-          // setNotification(data);
-        } else {
-          // Mock 데이터 사용
-          await new Promise((resolve) => setTimeout(resolve, 300));
-          const data = MOCK_NOTIFICATIONS[Number(id)];
-          if (data) {
-            setNotification(data);
-          }
-        }
-      } catch (error) {
-        console.error('Failed to load notification:', error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    if (id) {
-      loadNotification();
+  const handleMarkAsRead = () => {
+    if (notification && !notification.isRead) {
+      markAsReadMutation.mutate(notification.id);
     }
-  }, [id]);
+  };
 
-  const handleDelete = async () => {
+  const handleDelete = () => {
     if (!notification) return;
-
-    setIsDeleting(true);
-    try {
-      if (USE_API) {
-        // API 호출 (구현 필요)
-        // await notificationService.deleteNotifications({ notificationIds: [notification.id] });
-      } else {
-        await new Promise((resolve) => setTimeout(resolve, 300));
-      }
-      navigate('/tu/b2c/notifications');
-    } catch (error) {
-      console.error('Failed to delete notification:', error);
-    } finally {
-      setIsDeleting(false);
-    }
+    deleteNotificationMutation.mutate(notification.id, {
+      onSuccess: () => {
+        navigate('/tu/b2c/notifications');
+      },
+    });
   };
 
   // 로딩 상태
@@ -414,86 +196,18 @@ export function NotificationDetailPage() {
             </div>
 
             {/* Content */}
-            <div className={`prose prose-sm max-w-none mb-8 ${
-              isDark
-                ? 'prose-invert prose-p:text-gray-300 prose-headings:text-white prose-strong:text-white prose-code:text-[#6778ff] prose-blockquote:border-l-[#6778ff] prose-blockquote:text-gray-400'
-                : 'prose-gray'
-            }`}>
-              {notification.content ? (
-                <div className="whitespace-pre-wrap">
-                  {notification.content.split('\n').map((line, index) => {
-                    // Heading 2
-                    if (line.startsWith('## ')) {
-                      return <h2 key={index} className="text-xl font-bold mt-6 mb-3">{line.replace('## ', '')}</h2>;
-                    }
-                    // Heading 3
-                    if (line.startsWith('### ')) {
-                      return <h3 key={index} className="text-lg font-semibold mt-4 mb-2">{line.replace('### ', '')}</h3>;
-                    }
-                    // List item
-                    if (line.startsWith('- ')) {
-                      return (
-                        <li key={index} className={`ml-4 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
-                          {line.replace('- ', '')}
-                        </li>
-                      );
-                    }
-                    // Numbered list
-                    if (/^\d+\. /.test(line)) {
-                      return (
-                        <li key={index} className={`ml-4 list-decimal ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
-                          {line.replace(/^\d+\. /, '')}
-                        </li>
-                      );
-                    }
-                    // Blockquote
-                    if (line.startsWith('> ')) {
-                      return (
-                        <blockquote key={index} className={`border-l-4 pl-4 my-2 ${isDark ? 'border-[#6778ff] text-gray-400' : 'border-gray-300 text-gray-600'}`}>
-                          {line.replace('> ', '')}
-                        </blockquote>
-                      );
-                    }
-                    // Bold text
-                    if (line.includes('**')) {
-                      const parts = line.split(/\*\*(.*?)\*\*/g);
-                      return (
-                        <p key={index} className={`my-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
-                          {parts.map((part, i) =>
-                            i % 2 === 1 ? <strong key={i} className={isDark ? 'text-white' : 'text-gray-900'}>{part}</strong> : part
-                          )}
-                        </p>
-                      );
-                    }
-                    // Code block start/end
-                    if (line.startsWith('```')) {
-                      return null;
-                    }
-                    // Empty line
-                    if (line.trim() === '') {
-                      return <br key={index} />;
-                    }
-                    // Regular paragraph
-                    return (
-                      <p key={index} className={`my-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
-                        {line}
-                      </p>
-                    );
-                  })}
-                </div>
-              ) : (
-                <p className={isDark ? 'text-gray-300' : 'text-gray-700'}>{notification.message}</p>
-              )}
+            <div className={`mb-8 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+              <p className="text-base leading-relaxed">{notification.message}</p>
             </div>
 
-            {/* Action Button */}
-            {notification.actionUrl && (
+            {/* Action Button - 알림에 링크가 있는 경우 */}
+            {notification.link && (
               <div className="mb-6">
                 <Link
-                  to={notification.actionUrl}
+                  to={notification.link}
                   className="inline-flex items-center gap-2 landing-btn-primary px-6 py-3 rounded-xl text-white font-medium"
                 >
-                  {notification.actionLabel || '자세히 보기'}
+                  자세히 보기
                   <ExternalLink className="w-4 h-4" />
                 </Link>
               </div>
@@ -506,27 +220,33 @@ export function NotificationDetailPage() {
               <div className="flex items-center gap-4">
                 {!notification.isRead && (
                   <button
-                    className={`flex items-center gap-2 text-sm transition-colors ${
+                    onClick={handleMarkAsRead}
+                    disabled={markAsReadMutation.isPending}
+                    className={`flex items-center gap-2 text-sm transition-colors disabled:opacity-50 ${
                       isDark
                         ? 'text-gray-400 hover:text-white'
                         : 'text-gray-500 hover:text-gray-900'
                     }`}
                   >
-                    <CheckCheck className="w-4 h-4" />
+                    {markAsReadMutation.isPending ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <CheckCheck className="w-4 h-4" />
+                    )}
                     읽음 처리
                   </button>
                 )}
               </div>
               <button
                 onClick={handleDelete}
-                disabled={isDeleting}
+                disabled={deleteNotificationMutation.isPending}
                 className={`flex items-center gap-2 text-sm transition-colors disabled:opacity-50 ${
                   isDark
                     ? 'text-gray-400 hover:text-red-400'
                     : 'text-gray-500 hover:text-red-500'
                 }`}
               >
-                {isDeleting ? (
+                {deleteNotificationMutation.isPending ? (
                   <Loader2 className="w-4 h-4 animate-spin" />
                 ) : (
                   <Trash2 className="w-4 h-4" />

--- a/src/pages/tu/main/NotificationsPage.tsx
+++ b/src/pages/tu/main/NotificationsPage.tsx
@@ -1,85 +1,30 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Bell, CheckCheck, Trash2, Settings, Gift, MessageSquare, BookOpen, Megaphone, Loader2, FileText, AlertCircle } from 'lucide-react';
+import { Bell, CheckCheck, Trash2, Settings, Heart, MessageSquare, BookOpen, Megaphone, Loader2, FileText, AlertCircle } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
-import { useNotifications, useMarkAsRead, useMarkAllAsRead, useDeleteNotifications, useDeleteReadNotifications } from '@/hooks/tu';
-import type { NotificationItem, NotificationType } from '@/types/tu';
-
-// 환경 설정: true면 API 사용, false면 더미 데이터 사용
-const USE_API = false;
-
-// 더미 알림 데이터
-const MOCK_NOTIFICATIONS: NotificationItem[] = [
-  {
-    id: 1,
-    type: 'promotion',
-    title: '블랙위크 특별 할인!',
-    message: '모든 강의 25% 할인 + 100% 환급 이벤트가 시작되었습니다. 지금 바로 확인해보세요!',
-    createdAt: '2024-12-30T09:50:00Z',
-    isRead: false,
-  },
-  {
-    id: 2,
-    type: 'course',
-    title: '새 강의가 업데이트되었습니다',
-    message: '"실전! Next.js 15 완벽 마스터" 강의에 새로운 섹션이 추가되었습니다.',
-    createdAt: '2024-12-30T09:00:00Z',
-    isRead: false,
-  },
-  {
-    id: 3,
-    type: 'comment',
-    title: '질문에 답변이 달렸습니다',
-    message: '김개발 강사님이 회원님의 질문에 답변을 남겼습니다.',
-    createdAt: '2024-12-30T07:00:00Z',
-    isRead: false,
-  },
-  {
-    id: 4,
-    type: 'system',
-    title: '서비스 점검 안내',
-    message: '12월 5일 오전 2시~4시 서비스 점검이 예정되어 있습니다.',
-    createdAt: '2024-12-29T10:00:00Z',
-    isRead: true,
-  },
-  {
-    id: 5,
-    type: 'course',
-    title: '수강 완료를 축하합니다!',
-    message: '"React 기초부터 실전까지" 강의를 완료하셨습니다. 수료증을 다운로드해보세요!',
-    createdAt: '2024-12-28T10:00:00Z',
-    isRead: true,
-  },
-  {
-    id: 6,
-    type: 'promotion',
-    title: '첫 구매 할인 쿠폰 도착',
-    message: '첫 강의 구매 시 사용할 수 있는 20% 할인 쿠폰이 발급되었습니다.',
-    createdAt: '2024-12-27T10:00:00Z',
-    isRead: true,
-  },
-];
+import { useNotifications, useMarkAsRead, useMarkAllAsRead, useDeleteNotification, useDeleteReadNotifications } from '@/hooks/tu';
+import type { NotificationType } from '@/types/tu';
 
 // 알림 타입별 필터 옵션
 const notificationTypes: { id: NotificationType | 'all'; label: string }[] = [
   { id: 'all', label: '전체' },
-  { id: 'promotion', label: '이벤트' },
-  { id: 'course', label: '강의' },
-  { id: 'comment', label: '댓글' },
-  { id: 'system', label: '공지' },
-  { id: 'assignment', label: '과제' },
+  { id: 'COMMENT', label: '댓글' },
+  { id: 'LIKE', label: '좋아요' },
+  { id: 'COURSE', label: '강의' },
+  { id: 'SYSTEM', label: '시스템' },
+  { id: 'ASSIGNMENT', label: '과제' },
 ];
 
 // 알림 타입별 아이콘 매핑
 const getNotificationIcon = (type: NotificationType) => {
   switch (type) {
-    case 'promotion': return Gift;
-    case 'course': return BookOpen;
-    case 'comment': return MessageSquare;
-    case 'system': return Megaphone;
-    case 'assignment': return FileText;
+    case 'COMMENT': return MessageSquare;
+    case 'LIKE': return Heart;
+    case 'COURSE': return BookOpen;
+    case 'SYSTEM': return Megaphone;
+    case 'ASSIGNMENT': return FileText;
     default: return AlertCircle;
   }
 };
@@ -87,11 +32,11 @@ const getNotificationIcon = (type: NotificationType) => {
 // 알림 타입별 색상 매핑
 const getIconColor = (type: NotificationType) => {
   switch (type) {
-    case 'promotion': return 'text-[#f59e0b] bg-[#f59e0b]/20';
-    case 'course': return 'text-[#6778ff] bg-[#6778ff]/20';
-    case 'comment': return 'text-[#10b981] bg-[#10b981]/20';
-    case 'system': return 'text-[#ec4899] bg-[#ec4899]/20';
-    case 'assignment': return 'text-[#8b5cf6] bg-[#8b5cf6]/20';
+    case 'COMMENT': return 'text-[#10b981] bg-[#10b981]/20';
+    case 'LIKE': return 'text-[#f43f5e] bg-[#f43f5e]/20';
+    case 'COURSE': return 'text-[#6778ff] bg-[#6778ff]/20';
+    case 'SYSTEM': return 'text-[#f59e0b] bg-[#f59e0b]/20';
+    case 'ASSIGNMENT': return 'text-[#8b5cf6] bg-[#8b5cf6]/20';
     default: return 'text-gray-400 bg-gray-400/20';
   }
 };
@@ -115,19 +60,16 @@ export function NotificationsPage() {
   const navigate = useNavigate();
   const [activeType, setActiveType] = useState<NotificationType | 'all'>('all');
 
-  // React Query 훅 (API 모드일 때만 활성화)
+  // React Query 훅
   const filter = activeType === 'all' ? undefined : { type: activeType };
-  const { data: apiNotificationData, isLoading, error } = useNotifications(filter, USE_API);
+  const { data: apiNotificationData, isLoading, error } = useNotifications(filter);
   const markAsReadMutation = useMarkAsRead();
   const markAllAsReadMutation = useMarkAllAsRead();
-  const deleteNotificationsMutation = useDeleteNotifications();
+  const deleteNotificationMutation = useDeleteNotification();
   const deleteReadNotificationsMutation = useDeleteReadNotifications();
 
-  // 로컬 상태 (Mock 모드에서 사용)
-  const [mockNotifications, setMockNotifications] = useState(MOCK_NOTIFICATIONS);
-
   // 실제 사용할 데이터 결정
-  const allNotifications = USE_API ? (apiNotificationData?.notifications || []) : mockNotifications;
+  const allNotifications = apiNotificationData?.notifications || [];
 
   // 필터링 적용
   const filteredNotifications = activeType === 'all'
@@ -137,41 +79,23 @@ export function NotificationsPage() {
   const unreadCount = allNotifications.filter(n => !n.isRead).length;
 
   const markAsRead = (id: number) => {
-    if (USE_API) {
-      markAsReadMutation.mutate({ notificationIds: [id] });
-    } else {
-      setMockNotifications(mockNotifications.map(n =>
-        n.id === id ? { ...n, isRead: true } : n
-      ));
-    }
+    markAsReadMutation.mutate(id);
   };
 
   const handleMarkAllAsRead = () => {
-    if (USE_API) {
-      markAllAsReadMutation.mutate();
-    } else {
-      setMockNotifications(mockNotifications.map(n => ({ ...n, isRead: true })));
-    }
+    markAllAsReadMutation.mutate();
   };
 
   const deleteNotification = (id: number) => {
-    if (USE_API) {
-      deleteNotificationsMutation.mutate({ notificationIds: [id] });
-    } else {
-      setMockNotifications(mockNotifications.filter(n => n.id !== id));
-    }
+    deleteNotificationMutation.mutate(id);
   };
 
   const handleDeleteAllRead = () => {
-    if (USE_API) {
-      deleteReadNotificationsMutation.mutate();
-    } else {
-      setMockNotifications(mockNotifications.filter(n => !n.isRead));
-    }
+    deleteReadNotificationsMutation.mutate();
   };
 
   // 로딩 상태
-  if (USE_API && isLoading) {
+  if (isLoading) {
     return (
       <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
         <LandingHeader />
@@ -189,7 +113,7 @@ export function NotificationsPage() {
   }
 
   // 에러 상태
-  if (USE_API && error) {
+  if (error) {
     return (
       <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
         <LandingHeader />
@@ -340,7 +264,7 @@ export function NotificationsPage() {
                           e.stopPropagation();
                           deleteNotification(notification.id);
                         }}
-                        disabled={deleteNotificationsMutation.isPending}
+                        disabled={deleteNotificationMutation.isPending}
                         className={`p-1 transition-colors disabled:opacity-50 ${
                           isDark
                             ? 'text-gray-500 hover:text-red-400'

--- a/src/services/tu/notificationService.ts
+++ b/src/services/tu/notificationService.ts
@@ -5,12 +5,19 @@
 import axiosInstance from '@/services/common/api/axiosInstance';
 import type {
   NotificationListResponse,
+  NotificationItem,
   NotificationFilter,
-  MarkAsReadRequest,
-  DeleteNotificationRequest,
+  UnreadCountResponse,
 } from '@/types/tu/notification.types';
 
 const BASE_URL = '/tu/notifications';
+
+// API 응답 래퍼 타입
+interface ApiResponse<T> {
+  success: boolean;
+  data: T;
+  error?: string;
+}
 
 export const notificationService = {
   /**
@@ -24,18 +31,34 @@ export const notificationService = {
     if (filter?.isRead !== undefined) {
       params.append('isRead', String(filter.isRead));
     }
+    if (filter?.page !== undefined) {
+      params.append('page', String(filter.page));
+    }
+    if (filter?.pageSize !== undefined) {
+      params.append('pageSize', String(filter.pageSize));
+    }
 
     const query = params.toString();
     const url = query ? `${BASE_URL}?${query}` : BASE_URL;
-    const response = await axiosInstance.get<NotificationListResponse>(url);
-    return response.data;
+    const response = await axiosInstance.get<ApiResponse<NotificationListResponse>>(url);
+    return response.data.data;
+  },
+
+  /**
+   * 알림 상세 조회
+   */
+  getNotification: async (notificationId: number): Promise<NotificationItem> => {
+    const response = await axiosInstance.get<ApiResponse<NotificationItem>>(
+      `${BASE_URL}/${notificationId}`
+    );
+    return response.data.data;
   },
 
   /**
    * 알림 읽음 처리
    */
-  markAsRead: async (data: MarkAsReadRequest): Promise<void> => {
-    await axiosInstance.patch(`${BASE_URL}/read`, data);
+  markAsRead: async (notificationId: number): Promise<void> => {
+    await axiosInstance.patch(`${BASE_URL}/${notificationId}/read`);
   },
 
   /**
@@ -48,8 +71,8 @@ export const notificationService = {
   /**
    * 알림 삭제
    */
-  deleteNotifications: async (data: DeleteNotificationRequest): Promise<void> => {
-    await axiosInstance.delete(BASE_URL, { data });
+  deleteNotification: async (notificationId: number): Promise<void> => {
+    await axiosInstance.delete(`${BASE_URL}/${notificationId}`);
   },
 
   /**
@@ -62,8 +85,10 @@ export const notificationService = {
   /**
    * 읽지 않은 알림 개수 조회
    */
-  getUnreadCount: async (): Promise<{ count: number }> => {
-    const response = await axiosInstance.get<{ count: number }>(`${BASE_URL}/unread-count`);
-    return response.data;
+  getUnreadCount: async (): Promise<UnreadCountResponse> => {
+    const response = await axiosInstance.get<ApiResponse<UnreadCountResponse>>(
+      `${BASE_URL}/unread-count`
+    );
+    return response.data.data;
   },
 };

--- a/src/types/tu/index.ts
+++ b/src/types/tu/index.ts
@@ -130,12 +130,11 @@ export type {
   NotificationType,
   NotificationItem,
   NotificationListResponse,
-  MarkAsReadRequest,
-  DeleteNotificationRequest,
+  UnreadCountResponse,
   NotificationFilter,
 } from './notification.types';
 
-export { NOTIFICATION_TYPE_LABELS } from './notification.types';
+export { NOTIFICATION_TYPE_LABELS, NOTIFICATION_TYPE_COLORS } from './notification.types';
 
 // Course Explore (강의 탐색)
 export type {

--- a/src/types/tu/notification.types.ts
+++ b/src/types/tu/notification.types.ts
@@ -2,13 +2,13 @@
  * 알림(Notification) 관련 타입 정의
  */
 
-// 알림 타입
+// 알림 타입 (Backend NotificationType enum과 일치)
 export type NotificationType =
-  | 'course'      // 강의 관련
-  | 'system'      // 시스템 알림
-  | 'promotion'   // 프로모션
-  | 'comment'     // 댓글/답변
-  | 'assignment'; // 과제/제출
+  | 'COMMENT'     // 댓글 알림
+  | 'LIKE'        // 좋아요 알림
+  | 'COURSE'      // 강의 관련 알림
+  | 'SYSTEM'      // 시스템 알림
+  | 'ASSIGNMENT'; // 과제 알림
 
 // 알림 아이템
 export interface NotificationItem {
@@ -19,37 +19,49 @@ export interface NotificationItem {
   isRead: boolean;
   createdAt: string;
   link?: string;
-  metadata?: Record<string, unknown>;
+  referenceId?: number;
+  referenceType?: string;
+  actorId?: number;
+  actorName?: string;
 }
 
 // 알림 목록 응답
 export interface NotificationListResponse {
   notifications: NotificationItem[];
   totalCount: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
   unreadCount: number;
 }
 
-// 알림 읽음 처리 요청
-export interface MarkAsReadRequest {
-  notificationIds: number[];
-}
-
-// 알림 삭제 요청
-export interface DeleteNotificationRequest {
-  notificationIds: number[];
+// 읽지 않은 알림 개수 응답
+export interface UnreadCountResponse {
+  count: number;
 }
 
 // 알림 필터 옵션
 export interface NotificationFilter {
   type?: NotificationType | 'all';
   isRead?: boolean;
+  page?: number;
+  pageSize?: number;
 }
 
 // 알림 타입 레이블
 export const NOTIFICATION_TYPE_LABELS: Record<NotificationType, string> = {
-  course: '강의',
-  system: '시스템',
-  promotion: '프로모션',
-  comment: '댓글',
-  assignment: '과제',
+  COMMENT: '댓글',
+  LIKE: '좋아요',
+  COURSE: '강의',
+  SYSTEM: '시스템',
+  ASSIGNMENT: '과제',
+};
+
+// 알림 타입 아이콘 색상
+export const NOTIFICATION_TYPE_COLORS: Record<NotificationType, string> = {
+  COMMENT: 'emerald',
+  LIKE: 'rose',
+  COURSE: 'blue',
+  SYSTEM: 'amber',
+  ASSIGNMENT: 'purple',
 };


### PR DESCRIPTION
## Summary
알림 페이지를 백엔드 API와 연동하고, 헤더에 읽지 않은 알림 개수 배지를 추가했습니다.

## Related Issue
- Closes #204

## Changes
- `notificationService.ts` - 백엔드 API 호출 메서드 구현
- `useNotificationQueries.ts` - React Query 훅 구현 (useNotifications, useNotification, useUnreadNotificationCount, useMarkAsRead, useMarkAllAsRead, useDeleteNotification, useDeleteReadNotifications)
- `notification.types.ts` - 타입 정의 (NotificationType, NotificationItem, NotificationListResponse 등)
- `NotificationsPage.tsx` - Mock 데이터 제거, API 연동, 타입명 대문자로 수정 (COMMENT, LIKE, COURSE, SYSTEM, ASSIGNMENT)
- `NotificationDetailPage.tsx` - React Query 훅으로 리팩토링
- `LandingHeader.tsx` - 읽지 않은 알림 개수 배지 추가
- `hooks/tu/index.ts`, `types/tu/index.ts` - export 정리

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots
<img width="1009" height="746" alt="image" src="https://github.com/user-attachments/assets/d08e28e1-f038-443c-994a-7ba92164b19f" />
<img width="1020" height="728" alt="image" src="https://github.com/user-attachments/assets/e8add48e-211f-4cac-8d3f-a4f1bae08b9d" />
<img width="992" height="706" alt="image" src="https://github.com/user-attachments/assets/5e91aedc-ff68-46bb-a3dc-8cce4a37fbda" />


## Additional Notes
- React Query를 사용하여 서버 상태 관리
- 알림 읽음/삭제 시 자동으로 캐시 무효화
- 로그인 상태에서만 알림 개수 조회
- 알림 목록 페이지: 타입별/읽음 상태별 필터링
- 헤더 알림 배지: 읽지 않은 알림 개수 표시 (99+ 처리 포함)