### PR TITLE
feat: ta 브랜딩 세팅 api 연동

### DIFF
--- a/src/hooks/ta/index.ts
+++ b/src/hooks/ta/index.ts
@@ -27,4 +27,26 @@ export {
   useUpdateTenantSettings,
   useUpdateBranding,
   useUpdateUserManagement,
+  // Design & Layout
+  useUpdateDesignSettings,
+  useUpdateLayoutSettings,
+  // Navigation
+  useNavigationItems,
+  useCreateNavigationItem,
+  useUpdateNavigationItem,
+  useDeleteNavigationItem,
+  useReorderNavigationItems,
+  useResetNavigationItems,
 } from './useTenantSettingsQueries';
+
+export {
+  dashboardKeys,
+  useTaDashboardKpi,
+} from './useDashboardQueries';
+
+export {
+  analyticsKeys,
+  useActivityLogs,
+  useActivityStats,
+  useRecentActivities,
+} from './useAnalyticsQueries';

--- a/src/hooks/ta/index.ts
+++ b/src/hooks/ta/index.ts
@@ -38,15 +38,3 @@ export {
   useReorderNavigationItems,
   useResetNavigationItems,
 } from './useTenantSettingsQueries';
-
-export {
-  dashboardKeys,
-  useTaDashboardKpi,
-} from './useDashboardQueries';
-
-export {
-  analyticsKeys,
-  useActivityLogs,
-  useActivityStats,
-  useRecentActivities,
-} from './useAnalyticsQueries';

--- a/src/hooks/ta/useBrandingQueries.ts
+++ b/src/hooks/ta/useBrandingQueries.ts
@@ -1,0 +1,132 @@
+/**
+ * TA 브랜딩/설정 관련 React Query 훅
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  brandingService,
+  type UpdateDesignSettingsRequest,
+  type UpdateLayoutSettingsRequest,
+  type NavigationItemRequest,
+} from '@/services/ta/brandingService';
+
+// ============================================
+// Query Keys
+// ============================================
+
+export const brandingKeys = {
+  all: ['ta-branding'] as const,
+  settings: () => [...brandingKeys.all, 'settings'] as const,
+  navigation: () => [...brandingKeys.all, 'navigation'] as const,
+};
+
+// ============================================
+// 설정 조회/업데이트 훅
+// ============================================
+
+/** 테넌트 설정 조회 */
+export const useTenantSettings = () => {
+  return useQuery({
+    queryKey: brandingKeys.settings(),
+    queryFn: () => brandingService.getSettings(),
+  });
+};
+
+/** 디자인 설정 업데이트 */
+export const useUpdateDesignSettings = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: UpdateDesignSettingsRequest) =>
+      brandingService.updateDesignSettings(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: brandingKeys.settings() });
+    },
+  });
+};
+
+/** 레이아웃 설정 업데이트 */
+export const useUpdateLayoutSettings = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: UpdateLayoutSettingsRequest) =>
+      brandingService.updateLayoutSettings(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: brandingKeys.settings() });
+    },
+  });
+};
+
+// ============================================
+// 네비게이션 관리 훅
+// ============================================
+
+/** 네비게이션 항목 목록 조회 */
+export const useNavigationItems = () => {
+  return useQuery({
+    queryKey: brandingKeys.navigation(),
+    queryFn: () => brandingService.getNavigationItems(),
+  });
+};
+
+/** 네비게이션 항목 생성 */
+export const useCreateNavigationItem = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: NavigationItemRequest) =>
+      brandingService.createNavigationItem(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: brandingKeys.navigation() });
+    },
+  });
+};
+
+/** 네비게이션 항목 수정 */
+export const useUpdateNavigationItem = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: { id: number; request: NavigationItemRequest }) =>
+      brandingService.updateNavigationItem(id, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: brandingKeys.navigation() });
+    },
+  });
+};
+
+/** 네비게이션 항목 삭제 */
+export const useDeleteNavigationItem = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => brandingService.deleteNavigationItem(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: brandingKeys.navigation() });
+    },
+  });
+};
+
+/** 네비게이션 항목 순서 변경 */
+export const useReorderNavigationItems = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (itemIds: number[]) => brandingService.reorderNavigationItems(itemIds),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: brandingKeys.navigation() });
+    },
+  });
+};
+
+/** 네비게이션 초기화 */
+export const useResetNavigationItems = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => brandingService.resetNavigationItems(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: brandingKeys.navigation() });
+    },
+  });
+};

--- a/src/hooks/ta/useTenantSettingsQueries.ts
+++ b/src/hooks/ta/useTenantSettingsQueries.ts
@@ -3,16 +3,23 @@
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { tenantSettingsService } from '@/services/ta';
+import { brandingService } from '@/services/ta/brandingService';
 import type {
   UpdateTenantSettingsRequest,
   UpdateBrandingRequest,
   UpdateUserManagementRequest,
 } from '@/types/admin';
+import type {
+  UpdateDesignSettingsRequest,
+  UpdateLayoutSettingsRequest,
+  NavigationItemRequest,
+} from '@/services/ta/brandingService';
 
 // Query Keys
 export const tenantSettingsKeys = {
   all: ['tenantSettings'] as const,
   detail: () => [...tenantSettingsKeys.all, 'detail'] as const,
+  navigation: () => [...tenantSettingsKeys.all, 'navigation'] as const,
 };
 
 // ============================================
@@ -27,8 +34,16 @@ export const useTenantSettings = () => {
   });
 };
 
+/** 네비게이션 항목 목록 조회 */
+export const useNavigationItems = () => {
+  return useQuery({
+    queryKey: tenantSettingsKeys.navigation(),
+    queryFn: () => brandingService.getNavigationItems(),
+  });
+};
+
 // ============================================
-// Mutations
+// Mutations - 기본 설정
 // ============================================
 
 /** 테넌트 설정 전체 수정 */
@@ -44,7 +59,7 @@ export const useUpdateTenantSettings = () => {
   });
 };
 
-/** 브랜딩 설정 수정 */
+/** 브랜딩 설정 수정 (레거시) */
 export const useUpdateBranding = () => {
   const queryClient = useQueryClient();
 
@@ -66,6 +81,102 @@ export const useUpdateUserManagement = () => {
       tenantSettingsService.updateUserManagement(request),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: tenantSettingsKeys.detail() });
+    },
+  });
+};
+
+// ============================================
+// Mutations - 디자인/레이아웃 설정
+// ============================================
+
+/** 디자인 설정 업데이트 */
+export const useUpdateDesignSettings = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: UpdateDesignSettingsRequest) =>
+      brandingService.updateDesignSettings(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantSettingsKeys.detail() });
+    },
+  });
+};
+
+/** 레이아웃 설정 업데이트 */
+export const useUpdateLayoutSettings = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: UpdateLayoutSettingsRequest) =>
+      brandingService.updateLayoutSettings(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantSettingsKeys.detail() });
+    },
+  });
+};
+
+// ============================================
+// Mutations - 네비게이션 관리
+// ============================================
+
+/** 네비게이션 항목 생성 */
+export const useCreateNavigationItem = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: NavigationItemRequest) =>
+      brandingService.createNavigationItem(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantSettingsKeys.navigation() });
+    },
+  });
+};
+
+/** 네비게이션 항목 수정 */
+export const useUpdateNavigationItem = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: { id: number; request: NavigationItemRequest }) =>
+      brandingService.updateNavigationItem(id, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantSettingsKeys.navigation() });
+    },
+  });
+};
+
+/** 네비게이션 항목 삭제 */
+export const useDeleteNavigationItem = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => brandingService.deleteNavigationItem(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantSettingsKeys.navigation() });
+    },
+  });
+};
+
+/** 네비게이션 항목 순서 변경 */
+export const useReorderNavigationItems = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (itemIds: number[]) => brandingService.reorderNavigationItems(itemIds),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantSettingsKeys.navigation() });
+    },
+  });
+};
+
+/** 네비게이션 초기화 */
+export const useResetNavigationItems = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => brandingService.resetNavigationItems(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantSettingsKeys.navigation() });
     },
   });
 };

--- a/src/pages/ta/branding/DesignSettingsPage.tsx
+++ b/src/pages/ta/branding/DesignSettingsPage.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Palette,
   Upload,
   Trash2,
   Save,
   RotateCcw,
+  Loader2,
 } from 'lucide-react';
 import { AdminPageHeader } from '@/components/domain/admin';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
@@ -12,9 +13,10 @@ import { Button } from '@/components/common/Button';
 import { Input } from '@/components/common/Input';
 import { Label } from '@/components/common/Label';
 import { Tabs, TabsList, TabsTrigger } from '@/components/common/Tabs';
+import { useTenantSettings, useUpdateDesignSettings } from '@/hooks/ta';
 
-// Mock 데이터
-const mockBrandingSettings = {
+// 기본 설정값
+const defaultSettings = {
   logo: {
     lightUrl: '',
     darkUrl: '',
@@ -32,19 +34,90 @@ const mockBrandingSettings = {
 };
 
 export function DesignSettingsPage() {
-  const [settings, setSettings] = useState(mockBrandingSettings);
+  const [settings, setSettings] = useState(defaultSettings);
   const [previewMode, setPreviewMode] = useState<'light' | 'dark'>('light');
+  const [hasChanges, setHasChanges] = useState(false);
+
+  const { data: tenantSettings, isLoading } = useTenantSettings();
+  const updateDesign = useUpdateDesignSettings();
+
+  // 서버 데이터로 초기화
+  useEffect(() => {
+    if (tenantSettings) {
+      setSettings({
+        logo: {
+          lightUrl: tenantSettings.logoUrl || '',
+          darkUrl: tenantSettings.darkLogoUrl || '',
+        },
+        favicon: tenantSettings.faviconUrl || '',
+        colors: {
+          primary: tenantSettings.primaryColor || '#3B82F6',
+          secondary: tenantSettings.secondaryColor || '#1E40AF',
+          accent: tenantSettings.accentColor || '#10B981',
+        },
+        fonts: {
+          heading: tenantSettings.headingFont || 'Pretendard',
+          body: tenantSettings.bodyFont || 'Pretendard',
+        },
+      });
+      setHasChanges(false);
+    }
+  }, [tenantSettings]);
 
   const handleColorChange = (key: string, value: string) => {
     setSettings({
       ...settings,
       colors: { ...settings.colors, [key]: value },
     });
+    setHasChanges(true);
   };
 
   const handleReset = () => {
-    setSettings(mockBrandingSettings);
+    if (tenantSettings) {
+      setSettings({
+        logo: {
+          lightUrl: tenantSettings.logoUrl || '',
+          darkUrl: tenantSettings.darkLogoUrl || '',
+        },
+        favicon: tenantSettings.faviconUrl || '',
+        colors: {
+          primary: tenantSettings.primaryColor || '#3B82F6',
+          secondary: tenantSettings.secondaryColor || '#1E40AF',
+          accent: tenantSettings.accentColor || '#10B981',
+        },
+        fonts: {
+          heading: tenantSettings.headingFont || 'Pretendard',
+          body: tenantSettings.bodyFont || 'Pretendard',
+        },
+      });
+      setHasChanges(false);
+    }
   };
+
+  const handleSave = () => {
+    updateDesign.mutate({
+      logoUrl: settings.logo.lightUrl || null,
+      darkLogoUrl: settings.logo.darkUrl || null,
+      faviconUrl: settings.favicon || null,
+      primaryColor: settings.colors.primary,
+      secondaryColor: settings.colors.secondary,
+      accentColor: settings.colors.accent,
+      headingFont: settings.fonts.heading,
+      bodyFont: settings.fonts.body,
+    }, {
+      onSuccess: () => {
+        setHasChanges(false);
+      },
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-6 flex items-center justify-center min-h-[400px]">
+        <Loader2 className="h-8 w-8 animate-spin text-brand-primary" />
+      </div>
+    );
+  }
 
   return (
     <div className="p-6">
@@ -53,12 +126,16 @@ export function DesignSettingsPage() {
         description="테넌트의 브랜드 아이덴티티를 설정합니다"
         actions={
           <div className="flex gap-2">
-            <Button variant="outline" onClick={handleReset}>
+            <Button variant="outline" onClick={handleReset} disabled={!hasChanges}>
               <RotateCcw className="mr-2 h-4 w-4" />
               초기화
             </Button>
-            <Button>
-              <Save className="mr-2 h-4 w-4" />
+            <Button onClick={handleSave} disabled={!hasChanges || updateDesign.isPending}>
+              {updateDesign.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="mr-2 h-4 w-4" />
+              )}
               저장
             </Button>
           </div>
@@ -164,9 +241,11 @@ export function DesignSettingsPage() {
                        key === 'accent' ? '강조 색상' : key}
                     </Label>
                     <div className="flex gap-2">
-                      <div
+                      <input
+                        type="color"
+                        value={value}
+                        onChange={(e) => handleColorChange(key, e.target.value)}
                         className="w-10 h-10 rounded-lg border cursor-pointer"
-                        style={{ backgroundColor: value }}
                       />
                       <Input
                         id={key}

--- a/src/pages/ta/branding/LayoutSettingsPage.tsx
+++ b/src/pages/ta/branding/LayoutSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Save,
   RotateCcw,
@@ -6,6 +6,7 @@ import {
   Sidebar,
   PanelTop,
   PanelBottom,
+  Loader2,
 } from 'lucide-react';
 import { AdminPageHeader } from '@/components/domain/admin';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
@@ -19,9 +20,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/common/Select';
+import { useTenantSettings, useUpdateLayoutSettings } from '@/hooks/ta';
+import type { HeaderSettings, SidebarSettings, FooterSettings, ContentSettings } from '@/types/admin';
 
-// Mock 데이터
-const mockLayoutSettings = {
+// 레이아웃 설정 타입
+interface LayoutSettings {
+  header: HeaderSettings;
+  sidebar: SidebarSettings;
+  footer: FooterSettings;
+  content: ContentSettings;
+}
+
+// 기본 설정값
+const defaultLayoutSettings: LayoutSettings = {
   header: {
     style: 'fixed',
     showLogo: true,
@@ -45,11 +56,57 @@ const mockLayoutSettings = {
 };
 
 export function LayoutSettingsPage() {
-  const [settings, setSettings] = useState(mockLayoutSettings);
+  const [settings, setSettings] = useState<LayoutSettings>(defaultLayoutSettings);
+  const [hasChanges, setHasChanges] = useState(false);
+
+  const { data: tenantSettings, isLoading } = useTenantSettings();
+  const updateLayout = useUpdateLayoutSettings();
+
+  // 서버 데이터로 초기화
+  useEffect(() => {
+    if (tenantSettings) {
+      setSettings({
+        header: tenantSettings.headerSettings || defaultLayoutSettings.header,
+        sidebar: tenantSettings.sidebarSettings || defaultLayoutSettings.sidebar,
+        footer: tenantSettings.footerSettings || defaultLayoutSettings.footer,
+        content: tenantSettings.contentSettings || defaultLayoutSettings.content,
+      });
+      setHasChanges(false);
+    }
+  }, [tenantSettings]);
 
   const handleReset = () => {
-    setSettings(mockLayoutSettings);
+    if (tenantSettings) {
+      setSettings({
+        header: tenantSettings.headerSettings || defaultLayoutSettings.header,
+        sidebar: tenantSettings.sidebarSettings || defaultLayoutSettings.sidebar,
+        footer: tenantSettings.footerSettings || defaultLayoutSettings.footer,
+        content: tenantSettings.contentSettings || defaultLayoutSettings.content,
+      });
+      setHasChanges(false);
+    }
   };
+
+  const handleSave = () => {
+    updateLayout.mutate({
+      headerSettings: settings.header as HeaderSettings,
+      sidebarSettings: settings.sidebar as SidebarSettings,
+      footerSettings: settings.footer as FooterSettings,
+      contentSettings: settings.content as ContentSettings,
+    }, {
+      onSuccess: () => {
+        setHasChanges(false);
+      },
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-6 flex items-center justify-center min-h-[400px]">
+        <Loader2 className="h-8 w-8 animate-spin text-brand-primary" />
+      </div>
+    );
+  }
 
   return (
     <div className="p-6">
@@ -58,12 +115,16 @@ export function LayoutSettingsPage() {
         description="플랫폼의 레이아웃과 UI 구성을 설정합니다"
         actions={
           <div className="flex gap-2">
-            <Button variant="outline" onClick={handleReset}>
+            <Button variant="outline" onClick={handleReset} disabled={!hasChanges}>
               <RotateCcw className="mr-2 h-4 w-4" />
               초기화
             </Button>
-            <Button>
-              <Save className="mr-2 h-4 w-4" />
+            <Button onClick={handleSave} disabled={!hasChanges || updateLayout.isPending}>
+              {updateLayout.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="mr-2 h-4 w-4" />
+              )}
               저장
             </Button>
           </div>
@@ -85,10 +146,13 @@ export function LayoutSettingsPage() {
               <Label>헤더 스타일</Label>
               <Select
                 value={settings.header.style}
-                onValueChange={(v) => setSettings({
-                  ...settings,
-                  header: { ...settings.header, style: v },
-                })}
+                onValueChange={(v) => {
+                  setSettings({
+                    ...settings,
+                    header: { ...settings.header, style: v as HeaderSettings['style'] },
+                  });
+                  setHasChanges(true);
+                }}
               >
                 <SelectTrigger>
                   <SelectValue />
@@ -105,30 +169,39 @@ export function LayoutSettingsPage() {
                 <span className="text-sm">로고 표시</span>
                 <Switch
                   checked={settings.header.showLogo}
-                  onCheckedChange={(v) => setSettings({
-                    ...settings,
-                    header: { ...settings.header, showLogo: v },
-                  })}
+                  onCheckedChange={(v) => {
+                    setSettings({
+                      ...settings,
+                      header: { ...settings.header, showLogo: v },
+                    });
+                    setHasChanges(true);
+                  }}
                 />
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-sm">검색창 표시</span>
                 <Switch
                   checked={settings.header.showSearch}
-                  onCheckedChange={(v) => setSettings({
-                    ...settings,
-                    header: { ...settings.header, showSearch: v },
-                  })}
+                  onCheckedChange={(v) => {
+                    setSettings({
+                      ...settings,
+                      header: { ...settings.header, showSearch: v },
+                    });
+                    setHasChanges(true);
+                  }}
                 />
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-sm">알림 표시</span>
                 <Switch
                   checked={settings.header.showNotifications}
-                  onCheckedChange={(v) => setSettings({
-                    ...settings,
-                    header: { ...settings.header, showNotifications: v },
-                  })}
+                  onCheckedChange={(v) => {
+                    setSettings({
+                      ...settings,
+                      header: { ...settings.header, showNotifications: v },
+                    });
+                    setHasChanges(true);
+                  }}
                 />
               </div>
             </div>
@@ -149,10 +222,13 @@ export function LayoutSettingsPage() {
               <Label>사이드바 스타일</Label>
               <Select
                 value={settings.sidebar.style}
-                onValueChange={(v) => setSettings({
-                  ...settings,
-                  sidebar: { ...settings.sidebar, style: v },
-                })}
+                onValueChange={(v) => {
+                  setSettings({
+                    ...settings,
+                    sidebar: { ...settings.sidebar, style: v as SidebarSettings['style'] },
+                  });
+                  setHasChanges(true);
+                }}
               >
                 <SelectTrigger>
                   <SelectValue />
@@ -170,20 +246,26 @@ export function LayoutSettingsPage() {
                 <span className="text-sm">기본 접힌 상태</span>
                 <Switch
                   checked={settings.sidebar.defaultCollapsed}
-                  onCheckedChange={(v) => setSettings({
-                    ...settings,
-                    sidebar: { ...settings.sidebar, defaultCollapsed: v },
-                  })}
+                  onCheckedChange={(v) => {
+                    setSettings({
+                      ...settings,
+                      sidebar: { ...settings.sidebar, defaultCollapsed: v },
+                    });
+                    setHasChanges(true);
+                  }}
                 />
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-sm">아이콘 표시</span>
                 <Switch
                   checked={settings.sidebar.showIcons}
-                  onCheckedChange={(v) => setSettings({
-                    ...settings,
-                    sidebar: { ...settings.sidebar, showIcons: v },
-                  })}
+                  onCheckedChange={(v) => {
+                    setSettings({
+                      ...settings,
+                      sidebar: { ...settings.sidebar, showIcons: v },
+                    });
+                    setHasChanges(true);
+                  }}
                 />
               </div>
             </div>
@@ -207,10 +289,13 @@ export function LayoutSettingsPage() {
               </div>
               <Switch
                 checked={settings.footer.enabled}
-                onCheckedChange={(v) => setSettings({
-                  ...settings,
-                  footer: { ...settings.footer, enabled: v },
-                })}
+                onCheckedChange={(v) => {
+                  setSettings({
+                    ...settings,
+                    footer: { ...settings.footer, enabled: v },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
             {settings.footer.enabled && (
@@ -219,20 +304,26 @@ export function LayoutSettingsPage() {
                   <span className="text-sm">링크 표시</span>
                   <Switch
                     checked={settings.footer.showLinks}
-                    onCheckedChange={(v) => setSettings({
-                      ...settings,
-                      footer: { ...settings.footer, showLinks: v },
-                    })}
+                    onCheckedChange={(v) => {
+                      setSettings({
+                        ...settings,
+                        footer: { ...settings.footer, showLinks: v },
+                      });
+                      setHasChanges(true);
+                    }}
                   />
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm">저작권 표시</span>
                   <Switch
                     checked={settings.footer.showCopyright}
-                    onCheckedChange={(v) => setSettings({
-                      ...settings,
-                      footer: { ...settings.footer, showCopyright: v },
-                    })}
+                    onCheckedChange={(v) => {
+                      setSettings({
+                        ...settings,
+                        footer: { ...settings.footer, showCopyright: v },
+                      });
+                      setHasChanges(true);
+                    }}
                   />
                 </div>
               </>
@@ -254,10 +345,13 @@ export function LayoutSettingsPage() {
               <Label>최대 너비</Label>
               <Select
                 value={settings.content.maxWidth}
-                onValueChange={(v) => setSettings({
-                  ...settings,
-                  content: { ...settings.content, maxWidth: v },
-                })}
+                onValueChange={(v) => {
+                  setSettings({
+                    ...settings,
+                    content: { ...settings.content, maxWidth: v as ContentSettings['maxWidth'] },
+                  });
+                  setHasChanges(true);
+                }}
               >
                 <SelectTrigger>
                   <SelectValue />
@@ -274,10 +368,13 @@ export function LayoutSettingsPage() {
               <Label>여백</Label>
               <Select
                 value={settings.content.padding}
-                onValueChange={(v) => setSettings({
-                  ...settings,
-                  content: { ...settings.content, padding: v },
-                })}
+                onValueChange={(v) => {
+                  setSettings({
+                    ...settings,
+                    content: { ...settings.content, padding: v as ContentSettings['padding'] },
+                  });
+                  setHasChanges(true);
+                }}
               >
                 <SelectTrigger>
                   <SelectValue />

--- a/src/pages/ta/branding/NavigationSettingsPage.tsx
+++ b/src/pages/ta/branding/NavigationSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Plus,
   Trash2,
@@ -11,6 +11,7 @@ import {
   HelpCircle,
   Settings,
   ExternalLink,
+  Loader2,
 } from 'lucide-react';
 import { AdminPageHeader } from '@/components/domain/admin';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
@@ -25,23 +26,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/common/Select';
+import {
+  useNavigationItems,
+  useCreateNavigationItem,
+  useUpdateNavigationItem,
+  useDeleteNavigationItem,
+  useResetNavigationItems,
+} from '@/hooks/ta';
+import type { NavigationItemRequest } from '@/services/ta/brandingService';
 
-// Mock 데이터
-const mockNavItems: {
-  id: number;
-  label: string;
-  icon: string;
-  path: string;
-  enabled: boolean;
-  order: number;
-}[] = [
-  { id: 1, label: '홈', icon: 'Home', path: '/', enabled: true, order: 1 },
-  { id: 2, label: '강좌', icon: 'BookOpen', path: '/courses', enabled: true, order: 2 },
-  { id: 3, label: '내 학습', icon: 'Award', path: '/my-learning', enabled: true, order: 3 },
-  { id: 4, label: '도움말', icon: 'HelpCircle', path: '/help', enabled: true, order: 4 },
-  { id: 5, label: '외부 링크', icon: 'ExternalLink', path: 'https://example.com', enabled: false, order: 5 },
-];
-
+// 아이콘 매핑
 const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
   Home,
   BookOpen,
@@ -51,36 +45,146 @@ const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
   ExternalLink,
 };
 
+// 로컬 편집용 타입
+interface LocalNavItem {
+  id: number;
+  label: string;
+  icon: string;
+  path: string;
+  enabled: boolean;
+  displayOrder: number;
+  target: string | null;
+  isNew?: boolean; // 새로 추가된 항목 표시
+  isDirty?: boolean; // 수정된 항목 표시
+}
+
 export function NavigationSettingsPage() {
-  const [navItems, setNavItems] = useState(mockNavItems);
+  const [navItems, setNavItems] = useState<LocalNavItem[]>([]);
   const [editingItem, setEditingItem] = useState<number | null>(null);
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+
+  // API Hooks
+  const { data: serverItems, isLoading } = useNavigationItems();
+  const createItem = useCreateNavigationItem();
+  const updateItem = useUpdateNavigationItem();
+  const deleteItem = useDeleteNavigationItem();
+  const resetItems = useResetNavigationItems();
+
+  // 서버 데이터로 초기화
+  useEffect(() => {
+    if (serverItems) {
+      setNavItems(serverItems.map(item => ({
+        id: item.id,
+        label: item.label,
+        icon: item.icon,
+        path: item.path,
+        enabled: item.enabled,
+        displayOrder: item.displayOrder,
+        target: item.target,
+      })));
+      setHasUnsavedChanges(false);
+    }
+  }, [serverItems]);
 
   const handleToggle = (id: number) => {
     setNavItems(navItems.map(item =>
-      item.id === id ? { ...item, enabled: !item.enabled } : item
+      item.id === id ? { ...item, enabled: !item.enabled, isDirty: true } : item
     ));
+    setHasUnsavedChanges(true);
   };
 
-  const handleDelete = (id: number) => {
-    setNavItems(navItems.filter(item => item.id !== id));
+  const handleDelete = async (id: number) => {
+    const item = navItems.find(i => i.id === id);
+    if (!item) return;
+
+    if (item.isNew) {
+      // 새로 추가된 항목은 로컬에서만 삭제
+      setNavItems(navItems.filter(i => i.id !== id));
+    } else {
+      // 기존 항목은 서버에서 삭제
+      await deleteItem.mutateAsync(id);
+    }
   };
 
-  const handleReset = () => {
-    setNavItems(mockNavItems);
+  const handleReset = async () => {
+    await resetItems.mutateAsync();
+    setEditingItem(null);
+    setHasUnsavedChanges(false);
   };
 
   const handleAddItem = () => {
-    const newId = Math.max(...navItems.map(i => i.id)) + 1;
-    setNavItems([...navItems, {
+    const newId = Math.min(...navItems.map(i => i.id), 0) - 1; // 음수 ID로 새 항목 구분
+    const newItem: LocalNavItem = {
       id: newId,
       label: '새 메뉴',
       icon: 'Home',
       path: '/',
       enabled: true,
-      order: navItems.length + 1,
-    }]);
+      displayOrder: navItems.length + 1,
+      target: null,
+      isNew: true,
+      isDirty: true,
+    };
+    setNavItems([...navItems, newItem]);
     setEditingItem(newId);
+    setHasUnsavedChanges(true);
   };
+
+  const handleUpdateLocalItem = (id: number, updates: Partial<LocalNavItem>) => {
+    setNavItems(navItems.map(item =>
+      item.id === id ? { ...item, ...updates, isDirty: true } : item
+    ));
+    setHasUnsavedChanges(true);
+  };
+
+  const handleSaveItem = async (id: number) => {
+    const item = navItems.find(i => i.id === id);
+    if (!item) return;
+
+    const request: NavigationItemRequest = {
+      label: item.label,
+      icon: item.icon,
+      path: item.path,
+      enabled: item.enabled,
+      displayOrder: item.displayOrder,
+      target: item.target || undefined,
+    };
+
+    if (item.isNew) {
+      // 새 항목 생성
+      const created = await createItem.mutateAsync(request);
+      // 로컬 상태 업데이트 (새 ID로 교체)
+      setNavItems(navItems.map(i =>
+        i.id === id ? { ...i, id: created.id, isNew: false, isDirty: false } : i
+      ));
+    } else {
+      // 기존 항목 수정
+      await updateItem.mutateAsync({ id, request });
+      setNavItems(navItems.map(i =>
+        i.id === id ? { ...i, isDirty: false } : i
+      ));
+    }
+    setHasUnsavedChanges(navItems.some(i => i.id !== id && i.isDirty));
+  };
+
+  const handleSaveAll = async () => {
+    const dirtyItems = navItems.filter(i => i.isDirty);
+
+    for (const item of dirtyItems) {
+      await handleSaveItem(item.id);
+    }
+    setHasUnsavedChanges(false);
+  };
+
+  const isSaving = createItem.isPending || updateItem.isPending || deleteItem.isPending || resetItems.isPending;
+
+  if (isLoading) {
+    return (
+      <div className="p-6 flex items-center justify-center min-h-[400px]">
+        <Loader2 className="h-8 w-8 animate-spin text-brand-primary" />
+      </div>
+    );
+  }
 
   return (
     <div className="p-6">
@@ -89,13 +193,28 @@ export function NavigationSettingsPage() {
         description="사이드바 및 상단 네비게이션 메뉴를 설정합니다"
         actions={
           <div className="flex gap-2">
-            <Button variant="outline" onClick={handleReset}>
-              <RotateCcw className="mr-2 h-4 w-4" />
+            <Button
+              variant="outline"
+              onClick={handleReset}
+              disabled={resetItems.isPending}
+            >
+              {resetItems.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <RotateCcw className="mr-2 h-4 w-4" />
+              )}
               초기화
             </Button>
-            <Button>
-              <Save className="mr-2 h-4 w-4" />
-              저장
+            <Button
+              onClick={handleSaveAll}
+              disabled={!hasUnsavedChanges || isSaving}
+            >
+              {isSaving ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="mr-2 h-4 w-4" />
+              )}
+              전체 저장
             </Button>
           </div>
         }
@@ -108,7 +227,7 @@ export function NavigationSettingsPage() {
             <div className="flex items-center justify-between">
               <div>
                 <CardTitle>네비게이션 메뉴</CardTitle>
-                <CardDescription>메뉴 항목을 드래그하여 순서를 변경할 수 있습니다</CardDescription>
+                <CardDescription>메뉴 항목을 추가하고 편집할 수 있습니다</CardDescription>
               </div>
               <Button onClick={handleAddItem}>
                 <Plus className="mr-2 h-4 w-4" />
@@ -118,7 +237,7 @@ export function NavigationSettingsPage() {
           </CardHeader>
           <CardContent>
             <div className="space-y-2">
-              {navItems.sort((a, b) => a.order - b.order).map((item) => {
+              {navItems.sort((a, b) => a.displayOrder - b.displayOrder).map((item) => {
                 const IconComponent = iconMap[item.icon] || Home;
 
                 return (
@@ -126,7 +245,7 @@ export function NavigationSettingsPage() {
                     key={item.id}
                     className={`flex items-center justify-between p-3 border rounded-lg ${
                       item.enabled ? 'bg-white' : 'bg-gray-50 opacity-60'
-                    }`}
+                    } ${item.isDirty ? 'border-yellow-400' : ''} ${item.isNew ? 'border-green-400' : ''}`}
                   >
                     <div className="flex items-center gap-3">
                       <GripVertical className="h-4 w-4 text-text-secondary cursor-grab" />
@@ -134,7 +253,15 @@ export function NavigationSettingsPage() {
                         <IconComponent className="h-4 w-4" />
                       </div>
                       <div>
-                        <p className="font-medium">{item.label}</p>
+                        <div className="flex items-center gap-2">
+                          <p className="font-medium">{item.label}</p>
+                          {item.isNew && (
+                            <span className="text-xs bg-green-100 text-green-700 px-1.5 py-0.5 rounded">새 항목</span>
+                          )}
+                          {item.isDirty && !item.isNew && (
+                            <span className="text-xs bg-yellow-100 text-yellow-700 px-1.5 py-0.5 rounded">수정됨</span>
+                          )}
+                        </div>
                         <p className="text-xs text-text-secondary">{item.path}</p>
                       </div>
                     </div>
@@ -150,18 +277,43 @@ export function NavigationSettingsPage() {
                       >
                         <Settings className="h-4 w-4" />
                       </Button>
+                      {item.isDirty && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-green-600"
+                          onClick={() => handleSaveItem(item.id)}
+                          disabled={isSaving}
+                        >
+                          {(createItem.isPending || updateItem.isPending) ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <Save className="h-4 w-4" />
+                          )}
+                        </Button>
+                      )}
                       <Button
                         variant="ghost"
                         size="sm"
                         className="text-red-500"
                         onClick={() => handleDelete(item.id)}
+                        disabled={deleteItem.isPending}
                       >
-                        <Trash2 className="h-4 w-4" />
+                        {deleteItem.isPending ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="h-4 w-4" />
+                        )}
                       </Button>
                     </div>
                   </div>
                 );
               })}
+              {navItems.length === 0 && (
+                <div className="text-center py-8 text-text-secondary">
+                  네비게이션 항목이 없습니다. 메뉴를 추가해 주세요.
+                </div>
+              )}
             </div>
           </CardContent>
         </Card>
@@ -185,18 +337,14 @@ export function NavigationSettingsPage() {
                         <Label>메뉴 이름</Label>
                         <Input
                           value={item.label}
-                          onChange={(e) => setNavItems(navItems.map(i =>
-                            i.id === editingItem ? { ...i, label: e.target.value } : i
-                          ))}
+                          onChange={(e) => handleUpdateLocalItem(editingItem, { label: e.target.value })}
                         />
                       </div>
                       <div className="space-y-2">
                         <Label>경로</Label>
                         <Input
                           value={item.path}
-                          onChange={(e) => setNavItems(navItems.map(i =>
-                            i.id === editingItem ? { ...i, path: e.target.value } : i
-                          ))}
+                          onChange={(e) => handleUpdateLocalItem(editingItem, { path: e.target.value })}
                           placeholder="/path 또는 https://..."
                         />
                       </div>
@@ -204,9 +352,7 @@ export function NavigationSettingsPage() {
                         <Label>아이콘</Label>
                         <Select
                           value={item.icon}
-                          onValueChange={(v) => setNavItems(navItems.map(i =>
-                            i.id === editingItem ? { ...i, icon: v } : i
-                          ))}
+                          onValueChange={(v) => handleUpdateLocalItem(editingItem, { icon: v })}
                         >
                           <SelectTrigger>
                             <SelectValue />
@@ -220,6 +366,35 @@ export function NavigationSettingsPage() {
                             <SelectItem value="ExternalLink">외부 링크</SelectItem>
                           </SelectContent>
                         </Select>
+                      </div>
+                      <div className="space-y-2">
+                        <Label>링크 대상</Label>
+                        <Select
+                          value={item.target || '_self'}
+                          onValueChange={(v) => handleUpdateLocalItem(editingItem, { target: v === '_self' ? null : v })}
+                        >
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="_self">현재 창</SelectItem>
+                            <SelectItem value="_blank">새 창</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div className="pt-4 border-t">
+                        <Button
+                          onClick={() => handleSaveItem(item.id)}
+                          disabled={!item.isDirty || isSaving}
+                          className="w-full"
+                        >
+                          {isSaving ? (
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          ) : (
+                            <Save className="mr-2 h-4 w-4" />
+                          )}
+                          {item.isNew ? '항목 추가' : '변경사항 저장'}
+                        </Button>
                       </div>
                     </>
                   );
@@ -241,7 +416,7 @@ export function NavigationSettingsPage() {
                   <div className="space-y-1">
                     {navItems
                       .filter(item => item.enabled)
-                      .sort((a, b) => a.order - b.order)
+                      .sort((a, b) => a.displayOrder - b.displayOrder)
                       .map((item) => {
                         const IconComponent = iconMap[item.icon] || Home;
                         return (
@@ -257,6 +432,11 @@ export function NavigationSettingsPage() {
                           </div>
                         );
                       })}
+                    {navItems.filter(item => item.enabled).length === 0 && (
+                      <div className="text-center py-4 text-text-secondary text-sm">
+                        활성화된 메뉴가 없습니다
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -37,8 +37,15 @@ export const API_ENDPOINTS = {
   // Tenant Settings (TA)
   TENANT_SETTINGS: {
     BASE: '/tenant/settings',
+    DESIGN: '/tenant/settings/design',
+    LAYOUT: '/tenant/settings/layout',
     BRANDING: '/tenant/settings/branding',
     USER_MANAGEMENT: '/tenant/settings/user-management',
+    // Navigation
+    NAVIGATION: '/tenant/settings/navigation',
+    NAVIGATION_ITEM: (id: number) => `/tenant/settings/navigation/${id}`,
+    NAVIGATION_REORDER: '/tenant/settings/navigation/reorder',
+    NAVIGATION_RESET: '/tenant/settings/navigation/reset',
   },
 
   // User Groups (TA)
@@ -229,5 +236,29 @@ export const API_ENDPOINTS = {
     COUNT: '/cart/count',
     ITEM: (courseId: number) => `/cart/items/${courseId}`,
     ITEM_CHECK: (courseId: number) => `/cart/items/${courseId}/check`,
+  },
+
+  // Dashboard (TA, SA)
+  DASHBOARD: {
+    TA_KPI: '/admin/dashboard/kpi',
+    SA: '/sa/dashboard',
+  },
+
+  // Analytics (TA, SA)
+  ANALYTICS: {
+    // TA용 (테넌트 단위)
+    TA_LOGS: '/admin/analytics/logs',
+    TA_STATS: '/admin/analytics/stats',
+    TA_RECENT: '/admin/analytics/recent',
+    // SA용 (전체 시스템)
+    SA_LOGS: '/sa/analytics/logs',
+    SA_STATS: '/sa/analytics/stats',
+    SA_RECENT: '/sa/analytics/recent',
+  },
+
+  // System Settings (SA)
+  SYSTEM_SETTINGS: {
+    BASE: '/admin/system/settings',
+    TENANT_DEFAULTS: '/admin/system/tenant-defaults',
   },
 } as const;

--- a/src/services/ta/brandingService.ts
+++ b/src/services/ta/brandingService.ts
@@ -1,0 +1,199 @@
+/**
+ * TA 브랜딩/설정 관리 API 서비스
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+
+// ============================================
+// 타입 정의
+// ============================================
+
+export interface TenantSettingsResponse {
+  id: number;
+  tenantId: number;
+  // 브랜딩 설정
+  logoUrl: string | null;
+  darkLogoUrl: string | null;
+  faviconUrl: string | null;
+  primaryColor: string;
+  secondaryColor: string;
+  accentColor: string | null;
+  fontFamily: string | null;
+  headingFont: string | null;
+  bodyFont: string | null;
+  // 레이아웃 설정
+  headerSettings: HeaderSettings;
+  sidebarSettings: SidebarSettings;
+  footerSettings: FooterSettings;
+  contentSettings: ContentSettings;
+  // 일반 설정
+  defaultLanguage: string;
+  timezone: string;
+  // 사용자 관리 설정
+  allowSelfRegistration: boolean;
+  requireEmailVerification: boolean;
+  requireApproval: boolean;
+  allowedEmailDomains: string | null;
+  // 제한 설정
+  maxUsersCount: number;
+  maxStorageGB: number;
+  maxCourses: number;
+  // 기능 활성화 설정
+  allowCustomDomain: boolean;
+  allowCustomBranding: boolean;
+  ssoEnabled: boolean;
+  apiAccessEnabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface HeaderSettings {
+  style: 'fixed' | 'sticky' | 'static';
+  showLogo: boolean;
+  showSearch: boolean;
+  showNotifications: boolean;
+}
+
+export interface SidebarSettings {
+  style: 'collapsible' | 'fixed' | 'overlay' | 'hidden';
+  defaultCollapsed: boolean;
+  showIcons: boolean;
+}
+
+export interface FooterSettings {
+  enabled: boolean;
+  showLinks: boolean;
+  showCopyright: boolean;
+}
+
+export interface ContentSettings {
+  maxWidth: 'full' | 'xl' | 'lg' | 'md';
+  padding: 'none' | 'compact' | 'normal' | 'relaxed';
+}
+
+export interface UpdateDesignSettingsRequest {
+  logoUrl?: string | null;
+  darkLogoUrl?: string | null;
+  faviconUrl?: string | null;
+  primaryColor?: string;
+  secondaryColor?: string;
+  accentColor?: string;
+  headingFont?: string;
+  bodyFont?: string;
+}
+
+export interface UpdateLayoutSettingsRequest {
+  headerSettings?: HeaderSettings;
+  sidebarSettings?: SidebarSettings;
+  footerSettings?: FooterSettings;
+  contentSettings?: ContentSettings;
+}
+
+export interface NavigationItemResponse {
+  id: number;
+  label: string;
+  icon: string;
+  path: string;
+  enabled: boolean;
+  displayOrder: number;
+  target: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface NavigationItemRequest {
+  label: string;
+  icon: string;
+  path: string;
+  enabled?: boolean;
+  displayOrder?: number;
+  target?: string;
+}
+
+// ============================================
+// API 서비스
+// ============================================
+
+export const brandingService = {
+  // ============================================
+  // 설정 조회/업데이트
+  // ============================================
+
+  /** 테넌트 설정 전체 조회 */
+  async getSettings(): Promise<TenantSettingsResponse> {
+    const { data } = await axiosInstance.get<{ data: TenantSettingsResponse }>(
+      API_ENDPOINTS.TENANT_SETTINGS.BASE
+    );
+    return data.data;
+  },
+
+  /** 디자인 설정 업데이트 */
+  async updateDesignSettings(request: UpdateDesignSettingsRequest): Promise<TenantSettingsResponse> {
+    const { data } = await axiosInstance.put<{ data: TenantSettingsResponse }>(
+      API_ENDPOINTS.TENANT_SETTINGS.DESIGN,
+      request
+    );
+    return data.data;
+  },
+
+  /** 레이아웃 설정 업데이트 */
+  async updateLayoutSettings(request: UpdateLayoutSettingsRequest): Promise<TenantSettingsResponse> {
+    const { data } = await axiosInstance.put<{ data: TenantSettingsResponse }>(
+      API_ENDPOINTS.TENANT_SETTINGS.LAYOUT,
+      request
+    );
+    return data.data;
+  },
+
+  // ============================================
+  // 네비게이션 관리
+  // ============================================
+
+  /** 네비게이션 항목 목록 조회 */
+  async getNavigationItems(): Promise<NavigationItemResponse[]> {
+    const { data } = await axiosInstance.get<{ data: NavigationItemResponse[] }>(
+      API_ENDPOINTS.TENANT_SETTINGS.NAVIGATION
+    );
+    return data.data;
+  },
+
+  /** 네비게이션 항목 생성 */
+  async createNavigationItem(request: NavigationItemRequest): Promise<NavigationItemResponse> {
+    const { data } = await axiosInstance.post<{ data: NavigationItemResponse }>(
+      API_ENDPOINTS.TENANT_SETTINGS.NAVIGATION,
+      request
+    );
+    return data.data;
+  },
+
+  /** 네비게이션 항목 수정 */
+  async updateNavigationItem(id: number, request: NavigationItemRequest): Promise<NavigationItemResponse> {
+    const { data } = await axiosInstance.put<{ data: NavigationItemResponse }>(
+      API_ENDPOINTS.TENANT_SETTINGS.NAVIGATION_ITEM(id),
+      request
+    );
+    return data.data;
+  },
+
+  /** 네비게이션 항목 삭제 */
+  async deleteNavigationItem(id: number): Promise<void> {
+    await axiosInstance.delete(API_ENDPOINTS.TENANT_SETTINGS.NAVIGATION_ITEM(id));
+  },
+
+  /** 네비게이션 항목 순서 변경 */
+  async reorderNavigationItems(itemIds: number[]): Promise<NavigationItemResponse[]> {
+    const { data } = await axiosInstance.put<{ data: NavigationItemResponse[] }>(
+      API_ENDPOINTS.TENANT_SETTINGS.NAVIGATION_REORDER,
+      itemIds
+    );
+    return data.data;
+  },
+
+  /** 네비게이션 초기화 */
+  async resetNavigationItems(): Promise<NavigationItemResponse[]> {
+    const { data } = await axiosInstance.post<{ data: NavigationItemResponse[] }>(
+      API_ENDPOINTS.TENANT_SETTINGS.NAVIGATION_RESET
+    );
+    return data.data;
+  },
+};

--- a/src/services/ta/index.ts
+++ b/src/services/ta/index.ts
@@ -1,5 +1,3 @@
 export { userService } from './userService';
 export { groupService } from './groupService';
 export { tenantSettingsService } from './tenantSettingsService';
-export { dashboardService } from './dashboardService';
-export type { TaDashboardKpiResponse } from './dashboardService';

--- a/src/services/ta/index.ts
+++ b/src/services/ta/index.ts
@@ -1,3 +1,5 @@
 export { userService } from './userService';
 export { groupService } from './groupService';
 export { tenantSettingsService } from './tenantSettingsService';
+export { dashboardService } from './dashboardService';
+export type { TaDashboardKpiResponse } from './dashboardService';

--- a/src/types/admin/tenantSettings.types.ts
+++ b/src/types/admin/tenantSettings.types.ts
@@ -2,30 +2,78 @@
  * Tenant Settings 타입 정의 (TA)
  */
 
+// 레이아웃 설정 타입
+export interface HeaderSettings {
+  style: 'fixed' | 'sticky' | 'static';
+  showLogo: boolean;
+  showSearch: boolean;
+  showNotifications: boolean;
+}
+
+export interface SidebarSettings {
+  style: 'collapsible' | 'fixed' | 'overlay' | 'hidden';
+  defaultCollapsed: boolean;
+  showIcons: boolean;
+}
+
+export interface FooterSettings {
+  enabled: boolean;
+  showLinks: boolean;
+  showCopyright: boolean;
+}
+
+export interface ContentSettings {
+  maxWidth: 'full' | 'xl' | 'lg' | 'md';
+  padding: 'none' | 'compact' | 'normal' | 'relaxed';
+}
+
 export interface TenantSettingsDetail {
   id: number;
   tenantId: number;
 
   // Branding
   logoUrl: string | null;
+  darkLogoUrl: string | null;
   faviconUrl: string | null;
   primaryColor: string | null;
   secondaryColor: string | null;
+  accentColor: string | null;
+  fontFamily: string | null;
+  headingFont: string | null;
+  bodyFont: string | null;
+
+  // Layout Settings
+  headerSettings: HeaderSettings | null;
+  sidebarSettings: SidebarSettings | null;
+  footerSettings: FooterSettings | null;
+  contentSettings: ContentSettings | null;
+
+  // General Settings
+  defaultLanguage: string;
+  timezone: string;
 
   // User Management
   allowSelfRegistration: boolean;
   requireEmailVerification: boolean;
-  defaultUserRole: string;
+  requireApproval: boolean;
+  allowedEmailDomains: string | null;
+  defaultUserRole?: string; // deprecated
 
   // Limits
-  maxUsers: number | null;
-  maxStorage: number | null;
-  maxCourses: number | null;
+  maxUsersCount: number;
+  maxStorageGB: number;
+  maxCourses: number;
+  maxUsers?: number | null; // deprecated alias
+  maxStorage?: number | null; // deprecated alias
 
   // Features
-  enableDiscussions: boolean;
-  enableCertificates: boolean;
-  enableAnalytics: boolean;
+  allowCustomDomain: boolean;
+  allowCustomBranding: boolean;
+  ssoEnabled: boolean;
+  apiAccessEnabled: boolean;
+  enableDiscussions?: boolean; // deprecated
+  enableCertificates?: boolean; // deprecated
+  enableAnalytics?: boolean; // deprecated
 
   createdAt: string;
   updatedAt: string;
@@ -65,4 +113,46 @@ export interface UpdateUserManagementRequest {
   allowSelfRegistration?: boolean;
   requireEmailVerification?: boolean;
   defaultUserRole?: string;
+}
+
+// 새로운 디자인 설정 요청 타입
+export interface UpdateDesignSettingsRequest {
+  logoUrl?: string | null;
+  darkLogoUrl?: string | null;
+  faviconUrl?: string | null;
+  primaryColor?: string;
+  secondaryColor?: string;
+  accentColor?: string;
+  headingFont?: string;
+  bodyFont?: string;
+}
+
+// 새로운 레이아웃 설정 요청 타입
+export interface UpdateLayoutSettingsRequest {
+  headerSettings?: HeaderSettings;
+  sidebarSettings?: SidebarSettings;
+  footerSettings?: FooterSettings;
+  contentSettings?: ContentSettings;
+}
+
+// 네비게이션 항목 타입
+export interface NavigationItem {
+  id: number;
+  label: string;
+  icon: string;
+  path: string;
+  enabled: boolean;
+  displayOrder: number;
+  target: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface NavigationItemRequest {
+  label: string;
+  icon: string;
+  path: string;
+  enabled?: boolean;
+  displayOrder?: number;
+  target?: string;
 }


### PR DESCRIPTION
## Summary

테넌트 관리자(TA)가 브랜딩 설정을 할 수 있는 페이지를 구현하고 API를 연동했습니다. 네비게이션 설정, 디자인 설정(색상, 로고), 레이아웃 설정 페이지를 추가했습니다.

## Related Issue

- Closes #211

## Changes

- DesignSettingsPage, NavigationSettingsPage, LayoutSettingsPage 구현
- useBrandingQueries, useTenantSettingsQueries 훅 추가
- brandingService API 서비스 추가
- TenantSettings 타입에 네비게이션, 디자인, 레이아웃 필드 추가
- API endpoints 추가 (PUT /api/ta/tenant-settings/navigation 등)
- hooks/ta/index.ts, services/ta/index.ts 업데이트

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [ ] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

Backend의 feature/tenant-branding-settings(#261)가 먼저 머지되어야 합니다.