### PR TITLE
feat(dashboard): SA/TA/TO 대시보드 API 연동 및 UI/UX 개선

### DIFF
--- a/src/hooks/sa/index.ts
+++ b/src/hooks/sa/index.ts
@@ -21,3 +21,5 @@ export {
   useDistributeNotice,
   useDistributeAllNotice,
 } from './useNoticeQueries';
+
+export { saDashboardKeys, useSaDashboard } from './useDashboardQueries';

--- a/src/hooks/sa/useDashboardQueries.ts
+++ b/src/hooks/sa/useDashboardQueries.ts
@@ -1,0 +1,19 @@
+/**
+ * SA Dashboard React Query Hooks (SYSTEM_ADMIN)
+ */
+import { useQuery } from '@tanstack/react-query';
+import { saDashboardService } from '@/services/sa';
+
+// Query Keys
+export const saDashboardKeys = {
+  all: ['sa-dashboard'] as const,
+  dashboard: () => [...saDashboardKeys.all, 'stats'] as const,
+};
+
+/** SA 대시보드 통계 조회 */
+export const useSaDashboard = () => {
+  return useQuery({
+    queryKey: saDashboardKeys.dashboard(),
+    queryFn: () => saDashboardService.getDashboard(),
+  });
+};

--- a/src/hooks/ta/index.ts
+++ b/src/hooks/ta/index.ts
@@ -28,3 +28,5 @@ export {
   useUpdateBranding,
   useUpdateUserManagement,
 } from './useTenantSettingsQueries';
+
+export { taDashboardKeys, useTaKpiDashboard } from './useDashboardQueries';

--- a/src/hooks/ta/useDashboardQueries.ts
+++ b/src/hooks/ta/useDashboardQueries.ts
@@ -1,0 +1,19 @@
+/**
+ * TA Dashboard React Query Hooks (TENANT_ADMIN)
+ */
+import { useQuery } from '@tanstack/react-query';
+import { taDashboardService } from '@/services/ta';
+
+// Query Keys
+export const taDashboardKeys = {
+  all: ['ta-dashboard'] as const,
+  kpi: () => [...taDashboardKeys.all, 'kpi'] as const,
+};
+
+/** TA KPI 대시보드 통계 조회 */
+export const useTaKpiDashboard = () => {
+  return useQuery({
+    queryKey: taDashboardKeys.kpi(),
+    queryFn: () => taDashboardService.getKpiDashboard(),
+  });
+};

--- a/src/hooks/to/index.ts
+++ b/src/hooks/to/index.ts
@@ -3,3 +3,4 @@ export * from './useInstructorAssignmentQueries';
 export * from './useProgramQueries';
 export * from './useUserQueries';
 export * from './useEnrollmentQueries';
+export * from './useDashboardQueries';

--- a/src/hooks/to/useDashboardQueries.ts
+++ b/src/hooks/to/useDashboardQueries.ts
@@ -1,0 +1,19 @@
+/**
+ * TO Dashboard React Query Hooks (OPERATOR)
+ */
+import { useQuery } from '@tanstack/react-query';
+import { toDashboardService } from '@/services/to';
+
+// Query Keys
+export const toDashboardKeys = {
+  all: ['to-dashboard'] as const,
+  tasks: () => [...toDashboardKeys.all, 'tasks'] as const,
+};
+
+/** TO 운영 대시보드 통계 조회 */
+export const useToDashboard = () => {
+  return useQuery({
+    queryKey: toDashboardKeys.tasks(),
+    queryFn: () => toDashboardService.getDashboard(),
+  });
+};

--- a/src/pages/sa/dashboard/DashboardPage.tsx
+++ b/src/pages/sa/dashboard/DashboardPage.tsx
@@ -1,53 +1,44 @@
-import { Building2, Users, Activity, Server } from 'lucide-react';
+import { Building2, Users, AlertCircle, Clock } from 'lucide-react';
 import {
   AdminPageHeader,
   AdminStatsCard,
   AdminStatsGrid,
   StatusBadge,
   PlanBadge,
-  
 } from '@/components/domain/admin';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/common/Card';
 import { Progress } from '@/components/common/Progress';
+import { Skeleton } from '@/components/common/Skeleton';
+import { useSaDashboard } from '@/hooks/sa';
 import type { TenantStatus, PlanType } from '@/types/admin';
 
-// Mock 데이터 (추후 API 연동)
-const mockStats = {
-  tenants: {
-    total: 24,
-    active: 20,
-    inactive: 3,
-    suspended: 1,
-  },
-  users: {
-    total: 1250,
-    activeToday: 342,
-  },
-  systemHealth: {
-    status: 'healthy' as const,
-    uptime: '99.9%',
-    cpuUsage: 45,
-    memoryUsage: 62,
-    diskUsage: 38,
-  },
-};
-
-const mockRecentTenants: {
-  id: number;
-  name: string;
-  code: string;
-  status: TenantStatus;
-  plan: PlanType;
-  createdAt: string;
-}[] = [
-  { id: 1, name: '메가존클라우드', code: 'mzc', status: 'ACTIVE', plan: 'ENTERPRISE', createdAt: '2025-12-28' },
-  { id: 2, name: '삼성전자', code: 'samsung', status: 'ACTIVE', plan: 'ENTERPRISE', createdAt: '2025-12-27' },
-  { id: 3, name: '네이버', code: 'naver', status: 'PENDING', plan: 'PRO', createdAt: '2025-12-26' },
-  { id: 4, name: '카카오', code: 'kakao', status: 'ACTIVE', plan: 'PRO', createdAt: '2025-12-25' },
-  { id: 5, name: '라인', code: 'line', status: 'INACTIVE', plan: 'BASIC', createdAt: '2025-12-24' },
-];
-
 export function DashboardPage() {
+  const { data, isLoading, error } = useSaDashboard();
+
+  if (error) {
+    return (
+      <div className="p-6">
+        <AdminPageHeader
+          title="대시보드"
+          description="시스템 전체 현황을 확인합니다"
+        />
+        <Card className="mt-6">
+          <CardContent className="py-12">
+            <div className="flex flex-col items-center justify-center text-center">
+              <AlertCircle className="h-12 w-12 text-destructive mb-4" />
+              <p className="text-lg font-medium text-text-primary">데이터를 불러올 수 없습니다</p>
+              <p className="text-sm text-text-secondary mt-1">잠시 후 다시 시도해주세요</p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const tenantStats = data?.tenantStats ?? { total: 0, active: 0, pending: 0, suspended: 0, terminated: 0 };
+  const userStats = data?.userStats ?? { total: 0, active: 0, suspended: 0, withdrawn: 0 };
+  const recentTenants = data?.recentTenants ?? [];
+
   return (
     <div className="p-6">
       <AdminPageHeader
@@ -57,36 +48,45 @@ export function DashboardPage() {
 
       {/* Stats Grid */}
       <AdminStatsGrid columns={4} className="mb-6">
-        <AdminStatsCard
-          title="전체 테넌트"
-          value={mockStats.tenants.total}
-          subtitle={`활성 ${mockStats.tenants.active}개`}
-          icon={Building2}
-          variant="primary"
-          trend={{ value: 12, label: '지난 달 대비' }}
-        />
-        <AdminStatsCard
-          title="전체 사용자"
-          value={mockStats.users.total.toLocaleString()}
-          subtitle={`오늘 활성 ${mockStats.users.activeToday}명`}
-          icon={Users}
-          variant="success"
-          trend={{ value: 8, label: '지난 달 대비' }}
-        />
-        <AdminStatsCard
-          title="시스템 상태"
-          value={mockStats.systemHealth.status === 'healthy' ? '정상' : '점검 필요'}
-          subtitle={`가동률 ${mockStats.systemHealth.uptime}`}
-          icon={Activity}
-          variant={mockStats.systemHealth.status === 'healthy' ? 'success' : 'warning'}
-        />
-        <AdminStatsCard
-          title="서버 리소스"
-          value={`${mockStats.systemHealth.cpuUsage}%`}
-          subtitle="CPU 사용률"
-          icon={Server}
-          variant="default"
-        />
+        {isLoading ? (
+          <>
+            <Skeleton className="h-28" />
+            <Skeleton className="h-28" />
+            <Skeleton className="h-28" />
+            <Skeleton className="h-28" />
+          </>
+        ) : (
+          <>
+            <AdminStatsCard
+              title="전체 테넌트"
+              value={tenantStats.total}
+              subtitle={`활성 ${tenantStats.active}개`}
+              icon={Building2}
+              variant="primary"
+            />
+            <AdminStatsCard
+              title="전체 사용자"
+              value={userStats.total.toLocaleString()}
+              subtitle={`활성 ${userStats.active.toLocaleString()}명`}
+              icon={Users}
+              variant="success"
+            />
+            <AdminStatsCard
+              title="대기 중 테넌트"
+              value={tenantStats.pending}
+              subtitle="승인 대기"
+              icon={Clock}
+              variant="warning"
+            />
+            <AdminStatsCard
+              title="정지된 테넌트"
+              value={tenantStats.suspended}
+              subtitle={`종료 ${tenantStats.terminated}개`}
+              icon={AlertCircle}
+              variant="error"
+            />
+          </>
+        )}
       </AdminStatsGrid>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -96,61 +96,85 @@ export function DashboardPage() {
             <CardTitle>테넌트 현황</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <span className="text-sm">활성</span>
-                <div className="flex items-center gap-2">
-                  <Progress value={(mockStats.tenants.active / mockStats.tenants.total) * 100} className="w-32" />
-                  <span className="text-sm font-medium w-8">{mockStats.tenants.active}</span>
+            {isLoading ? (
+              <div className="space-y-4">
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">활성</span>
+                  <div className="flex items-center gap-2">
+                    <Progress value={tenantStats.total > 0 ? (tenantStats.active / tenantStats.total) * 100 : 0} className="w-32" />
+                    <span className="text-sm font-medium w-8">{tenantStats.active}</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">대기</span>
+                  <div className="flex items-center gap-2">
+                    <Progress value={tenantStats.total > 0 ? (tenantStats.pending / tenantStats.total) * 100 : 0} className="w-32" />
+                    <span className="text-sm font-medium w-8">{tenantStats.pending}</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">정지</span>
+                  <div className="flex items-center gap-2">
+                    <Progress value={tenantStats.total > 0 ? (tenantStats.suspended / tenantStats.total) * 100 : 0} className="w-32" />
+                    <span className="text-sm font-medium w-8">{tenantStats.suspended}</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">종료</span>
+                  <div className="flex items-center gap-2">
+                    <Progress value={tenantStats.total > 0 ? (tenantStats.terminated / tenantStats.total) * 100 : 0} className="w-32" />
+                    <span className="text-sm font-medium w-8">{tenantStats.terminated}</span>
+                  </div>
                 </div>
               </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm">비활성</span>
-                <div className="flex items-center gap-2">
-                  <Progress value={(mockStats.tenants.inactive / mockStats.tenants.total) * 100} className="w-32" />
-                  <span className="text-sm font-medium w-8">{mockStats.tenants.inactive}</span>
-                </div>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm">정지</span>
-                <div className="flex items-center gap-2">
-                  <Progress value={(mockStats.tenants.suspended / mockStats.tenants.total) * 100} className="w-32" />
-                  <span className="text-sm font-medium w-8">{mockStats.tenants.suspended}</span>
-                </div>
-              </div>
-            </div>
+            )}
           </CardContent>
         </Card>
 
-        {/* 시스템 리소스 */}
+        {/* 사용자 현황 */}
         <Card>
           <CardHeader>
-            <CardTitle>시스템 리소스</CardTitle>
+            <CardTitle>사용자 현황</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <span className="text-sm">CPU</span>
-                <div className="flex items-center gap-2">
-                  <Progress value={mockStats.systemHealth.cpuUsage} className="w-32" />
-                  <span className="text-sm font-medium w-12">{mockStats.systemHealth.cpuUsage}%</span>
+            {isLoading ? (
+              <div className="space-y-4">
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">활성</span>
+                  <div className="flex items-center gap-2">
+                    <Progress value={userStats.total > 0 ? (userStats.active / userStats.total) * 100 : 0} className="w-32" />
+                    <span className="text-sm font-medium w-12">{userStats.active.toLocaleString()}</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">정지</span>
+                  <div className="flex items-center gap-2">
+                    <Progress value={userStats.total > 0 ? (userStats.suspended / userStats.total) * 100 : 0} className="w-32" />
+                    <span className="text-sm font-medium w-12">{userStats.suspended.toLocaleString()}</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">탈퇴</span>
+                  <div className="flex items-center gap-2">
+                    <Progress value={userStats.total > 0 ? (userStats.withdrawn / userStats.total) * 100 : 0} className="w-32" />
+                    <span className="text-sm font-medium w-12">{userStats.withdrawn.toLocaleString()}</span>
+                  </div>
                 </div>
               </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm">메모리</span>
-                <div className="flex items-center gap-2">
-                  <Progress value={mockStats.systemHealth.memoryUsage} className="w-32" />
-                  <span className="text-sm font-medium w-12">{mockStats.systemHealth.memoryUsage}%</span>
-                </div>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm">디스크</span>
-                <div className="flex items-center gap-2">
-                  <Progress value={mockStats.systemHealth.diskUsage} className="w-32" />
-                  <span className="text-sm font-medium w-12">{mockStats.systemHealth.diskUsage}%</span>
-                </div>
-              </div>
-            </div>
+            )}
           </CardContent>
         </Card>
 
@@ -163,34 +187,50 @@ export function DashboardPage() {
             </a>
           </CardHeader>
           <CardContent>
-            <div className="overflow-x-auto">
-              <table className="w-full">
-                <thead>
-                  <tr className="border-b">
-                    <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">테넌트명</th>
-                    <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">코드</th>
-                    <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">상태</th>
-                    <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">플랜</th>
-                    <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">생성일</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {mockRecentTenants.map((tenant) => (
-                    <tr key={tenant.id} className="border-b last:border-b-0 hover:bg-bg-secondary">
-                      <td className="py-3 px-4 font-medium">{tenant.name}</td>
-                      <td className="py-3 px-4 text-text-secondary">{tenant.code}</td>
-                      <td className="py-3 px-4">
-                        <StatusBadge status={tenant.status} />
-                      </td>
-                      <td className="py-3 px-4">
-                        <PlanBadge plan={tenant.plan} />
-                      </td>
-                      <td className="py-3 px-4 text-text-secondary">{tenant.createdAt}</td>
+            {isLoading ? (
+              <div className="space-y-3">
+                <Skeleton className="h-12" />
+                <Skeleton className="h-12" />
+                <Skeleton className="h-12" />
+                <Skeleton className="h-12" />
+                <Skeleton className="h-12" />
+              </div>
+            ) : recentTenants.length === 0 ? (
+              <div className="py-8 text-center text-text-secondary">
+                최근 생성된 테넌트가 없습니다
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead>
+                    <tr className="border-b">
+                      <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">테넌트명</th>
+                      <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">코드</th>
+                      <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">상태</th>
+                      <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">플랜</th>
+                      <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">생성일</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+                  </thead>
+                  <tbody>
+                    {recentTenants.map((tenant) => (
+                      <tr key={tenant.id} className="border-b last:border-b-0 hover:bg-bg-secondary">
+                        <td className="py-3 px-4 font-medium">{tenant.name}</td>
+                        <td className="py-3 px-4 text-text-secondary">{tenant.code}</td>
+                        <td className="py-3 px-4">
+                          <StatusBadge status={tenant.status as TenantStatus} />
+                        </td>
+                        <td className="py-3 px-4">
+                          <PlanBadge plan={tenant.plan as PlanType} />
+                        </td>
+                        <td className="py-3 px-4 text-text-secondary">
+                          {new Date(tenant.createdAt).toLocaleDateString('ko-KR')}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/src/pages/sa/dashboard/DashboardPage.tsx
+++ b/src/pages/sa/dashboard/DashboardPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Building2, Users, AlertCircle, Clock } from 'lucide-react';
 import {
   AdminPageHeader,
@@ -9,11 +10,24 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/common/Card';
 import { Progress } from '@/components/common/Progress';
 import { Skeleton } from '@/components/common/Skeleton';
+import { NoDataEmpty } from '@/components/common/EmptyState';
 import { useSaDashboard } from '@/hooks/sa';
 import type { TenantStatus, PlanType } from '@/types/admin';
 
+type DateRange = '7d' | '30d' | 'all';
+
+const DATE_RANGE_OPTIONS: { value: DateRange; label: string }[] = [
+  { value: 'all', label: '전체' },
+  { value: '7d', label: '최근 7일' },
+  { value: '30d', label: '이번 달' },
+];
+
 export function DashboardPage() {
   const { data, isLoading, error } = useSaDashboard();
+  const [dateRange, setDateRange] = useState<DateRange>('all');
+
+  // 선택된 기간 라벨 가져오기
+  const selectedRangeLabel = DATE_RANGE_OPTIONS.find((opt) => opt.value === dateRange)?.label ?? '';
 
   if (error) {
     return (
@@ -43,7 +57,24 @@ export function DashboardPage() {
     <div className="p-6">
       <AdminPageHeader
         title="대시보드"
-        description="시스템 전체 현황을 확인합니다"
+        description={`시스템 전체 현황을 확인합니다 • ${selectedRangeLabel} 기준`}
+        actions={
+          <div className="flex gap-1">
+            {DATE_RANGE_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                onClick={() => setDateRange(option.value)}
+                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                  dateRange === option.value
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted text-muted-foreground hover:bg-muted/80'
+                }`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        }
       />
 
       {/* Stats Grid */}
@@ -196,9 +227,11 @@ export function DashboardPage() {
                 <Skeleton className="h-12" />
               </div>
             ) : recentTenants.length === 0 ? (
-              <div className="py-8 text-center text-text-secondary">
-                최근 생성된 테넌트가 없습니다
-              </div>
+              <NoDataEmpty
+                title="최근 생성된 테넌트가 없습니다"
+                description="새로운 테넌트가 등록되면 여기에 표시됩니다."
+                className="py-8"
+              />
             ) : (
               <div className="overflow-x-auto">
                 <table className="w-full">

--- a/src/pages/ta/dashboard/DashboardPage.tsx
+++ b/src/pages/ta/dashboard/DashboardPage.tsx
@@ -1,64 +1,52 @@
-import { Users, BookOpen, TrendingUp, Clock } from 'lucide-react';
+import { Users, BookOpen, TrendingUp, GraduationCap, AlertCircle, UserPlus, FileText, CheckCircle } from 'lucide-react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
 import {
   AdminPageHeader,
   AdminStatsCard,
   AdminStatsGrid,
-  StatusBadge,
-  RoleBadge,
 } from '@/components/domain/admin';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/common/Card';
 import { Progress } from '@/components/common/Progress';
-import type { UserStatus, SystemRole } from '@/components/domain/admin';
-
-// Mock 데이터 (추후 API 연동)
-const mockStats = {
-  users: {
-    total: 450,
-    active: 380,
-    inactive: 50,
-    pending: 20,
-  },
-  courses: {
-    total: 32,
-    active: 28,
-    draft: 4,
-  },
-  learning: {
-    completionRate: 72,
-    averageProgress: 65,
-    activeLearnersToday: 124,
-  },
-  activity: {
-    dailyActiveUsers: 156,
-    weeklyActiveUsers: 342,
-    monthlyActiveUsers: 410,
-  },
-};
-
-const mockRecentUsers: {
-  id: number;
-  name: string;
-  email: string;
-  status: UserStatus;
-  role: SystemRole;
-  joinedAt: string;
-}[] = [
-  { id: 1, name: '김민수', email: 'minsu.kim@company.com', status: 'ACTIVE', role: 'USER', joinedAt: '2025-12-28' },
-  { id: 2, name: '이영희', email: 'younghee.lee@company.com', status: 'ACTIVE', role: 'OPERATOR', joinedAt: '2025-12-27' },
-  { id: 3, name: '박철수', email: 'cheolsu.park@company.com', status: 'PENDING', role: 'USER', joinedAt: '2025-12-26' },
-  { id: 4, name: '정수진', email: 'sujin.jung@company.com', status: 'ACTIVE', role: 'USER', joinedAt: '2025-12-25' },
-  { id: 5, name: '최동현', email: 'donghyun.choi@company.com', status: 'INACTIVE', role: 'USER', joinedAt: '2025-12-24' },
-];
-
-const mockPopularCourses = [
-  { id: 1, title: 'AWS 기초 마스터', enrollments: 156, completionRate: 78 },
-  { id: 2, title: 'React 실전 프로젝트', enrollments: 142, completionRate: 65 },
-  { id: 3, title: 'Python 데이터 분석', enrollments: 128, completionRate: 82 },
-  { id: 4, title: 'Docker & Kubernetes', enrollments: 98, completionRate: 54 },
-  { id: 5, title: 'TypeScript 완벽 가이드', enrollments: 87, completionRate: 71 },
-];
+import { Skeleton } from '@/components/common/Skeleton';
+import { useTaKpiDashboard } from '@/hooks/ta';
 
 export function DashboardPage() {
+  const { data, isLoading, error } = useTaKpiDashboard();
+
+  if (error) {
+    return (
+      <div className="p-6">
+        <AdminPageHeader
+          title="대시보드"
+          description="테넌트 현황을 한눈에 확인합니다"
+        />
+        <Card className="mt-6">
+          <CardContent className="py-12">
+            <div className="flex flex-col items-center justify-center text-center">
+              <AlertCircle className="h-12 w-12 text-destructive mb-4" />
+              <p className="text-lg font-medium text-text-primary">데이터를 불러올 수 없습니다</p>
+              <p className="text-sm text-text-secondary mt-1">잠시 후 다시 시도해주세요</p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const userStats = data?.userStats ?? { total: 0, active: 0, inactive: 0, suspended: 0, withdrawn: 0, newThisMonth: 0 };
+  const programStats = data?.programStats ?? { total: 0, draft: 0, pending: 0, approved: 0, rejected: 0, closed: 0 };
+  const enrollmentStats = data?.enrollmentStats ?? { totalEnrollments: 0, byStatus: { enrolled: 0, completed: 0, dropped: 0, failed: 0 }, completionRate: 0 };
+  const monthlyTrend = data?.monthlyTrend ?? [];
+
   return (
     <div className="p-6">
       <AdminPageHeader
@@ -68,175 +56,269 @@ export function DashboardPage() {
 
       {/* Stats Grid */}
       <AdminStatsGrid columns={4} className="mb-6">
-        <AdminStatsCard
-          title="전체 사용자"
-          value={mockStats.users.total}
-          subtitle={`활성 ${mockStats.users.active}명`}
-          icon={Users}
-          variant="primary"
-          trend={{ value: 15, label: '지난 달 대비' }}
-        />
-        <AdminStatsCard
-          title="전체 강좌"
-          value={mockStats.courses.total}
-          subtitle={`활성 ${mockStats.courses.active}개`}
-          icon={BookOpen}
-          variant="success"
-          trend={{ value: 8, label: '지난 달 대비' }}
-        />
-        <AdminStatsCard
-          title="평균 완료율"
-          value={`${mockStats.learning.completionRate}%`}
-          subtitle="전체 강좌 기준"
-          icon={TrendingUp}
-          variant="warning"
-          trend={{ value: 5, label: '지난 달 대비' }}
-        />
-        <AdminStatsCard
-          title="오늘 활성 학습자"
-          value={mockStats.learning.activeLearnersToday}
-          subtitle="현재 학습 중"
-          icon={Clock}
-          variant="default"
-        />
+        {isLoading ? (
+          <>
+            <Skeleton className="h-28" />
+            <Skeleton className="h-28" />
+            <Skeleton className="h-28" />
+            <Skeleton className="h-28" />
+          </>
+        ) : (
+          <>
+            <AdminStatsCard
+              title="전체 사용자"
+              value={userStats.total.toLocaleString()}
+              subtitle={`활성 ${userStats.active.toLocaleString()}명`}
+              icon={Users}
+              variant="primary"
+            />
+            <AdminStatsCard
+              title="이번 달 신규"
+              value={userStats.newThisMonth.toLocaleString()}
+              subtitle="신규 가입자"
+              icon={UserPlus}
+              variant="success"
+            />
+            <AdminStatsCard
+              title="전체 프로그램"
+              value={programStats.total.toLocaleString()}
+              subtitle={`승인 ${programStats.approved}개`}
+              icon={BookOpen}
+              variant="warning"
+            />
+            <AdminStatsCard
+              title="수강 완료율"
+              value={`${enrollmentStats.completionRate}%`}
+              subtitle={`전체 ${enrollmentStats.totalEnrollments.toLocaleString()}건`}
+              icon={GraduationCap}
+              variant="default"
+            />
+          </>
+        )}
       </AdminStatsGrid>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
         {/* 사용자 현황 */}
         <Card>
           <CardHeader>
             <CardTitle>사용자 현황</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <span className="text-sm">활성</span>
-                <div className="flex items-center gap-2">
-                  <Progress value={(mockStats.users.active / mockStats.users.total) * 100} className="w-32" />
-                  <span className="text-sm font-medium w-12">{mockStats.users.active}명</span>
+            {isLoading ? (
+              <div className="space-y-4">
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">활성</span>
+                  <div className="flex items-center gap-2">
+                    <Progress value={userStats.total > 0 ? (userStats.active / userStats.total) * 100 : 0} className="w-32" />
+                    <span className="text-sm font-medium w-16">{userStats.active.toLocaleString()}명</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">비활성</span>
+                  <div className="flex items-center gap-2">
+                    <Progress value={userStats.total > 0 ? (userStats.inactive / userStats.total) * 100 : 0} className="w-32" />
+                    <span className="text-sm font-medium w-16">{userStats.inactive.toLocaleString()}명</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">정지</span>
+                  <div className="flex items-center gap-2">
+                    <Progress value={userStats.total > 0 ? (userStats.suspended / userStats.total) * 100 : 0} className="w-32" />
+                    <span className="text-sm font-medium w-16">{userStats.suspended.toLocaleString()}명</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">탈퇴</span>
+                  <div className="flex items-center gap-2">
+                    <Progress value={userStats.total > 0 ? (userStats.withdrawn / userStats.total) * 100 : 0} className="w-32" />
+                    <span className="text-sm font-medium w-16">{userStats.withdrawn.toLocaleString()}명</span>
+                  </div>
                 </div>
               </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm">비활성</span>
-                <div className="flex items-center gap-2">
-                  <Progress value={(mockStats.users.inactive / mockStats.users.total) * 100} className="w-32" />
-                  <span className="text-sm font-medium w-12">{mockStats.users.inactive}명</span>
-                </div>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm">대기</span>
-                <div className="flex items-center gap-2">
-                  <Progress value={(mockStats.users.pending / mockStats.users.total) * 100} className="w-32" />
-                  <span className="text-sm font-medium w-12">{mockStats.users.pending}명</span>
-                </div>
-              </div>
-            </div>
+            )}
           </CardContent>
         </Card>
 
-        {/* 학습 활동 */}
+        {/* 프로그램 현황 */}
         <Card>
           <CardHeader>
-            <CardTitle>학습 활동</CardTitle>
+            <CardTitle>프로그램 현황</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <span className="text-sm">일간 활성 사용자</span>
-                <div className="flex items-center gap-2">
-                  <Progress value={(mockStats.activity.dailyActiveUsers / mockStats.users.total) * 100} className="w-32" />
-                  <span className="text-sm font-medium w-12">{mockStats.activity.dailyActiveUsers}명</span>
+            {isLoading ? (
+              <div className="space-y-4">
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <FileText className="h-4 w-4 text-text-secondary" />
+                    <span className="text-sm">작성중</span>
+                  </div>
+                  <span className="text-sm font-medium">{programStats.draft}개</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <TrendingUp className="h-4 w-4 text-warning" />
+                    <span className="text-sm">검토 대기</span>
+                  </div>
+                  <span className="text-sm font-medium">{programStats.pending}개</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <CheckCircle className="h-4 w-4 text-success" />
+                    <span className="text-sm">승인됨</span>
+                  </div>
+                  <span className="text-sm font-medium">{programStats.approved}개</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <AlertCircle className="h-4 w-4 text-destructive" />
+                    <span className="text-sm">반려됨</span>
+                  </div>
+                  <span className="text-sm font-medium">{programStats.rejected}개</span>
                 </div>
               </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm">주간 활성 사용자</span>
-                <div className="flex items-center gap-2">
-                  <Progress value={(mockStats.activity.weeklyActiveUsers / mockStats.users.total) * 100} className="w-32" />
-                  <span className="text-sm font-medium w-12">{mockStats.activity.weeklyActiveUsers}명</span>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* 수강 현황 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>수강 현황</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="space-y-4">
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">수강 중</span>
+                  <div className="flex items-center gap-2">
+                    <Progress
+                      value={enrollmentStats.totalEnrollments > 0 ? (enrollmentStats.byStatus.enrolled / enrollmentStats.totalEnrollments) * 100 : 0}
+                      className="w-32"
+                    />
+                    <span className="text-sm font-medium w-16">{enrollmentStats.byStatus.enrolled.toLocaleString()}건</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">수료</span>
+                  <div className="flex items-center gap-2">
+                    <Progress
+                      value={enrollmentStats.totalEnrollments > 0 ? (enrollmentStats.byStatus.completed / enrollmentStats.totalEnrollments) * 100 : 0}
+                      className="w-32"
+                    />
+                    <span className="text-sm font-medium w-16">{enrollmentStats.byStatus.completed.toLocaleString()}건</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">중도 포기</span>
+                  <div className="flex items-center gap-2">
+                    <Progress
+                      value={enrollmentStats.totalEnrollments > 0 ? (enrollmentStats.byStatus.dropped / enrollmentStats.totalEnrollments) * 100 : 0}
+                      className="w-32"
+                    />
+                    <span className="text-sm font-medium w-16">{enrollmentStats.byStatus.dropped.toLocaleString()}건</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">미수료</span>
+                  <div className="flex items-center gap-2">
+                    <Progress
+                      value={enrollmentStats.totalEnrollments > 0 ? (enrollmentStats.byStatus.failed / enrollmentStats.totalEnrollments) * 100 : 0}
+                      className="w-32"
+                    />
+                    <span className="text-sm font-medium w-16">{enrollmentStats.byStatus.failed.toLocaleString()}건</span>
+                  </div>
                 </div>
               </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm">월간 활성 사용자</span>
-                <div className="flex items-center gap-2">
-                  <Progress value={(mockStats.activity.monthlyActiveUsers / mockStats.users.total) * 100} className="w-32" />
-                  <span className="text-sm font-medium w-12">{mockStats.activity.monthlyActiveUsers}명</span>
-                </div>
-              </div>
-            </div>
+            )}
           </CardContent>
         </Card>
 
-        {/* 인기 강좌 */}
+        {/* 월별 수강 추이 차트 */}
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle>인기 강좌</CardTitle>
-            <a href="/ta/courses" className="text-sm text-brand-primary hover:underline">
-              전체 보기
-            </a>
+          <CardHeader>
+            <CardTitle>월별 수강 추이</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="space-y-3">
-              {mockPopularCourses.map((course, index) => (
-                <div key={course.id} className="flex items-center justify-between py-2 border-b last:border-b-0">
-                  <div className="flex items-center gap-3">
-                    <span className="w-6 h-6 rounded-full bg-brand-primary/10 text-brand-primary text-sm font-medium flex items-center justify-center">
-                      {index + 1}
-                    </span>
-                    <div>
-                      <p className="font-medium text-sm">{course.title}</p>
-                      <p className="text-xs text-text-secondary">수강생 {course.enrollments}명</p>
-                    </div>
-                  </div>
-                  <div className="text-right">
-                    <p className="text-sm font-medium">{course.completionRate}%</p>
-                    <p className="text-xs text-text-secondary">완료율</p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* 최근 가입 사용자 */}
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle>최근 가입 사용자</CardTitle>
-            <a href="/ta/users" className="text-sm text-brand-primary hover:underline">
-              전체 보기
-            </a>
-          </CardHeader>
-          <CardContent>
-            <div className="overflow-x-auto">
-              <table className="w-full">
-                <thead>
-                  <tr className="border-b">
-                    <th className="text-left py-2 px-2 text-sm font-medium text-text-secondary">이름</th>
-                    <th className="text-left py-2 px-2 text-sm font-medium text-text-secondary">상태</th>
-                    <th className="text-left py-2 px-2 text-sm font-medium text-text-secondary">역할</th>
-                    <th className="text-left py-2 px-2 text-sm font-medium text-text-secondary">가입일</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {mockRecentUsers.map((user) => (
-                    <tr key={user.id} className="border-b last:border-b-0 hover:bg-bg-secondary">
-                      <td className="py-2 px-2">
-                        <div>
-                          <p className="font-medium text-sm">{user.name}</p>
-                          <p className="text-xs text-text-secondary">{user.email}</p>
-                        </div>
-                      </td>
-                      <td className="py-2 px-2">
-                        <StatusBadge status={user.status} />
-                      </td>
-                      <td className="py-2 px-2">
-                        <RoleBadge role={user.role} />
-                      </td>
-                      <td className="py-2 px-2 text-sm text-text-secondary">{user.joinedAt}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            {isLoading ? (
+              <Skeleton className="h-64" />
+            ) : monthlyTrend.length === 0 ? (
+              <div className="h-64 flex items-center justify-center text-text-secondary">
+                데이터가 없습니다
+              </div>
+            ) : (
+              <div className="h-64">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart
+                    data={monthlyTrend}
+                    margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+                  >
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                    <XAxis
+                      dataKey="month"
+                      className="text-xs fill-text-secondary"
+                      tickFormatter={(value) => {
+                        const [, month] = value.split('-');
+                        return `${month}월`;
+                      }}
+                    />
+                    <YAxis className="text-xs fill-text-secondary" />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: 'hsl(var(--bg-default))',
+                        border: '1px solid hsl(var(--border))',
+                        borderRadius: '8px',
+                      }}
+                      labelFormatter={(value) => {
+                        const [year, month] = value.split('-');
+                        return `${year}년 ${month}월`;
+                      }}
+                    />
+                    <Legend />
+                    <Line
+                      type="monotone"
+                      dataKey="enrollments"
+                      name="수강 신청"
+                      stroke="hsl(var(--brand-primary))"
+                      strokeWidth={2}
+                      dot={{ fill: 'hsl(var(--brand-primary))' }}
+                      activeDot={{ r: 6 }}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="completions"
+                      name="수료"
+                      stroke="hsl(var(--success))"
+                      strokeWidth={2}
+                      dot={{ fill: 'hsl(var(--success))' }}
+                      activeDot={{ r: 6 }}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/src/pages/ta/dashboard/DashboardPage.tsx
+++ b/src/pages/ta/dashboard/DashboardPage.tsx
@@ -1,7 +1,8 @@
+import { useState, useMemo } from 'react';
 import { Users, BookOpen, TrendingUp, GraduationCap, AlertCircle, UserPlus, FileText, CheckCircle } from 'lucide-react';
 import {
-  LineChart,
-  Line,
+  AreaChart,
+  Area,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -17,10 +18,23 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/common/Card';
 import { Progress } from '@/components/common/Progress';
 import { Skeleton } from '@/components/common/Skeleton';
+import { NoDataEmpty } from '@/components/common/EmptyState';
 import { useTaKpiDashboard } from '@/hooks/ta';
+
+type DateRange = '7d' | '30d' | 'all';
+
+const DATE_RANGE_OPTIONS: { value: DateRange; label: string }[] = [
+  { value: 'all', label: '전체' },
+  { value: '7d', label: '최근 7일' },
+  { value: '30d', label: '이번 달' },
+];
 
 export function DashboardPage() {
   const { data, isLoading, error } = useTaKpiDashboard();
+  const [dateRange, setDateRange] = useState<DateRange>('all');
+
+  // 선택된 기간 라벨 가져오기
+  const selectedRangeLabel = DATE_RANGE_OPTIONS.find((opt) => opt.value === dateRange)?.label ?? '';
 
   if (error) {
     return (
@@ -47,11 +61,117 @@ export function DashboardPage() {
   const enrollmentStats = data?.enrollmentStats ?? { totalEnrollments: 0, byStatus: { enrolled: 0, completed: 0, dropped: 0, failed: 0 }, completionRate: 0 };
   const monthlyTrend = data?.monthlyTrend ?? [];
 
+  // 1~12월 전체 X축 데이터 생성 (미래 데이터는 null로 처리)
+  const fullYearChartData = useMemo(() => {
+    const currentDate = new Date();
+    const currentYear = currentDate.getFullYear();
+    const currentMonth = currentDate.getMonth() + 1; // 1-12
+
+    // 1~12월 기본 데이터 생성
+    const fullYearData = Array.from({ length: 12 }, (_, i) => {
+      const month = i + 1;
+      const monthKey = `${currentYear}-${String(month).padStart(2, '0')}`;
+
+      // 기존 데이터에서 해당 월 찾기
+      const existingData = monthlyTrend.find((item) => item.month === monthKey);
+
+      // 미래 데이터는 null, 과거/현재는 데이터 또는 0
+      if (month > currentMonth) {
+        return {
+          month: monthKey,
+          enrollments: null,
+          completions: null,
+        };
+      }
+
+      return {
+        month: monthKey,
+        enrollments: existingData?.enrollments ?? 0,
+        completions: existingData?.completions ?? 0,
+      };
+    });
+
+    return fullYearData;
+  }, [monthlyTrend]);
+
+  // 선택한 기간에 따라 월별 트렌드 필터링 + 가짜 시작점 추가
+  const filteredMonthlyTrend = useMemo(() => {
+    let baseData: typeof fullYearChartData;
+
+    if (dateRange === 'all') {
+      baseData = fullYearChartData;
+    } else {
+      const currentDate = new Date();
+      const currentMonth = currentDate.getMonth(); // 0-11
+
+      if (dateRange === '7d') {
+        // 이번 달만
+        baseData = fullYearChartData.slice(currentMonth, currentMonth + 1);
+      } else {
+        // 30d: 최근 6개월
+        const startMonth = Math.max(0, currentMonth - 5);
+        baseData = fullYearChartData.slice(startMonth, currentMonth + 1);
+      }
+    }
+
+    // 실제 데이터가 있는 포인트 개수 확인 (null이 아닌 데이터)
+    const validDataPoints = baseData.filter(
+      (item) => item.enrollments !== null || item.completions !== null
+    ).length;
+
+    // 데이터 포인트가 1개일 때: 가짜 시작점 추가 (바닥에서 올라가는 삼각형 효과)
+    if (validDataPoints === 1 && baseData.length > 0) {
+      const firstDataIndex = baseData.findIndex(
+        (item) => item.enrollments !== null || item.completions !== null
+      );
+
+      if (firstDataIndex > 0) {
+        // 앞에 데이터가 있으면 이전 월을 0으로 설정
+        const newData = [...baseData];
+        const prevMonth = newData[firstDataIndex - 1];
+        newData[firstDataIndex - 1] = {
+          ...prevMonth,
+          enrollments: 0,
+          completions: 0,
+        };
+        return newData;
+      } else {
+        // 첫 번째 월이 데이터 포인트면 앞에 가짜 시작점 추가
+        const currentYear = new Date().getFullYear();
+        const dummyStart = {
+          month: `${currentYear}-00`, // 가상의 0월 (표시 안 됨)
+          enrollments: 0,
+          completions: 0,
+        };
+        return [dummyStart, ...baseData];
+      }
+    }
+
+    return baseData;
+  }, [fullYearChartData, dateRange]);
+
   return (
     <div className="p-6">
       <AdminPageHeader
         title="대시보드"
-        description="테넌트 현황을 한눈에 확인합니다"
+        description={`테넌트 현황을 한눈에 확인합니다 • ${selectedRangeLabel} 기준`}
+        actions={
+          <div className="flex gap-1">
+            {DATE_RANGE_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                onClick={() => setDateRange(option.value)}
+                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                  dateRange === option.value
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted text-muted-foreground hover:bg-muted/80'
+                }`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        }
       />
 
       {/* Stats Grid */}
@@ -264,58 +384,91 @@ export function DashboardPage() {
           <CardContent>
             {isLoading ? (
               <Skeleton className="h-64" />
-            ) : monthlyTrend.length === 0 ? (
-              <div className="h-64 flex items-center justify-center text-text-secondary">
-                데이터가 없습니다
-              </div>
+            ) : filteredMonthlyTrend.length === 0 ? (
+              <NoDataEmpty
+                title="데이터가 없습니다"
+                description="선택한 기간에 수강 데이터가 없습니다."
+                className="h-64"
+              />
             ) : (
               <div className="h-64">
                 <ResponsiveContainer width="100%" height="100%">
-                  <LineChart
-                    data={monthlyTrend}
+                  <AreaChart
+                    data={filteredMonthlyTrend}
                     margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
                   >
-                    <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                    <defs>
+                      {/* 수강 신청: indigo (브랜드 컬러) - 낮은 투명도 */}
+                      <linearGradient id="enrollmentGradient" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stopColor="#4C2D9A" stopOpacity={0.15} />
+                        <stop offset="100%" stopColor="#4C2D9A" stopOpacity={0.02} />
+                      </linearGradient>
+                      {/* 수료: green (성공 컬러) - 낮은 투명도 */}
+                      <linearGradient id="completionGradient" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stopColor="#3D7A4A" stopOpacity={0.15} />
+                        <stop offset="100%" stopColor="#3D7A4A" stopOpacity={0.02} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
                     <XAxis
                       dataKey="month"
-                      className="text-xs fill-text-secondary"
+                      tick={{ fontSize: 12, fill: 'var(--muted-foreground)' }}
                       tickFormatter={(value) => {
                         const [, month] = value.split('-');
-                        return `${month}월`;
+                        const monthNum = parseInt(month);
+                        // 가짜 0월은 표시하지 않음
+                        if (monthNum === 0) return '';
+                        return `${monthNum}월`;
                       }}
                     />
-                    <YAxis className="text-xs fill-text-secondary" />
+                    <YAxis
+                      tick={{ fontSize: 12, fill: 'var(--muted-foreground)' }}
+                      allowDecimals={false}
+                    />
                     <Tooltip
                       contentStyle={{
-                        backgroundColor: 'hsl(var(--bg-default))',
-                        border: '1px solid hsl(var(--border))',
+                        backgroundColor: 'var(--card)',
+                        border: '1px solid var(--border)',
                         borderRadius: '8px',
                       }}
                       labelFormatter={(value) => {
                         const [year, month] = value.split('-');
-                        return `${year}년 ${month}월`;
+                        const monthNum = parseInt(month);
+                        // 가짜 0월은 "시작점"으로 표시
+                        if (monthNum === 0) return '시작점';
+                        return `${year}년 ${monthNum}월`;
+                      }}
+                      formatter={(value, name) => {
+                        if (value === null) return ['데이터 없음', name];
+                        return [value, name];
                       }}
                     />
                     <Legend />
-                    <Line
+                    {/* 수강 신청을 먼저 그려서 뒤에 배치 (값이 보통 더 큼) */}
+                    <Area
                       type="monotone"
                       dataKey="enrollments"
                       name="수강 신청"
-                      stroke="hsl(var(--brand-primary))"
-                      strokeWidth={2}
-                      dot={{ fill: 'hsl(var(--brand-primary))' }}
-                      activeDot={{ r: 6 }}
+                      stroke="#4C2D9A"
+                      strokeWidth={3}
+                      fill="url(#enrollmentGradient)"
+                      connectNulls={false}
+                      dot={{ fill: '#4C2D9A', strokeWidth: 2, r: 4 }}
+                      activeDot={{ r: 6, strokeWidth: 2 }}
                     />
-                    <Line
+                    {/* 수료를 나중에 그려서 앞에 배치 */}
+                    <Area
                       type="monotone"
                       dataKey="completions"
                       name="수료"
-                      stroke="hsl(var(--success))"
-                      strokeWidth={2}
-                      dot={{ fill: 'hsl(var(--success))' }}
-                      activeDot={{ r: 6 }}
+                      stroke="#3D7A4A"
+                      strokeWidth={3}
+                      fill="url(#completionGradient)"
+                      connectNulls={false}
+                      dot={{ fill: '#3D7A4A', strokeWidth: 2, r: 4 }}
+                      activeDot={{ r: 6, strokeWidth: 2 }}
                     />
-                  </LineChart>
+                  </AreaChart>
                 </ResponsiveContainer>
               </div>
             )}

--- a/src/pages/to/dashboard/DashboardPage.tsx
+++ b/src/pages/to/dashboard/DashboardPage.tsx
@@ -1,0 +1,361 @@
+import {
+  Clock,
+  Users,
+  GraduationCap,
+  BookOpen,
+  AlertCircle,
+  UserX,
+  CheckCircle,
+  TrendingUp,
+} from 'lucide-react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import {
+  AdminPageHeader,
+  AdminStatsCard,
+  AdminStatsGrid,
+} from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/common/Card';
+import { Progress } from '@/components/common/Progress';
+import { Skeleton } from '@/components/common/Skeleton';
+import { useToDashboard } from '@/hooks/to';
+
+export function DashboardPage() {
+  const { data, isLoading, error } = useToDashboard();
+
+  if (error) {
+    return (
+      <div className="p-6">
+        <AdminPageHeader
+          title="대시보드"
+          description="운영 현황을 한눈에 확인합니다"
+        />
+        <Card className="mt-6">
+          <CardContent className="py-12">
+            <div className="flex flex-col items-center justify-center text-center">
+              <AlertCircle className="h-12 w-12 text-destructive mb-4" />
+              <p className="text-lg font-medium text-text-primary">데이터를 불러올 수 없습니다</p>
+              <p className="text-sm text-text-secondary mt-1">잠시 후 다시 시도해주세요</p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const pendingTasks = data?.pendingTasks ?? { programsPendingApproval: 0, courseTimesNeedingInstructor: 0 };
+  const courseTimeStats = data?.courseTimeStats ?? {
+    byStatus: { draft: 0, recruiting: 0, ongoing: 0, closed: 0, archived: 0 },
+    byDeliveryType: { online: 0, offline: 0, blended: 0, live: 0 },
+    freeVsPaid: { free: 0, paid: 0 },
+    total: 0,
+  };
+  const enrollmentStats = data?.enrollmentStats ?? {
+    totalEnrollments: 0,
+    byStatus: { enrolled: 0, completed: 0, dropped: 0, failed: 0 },
+    byType: { voluntary: 0, mandatory: 0 },
+    completionRate: 0,
+    averageCapacityUtilization: 0,
+  };
+  const dailyTrend = data?.dailyTrend ?? [];
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="대시보드"
+        description="운영 현황을 한눈에 확인합니다"
+      />
+
+      {/* Stats Grid */}
+      <AdminStatsGrid columns={4} className="mb-6">
+        {isLoading ? (
+          <>
+            <Skeleton className="h-28" />
+            <Skeleton className="h-28" />
+            <Skeleton className="h-28" />
+            <Skeleton className="h-28" />
+          </>
+        ) : (
+          <>
+            <AdminStatsCard
+              title="검토 대기 프로그램"
+              value={pendingTasks.programsPendingApproval}
+              subtitle="승인 대기"
+              icon={Clock}
+              variant="warning"
+            />
+            <AdminStatsCard
+              title="강사 미배정 차수"
+              value={pendingTasks.courseTimesNeedingInstructor}
+              subtitle="배정 필요"
+              icon={UserX}
+              variant="error"
+            />
+            <AdminStatsCard
+              title="전체 차수"
+              value={courseTimeStats.total}
+              subtitle={`진행 중 ${courseTimeStats.byStatus.ongoing}개`}
+              icon={BookOpen}
+              variant="primary"
+            />
+            <AdminStatsCard
+              title="수강 완료율"
+              value={`${enrollmentStats.completionRate}%`}
+              subtitle={`전체 ${enrollmentStats.totalEnrollments.toLocaleString()}건`}
+              icon={GraduationCap}
+              variant="success"
+            />
+          </>
+        )}
+      </AdminStatsGrid>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+        {/* 차수 상태별 현황 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>차수 상태별 현황</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="space-y-4">
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">작성 중</span>
+                  <div className="flex items-center gap-2">
+                    <Progress value={courseTimeStats.total > 0 ? (courseTimeStats.byStatus.draft / courseTimeStats.total) * 100 : 0} className="w-32" />
+                    <span className="text-sm font-medium w-8">{courseTimeStats.byStatus.draft}</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">모집 중</span>
+                  <div className="flex items-center gap-2">
+                    <Progress value={courseTimeStats.total > 0 ? (courseTimeStats.byStatus.recruiting / courseTimeStats.total) * 100 : 0} className="w-32" />
+                    <span className="text-sm font-medium w-8">{courseTimeStats.byStatus.recruiting}</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">진행 중</span>
+                  <div className="flex items-center gap-2">
+                    <Progress value={courseTimeStats.total > 0 ? (courseTimeStats.byStatus.ongoing / courseTimeStats.total) * 100 : 0} className="w-32" />
+                    <span className="text-sm font-medium w-8">{courseTimeStats.byStatus.ongoing}</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">종료됨</span>
+                  <div className="flex items-center gap-2">
+                    <Progress value={courseTimeStats.total > 0 ? (courseTimeStats.byStatus.closed / courseTimeStats.total) * 100 : 0} className="w-32" />
+                    <span className="text-sm font-medium w-8">{courseTimeStats.byStatus.closed}</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">보관됨</span>
+                  <div className="flex items-center gap-2">
+                    <Progress value={courseTimeStats.total > 0 ? (courseTimeStats.byStatus.archived / courseTimeStats.total) * 100 : 0} className="w-32" />
+                    <span className="text-sm font-medium w-8">{courseTimeStats.byStatus.archived}</span>
+                  </div>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* 차수 운영 방식 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>차수 운영 방식</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="space-y-4">
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <TrendingUp className="h-4 w-4 text-brand-primary" />
+                    <span className="text-sm">온라인</span>
+                  </div>
+                  <span className="text-sm font-medium">{courseTimeStats.byDeliveryType.online}개</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <Users className="h-4 w-4 text-success" />
+                    <span className="text-sm">오프라인</span>
+                  </div>
+                  <span className="text-sm font-medium">{courseTimeStats.byDeliveryType.offline}개</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <CheckCircle className="h-4 w-4 text-warning" />
+                    <span className="text-sm">블렌디드</span>
+                  </div>
+                  <span className="text-sm font-medium">{courseTimeStats.byDeliveryType.blended}개</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <BookOpen className="h-4 w-4 text-destructive" />
+                    <span className="text-sm">실시간</span>
+                  </div>
+                  <span className="text-sm font-medium">{courseTimeStats.byDeliveryType.live}개</span>
+                </div>
+                <div className="border-t pt-4 mt-4">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-text-secondary">무료 / 유료</span>
+                    <span className="text-sm font-medium">
+                      {courseTimeStats.freeVsPaid.free}개 / {courseTimeStats.freeVsPaid.paid}개
+                    </span>
+                  </div>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* 수강 현황 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>수강 현황</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="space-y-4">
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">수강 중</span>
+                  <div className="flex items-center gap-2">
+                    <Progress
+                      value={enrollmentStats.totalEnrollments > 0 ? (enrollmentStats.byStatus.enrolled / enrollmentStats.totalEnrollments) * 100 : 0}
+                      className="w-32"
+                    />
+                    <span className="text-sm font-medium w-16">{enrollmentStats.byStatus.enrolled.toLocaleString()}건</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">수료</span>
+                  <div className="flex items-center gap-2">
+                    <Progress
+                      value={enrollmentStats.totalEnrollments > 0 ? (enrollmentStats.byStatus.completed / enrollmentStats.totalEnrollments) * 100 : 0}
+                      className="w-32"
+                    />
+                    <span className="text-sm font-medium w-16">{enrollmentStats.byStatus.completed.toLocaleString()}건</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">중도 포기</span>
+                  <div className="flex items-center gap-2">
+                    <Progress
+                      value={enrollmentStats.totalEnrollments > 0 ? (enrollmentStats.byStatus.dropped / enrollmentStats.totalEnrollments) * 100 : 0}
+                      className="w-32"
+                    />
+                    <span className="text-sm font-medium w-16">{enrollmentStats.byStatus.dropped.toLocaleString()}건</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">미수료</span>
+                  <div className="flex items-center gap-2">
+                    <Progress
+                      value={enrollmentStats.totalEnrollments > 0 ? (enrollmentStats.byStatus.failed / enrollmentStats.totalEnrollments) * 100 : 0}
+                      className="w-32"
+                    />
+                    <span className="text-sm font-medium w-16">{enrollmentStats.byStatus.failed.toLocaleString()}건</span>
+                  </div>
+                </div>
+                <div className="border-t pt-4 mt-4">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-text-secondary">자발적 / 필수</span>
+                    <span className="font-medium">
+                      {enrollmentStats.byType.voluntary.toLocaleString()}건 / {enrollmentStats.byType.mandatory.toLocaleString()}건
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between text-sm mt-2">
+                    <span className="text-text-secondary">평균 정원 충족률</span>
+                    <span className="font-medium">{enrollmentStats.averageCapacityUtilization}%</span>
+                  </div>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* 일별 수강신청 추이 차트 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>일별 수강신청 추이</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <Skeleton className="h-64" />
+            ) : dailyTrend.length === 0 ? (
+              <div className="h-64 flex items-center justify-center text-text-secondary">
+                데이터가 없습니다
+              </div>
+            ) : (
+              <div className="h-64">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart
+                    data={dailyTrend}
+                    margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+                  >
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                    <XAxis
+                      dataKey="date"
+                      className="text-xs fill-text-secondary"
+                      tickFormatter={(value) => {
+                        const date = new Date(value);
+                        return `${date.getMonth() + 1}/${date.getDate()}`;
+                      }}
+                    />
+                    <YAxis className="text-xs fill-text-secondary" />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: 'hsl(var(--bg-default))',
+                        border: '1px solid hsl(var(--border))',
+                        borderRadius: '8px',
+                      }}
+                      labelFormatter={(value) => {
+                        const date = new Date(value);
+                        return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+                      }}
+                    />
+                    <Bar
+                      dataKey="enrollments"
+                      name="수강 신청"
+                      fill="hsl(var(--brand-primary))"
+                      radius={[4, 4, 0, 0]}
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/to/dashboard/DashboardPage.tsx
+++ b/src/pages/to/dashboard/DashboardPage.tsx
@@ -1,3 +1,4 @@
+import { useState, useMemo } from 'react';
 import {
   Clock,
   Users,
@@ -11,6 +12,8 @@ import {
 import {
   BarChart,
   Bar,
+  AreaChart,
+  Area,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -25,10 +28,20 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/common/Card';
 import { Progress } from '@/components/common/Progress';
 import { Skeleton } from '@/components/common/Skeleton';
+import { NoDataEmpty } from '@/components/common/EmptyState';
 import { useToDashboard } from '@/hooks/to';
+
+type DateRange = '7d' | '30d' | 'all';
+
+const DATE_RANGE_OPTIONS: { value: DateRange; label: string }[] = [
+  { value: 'all', label: '전체' },
+  { value: '7d', label: '최근 7일' },
+  { value: '30d', label: '이번 달' },
+];
 
 export function DashboardPage() {
   const { data, isLoading, error } = useToDashboard();
+  const [dateRange, setDateRange] = useState<DateRange>('all');
 
   if (error) {
     return (
@@ -66,11 +79,46 @@ export function DashboardPage() {
   };
   const dailyTrend = data?.dailyTrend ?? [];
 
+  // 선택한 기간에 따라 데이터 필터링
+  const filteredDailyTrend = useMemo(() => {
+    if (dailyTrend.length === 0) return [];
+    if (dateRange === 'all') return dailyTrend;
+
+    const days = dateRange === '7d' ? 7 : 30;
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - days);
+
+    return dailyTrend.filter((item) => {
+      const itemDate = new Date(item.date);
+      return itemDate >= cutoffDate;
+    });
+  }, [dailyTrend, dateRange]);
+
+  // 선택된 기간 라벨 가져오기
+  const selectedRangeLabel = DATE_RANGE_OPTIONS.find((opt) => opt.value === dateRange)?.label ?? '';
+
   return (
     <div className="p-6">
       <AdminPageHeader
         title="대시보드"
-        description="운영 현황을 한눈에 확인합니다"
+        description={`운영 현황을 한눈에 확인합니다 • ${selectedRangeLabel} 기준`}
+        actions={
+          <div className="flex gap-1">
+            {DATE_RANGE_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                onClick={() => setDateRange(option.value)}
+                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                  dateRange === option.value
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted text-muted-foreground hover:bg-muted/80'
+                }`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        }
       />
 
       {/* Stats Grid */}
@@ -311,45 +359,101 @@ export function DashboardPage() {
           <CardContent>
             {isLoading ? (
               <Skeleton className="h-64" />
-            ) : dailyTrend.length === 0 ? (
-              <div className="h-64 flex items-center justify-center text-text-secondary">
-                데이터가 없습니다
-              </div>
+            ) : filteredDailyTrend.length === 0 ? (
+              <NoDataEmpty
+                title="데이터가 없습니다"
+                description="선택한 기간에 수강 신청 데이터가 없습니다."
+                className="h-64"
+              />
             ) : (
               <div className="h-64">
                 <ResponsiveContainer width="100%" height="100%">
-                  <BarChart
-                    data={dailyTrend}
-                    margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
-                  >
-                    <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-                    <XAxis
-                      dataKey="date"
-                      className="text-xs fill-text-secondary"
-                      tickFormatter={(value) => {
-                        const date = new Date(value);
-                        return `${date.getMonth() + 1}/${date.getDate()}`;
-                      }}
-                    />
-                    <YAxis className="text-xs fill-text-secondary" />
-                    <Tooltip
-                      contentStyle={{
-                        backgroundColor: 'hsl(var(--bg-default))',
-                        border: '1px solid hsl(var(--border))',
-                        borderRadius: '8px',
-                      }}
-                      labelFormatter={(value) => {
-                        const date = new Date(value);
-                        return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
-                      }}
-                    />
-                    <Bar
-                      dataKey="enrollments"
-                      name="수강 신청"
-                      fill="hsl(var(--brand-primary))"
-                      radius={[4, 4, 0, 0]}
-                    />
-                  </BarChart>
+                  {filteredDailyTrend.length >= 7 ? (
+                    // 7일 이상: AreaChart로 트렌드 시각화
+                    <AreaChart
+                      data={filteredDailyTrend}
+                      margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+                    >
+                      <defs>
+                        <linearGradient id="areaGradient" x1="0" y1="0" x2="0" y2="1">
+                          <stop offset="0%" stopColor="#4C2D9A" stopOpacity={0.3} />
+                          <stop offset="100%" stopColor="#4C2D9A" stopOpacity={0.05} />
+                        </linearGradient>
+                      </defs>
+                      <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                      <XAxis
+                        dataKey="date"
+                        tick={{ fontSize: 12, fill: 'var(--muted-foreground)' }}
+                        tickFormatter={(value) => {
+                          const date = new Date(value);
+                          return `${date.getMonth() + 1}/${date.getDate()}`;
+                        }}
+                      />
+                      <YAxis tick={{ fontSize: 12, fill: 'var(--muted-foreground)' }} />
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: 'var(--card)',
+                          border: '1px solid var(--border)',
+                          borderRadius: '8px',
+                        }}
+                        labelFormatter={(value) => {
+                          const date = new Date(value);
+                          return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+                        }}
+                      />
+                      <Area
+                        type="monotone"
+                        dataKey="enrollments"
+                        name="수강 신청"
+                        stroke="#4C2D9A"
+                        strokeWidth={2}
+                        fill="url(#areaGradient)"
+                      />
+                    </AreaChart>
+                  ) : (
+                    // 7일 미만: BarChart (막대 너비 제한 + 호버 효과 + 그라데이션)
+                    <BarChart
+                      data={filteredDailyTrend}
+                      margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+                    >
+                      <defs>
+                        <linearGradient id="barGradient" x1="0" y1="0" x2="0" y2="1">
+                          <stop offset="0%" stopColor="#4C2D9A" stopOpacity={1} />
+                          <stop offset="100%" stopColor="#4C2D9A" stopOpacity={0.7} />
+                        </linearGradient>
+                      </defs>
+                      <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                      <XAxis
+                        dataKey="date"
+                        tick={{ fontSize: 12, fill: 'var(--muted-foreground)' }}
+                        tickFormatter={(value) => {
+                          const date = new Date(value);
+                          return `${date.getMonth() + 1}/${date.getDate()}`;
+                        }}
+                      />
+                      <YAxis tick={{ fontSize: 12, fill: 'var(--muted-foreground)' }} />
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: 'var(--card)',
+                          border: '1px solid var(--border)',
+                          borderRadius: '8px',
+                        }}
+                        labelFormatter={(value) => {
+                          const date = new Date(value);
+                          return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+                        }}
+                        cursor={{ fill: 'var(--muted)', opacity: 0.1 }}
+                      />
+                      <Bar
+                        dataKey="enrollments"
+                        name="수강 신청"
+                        fill="url(#barGradient)"
+                        radius={[4, 4, 0, 0]}
+                        maxBarSize={60}
+                        activeBar={{ fill: '#3D2478', opacity: 0.9 }}
+                      />
+                    </BarChart>
+                  )}
                 </ResponsiveContainer>
               </div>
             )}

--- a/src/pages/to/dashboard/index.ts
+++ b/src/pages/to/dashboard/index.ts
@@ -1,0 +1,1 @@
+export { DashboardPage } from './DashboardPage';

--- a/src/pages/to/index.ts
+++ b/src/pages/to/index.ts
@@ -1,2 +1,2 @@
-// Tenant Operator pages will be exported here
-// export { DashboardPage } from './DashboardPage';
+// Tenant Operator pages
+export { DashboardPage } from './dashboard';

--- a/src/routes/to.routes.tsx
+++ b/src/routes/to.routes.tsx
@@ -19,7 +19,8 @@ import {
 } from '@/pages/to/program';
 import { InstructorAssignmentsPage } from '@/pages/to/instructor';
 import { UserManagementPage } from '@/pages/to/user';
-import { DashboardPage, PlaceholderPage } from './pages';
+import { DashboardPage } from '@/pages/to';
+import { PlaceholderPage } from './pages';
 
 function TenantOperatorWrapper() {
   return (

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -44,6 +44,11 @@ export const API_ENDPOINTS = {
     KPI: '/admin/dashboard/kpi',
   },
 
+  // TO Dashboard (OPERATOR)
+  TO_DASHBOARD: {
+    TASKS: '/operator/dashboard/tasks',
+  },
+
   // Tenant Settings (TA)
   TENANT_SETTINGS: {
     BASE: '/tenant/settings',

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -34,6 +34,16 @@ export const API_ENDPOINTS = {
     BY_ID: (id: number) => `/tenants/${id}`,
   },
 
+  // SA Dashboard (SYSTEM_ADMIN)
+  SA_DASHBOARD: {
+    BASE: '/sa/dashboard',
+  },
+
+  // TA Dashboard (TENANT_ADMIN)
+  TA_DASHBOARD: {
+    KPI: '/admin/dashboard/kpi',
+  },
+
   // Tenant Settings (TA)
   TENANT_SETTINGS: {
     BASE: '/tenant/settings',

--- a/src/services/sa/dashboardService.ts
+++ b/src/services/sa/dashboardService.ts
@@ -1,0 +1,17 @@
+/**
+ * SA Dashboard API 서비스 (SYSTEM_ADMIN)
+ * GET /api/sa/dashboard
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type { SaDashboardResponse } from '@/types/admin';
+
+export const saDashboardService = {
+  /** SA 대시보드 통계 조회 */
+  async getDashboard(): Promise<SaDashboardResponse> {
+    const { data } = await axiosInstance.get<{ data: SaDashboardResponse }>(
+      API_ENDPOINTS.SA_DASHBOARD.BASE
+    );
+    return data.data;
+  },
+};

--- a/src/services/sa/index.ts
+++ b/src/services/sa/index.ts
@@ -1,3 +1,4 @@
 export { tenantService } from './tenantService';
 export type { TenantFilterParams } from './tenantService';
 export { noticeService } from './noticeService';
+export { saDashboardService } from './dashboardService';

--- a/src/services/ta/dashboardService.ts
+++ b/src/services/ta/dashboardService.ts
@@ -1,0 +1,17 @@
+/**
+ * TA Dashboard API 서비스 (TENANT_ADMIN)
+ * GET /api/admin/dashboard/kpi
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type { TaKpiDashboardResponse } from '@/types/admin';
+
+export const taDashboardService = {
+  /** TA KPI 대시보드 통계 조회 */
+  async getKpiDashboard(): Promise<TaKpiDashboardResponse> {
+    const { data } = await axiosInstance.get<{ data: TaKpiDashboardResponse }>(
+      API_ENDPOINTS.TA_DASHBOARD.KPI
+    );
+    return data.data;
+  },
+};

--- a/src/services/ta/index.ts
+++ b/src/services/ta/index.ts
@@ -1,3 +1,4 @@
 export { userService } from './userService';
 export { groupService } from './groupService';
 export { tenantSettingsService } from './tenantSettingsService';
+export { taDashboardService } from './dashboardService';

--- a/src/services/to/dashboardService.ts
+++ b/src/services/to/dashboardService.ts
@@ -1,0 +1,17 @@
+/**
+ * TO Dashboard API 서비스 (OPERATOR)
+ * GET /api/operator/dashboard/tasks
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type { ToOperatorDashboardResponse } from '@/types/to';
+
+export const toDashboardService = {
+  /** TO 운영 대시보드 통계 조회 */
+  async getDashboard(): Promise<ToOperatorDashboardResponse> {
+    const { data } = await axiosInstance.get<{ data: ToOperatorDashboardResponse }>(
+      API_ENDPOINTS.TO_DASHBOARD.TASKS
+    );
+    return data.data;
+  },
+};

--- a/src/services/to/index.ts
+++ b/src/services/to/index.ts
@@ -4,3 +4,4 @@ export * from './timeService';
 export * from './instructorAssignmentService';
 export * from './userService';
 export * from './enrollmentService';
+export * from './dashboardService';

--- a/src/types/admin/dashboard.types.ts
+++ b/src/types/admin/dashboard.types.ts
@@ -1,60 +1,98 @@
 /**
  * 어드민 대시보드 관련 타입 정의
+ * - SA Dashboard: GET /api/sa/dashboard
+ * - TA Dashboard: GET /api/admin/dashboard/kpi
  */
 
-import type { TenantStats, Tenant } from './tenant.types';
-import type { UserStats } from './user.types';
+// ============================================================
+// SA Dashboard (SYSTEM_ADMIN)
+// ============================================================
 
-// SA 대시보드 응답
-export interface SADashboardResponse {
-  tenantStats: TenantStats;
-  userStats: {
-    totalUsers: number;
-    activeToday: number;
-  };
-  recentTenants: Tenant[];
-  systemHealth: SystemHealth;
+/** SA 대시보드 응답 */
+export interface SaDashboardResponse {
+  tenantStats: SaTenantStats;
+  userStats: SaUserStats;
+  recentTenants: SaRecentTenant[];
 }
 
-export interface SystemHealth {
-  status: 'healthy' | 'degraded' | 'down';
-  uptime: string;
-  cpuUsage: number;
-  memoryUsage: number;
-  diskUsage: number;
-}
-
-// TA 대시보드 응답
-export interface TADashboardResponse {
-  userStats: UserStats;
-  courseStats: CourseStats;
-  enrollmentStats: EnrollmentStats;
-  recentActivities: RecentActivity[];
-}
-
-export interface CourseStats {
+/** SA 대시보드 - 테넌트 통계 */
+export interface SaTenantStats {
   total: number;
-  published: number;
-  draft: number;
-  archived: number;
-  totalEnrollments: number;
+  active: number;
+  pending: number;
+  suspended: number;
+  terminated: number;
+  byPlan: Record<string, number>;
 }
 
-export interface EnrollmentStats {
+/** SA 대시보드 - 사용자 통계 */
+export interface SaUserStats {
   total: number;
-  inProgress: number;
-  completed: number;
-  avgCompletionRate: number;
-  completionsThisMonth: number;
+  active: number;
+  suspended: number;
+  withdrawn: number;
 }
 
-export interface RecentActivity {
+/** SA 대시보드 - 최근 테넌트 */
+export interface SaRecentTenant {
   id: number;
-  type: 'USER_JOINED' | 'COURSE_CREATED' | 'ENROLLMENT' | 'COURSE_COMPLETED' | 'ROLE_CHANGED';
-  userId: number;
-  userName: string;
-  description: string;
-  targetId?: number;
-  targetName?: string;
+  code: string;
+  name: string;
+  status: string;
+  plan: string;
   createdAt: string;
+}
+
+// ============================================================
+// TA Dashboard (TENANT_ADMIN) - KPI Dashboard
+// ============================================================
+
+/** TA KPI 대시보드 응답 */
+export interface TaKpiDashboardResponse {
+  userStats: TaUserStats;
+  programStats: TaProgramStats;
+  enrollmentStats: TaEnrollmentStats;
+  monthlyTrend: TaMonthlyTrend[];
+}
+
+/** TA 대시보드 - 사용자 통계 */
+export interface TaUserStats {
+  active: number;
+  inactive: number;
+  suspended: number;
+  withdrawn: number;
+  total: number;
+  newThisMonth: number;
+}
+
+/** TA 대시보드 - 프로그램 통계 */
+export interface TaProgramStats {
+  draft: number;
+  pending: number;
+  approved: number;
+  rejected: number;
+  closed: number;
+  total: number;
+}
+
+/** TA 대시보드 - 수강 통계 */
+export interface TaEnrollmentStats {
+  totalEnrollments: number;
+  byStatus: TaEnrollmentByStatus;
+  completionRate: number;
+}
+
+/** TA 대시보드 - 수강 상태별 통계 */
+export interface TaEnrollmentByStatus {
+  enrolled: number;
+  completed: number;
+  dropped: number;
+  failed: number;
+}
+
+/** TA 대시보드 - 월별 추이 */
+export interface TaMonthlyTrend {
+  month: string;
+  enrollments: number;
+  completions: number;
 }

--- a/src/types/to/dashboard.types.ts
+++ b/src/types/to/dashboard.types.ts
@@ -1,0 +1,78 @@
+/**
+ * TO 운영 대시보드 관련 타입 정의
+ * GET /api/operator/dashboard/tasks
+ */
+
+/** TO 운영 대시보드 응답 */
+export interface ToOperatorDashboardResponse {
+  pendingTasks: ToPendingTasks;
+  courseTimeStats: ToCourseTimeStats;
+  enrollmentStats: ToEnrollmentStats;
+  dailyTrend: ToDailyEnrollment[];
+}
+
+/** 대기 중인 작업 */
+export interface ToPendingTasks {
+  programsPendingApproval: number;
+  courseTimesNeedingInstructor: number;
+}
+
+/** 차수 통계 */
+export interface ToCourseTimeStats {
+  byStatus: ToCourseTimeByStatus;
+  byDeliveryType: ToCourseTimeByDeliveryType;
+  freeVsPaid: ToFreeVsPaid;
+  total: number;
+}
+
+/** 차수 상태별 통계 */
+export interface ToCourseTimeByStatus {
+  draft: number;
+  recruiting: number;
+  ongoing: number;
+  closed: number;
+  archived: number;
+}
+
+/** 차수 운영 방식별 통계 */
+export interface ToCourseTimeByDeliveryType {
+  online: number;
+  offline: number;
+  blended: number;
+  live: number;
+}
+
+/** 무료/유료 통계 */
+export interface ToFreeVsPaid {
+  free: number;
+  paid: number;
+}
+
+/** 수강 통계 */
+export interface ToEnrollmentStats {
+  totalEnrollments: number;
+  byStatus: ToEnrollmentByStatus;
+  byType: ToEnrollmentByType;
+  completionRate: number;
+  averageCapacityUtilization: number;
+}
+
+/** 수강 상태별 통계 */
+export interface ToEnrollmentByStatus {
+  enrolled: number;
+  completed: number;
+  dropped: number;
+  failed: number;
+}
+
+/** 수강 유형별 통계 */
+export interface ToEnrollmentByType {
+  voluntary: number;
+  mandatory: number;
+}
+
+/** 일별 수강신청 추이 */
+export interface ToDailyEnrollment {
+  date: string;
+  enrollments: number;
+}

--- a/src/types/to/index.ts
+++ b/src/types/to/index.ts
@@ -5,3 +5,4 @@ export * from './time.types';
 export * from './instructorAssignment.types';
 export * from './user.types';
 export * from './enrollment.types';
+export * from './dashboard.types';


### PR DESCRIPTION
## Summary

SA/TA/TO 대시보드 API 연동 및 UI/UX 개선

## Related Issue

- Closes #218
- Closes #219
- Closes #220
- Closes #221

## Changes

### API 연동
- SA 대시보드 API 연동 (`GET /api/sa/dashboard`)
- TA 대시보드 API 연동 (`GET /api/admin/dashboard/kpi`)
- TO 대시보드 API 연동 (`GET /api/operator/dashboard/tasks`)
- React Query 훅 및 서비스 레이어 구현

### UI/UX 개선
- 기간 필터 UI 추가 (전체/최근 7일/이번 달)
- NoDataEmpty 컴포넌트로 빈 데이터 상태 개선
- TA 월별 차트 고도화 (AreaChart, X축 1~12월 고정, 그라디언트)
- TO 일별 차트 조건부 렌더링 (7일 미만: BarChart, 이상: AreaChart)
- 디자인 토큰 색상 적용 (indigo/green)

### 파일 추가
- `src/hooks/{sa,ta,to}/useDashboardQueries.ts`
- `src/services/{sa,ta,to}/dashboardService.ts`
- `src/pages/to/dashboard/DashboardPage.tsx`
- `src/types/to/dashboard.types.ts`

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 기간 필터는 현재 클라이언트 사이드 필터링으로 동작합니다
- 백엔드 period 파라미터 구현 후 서버 사이드 필터링으로 전환 예정 (#226, 백엔드 #268)