### PR TITLE
feat: 테넌트 동적 브랜딩 적용

### DIFF
--- a/src/components/landing/LandingFooter.tsx
+++ b/src/components/landing/LandingFooter.tsx
@@ -1,8 +1,11 @@
 import { Youtube, Instagram } from 'lucide-react';
 import { useTranslation } from '@/store/common/languageStore';
+import { useTenantBranding } from '@/contexts/TenantBrandingContext';
 
 export function LandingFooter() {
   const { t } = useTranslation();
+  const { branding } = useTenantBranding();
+  const tenantName = branding?.tenantName || 'MEGAZONECLOUD';
 
   return (
     <footer className="landing-footer-wrapper landing-text-secondary text-sm py-16">
@@ -12,7 +15,7 @@ export function LandingFooter() {
           <div className="flex flex-col lg:flex-row justify-between items-start gap-8">
             <div className="space-y-4">
               <div className="flex items-center gap-3">
-                <span className="text-2xl font-bold gradient-text">MEGAZONECLOUD</span>
+                <span className="text-2xl font-bold gradient-text">{tenantName}</span>
               </div>
               <div className="text-[12px] landing-text-muted leading-relaxed space-y-1">
                 <p>{t.footer.company} | {t.footer.ceo}</p>

--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -6,6 +6,7 @@ import { useMyProfile } from '@/hooks/common';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation } from '@/store/common/languageStore';
 import { useUnreadNotificationCount } from '@/hooks/tu';
+import { useTenantBranding } from '@/contexts/TenantBrandingContext';
 
 export function LandingHeader() {
   const [showBanner, setShowBanner] = useState(true);
@@ -19,14 +20,28 @@ export function LandingHeader() {
   const isDark = theme === 'dark';
   const { data: unreadCountData } = useUnreadNotificationCount(isAuthenticated);
   const unreadCount = unreadCountData?.count || 0;
+  const { branding } = useTenantBranding();
+
+  // API Base URL
+  const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api').replace('/api', '');
 
   // 프로필 이미지 URL 생성
-  const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api').replace('/api', '');
   const profileImageUrl = profile?.profileImageUrl
     ? profile.profileImageUrl.startsWith('http')
       ? profile.profileImageUrl
       : `${apiBaseUrl}${profile.profileImageUrl}`
     : null;
+
+  // 로고 URL 계산 (다크모드 우선)
+  const logoUrl = isDark
+    ? (branding?.darkLogoUrl || branding?.logoUrl)
+    : branding?.logoUrl;
+
+  const fullLogoUrl = logoUrl
+    ? (logoUrl.startsWith('http') ? logoUrl : `${apiBaseUrl}${logoUrl}`)
+    : null;
+
+  const tenantName = branding?.tenantName || 'MZC Learn';
 
   const handleLogout = () => {
     logout();
@@ -63,8 +78,14 @@ export function LandingHeader() {
           <div className="flex items-center gap-8 ml-2 md:ml-4">
             {/* Logo */}
             <Link to="/tu/b2c" className={`flex items-center gap-2 font-bold text-xl tracking-tight ${isDark ? '' : 'text-gray-900'}`}>
-              <span className="text-2xl">M</span>
-              <span className="gradient-text">MZC Learn</span>
+              {fullLogoUrl ? (
+                <img src={fullLogoUrl} alt={tenantName} className="h-8 object-contain" />
+              ) : (
+                <>
+                  <span className="text-2xl">M</span>
+                  <span className="gradient-text">{tenantName}</span>
+                </>
+              )}
             </Link>
 
             {/* Desktop Nav Links */}

--- a/src/contexts/TenantBrandingContext.tsx
+++ b/src/contexts/TenantBrandingContext.tsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, ReactNode } from 'react';
+import { usePublicBranding } from '@/hooks/tu/usePublicBranding';
+import { extractTenantIdentifier } from '@/utils/tenantUtils';
+import type { PublicBrandingResponse } from '@/types/tu/branding.types';
+
+interface TenantBrandingContextValue {
+  branding: PublicBrandingResponse | null | undefined;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const TenantBrandingContext = createContext<TenantBrandingContextValue | undefined>(undefined);
+
+export function TenantBrandingProvider({ children }: { children: ReactNode }) {
+  const tenantIdentifier = extractTenantIdentifier();
+
+  const { data: branding, isLoading, error } = usePublicBranding(
+    tenantIdentifier?.identifier,
+    tenantIdentifier?.type
+  );
+
+  return (
+    <TenantBrandingContext.Provider value={{ branding, isLoading, error }}>
+      {children}
+    </TenantBrandingContext.Provider>
+  );
+}
+
+export function useTenantBranding() {
+  const context = useContext(TenantBrandingContext);
+  if (context === undefined) {
+    throw new Error('useTenantBranding must be used within TenantBrandingProvider');
+  }
+  return context;
+}

--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -229,3 +229,11 @@ export {
   useCourseTimeCatalog,
   useCourseTimeDetail,
 } from './useCourseTimeCatalogQueries';
+
+// Public Branding Hooks
+export {
+  publicBrandingKeys,
+  usePublicBranding,
+} from './usePublicBranding';
+
+export { useBrandingApply } from './useBrandingApply';

--- a/src/hooks/tu/useBrandingApply.ts
+++ b/src/hooks/tu/useBrandingApply.ts
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+import type { PublicBrandingResponse } from '@/types/tu/branding.types';
+
+/**
+ * 브랜딩을 CSS 변수로 적용하는 Hook
+ */
+export function useBrandingApply(branding: PublicBrandingResponse | null | undefined) {
+  useEffect(() => {
+    if (!branding) return;
+
+    const root = document.documentElement;
+
+    // 색상 적용
+    if (branding.primaryColor) {
+      root.style.setProperty('--landing-primary-color', branding.primaryColor);
+      // gradient-text 업데이트
+      const gradientFrom = branding.primaryColor;
+      const gradientTo = branding.secondaryColor || branding.primaryColor;
+      root.style.setProperty('--landing-gradient-from', gradientFrom);
+      root.style.setProperty('--landing-gradient-to', gradientTo);
+    }
+
+    if (branding.secondaryColor) {
+      root.style.setProperty('--landing-secondary-color', branding.secondaryColor);
+    }
+
+    if (branding.accentColor) {
+      root.style.setProperty('--landing-accent-color', branding.accentColor);
+    }
+
+    // 폰트 적용
+    if (branding.headingFont) {
+      root.style.setProperty('--landing-heading-font', branding.headingFont);
+    }
+
+    if (branding.bodyFont) {
+      root.style.setProperty('--landing-body-font', branding.bodyFont);
+    }
+
+    // Favicon 적용
+    if (branding.faviconUrl) {
+      let link = document.querySelector("link[rel~='icon']") as HTMLLinkElement;
+      if (!link) {
+        link = document.createElement('link');
+        link.rel = 'icon';
+        document.head.appendChild(link);
+      }
+      link.href = branding.faviconUrl;
+    }
+
+    // Document title 업데이트
+    if (branding.tenantName) {
+      document.title = branding.tenantName;
+    }
+  }, [branding]);
+}

--- a/src/hooks/tu/usePublicBranding.ts
+++ b/src/hooks/tu/usePublicBranding.ts
@@ -1,0 +1,45 @@
+import { useQuery } from '@tanstack/react-query';
+import { publicBrandingService } from '@/services/tu/publicBrandingService';
+import type { PublicBrandingResponse } from '@/types/tu/branding.types';
+
+export const publicBrandingKeys = {
+  all: ['publicBranding'] as const,
+  byIdentifier: (identifier: string, type: string) =>
+    [...publicBrandingKeys.all, identifier, type] as const,
+};
+
+/**
+ * 공개 브랜딩 정보 조회 Hook
+ *
+ * @param identifier - subdomain 또는 customDomain 값
+ * @param type - 'subdomain' 또는 'customDomain'
+ */
+export function usePublicBranding(
+  identifier: string | null | undefined,
+  type: 'subdomain' | 'customDomain' = 'subdomain'
+) {
+  return useQuery({
+    queryKey: publicBrandingKeys.byIdentifier(identifier || '', type),
+    queryFn: (): Promise<PublicBrandingResponse> => {
+      if (!identifier) {
+        // identifier가 없으면 기본 브랜딩 사용
+        return Promise.resolve({
+          tenantName: 'MZC Learn',
+          logoUrl: null,
+          darkLogoUrl: null,
+          faviconUrl: null,
+          primaryColor: '#6778ff',
+          secondaryColor: '#a855f7',
+          accentColor: '#10B981',
+          headingFont: 'Pretendard',
+          bodyFont: 'Pretendard',
+        });
+      }
+      return publicBrandingService.getPublicBranding(identifier, type);
+    },
+    staleTime: 1000 * 60 * 30, // 30분 캐싱
+    gcTime: 1000 * 60 * 60, // 1시간 가비지 컬렉션
+    retry: 1,
+    enabled: true, // 항상 활성화
+  });
+}

--- a/src/index.css
+++ b/src/index.css
@@ -121,6 +121,15 @@
   /* === TU Theme Colors === */
   --tu-bg-light: #f9fafb;
   --tu-bg-dark: #1e1e1e;
+
+  /* === Dynamic Landing Branding Variables (Updated by JavaScript) === */
+  --landing-primary-color: #6778ff;
+  --landing-secondary-color: #a855f7;
+  --landing-accent-color: #10B981;
+  --landing-gradient-from: #6778ff;
+  --landing-gradient-to: #a855f7;
+  --landing-heading-font: 'Pretendard', sans-serif;
+  --landing-body-font: 'Pretendard', sans-serif;
 }
 
 @layer base {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TenantBrandingProvider } from '@/contexts/TenantBrandingContext';
 import App from './App';
 import './index.css';
 
@@ -16,7 +17,9 @@ const queryClient = new QueryClient({
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <TenantBrandingProvider>
+        <App />
+      </TenantBrandingProvider>
     </QueryClientProvider>
   </StrictMode>
 );

--- a/src/pages/tu/main/LandingPage.tsx
+++ b/src/pages/tu/main/LandingPage.tsx
@@ -10,6 +10,8 @@ import {
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation } from '@/store/common/languageStore';
 import { usePopularInstructors, useCourseTimeCatalog } from '@/hooks/tu';
+import { useTenantBranding } from '@/contexts/TenantBrandingContext';
+import { useBrandingApply } from '@/hooks/tu/useBrandingApply';
 import type { InstructorSummary } from '@/types/tu';
 import type { CourseTimeCatalogResponse } from '@/types/tu/courseTimeCatalog.types';
 
@@ -132,6 +134,10 @@ export function LandingPage() {
   const { theme } = useThemeStore();
   const { t } = useTranslation();
   const isDark = theme === 'dark';
+  const { branding } = useTenantBranding();
+
+  // 브랜딩 CSS 적용
+  useBrandingApply(branding);
 
   // CourseTime API로 강의 데이터 로드 (모집중/진행중, 카테고리 필터 적용)
   const { data: courseTimeData, isLoading: isCoursesLoading } = useCourseTimeCatalog({

--- a/src/services/tu/index.ts
+++ b/src/services/tu/index.ts
@@ -12,3 +12,4 @@ export { roadmapExploreService } from './roadmapExploreService';
 export { communityService } from './communityService';
 export { instructorService } from './instructorService';
 export { courseTimeCatalogService } from './courseTimeCatalogService';
+export { publicBrandingService } from './publicBrandingService';

--- a/src/services/tu/publicBrandingService.ts
+++ b/src/services/tu/publicBrandingService.ts
@@ -1,0 +1,26 @@
+import axiosInstance from '@/services/common/api/axiosInstance';
+import type { PublicBrandingResponse } from '@/types/tu/branding.types';
+
+/**
+ * 공개 브랜딩 API 서비스
+ * 인증 없이 접근 가능한 테넌트 브랜딩 정보 조회
+ */
+export const publicBrandingService = {
+  /**
+   * 공개 브랜딩 정보 조회 (인증 불필요)
+   * @param identifier subdomain 또는 customDomain
+   * @param type 'subdomain' 또는 'customDomain'
+   */
+  async getPublicBranding(
+    identifier: string,
+    type: 'subdomain' | 'customDomain' = 'subdomain'
+  ): Promise<PublicBrandingResponse> {
+    const { data } = await axiosInstance.get<{ data: PublicBrandingResponse }>(
+      '/api/public/tenants/branding',
+      {
+        params: { identifier, type },
+      }
+    );
+    return data.data;
+  },
+};

--- a/src/types/tu/branding.types.ts
+++ b/src/types/tu/branding.types.ts
@@ -1,0 +1,14 @@
+/**
+ * 공개 브랜딩 정보 타입
+ */
+export interface PublicBrandingResponse {
+  tenantName: string;
+  logoUrl: string | null;
+  darkLogoUrl: string | null;
+  faviconUrl: string | null;
+  primaryColor: string;
+  secondaryColor: string;
+  accentColor: string | null;
+  headingFont: string | null;
+  bodyFont: string | null;
+}

--- a/src/utils/tenantUtils.ts
+++ b/src/utils/tenantUtils.ts
@@ -1,0 +1,50 @@
+/**
+ * 테넌트 식별 유틸리티
+ *
+ * 도메인 구조:
+ * - Subdomain: {subdomain}.mzclearn.com
+ * - Custom Domain: company.com
+ */
+
+export interface TenantIdentifier {
+  type: 'subdomain' | 'customDomain';
+  identifier: string;
+}
+
+/**
+ * 현재 호스트네임에서 테넌트 식별자 추출
+ *
+ * 예시:
+ * - samsung.mzclearn.com → { type: 'subdomain', identifier: 'samsung' }
+ * - company.com → { type: 'customDomain', identifier: 'company.com' }
+ * - localhost:3000 → null (개발 환경, 기본 테넌트)
+ */
+export function extractTenantIdentifier(): TenantIdentifier | null {
+  const hostname = window.location.hostname;
+
+  // 로컬 개발 환경
+  if (hostname === 'localhost' || hostname === '127.0.0.1') {
+    return null; // 기본 브랜딩 사용
+  }
+
+  // 메인 도메인 패턴 (예: mzclearn.com)
+  const mainDomain = import.meta.env.VITE_MAIN_DOMAIN || 'mzclearn.com';
+
+  // Subdomain 확인
+  if (hostname.endsWith(`.${mainDomain}`)) {
+    const subdomain = hostname.replace(`.${mainDomain}`, '');
+    // www는 메인 도메인으로 처리
+    if (subdomain === 'www' || subdomain === '') {
+      return null;
+    }
+    return { type: 'subdomain', identifier: subdomain };
+  }
+
+  // 메인 도메인 자체 (mzclearn.com)
+  if (hostname === mainDomain || hostname === `www.${mainDomain}`) {
+    return null;
+  }
+
+  // Custom Domain
+  return { type: 'customDomain', identifier: hostname };
+}


### PR DESCRIPTION
## Summary

랜딩 페이지에 테넌트별 동적 브랜딩을 적용하는 기능을 구현했습니다. URL(subdomain/customDomain)로 테넌트를 식별하여 해당 테넌트의 브랜딩(로고, 색상, 폰트, favicon, title)을 동적으로 적용합니다.

## Related Issue

- Related to Backend #261

## Changes

- TenantBrandingContext, TenantBrandingProvider 추가
- usePublicBranding, useBrandingApply 훅 구현
- publicBrandingService API 서비스 추가
- tenantUtils (URL에서 테넌트 식별자 추출) 추가
- LandingHeader, LandingFooter에 동적 로고 및 테넌트명 적용
- LandingPage에 브랜딩 CSS 변수 적용
- index.css에 동적 브랜딩 CSS 변수 추가
- main.tsx에 TenantBrandingProvider 추가
- branding.types.ts (PublicBrandingResponse 타입 정의)

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [ ] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

Backend의 feature/public-branding-api가 먼저 머지되어야 합니다. React Query 캐시는 30분으로 설정되어 있습니다.