### PR TITLE
feat: Add SA 설정 페이지 및 API 연동

### DIFF
--- a/src/hooks/sa/index.ts
+++ b/src/hooks/sa/index.ts
@@ -23,18 +23,6 @@ export {
 } from './useNoticeQueries';
 
 export {
-  dashboardKeys,
-  useSaDashboard,
-} from './useDashboardQueries';
-
-export {
-  saAnalyticsKeys,
-  useSaActivityLogs,
-  useSaActivityStats,
-  useSaRecentActivities,
-} from './useAnalyticsQueries';
-
-export {
   systemSettingsKeys,
   useSystemSettings,
   useTenantDefaults,

--- a/src/hooks/sa/index.ts
+++ b/src/hooks/sa/index.ts
@@ -21,3 +21,23 @@ export {
   useDistributeNotice,
   useDistributeAllNotice,
 } from './useNoticeQueries';
+
+export {
+  dashboardKeys,
+  useSaDashboard,
+} from './useDashboardQueries';
+
+export {
+  saAnalyticsKeys,
+  useSaActivityLogs,
+  useSaActivityStats,
+  useSaRecentActivities,
+} from './useAnalyticsQueries';
+
+export {
+  systemSettingsKeys,
+  useSystemSettings,
+  useTenantDefaults,
+  useUpdateSystemSettings,
+  useUpdateTenantDefaults,
+} from './useSystemSettingsQueries';

--- a/src/hooks/sa/useSystemSettingsQueries.ts
+++ b/src/hooks/sa/useSystemSettingsQueries.ts
@@ -1,0 +1,66 @@
+/**
+ * SA System Settings React Query Hooks
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { systemSettingsService } from '@/services/sa/systemSettingsService';
+import type {
+  UpdateSystemSettingsRequest,
+  UpdateTenantDefaultsRequest,
+} from '@/services/sa/systemSettingsService';
+
+// Query Keys
+export const systemSettingsKeys = {
+  all: ['systemSettings'] as const,
+  settings: () => [...systemSettingsKeys.all, 'settings'] as const,
+  tenantDefaults: () => [...systemSettingsKeys.all, 'tenantDefaults'] as const,
+};
+
+// ============================================
+// 시스템 설정 Queries
+// ============================================
+
+/** 시스템 설정 조회 */
+export const useSystemSettings = () => {
+  return useQuery({
+    queryKey: systemSettingsKeys.settings(),
+    queryFn: () => systemSettingsService.getSystemSettings(),
+  });
+};
+
+/** 테넌트 기본값 조회 */
+export const useTenantDefaults = () => {
+  return useQuery({
+    queryKey: systemSettingsKeys.tenantDefaults(),
+    queryFn: () => systemSettingsService.getTenantDefaults(),
+  });
+};
+
+// ============================================
+// 시스템 설정 Mutations
+// ============================================
+
+/** 시스템 설정 업데이트 */
+export const useUpdateSystemSettings = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: UpdateSystemSettingsRequest) =>
+      systemSettingsService.updateSystemSettings(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: systemSettingsKeys.settings() });
+    },
+  });
+};
+
+/** 테넌트 기본값 업데이트 */
+export const useUpdateTenantDefaults = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: UpdateTenantDefaultsRequest) =>
+      systemSettingsService.updateTenantDefaults(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: systemSettingsKeys.tenantDefaults() });
+    },
+  });
+};

--- a/src/pages/sa/settings/SystemSettingsPage.tsx
+++ b/src/pages/sa/settings/SystemSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Settings,
   Save,
@@ -6,6 +6,7 @@ import {
   Shield,
   Database,
   Mail,
+  Loader2,
 } from 'lucide-react';
 import { AdminPageHeader } from '@/components/domain/admin';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
@@ -20,9 +21,40 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/common/Select';
+import { useSystemSettings, useUpdateSystemSettings } from '@/hooks/sa';
+import type { UpdateSystemSettingsRequest } from '@/services/sa/systemSettingsService';
 
-// Mock 데이터
-const mockSettings = {
+// 로컬 설정 타입
+interface LocalSettings {
+  general: {
+    platformName: string;
+    timezone: string;
+    language: string;
+    maintenanceMode: boolean;
+  };
+  security: {
+    sessionTimeout: number;
+    maxLoginAttempts: number;
+    passwordExpiry: number;
+    mfaRequired: boolean;
+    ipWhitelist: string;
+  };
+  storage: {
+    maxUploadSize: number;
+    allowedFormats: string;
+    autoCleanup: boolean;
+    cleanupDays: number;
+  };
+  email: {
+    smtpHost: string;
+    smtpPort: number;
+    smtpUser: string;
+    useTls: boolean;
+  };
+}
+
+// 기본 설정값
+const defaultSettings: LocalSettings = {
   general: {
     platformName: 'MZC Learn Platform',
     timezone: 'Asia/Seoul',
@@ -43,19 +75,122 @@ const mockSettings = {
     cleanupDays: 30,
   },
   email: {
-    smtpHost: 'smtp.example.com',
+    smtpHost: '',
     smtpPort: 587,
-    smtpUser: 'noreply@mzc.com',
+    smtpUser: '',
     useTls: true,
   },
 };
 
 export function SystemSettingsPage() {
-  const [settings, setSettings] = useState(mockSettings);
+  const [settings, setSettings] = useState<LocalSettings>(defaultSettings);
+  const [hasChanges, setHasChanges] = useState(false);
+
+  const { data: serverSettings, isLoading } = useSystemSettings();
+  const updateSettings = useUpdateSystemSettings();
+
+  // 서버 데이터로 초기화
+  useEffect(() => {
+    if (serverSettings) {
+      setSettings({
+        general: {
+          platformName: serverSettings.general.platformName,
+          timezone: serverSettings.general.timezone,
+          language: serverSettings.general.language,
+          maintenanceMode: serverSettings.general.maintenanceMode,
+        },
+        security: {
+          sessionTimeout: serverSettings.security.sessionTimeout,
+          maxLoginAttempts: serverSettings.security.maxLoginAttempts,
+          passwordExpiry: serverSettings.security.passwordExpiry,
+          mfaRequired: serverSettings.security.mfaRequired,
+          ipWhitelist: serverSettings.security.ipWhitelist || '',
+        },
+        storage: {
+          maxUploadSize: serverSettings.storage.maxUploadSize,
+          allowedFormats: serverSettings.storage.allowedFormats,
+          autoCleanup: serverSettings.storage.autoCleanup,
+          cleanupDays: serverSettings.storage.cleanupDays,
+        },
+        email: {
+          smtpHost: serverSettings.email.smtpHost || '',
+          smtpPort: serverSettings.email.smtpPort,
+          smtpUser: serverSettings.email.smtpUser || '',
+          useTls: serverSettings.email.useTls,
+        },
+      });
+      setHasChanges(false);
+    }
+  }, [serverSettings]);
 
   const handleReset = () => {
-    setSettings(mockSettings);
+    if (serverSettings) {
+      setSettings({
+        general: {
+          platformName: serverSettings.general.platformName,
+          timezone: serverSettings.general.timezone,
+          language: serverSettings.general.language,
+          maintenanceMode: serverSettings.general.maintenanceMode,
+        },
+        security: {
+          sessionTimeout: serverSettings.security.sessionTimeout,
+          maxLoginAttempts: serverSettings.security.maxLoginAttempts,
+          passwordExpiry: serverSettings.security.passwordExpiry,
+          mfaRequired: serverSettings.security.mfaRequired,
+          ipWhitelist: serverSettings.security.ipWhitelist || '',
+        },
+        storage: {
+          maxUploadSize: serverSettings.storage.maxUploadSize,
+          allowedFormats: serverSettings.storage.allowedFormats,
+          autoCleanup: serverSettings.storage.autoCleanup,
+          cleanupDays: serverSettings.storage.cleanupDays,
+        },
+        email: {
+          smtpHost: serverSettings.email.smtpHost || '',
+          smtpPort: serverSettings.email.smtpPort,
+          smtpUser: serverSettings.email.smtpUser || '',
+          useTls: serverSettings.email.useTls,
+        },
+      });
+      setHasChanges(false);
+    }
   };
+
+  const handleSave = () => {
+    const request: UpdateSystemSettingsRequest = {
+      platformName: settings.general.platformName,
+      timezone: settings.general.timezone,
+      language: settings.general.language,
+      maintenanceMode: settings.general.maintenanceMode,
+      sessionTimeout: settings.security.sessionTimeout,
+      maxLoginAttempts: settings.security.maxLoginAttempts,
+      passwordExpiry: settings.security.passwordExpiry,
+      mfaRequired: settings.security.mfaRequired,
+      ipWhitelist: settings.security.ipWhitelist || null,
+      maxUploadSize: settings.storage.maxUploadSize,
+      allowedFormats: settings.storage.allowedFormats,
+      autoCleanup: settings.storage.autoCleanup,
+      cleanupDays: settings.storage.cleanupDays,
+      smtpHost: settings.email.smtpHost || null,
+      smtpPort: settings.email.smtpPort,
+      smtpUser: settings.email.smtpUser || null,
+      useTls: settings.email.useTls,
+    };
+
+    updateSettings.mutate(request, {
+      onSuccess: () => {
+        setHasChanges(false);
+      },
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-6 flex items-center justify-center min-h-[400px]">
+        <Loader2 className="h-8 w-8 animate-spin text-brand-primary" />
+      </div>
+    );
+  }
 
   return (
     <div className="p-6">
@@ -64,12 +199,16 @@ export function SystemSettingsPage() {
         description="플랫폼 전역 시스템 설정을 관리합니다"
         actions={
           <div className="flex gap-2">
-            <Button variant="outline" onClick={handleReset}>
+            <Button variant="outline" onClick={handleReset} disabled={!hasChanges}>
               <RotateCcw className="mr-2 h-4 w-4" />
               초기화
             </Button>
-            <Button>
-              <Save className="mr-2 h-4 w-4" />
+            <Button onClick={handleSave} disabled={!hasChanges || updateSettings.isPending}>
+              {updateSettings.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="mr-2 h-4 w-4" />
+              )}
               저장
             </Button>
           </div>
@@ -92,20 +231,26 @@ export function SystemSettingsPage() {
                 <Label>플랫폼 이름</Label>
                 <Input
                   value={settings.general.platformName}
-                  onChange={(e) => setSettings({
-                    ...settings,
-                    general: { ...settings.general, platformName: e.target.value },
-                  })}
+                  onChange={(e) => {
+                    setSettings({
+                      ...settings,
+                      general: { ...settings.general, platformName: e.target.value },
+                    });
+                    setHasChanges(true);
+                  }}
                 />
               </div>
               <div className="space-y-2">
                 <Label>타임존</Label>
                 <Select
                   value={settings.general.timezone}
-                  onValueChange={(v) => setSettings({
-                    ...settings,
-                    general: { ...settings.general, timezone: v },
-                  })}
+                  onValueChange={(v) => {
+                    setSettings({
+                      ...settings,
+                      general: { ...settings.general, timezone: v },
+                    });
+                    setHasChanges(true);
+                  }}
                 >
                   <SelectTrigger>
                     <SelectValue />
@@ -126,10 +271,13 @@ export function SystemSettingsPage() {
               </div>
               <Switch
                 checked={settings.general.maintenanceMode}
-                onCheckedChange={(v) => setSettings({
-                  ...settings,
-                  general: { ...settings.general, maintenanceMode: v },
-                })}
+                onCheckedChange={(v) => {
+                  setSettings({
+                    ...settings,
+                    general: { ...settings.general, maintenanceMode: v },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
           </CardContent>
@@ -151,10 +299,13 @@ export function SystemSettingsPage() {
                 <Input
                   type="number"
                   value={settings.security.sessionTimeout}
-                  onChange={(e) => setSettings({
-                    ...settings,
-                    security: { ...settings.security, sessionTimeout: Number(e.target.value) },
-                  })}
+                  onChange={(e) => {
+                    setSettings({
+                      ...settings,
+                      security: { ...settings.security, sessionTimeout: Number(e.target.value) },
+                    });
+                    setHasChanges(true);
+                  }}
                 />
               </div>
               <div className="space-y-2">
@@ -162,10 +313,13 @@ export function SystemSettingsPage() {
                 <Input
                   type="number"
                   value={settings.security.maxLoginAttempts}
-                  onChange={(e) => setSettings({
-                    ...settings,
-                    security: { ...settings.security, maxLoginAttempts: Number(e.target.value) },
-                  })}
+                  onChange={(e) => {
+                    setSettings({
+                      ...settings,
+                      security: { ...settings.security, maxLoginAttempts: Number(e.target.value) },
+                    });
+                    setHasChanges(true);
+                  }}
                 />
               </div>
               <div className="space-y-2">
@@ -173,10 +327,13 @@ export function SystemSettingsPage() {
                 <Input
                   type="number"
                   value={settings.security.passwordExpiry}
-                  onChange={(e) => setSettings({
-                    ...settings,
-                    security: { ...settings.security, passwordExpiry: Number(e.target.value) },
-                  })}
+                  onChange={(e) => {
+                    setSettings({
+                      ...settings,
+                      security: { ...settings.security, passwordExpiry: Number(e.target.value) },
+                    });
+                    setHasChanges(true);
+                  }}
                 />
               </div>
             </div>
@@ -185,10 +342,13 @@ export function SystemSettingsPage() {
               <Input
                 placeholder="예: 192.168.1.0/24, 10.0.0.1"
                 value={settings.security.ipWhitelist}
-                onChange={(e) => setSettings({
-                  ...settings,
-                  security: { ...settings.security, ipWhitelist: e.target.value },
-                })}
+                onChange={(e) => {
+                  setSettings({
+                    ...settings,
+                    security: { ...settings.security, ipWhitelist: e.target.value },
+                  });
+                  setHasChanges(true);
+                }}
               />
               <p className="text-xs text-text-secondary">비워두면 모든 IP에서 접근 가능합니다</p>
             </div>
@@ -199,10 +359,13 @@ export function SystemSettingsPage() {
               </div>
               <Switch
                 checked={settings.security.mfaRequired}
-                onCheckedChange={(v) => setSettings({
-                  ...settings,
-                  security: { ...settings.security, mfaRequired: v },
-                })}
+                onCheckedChange={(v) => {
+                  setSettings({
+                    ...settings,
+                    security: { ...settings.security, mfaRequired: v },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
           </CardContent>
@@ -224,10 +387,13 @@ export function SystemSettingsPage() {
                 <Input
                   type="number"
                   value={settings.storage.maxUploadSize}
-                  onChange={(e) => setSettings({
-                    ...settings,
-                    storage: { ...settings.storage, maxUploadSize: Number(e.target.value) },
-                  })}
+                  onChange={(e) => {
+                    setSettings({
+                      ...settings,
+                      storage: { ...settings.storage, maxUploadSize: Number(e.target.value) },
+                    });
+                    setHasChanges(true);
+                  }}
                 />
               </div>
               <div className="space-y-2">
@@ -235,10 +401,13 @@ export function SystemSettingsPage() {
                 <Input
                   type="number"
                   value={settings.storage.cleanupDays}
-                  onChange={(e) => setSettings({
-                    ...settings,
-                    storage: { ...settings.storage, cleanupDays: Number(e.target.value) },
-                  })}
+                  onChange={(e) => {
+                    setSettings({
+                      ...settings,
+                      storage: { ...settings.storage, cleanupDays: Number(e.target.value) },
+                    });
+                    setHasChanges(true);
+                  }}
                 />
               </div>
             </div>
@@ -246,10 +415,13 @@ export function SystemSettingsPage() {
               <Label>허용 파일 형식</Label>
               <Input
                 value={settings.storage.allowedFormats}
-                onChange={(e) => setSettings({
-                  ...settings,
-                  storage: { ...settings.storage, allowedFormats: e.target.value },
-                })}
+                onChange={(e) => {
+                  setSettings({
+                    ...settings,
+                    storage: { ...settings.storage, allowedFormats: e.target.value },
+                  });
+                  setHasChanges(true);
+                }}
               />
               <p className="text-xs text-text-secondary">쉼표로 구분하여 입력</p>
             </div>
@@ -260,10 +432,13 @@ export function SystemSettingsPage() {
               </div>
               <Switch
                 checked={settings.storage.autoCleanup}
-                onCheckedChange={(v) => setSettings({
-                  ...settings,
-                  storage: { ...settings.storage, autoCleanup: v },
-                })}
+                onCheckedChange={(v) => {
+                  setSettings({
+                    ...settings,
+                    storage: { ...settings.storage, autoCleanup: v },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
           </CardContent>
@@ -284,10 +459,13 @@ export function SystemSettingsPage() {
                 <Label>SMTP 호스트</Label>
                 <Input
                   value={settings.email.smtpHost}
-                  onChange={(e) => setSettings({
-                    ...settings,
-                    email: { ...settings.email, smtpHost: e.target.value },
-                  })}
+                  onChange={(e) => {
+                    setSettings({
+                      ...settings,
+                      email: { ...settings.email, smtpHost: e.target.value },
+                    });
+                    setHasChanges(true);
+                  }}
                 />
               </div>
               <div className="space-y-2">
@@ -295,10 +473,13 @@ export function SystemSettingsPage() {
                 <Input
                   type="number"
                   value={settings.email.smtpPort}
-                  onChange={(e) => setSettings({
-                    ...settings,
-                    email: { ...settings.email, smtpPort: Number(e.target.value) },
-                  })}
+                  onChange={(e) => {
+                    setSettings({
+                      ...settings,
+                      email: { ...settings.email, smtpPort: Number(e.target.value) },
+                    });
+                    setHasChanges(true);
+                  }}
                 />
               </div>
             </div>
@@ -306,10 +487,13 @@ export function SystemSettingsPage() {
               <Label>SMTP 사용자</Label>
               <Input
                 value={settings.email.smtpUser}
-                onChange={(e) => setSettings({
-                  ...settings,
-                  email: { ...settings.email, smtpUser: e.target.value },
-                })}
+                onChange={(e) => {
+                  setSettings({
+                    ...settings,
+                    email: { ...settings.email, smtpUser: e.target.value },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
             <div className="flex items-center justify-between pt-4 border-t">
@@ -319,10 +503,13 @@ export function SystemSettingsPage() {
               </div>
               <Switch
                 checked={settings.email.useTls}
-                onCheckedChange={(v) => setSettings({
-                  ...settings,
-                  email: { ...settings.email, useTls: v },
-                })}
+                onCheckedChange={(v) => {
+                  setSettings({
+                    ...settings,
+                    email: { ...settings.email, useTls: v },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
           </CardContent>

--- a/src/pages/sa/settings/TenantDefaultsPage.tsx
+++ b/src/pages/sa/settings/TenantDefaultsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Building2,
   Save,
@@ -7,6 +7,7 @@ import {
   BookOpen,
   HardDrive,
   Palette,
+  Loader2,
 } from 'lucide-react';
 import { AdminPageHeader } from '@/components/domain/admin';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
@@ -14,9 +15,38 @@ import { Button } from '@/components/common/Button';
 import { Input } from '@/components/common/Input';
 import { Label } from '@/components/common/Label';
 import { Switch } from '@/components/common/Switch';
+import { useTenantDefaults, useUpdateTenantDefaults } from '@/hooks/sa';
+import type { UpdateTenantDefaultsRequest } from '@/services/sa/systemSettingsService';
 
-// Mock 데이터
-const mockDefaults = {
+// 로컬 설정 타입
+interface LocalDefaults {
+  limits: {
+    maxUsers: number;
+    maxCourses: number;
+    maxStorage: number;
+    maxAdmins: number;
+  };
+  features: {
+    customDomain: boolean;
+    ssoIntegration: boolean;
+    apiAccess: boolean;
+    whiteLabeling: boolean;
+    advancedAnalytics: boolean;
+  };
+  branding: {
+    allowCustomLogo: boolean;
+    allowCustomColors: boolean;
+    allowCustomFonts: boolean;
+  };
+  notifications: {
+    emailNotifications: boolean;
+    pushNotifications: boolean;
+    smsNotifications: boolean;
+  };
+}
+
+// 기본 설정값
+const defaultSettings: LocalDefaults = {
   limits: {
     maxUsers: 100,
     maxCourses: 50,
@@ -43,11 +73,108 @@ const mockDefaults = {
 };
 
 export function TenantDefaultsPage() {
-  const [defaults, setDefaults] = useState(mockDefaults);
+  const [defaults, setDefaults] = useState<LocalDefaults>(defaultSettings);
+  const [hasChanges, setHasChanges] = useState(false);
+
+  const { data: serverDefaults, isLoading } = useTenantDefaults();
+  const updateDefaults = useUpdateTenantDefaults();
+
+  // 서버 데이터로 초기화
+  useEffect(() => {
+    if (serverDefaults) {
+      setDefaults({
+        limits: {
+          maxUsers: serverDefaults.limits.maxUsers,
+          maxCourses: serverDefaults.limits.maxCourses,
+          maxStorage: serverDefaults.limits.maxStorage,
+          maxAdmins: serverDefaults.limits.maxAdmins,
+        },
+        features: {
+          customDomain: serverDefaults.features.customDomain,
+          ssoIntegration: serverDefaults.features.ssoIntegration,
+          apiAccess: serverDefaults.features.apiAccess,
+          whiteLabeling: serverDefaults.features.whiteLabeling,
+          advancedAnalytics: serverDefaults.features.advancedAnalytics,
+        },
+        branding: {
+          allowCustomLogo: serverDefaults.branding.allowCustomLogo,
+          allowCustomColors: serverDefaults.branding.allowCustomColors,
+          allowCustomFonts: serverDefaults.branding.allowCustomFonts,
+        },
+        notifications: {
+          emailNotifications: serverDefaults.notifications.emailNotifications,
+          pushNotifications: serverDefaults.notifications.pushNotifications,
+          smsNotifications: serverDefaults.notifications.smsNotifications,
+        },
+      });
+      setHasChanges(false);
+    }
+  }, [serverDefaults]);
 
   const handleReset = () => {
-    setDefaults(mockDefaults);
+    if (serverDefaults) {
+      setDefaults({
+        limits: {
+          maxUsers: serverDefaults.limits.maxUsers,
+          maxCourses: serverDefaults.limits.maxCourses,
+          maxStorage: serverDefaults.limits.maxStorage,
+          maxAdmins: serverDefaults.limits.maxAdmins,
+        },
+        features: {
+          customDomain: serverDefaults.features.customDomain,
+          ssoIntegration: serverDefaults.features.ssoIntegration,
+          apiAccess: serverDefaults.features.apiAccess,
+          whiteLabeling: serverDefaults.features.whiteLabeling,
+          advancedAnalytics: serverDefaults.features.advancedAnalytics,
+        },
+        branding: {
+          allowCustomLogo: serverDefaults.branding.allowCustomLogo,
+          allowCustomColors: serverDefaults.branding.allowCustomColors,
+          allowCustomFonts: serverDefaults.branding.allowCustomFonts,
+        },
+        notifications: {
+          emailNotifications: serverDefaults.notifications.emailNotifications,
+          pushNotifications: serverDefaults.notifications.pushNotifications,
+          smsNotifications: serverDefaults.notifications.smsNotifications,
+        },
+      });
+      setHasChanges(false);
+    }
   };
+
+  const handleSave = () => {
+    const request: UpdateTenantDefaultsRequest = {
+      maxUsers: defaults.limits.maxUsers,
+      maxCourses: defaults.limits.maxCourses,
+      maxStorage: defaults.limits.maxStorage,
+      maxAdmins: defaults.limits.maxAdmins,
+      customDomain: defaults.features.customDomain,
+      ssoIntegration: defaults.features.ssoIntegration,
+      apiAccess: defaults.features.apiAccess,
+      whiteLabeling: defaults.features.whiteLabeling,
+      advancedAnalytics: defaults.features.advancedAnalytics,
+      allowCustomLogo: defaults.branding.allowCustomLogo,
+      allowCustomColors: defaults.branding.allowCustomColors,
+      allowCustomFonts: defaults.branding.allowCustomFonts,
+      emailNotifications: defaults.notifications.emailNotifications,
+      pushNotifications: defaults.notifications.pushNotifications,
+      smsNotifications: defaults.notifications.smsNotifications,
+    };
+
+    updateDefaults.mutate(request, {
+      onSuccess: () => {
+        setHasChanges(false);
+      },
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-6 flex items-center justify-center min-h-[400px]">
+        <Loader2 className="h-8 w-8 animate-spin text-brand-primary" />
+      </div>
+    );
+  }
 
   return (
     <div className="p-6">
@@ -56,12 +183,16 @@ export function TenantDefaultsPage() {
         description="새 테넌트 생성 시 적용되는 기본값을 설정합니다"
         actions={
           <div className="flex gap-2">
-            <Button variant="outline" onClick={handleReset}>
+            <Button variant="outline" onClick={handleReset} disabled={!hasChanges}>
               <RotateCcw className="mr-2 h-4 w-4" />
               초기화
             </Button>
-            <Button>
-              <Save className="mr-2 h-4 w-4" />
+            <Button onClick={handleSave} disabled={!hasChanges || updateDefaults.isPending}>
+              {updateDefaults.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="mr-2 h-4 w-4" />
+              )}
               저장
             </Button>
           </div>
@@ -87,10 +218,13 @@ export function TenantDefaultsPage() {
               <Input
                 type="number"
                 value={defaults.limits.maxUsers}
-                onChange={(e) => setDefaults({
-                  ...defaults,
-                  limits: { ...defaults.limits, maxUsers: Number(e.target.value) },
-                })}
+                onChange={(e) => {
+                  setDefaults({
+                    ...defaults,
+                    limits: { ...defaults.limits, maxUsers: Number(e.target.value) },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
             <div className="space-y-2">
@@ -101,10 +235,13 @@ export function TenantDefaultsPage() {
               <Input
                 type="number"
                 value={defaults.limits.maxCourses}
-                onChange={(e) => setDefaults({
-                  ...defaults,
-                  limits: { ...defaults.limits, maxCourses: Number(e.target.value) },
-                })}
+                onChange={(e) => {
+                  setDefaults({
+                    ...defaults,
+                    limits: { ...defaults.limits, maxCourses: Number(e.target.value) },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
             <div className="space-y-2">
@@ -115,10 +252,13 @@ export function TenantDefaultsPage() {
               <Input
                 type="number"
                 value={defaults.limits.maxStorage}
-                onChange={(e) => setDefaults({
-                  ...defaults,
-                  limits: { ...defaults.limits, maxStorage: Number(e.target.value) },
-                })}
+                onChange={(e) => {
+                  setDefaults({
+                    ...defaults,
+                    limits: { ...defaults.limits, maxStorage: Number(e.target.value) },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
             <div className="space-y-2">
@@ -126,10 +266,13 @@ export function TenantDefaultsPage() {
               <Input
                 type="number"
                 value={defaults.limits.maxAdmins}
-                onChange={(e) => setDefaults({
-                  ...defaults,
-                  limits: { ...defaults.limits, maxAdmins: Number(e.target.value) },
-                })}
+                onChange={(e) => {
+                  setDefaults({
+                    ...defaults,
+                    limits: { ...defaults.limits, maxAdmins: Number(e.target.value) },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
           </CardContent>
@@ -149,10 +292,13 @@ export function TenantDefaultsPage() {
               </div>
               <Switch
                 checked={defaults.features.customDomain}
-                onCheckedChange={(v) => setDefaults({
-                  ...defaults,
-                  features: { ...defaults.features, customDomain: v },
-                })}
+                onCheckedChange={(v) => {
+                  setDefaults({
+                    ...defaults,
+                    features: { ...defaults.features, customDomain: v },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
             <div className="flex items-center justify-between">
@@ -162,10 +308,13 @@ export function TenantDefaultsPage() {
               </div>
               <Switch
                 checked={defaults.features.ssoIntegration}
-                onCheckedChange={(v) => setDefaults({
-                  ...defaults,
-                  features: { ...defaults.features, ssoIntegration: v },
-                })}
+                onCheckedChange={(v) => {
+                  setDefaults({
+                    ...defaults,
+                    features: { ...defaults.features, ssoIntegration: v },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
             <div className="flex items-center justify-between">
@@ -175,10 +324,13 @@ export function TenantDefaultsPage() {
               </div>
               <Switch
                 checked={defaults.features.apiAccess}
-                onCheckedChange={(v) => setDefaults({
-                  ...defaults,
-                  features: { ...defaults.features, apiAccess: v },
-                })}
+                onCheckedChange={(v) => {
+                  setDefaults({
+                    ...defaults,
+                    features: { ...defaults.features, apiAccess: v },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
             <div className="flex items-center justify-between">
@@ -188,10 +340,13 @@ export function TenantDefaultsPage() {
               </div>
               <Switch
                 checked={defaults.features.whiteLabeling}
-                onCheckedChange={(v) => setDefaults({
-                  ...defaults,
-                  features: { ...defaults.features, whiteLabeling: v },
-                })}
+                onCheckedChange={(v) => {
+                  setDefaults({
+                    ...defaults,
+                    features: { ...defaults.features, whiteLabeling: v },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
             <div className="flex items-center justify-between">
@@ -201,10 +356,13 @@ export function TenantDefaultsPage() {
               </div>
               <Switch
                 checked={defaults.features.advancedAnalytics}
-                onCheckedChange={(v) => setDefaults({
-                  ...defaults,
-                  features: { ...defaults.features, advancedAnalytics: v },
-                })}
+                onCheckedChange={(v) => {
+                  setDefaults({
+                    ...defaults,
+                    features: { ...defaults.features, advancedAnalytics: v },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
           </CardContent>
@@ -227,10 +385,13 @@ export function TenantDefaultsPage() {
               </div>
               <Switch
                 checked={defaults.branding.allowCustomLogo}
-                onCheckedChange={(v) => setDefaults({
-                  ...defaults,
-                  branding: { ...defaults.branding, allowCustomLogo: v },
-                })}
+                onCheckedChange={(v) => {
+                  setDefaults({
+                    ...defaults,
+                    branding: { ...defaults.branding, allowCustomLogo: v },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
             <div className="flex items-center justify-between">
@@ -240,10 +401,13 @@ export function TenantDefaultsPage() {
               </div>
               <Switch
                 checked={defaults.branding.allowCustomColors}
-                onCheckedChange={(v) => setDefaults({
-                  ...defaults,
-                  branding: { ...defaults.branding, allowCustomColors: v },
-                })}
+                onCheckedChange={(v) => {
+                  setDefaults({
+                    ...defaults,
+                    branding: { ...defaults.branding, allowCustomColors: v },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
             <div className="flex items-center justify-between">
@@ -253,10 +417,13 @@ export function TenantDefaultsPage() {
               </div>
               <Switch
                 checked={defaults.branding.allowCustomFonts}
-                onCheckedChange={(v) => setDefaults({
-                  ...defaults,
-                  branding: { ...defaults.branding, allowCustomFonts: v },
-                })}
+                onCheckedChange={(v) => {
+                  setDefaults({
+                    ...defaults,
+                    branding: { ...defaults.branding, allowCustomFonts: v },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
           </CardContent>
@@ -276,10 +443,13 @@ export function TenantDefaultsPage() {
               </div>
               <Switch
                 checked={defaults.notifications.emailNotifications}
-                onCheckedChange={(v) => setDefaults({
-                  ...defaults,
-                  notifications: { ...defaults.notifications, emailNotifications: v },
-                })}
+                onCheckedChange={(v) => {
+                  setDefaults({
+                    ...defaults,
+                    notifications: { ...defaults.notifications, emailNotifications: v },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
             <div className="flex items-center justify-between">
@@ -289,10 +459,13 @@ export function TenantDefaultsPage() {
               </div>
               <Switch
                 checked={defaults.notifications.pushNotifications}
-                onCheckedChange={(v) => setDefaults({
-                  ...defaults,
-                  notifications: { ...defaults.notifications, pushNotifications: v },
-                })}
+                onCheckedChange={(v) => {
+                  setDefaults({
+                    ...defaults,
+                    notifications: { ...defaults.notifications, pushNotifications: v },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
             <div className="flex items-center justify-between">
@@ -302,10 +475,13 @@ export function TenantDefaultsPage() {
               </div>
               <Switch
                 checked={defaults.notifications.smsNotifications}
-                onCheckedChange={(v) => setDefaults({
-                  ...defaults,
-                  notifications: { ...defaults.notifications, smsNotifications: v },
-                })}
+                onCheckedChange={(v) => {
+                  setDefaults({
+                    ...defaults,
+                    notifications: { ...defaults.notifications, smsNotifications: v },
+                  });
+                  setHasChanges(true);
+                }}
               />
             </div>
           </CardContent>

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -230,4 +230,10 @@ export const API_ENDPOINTS = {
     ITEM: (courseId: number) => `/cart/items/${courseId}`,
     ITEM_CHECK: (courseId: number) => `/cart/items/${courseId}/check`,
   },
+
+  // System Settings (SA)
+  SYSTEM_SETTINGS: {
+    BASE: '/sa/system-settings',
+    TENANT_DEFAULTS: '/sa/system-settings/tenant-defaults',
+  },
 } as const;

--- a/src/services/sa/index.ts
+++ b/src/services/sa/index.ts
@@ -1,3 +1,12 @@
 export { tenantService } from './tenantService';
 export type { TenantFilterParams } from './tenantService';
 export { noticeService } from './noticeService';
+export { dashboardService } from './dashboardService';
+export type { SaDashboardResponse } from './dashboardService';
+export { systemSettingsService } from './systemSettingsService';
+export type {
+  SystemSettingsResponse,
+  TenantDefaultsResponse,
+  UpdateSystemSettingsRequest,
+  UpdateTenantDefaultsRequest,
+} from './systemSettingsService';

--- a/src/services/sa/index.ts
+++ b/src/services/sa/index.ts
@@ -1,8 +1,6 @@
 export { tenantService } from './tenantService';
 export type { TenantFilterParams } from './tenantService';
 export { noticeService } from './noticeService';
-export { dashboardService } from './dashboardService';
-export type { SaDashboardResponse } from './dashboardService';
 export { systemSettingsService } from './systemSettingsService';
 export type {
   SystemSettingsResponse,

--- a/src/services/sa/systemSettingsService.ts
+++ b/src/services/sa/systemSettingsService.ts
@@ -1,0 +1,194 @@
+/**
+ * SA 시스템 설정 API 서비스
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+
+// ============================================
+// 타입 정의
+// ============================================
+
+export interface GeneralSettings {
+  platformName: string;
+  timezone: string;
+  language: string;
+  maintenanceMode: boolean;
+  maintenanceMessage: string | null;
+}
+
+export interface SecuritySettings {
+  sessionTimeout: number;
+  maxLoginAttempts: number;
+  passwordExpiry: number;
+  mfaRequired: boolean;
+  ipWhitelist: string | null;
+  loginLockoutMinutes: number;
+}
+
+export interface StorageSettings {
+  maxUploadSize: number;
+  allowedFormats: string;
+  autoCleanup: boolean;
+  cleanupDays: number;
+  totalStorageLimitGB: number;
+}
+
+export interface EmailSettings {
+  smtpHost: string | null;
+  smtpPort: number;
+  smtpUser: string | null;
+  useTls: boolean;
+  senderEmail: string | null;
+  senderName: string | null;
+}
+
+export interface SystemSettingsResponse {
+  id: number;
+  general: GeneralSettings;
+  security: SecuritySettings;
+  storage: StorageSettings;
+  email: EmailSettings;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdateSystemSettingsRequest {
+  // 일반 설정
+  platformName?: string;
+  timezone?: string;
+  language?: string;
+  maintenanceMode?: boolean;
+  maintenanceMessage?: string | null;
+  // 보안 설정
+  sessionTimeout?: number;
+  maxLoginAttempts?: number;
+  passwordExpiry?: number;
+  mfaRequired?: boolean;
+  ipWhitelist?: string | null;
+  loginLockoutMinutes?: number;
+  // 스토리지 설정
+  maxUploadSize?: number;
+  allowedFormats?: string;
+  autoCleanup?: boolean;
+  cleanupDays?: number;
+  totalStorageLimitGB?: number;
+  // 이메일 설정
+  smtpHost?: string | null;
+  smtpPort?: number;
+  smtpUser?: string | null;
+  smtpPassword?: string | null;
+  useTls?: boolean;
+  senderEmail?: string | null;
+  senderName?: string | null;
+}
+
+// ============================================
+// 테넌트 기본값 타입
+// ============================================
+
+export interface LimitsDefaults {
+  maxUsers: number;
+  maxCourses: number;
+  maxStorage: number;
+  maxAdmins: number;
+}
+
+export interface FeaturesDefaults {
+  customDomain: boolean;
+  ssoIntegration: boolean;
+  apiAccess: boolean;
+  whiteLabeling: boolean;
+  advancedAnalytics: boolean;
+}
+
+export interface BrandingDefaults {
+  allowCustomLogo: boolean;
+  allowCustomColors: boolean;
+  allowCustomFonts: boolean;
+}
+
+export interface NotificationsDefaults {
+  emailNotifications: boolean;
+  pushNotifications: boolean;
+  smsNotifications: boolean;
+}
+
+export interface TenantDefaultsResponse {
+  id: number;
+  limits: LimitsDefaults;
+  features: FeaturesDefaults;
+  branding: BrandingDefaults;
+  notifications: NotificationsDefaults;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdateTenantDefaultsRequest {
+  // 리소스 제한
+  maxUsers?: number;
+  maxCourses?: number;
+  maxStorage?: number;
+  maxAdmins?: number;
+  // 기능 활성화
+  customDomain?: boolean;
+  ssoIntegration?: boolean;
+  apiAccess?: boolean;
+  whiteLabeling?: boolean;
+  advancedAnalytics?: boolean;
+  // 브랜딩 권한
+  allowCustomLogo?: boolean;
+  allowCustomColors?: boolean;
+  allowCustomFonts?: boolean;
+  // 알림 설정
+  emailNotifications?: boolean;
+  pushNotifications?: boolean;
+  smsNotifications?: boolean;
+}
+
+// ============================================
+// API 서비스
+// ============================================
+
+export const systemSettingsService = {
+  // ============================================
+  // 시스템 설정
+  // ============================================
+
+  /** 시스템 설정 조회 */
+  async getSystemSettings(): Promise<SystemSettingsResponse> {
+    const { data } = await axiosInstance.get<{ data: SystemSettingsResponse }>(
+      API_ENDPOINTS.SYSTEM_SETTINGS.BASE
+    );
+    return data.data;
+  },
+
+  /** 시스템 설정 업데이트 */
+  async updateSystemSettings(request: UpdateSystemSettingsRequest): Promise<SystemSettingsResponse> {
+    const { data } = await axiosInstance.put<{ data: SystemSettingsResponse }>(
+      API_ENDPOINTS.SYSTEM_SETTINGS.BASE,
+      request
+    );
+    return data.data;
+  },
+
+  // ============================================
+  // 테넌트 기본값
+  // ============================================
+
+  /** 테넌트 기본값 조회 */
+  async getTenantDefaults(): Promise<TenantDefaultsResponse> {
+    const { data } = await axiosInstance.get<{ data: TenantDefaultsResponse }>(
+      API_ENDPOINTS.SYSTEM_SETTINGS.TENANT_DEFAULTS
+    );
+    return data.data;
+  },
+
+  /** 테넌트 기본값 업데이트 */
+  async updateTenantDefaults(request: UpdateTenantDefaultsRequest): Promise<TenantDefaultsResponse> {
+    const { data } = await axiosInstance.put<{ data: TenantDefaultsResponse }>(
+      API_ENDPOINTS.SYSTEM_SETTINGS.TENANT_DEFAULTS,
+      request
+    );
+    return data.data;
+  },
+};


### PR DESCRIPTION
## Summary

시스템 관리자(SA)를 위한 시스템 설정 페이지를 구현하고 API를 연동했습니다. 시스템 전역 설정 및 테넌트 기본값 설정 기능을 추가했습니다.

## Related Issue

- Closes #214

## Changes

- SystemSettingsPage, TenantDefaultsPage 구현 및 개선
- useSystemSettingsQueries 훅 추가
- systemSettingsService API 서비스 추가
- hooks/sa/index.ts, services/sa/index.ts 업데이트

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [ ] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

Backend의 feature/analytics-system(#262)가 먼저 머지되어야 합니다.