### PR TITLE
feat: TU 강의 상세 페이지 수강 신청 API 연동 (#236)

### DIFF
--- a/src/pages/tu/main/CourseDetailPage.tsx
+++ b/src/pages/tu/main/CourseDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import {
   Clock,
@@ -18,9 +18,10 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useThemeStore } from '@/store/common/themeStore';
+import { useAuthStore } from '@/store/common/authStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
-import { useCourseTimeDetail } from '@/hooks/tu';
+import { useCourseTimeDetail, useEnroll, useMyEnrollments } from '@/hooks/tu';
 import type { CurriculumItemResponse } from '@/types/tu/courseTimeCatalog.types';
 import {
   DELIVERY_TYPE_LABELS,
@@ -155,9 +156,25 @@ function CurriculumSection({ item, isExpanded, onToggle, isDark }: CurriculumSec
 export function CourseDetailPage() {
   const { id } = useParams<{ id: string }>();
   const courseTimeId = id ? parseInt(id, 10) : 0;
+  const navigate = useNavigate();
 
   // CourseTime 상세 조회
   const { data: courseTime, isLoading, error } = useCourseTimeDetail(courseTimeId);
+
+  // 수강 신청 mutation
+  const enrollMutation = useEnroll();
+
+  // 인증 상태
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  // 내 수강 신청 목록 조회 (이미 수강 중인지 확인용)
+  const { data: myEnrollments } = useMyEnrollments({ size: 100 });
+
+  // 이미 수강 신청된 강의인지 확인
+  const existingEnrollment = myEnrollments?.content.find(
+    (enrollment) => enrollment.courseTimeId === courseTimeId
+  );
+  const isAlreadyEnrolled = !!existingEnrollment;
 
   const [expandedSections, setExpandedSections] = useState<number[]>([0]);
   const [isWishlisted, setIsWishlisted] = useState(false);
@@ -225,7 +242,31 @@ export function CourseDetailPage() {
   };
 
   const handleEnroll = () => {
-    toast.success('수강 신청이 완료되었습니다.');
+    // 로그인 체크
+    if (!isAuthenticated) {
+      toast.error('로그인이 필요합니다.');
+      navigate('/auth/login', { state: { from: `/tu/b2c/courses/${courseTimeId}` } });
+      return;
+    }
+
+    // 이미 수강 신청된 강의인지 체크
+    if (isAlreadyEnrolled) {
+      toast.error('이미 수강 신청된 강의입니다.');
+      return;
+    }
+
+    // 수강 신청 API 호출
+    enrollMutation.mutate(courseTimeId, {
+      onSuccess: () => {
+        toast.success('수강 신청이 완료되었습니다.');
+        // 내 학습 페이지로 이동
+        navigate('/tu/b2c/mypage/learning');
+      },
+      onError: (error: Error & { response?: { data?: { error?: { message?: string } } } }) => {
+        const message = error.response?.data?.error?.message || '수강 신청에 실패했습니다.';
+        toast.error(message);
+      },
+    });
   };
 
   // 로딩 상태
@@ -552,13 +593,34 @@ export function CourseDetailPage() {
 
                   {/* Buttons */}
                   <div className="space-y-3">
-                    {canEnroll ? (
+                    {isAlreadyEnrolled ? (
+                      <>
+                        <button
+                          onClick={() => navigate(`/tu/b2c/mypage/learning/${existingEnrollment?.id}`)}
+                          className="w-full landing-btn-primary py-4 rounded-xl text-white font-bold text-lg flex items-center justify-center gap-2"
+                        >
+                          <PlayCircle className="w-5 h-5" />
+                          학습 계속하기
+                        </button>
+                        <p className={`text-center text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                          이미 수강 신청된 강의입니다
+                        </p>
+                      </>
+                    ) : canEnroll ? (
                       <>
                         <button
                           onClick={handleEnroll}
-                          className="w-full landing-btn-primary py-4 rounded-xl text-white font-bold text-lg"
+                          disabled={enrollMutation.isPending}
+                          className="w-full landing-btn-primary py-4 rounded-xl text-white font-bold text-lg disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
                         >
-                          수강 신청
+                          {enrollMutation.isPending ? (
+                            <>
+                              <Loader2 className="w-5 h-5 animate-spin" />
+                              신청 중...
+                            </>
+                          ) : (
+                            '수강 신청'
+                          )}
                         </button>
                         {!courseTime.isFree && (
                           <button

--- a/src/pages/tu/mypage/MyTeachingPage.tsx
+++ b/src/pages/tu/mypage/MyTeachingPage.tsx
@@ -280,7 +280,7 @@ export function MyTeachingPage() {
                           variant="outline"
                           size="sm"
                           onClick={() => handleViewCourse(String(course.courseId))}
-                          className={isDark ? 'border-white/20 text-white hover:bg-white/10' : ''}
+                          className={isDark ? '!bg-transparent !border-white/20 !text-white hover:!bg-white/10' : ''}
                         >
                           <Eye className="w-4 h-4 mr-1" />
                           {t.common.view}
@@ -289,7 +289,7 @@ export function MyTeachingPage() {
                           variant="outline"
                           size="sm"
                           onClick={() => handleEditCourse(String(course.courseId))}
-                          className={isDark ? 'border-white/20 text-white hover:bg-white/10' : ''}
+                          className={isDark ? '!bg-transparent !border-white/20 !text-white hover:!bg-white/10' : ''}
                         >
                           <Edit className="w-4 h-4 mr-1" />
                           {t.common.edit}
@@ -297,7 +297,7 @@ export function MyTeachingPage() {
                         <Button
                           variant="ghost"
                           size="sm"
-                          className={isDark ? 'text-gray-400 hover:text-white' : ''}
+                          className={isDark ? '!text-gray-400 hover:!text-white hover:!bg-white/10' : ''}
                         >
                           <MoreHorizontal className="w-4 h-4" />
                         </Button>


### PR DESCRIPTION
## Summary

TU 강의 상세 페이지에서 수강 신청 버튼 클릭 시 실제 API를 호출하여 수강 신청이 되도록 구현했습니다.

## Related Issue

- Closes #236

## Changes

- useEnroll mutation hook으로 수강 신청 API 연동
- 로그인 여부 체크 및 미로그인 시 로그인 페이지로 리다이렉트
- useMyEnrollments로 이미 수강 신청된 강의 중복 체크
- 수강 신청 성공 시 내 학습 페이지(/tu/b2c/mypage/learning)로 이동
- 수강 신청 실패 시 서버 에러 메시지 표시
- 버튼 로딩 상태 표시 (스피너 + "신청 중..." 텍스트)
- 이미 수강 중인 경우 "학습 계속하기" 버튼으로 변경

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)



## Additional Notes

- 수강 신청 API: `POST /api/times/{courseTimeId}/enrollments`
- 로그인 후 원래 페이지로 돌아올 수 있도록 state.from 전달
