### PR TITLE
feat: TU 학습/강사 통계 API 연동

### DIFF
--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -237,3 +237,15 @@ export {
 } from './usePublicBranding';
 
 export { useBrandingApply } from './useBrandingApply';
+
+// Learning Stats Hooks (내 학습 통계)
+export {
+  learningStatsKeys,
+  useMyLearningStats,
+} from './useLearningStatsQueries';
+
+// Owner Stats Hooks (강사 통계)
+export {
+  ownerStatsKeys,
+  useMyOwnerStats,
+} from './useOwnerStatsQueries';

--- a/src/hooks/tu/useEnrollmentQueries.ts
+++ b/src/hooks/tu/useEnrollmentQueries.ts
@@ -5,6 +5,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '@/store/common/authStore';
 import { enrollmentService, type EnrollmentFilterParams } from '@/services/tu/enrollmentService';
 import { catalogKeys } from './useCatalogQueries';
+import { ownerStatsKeys } from './useOwnerStatsQueries';
+import { learningStatsKeys } from './useLearningStatsQueries';
 
 // Query Keys
 export const enrollmentKeys = {
@@ -54,6 +56,9 @@ export const useEnroll = () => {
       queryClient.invalidateQueries({ queryKey: enrollmentKeys.my() });
       // 해당 차수의 수강 인원 갱신
       queryClient.invalidateQueries({ queryKey: catalogKeys.courseTime(courseTimeId) });
+      // 통계 갱신
+      queryClient.invalidateQueries({ queryKey: ownerStatsKeys.all });
+      queryClient.invalidateQueries({ queryKey: learningStatsKeys.all });
     },
   });
 };
@@ -71,6 +76,9 @@ export const useCancelEnrollment = () => {
       queryClient.invalidateQueries({ queryKey: enrollmentKeys.my() });
       // 해당 신청 상세 갱신
       queryClient.invalidateQueries({ queryKey: enrollmentKeys.detail(id) });
+      // 통계 갱신
+      queryClient.invalidateQueries({ queryKey: ownerStatsKeys.all });
+      queryClient.invalidateQueries({ queryKey: learningStatsKeys.all });
     },
   });
 };

--- a/src/hooks/tu/useLearningPlayerQueries.ts
+++ b/src/hooks/tu/useLearningPlayerQueries.ts
@@ -6,6 +6,8 @@ import { useAuthStore } from '@/store/common/authStore';
 import { enrollmentService } from '@/services/tu/enrollmentService';
 import type { UpdateProgressRequest } from '@/types/tu';
 import { enrollmentKeys } from './useEnrollmentQueries';
+import { ownerStatsKeys } from './useOwnerStatsQueries';
+import { learningStatsKeys } from './useLearningStatsQueries';
 
 // Query Keys
 export const learningPlayerKeys = {
@@ -61,6 +63,9 @@ export const useMarkItemComplete = () => {
       queryClient.invalidateQueries({ queryKey: enrollmentKeys.detail(enrollmentId) });
       // 내 수강 목록도 갱신 (진도율 반영)
       queryClient.invalidateQueries({ queryKey: enrollmentKeys.my() });
+      // 통계 갱신 (수료 상태 변경 가능)
+      queryClient.invalidateQueries({ queryKey: ownerStatsKeys.all });
+      queryClient.invalidateQueries({ queryKey: learningStatsKeys.all });
     },
   });
 };

--- a/src/hooks/tu/useLearningStatsQueries.ts
+++ b/src/hooks/tu/useLearningStatsQueries.ts
@@ -1,0 +1,48 @@
+/**
+ * Learning Stats React Query Hooks (TU - 학습자용)
+ */
+import { useQuery } from '@tanstack/react-query';
+import { useAuthStore } from '@/store/common/authStore';
+import { learningStatsService } from '@/services/tu/learningStatsService';
+
+// Query Keys
+export const learningStatsKeys = {
+  all: ['learning-stats'] as const,
+  my: () => [...learningStatsKeys.all, 'my'] as const,
+};
+
+/**
+ * 내 학습 통계 조회 훅
+ *
+ * @description
+ * 현재 로그인한 사용자의 학습 통계를 조회합니다.
+ * 수강 현황, 수료율, 진도율 등의 정보를 제공합니다.
+ *
+ * @returns 학습 통계 (overview, progress)
+ *
+ * @example
+ * ```tsx
+ * const { data: stats, isLoading } = useMyLearningStats();
+ *
+ * if (isLoading) return <Skeleton />;
+ *
+ * return (
+ *   <div>
+ *     <p>전체 과정: {stats?.overview.totalCourses}</p>
+ *     <p>진행 중: {stats?.overview.inProgress}</p>
+ *     <p>수료 완료: {stats?.overview.completed}</p>
+ *     <p>수료율: {stats?.overview.completionRate}%</p>
+ *     <p>평균 진도율: {stats?.progress.averageProgress}%</p>
+ *   </div>
+ * );
+ * ```
+ */
+export const useMyLearningStats = () => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  return useQuery({
+    queryKey: learningStatsKeys.my(),
+    queryFn: () => learningStatsService.getMyLearningStats(),
+    enabled: isAuthenticated,
+  });
+};

--- a/src/hooks/tu/useOwnerStatsQueries.ts
+++ b/src/hooks/tu/useOwnerStatsQueries.ts
@@ -1,0 +1,54 @@
+/**
+ * Owner Stats React Query Hooks (TU - 강사용)
+ */
+import { useQuery } from '@tanstack/react-query';
+import { useAuthStore } from '@/store/common/authStore';
+import { ownerStatsService } from '@/services/tu/ownerStatsService';
+
+// Query Keys
+export const ownerStatsKeys = {
+  all: ['owner-stats'] as const,
+  my: () => [...ownerStatsKeys.all, 'my'] as const,
+};
+
+/**
+ * 내 강사(Owner) 통계 조회 훅
+ *
+ * @description
+ * 현재 로그인한 강사의 통계를 조회합니다.
+ * 담당 프로그램, 수강생 현황, 수료율 등의 정보를 제공합니다.
+ *
+ * @returns 강사 통계 (overview, enrollmentStats, programStats)
+ *
+ * @example
+ * ```tsx
+ * const { data: stats, isLoading } = useMyOwnerStats();
+ *
+ * if (isLoading) return <Skeleton />;
+ *
+ * return (
+ *   <div>
+ *     <p>총 프로그램: {stats?.overview.totalPrograms}</p>
+ *     <p>총 차수: {stats?.overview.totalCourseTimes}</p>
+ *     <p>총 수강생: {stats?.overview.totalStudents}</p>
+ *     <p>평균 수료율: {stats?.enrollmentStats.averageCompletionRate}%</p>
+ *     <ul>
+ *       {stats?.programStats.map(program => (
+ *         <li key={program.programId}>
+ *           {program.programName} - 수료율: {program.completionRate}%
+ *         </li>
+ *       ))}
+ *     </ul>
+ *   </div>
+ * );
+ * ```
+ */
+export const useMyOwnerStats = () => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  return useQuery({
+    queryKey: ownerStatsKeys.my(),
+    queryFn: () => ownerStatsService.getMyOwnerStats(),
+    enabled: isAuthenticated,
+  });
+};

--- a/src/pages/tu/mypage/MyPageHome.tsx
+++ b/src/pages/tu/mypage/MyPageHome.tsx
@@ -19,7 +19,7 @@ import {
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/common/auth';
 import { useMyProfile, useUploadProfileImage } from '@/hooks/common';
-import { useMyEnrollments } from '@/hooks/tu';
+import { useMyEnrollments, useMyLearningStats } from '@/hooks/tu';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation, useLanguageStore } from '@/store/common/languageStore';
 import { Button, Card, CardContent, Badge } from '@/components/common';
@@ -136,18 +136,21 @@ export function MyPageHome() {
     fileInputRef.current?.click();
   };
 
-  // 학습 현황 조회
+  // 학습 통계 API 조회
+  const { data: learningStats, isLoading: isLoadingStats } = useMyLearningStats();
+
+  // 최근 학습을 위한 enrollment 목록 조회 (수강 중인 강의만)
   const { data: enrollmentData, isLoading: isLoadingEnrollments } = useMyEnrollments({
     page: 0,
-    size: 100,
+    size: 3,
   });
 
-  // 통계 계산
+  // 통계 (API에서 가져온 데이터 사용, 없으면 기본값)
   const stats = {
-    inProgress: enrollmentData?.content.filter((e) => e.status === 'APPROVED').length ?? 0,
-    completed: enrollmentData?.content.filter((e) => e.status === 'COMPLETED').length ?? 0,
-    pending: enrollmentData?.content.filter((e) => e.status === 'PENDING').length ?? 0,
-    total: enrollmentData?.content.length ?? 0,
+    inProgress: learningStats?.overview.inProgress ?? 0,
+    completed: learningStats?.overview.completed ?? 0,
+    dropped: learningStats?.overview.dropped ?? 0,
+    total: learningStats?.overview.totalCourses ?? 0,
   };
 
   // 최근 학습 (수강 중인 강의 최대 3개)
@@ -232,7 +235,7 @@ export function MyPageHome() {
             {[
               { label: t.mypage.inProgress, value: stats.inProgress, icon: <PlayCircle className="w-5 h-5" />, color: 'blue' },
               { label: t.mypage.completed, value: stats.completed, icon: <CheckCircle className="w-5 h-5" />, color: 'green' },
-              { label: t.mypage.pending, value: stats.pending, icon: <Clock className="w-5 h-5" />, color: 'orange' },
+              { label: t.mypage.dropped, value: stats.dropped, icon: <Clock className="w-5 h-5" />, color: 'orange' },
               { label: t.mypage.total, value: stats.total, icon: <TrendingUp className="w-5 h-5" />, color: 'purple' },
             ].map((stat) => (
               <div
@@ -262,7 +265,7 @@ export function MyPageHome() {
                   </span>
                 </div>
                 <p className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                  {isLoadingEnrollments ? '-' : stat.value}
+                  {isLoadingStats ? '-' : stat.value}
                 </p>
               </div>
             ))}

--- a/src/pages/tu/mypage/TeachingStatsPage.tsx
+++ b/src/pages/tu/mypage/TeachingStatsPage.tsx
@@ -295,7 +295,7 @@ export function TeachingStatsPage() {
               />
             ) : (
               <div className="space-y-3">
-                {stats.programStats.map((program) => (
+                {stats.programStats.map((program, index) => (
                   <div
                     key={program.programId}
                     onClick={() => navigate(`/tu/teaching/programs/${program.programId}`)}
@@ -319,7 +319,7 @@ export function TeachingStatsPage() {
                         {t.teaching.students}: {program.totalStudents}
                       </span>
                     </div>
-                    {/* 수료율 Progress Bar */}
+                    {/* 수료율 Progress Bar with Entrance Animation */}
                     <div className="space-y-1">
                       <div className="flex items-center justify-between text-sm">
                         <span className={isDark ? 'text-gray-400' : 'text-gray-500'}>
@@ -338,7 +338,7 @@ export function TeachingStatsPage() {
                         }`}
                       >
                         <div
-                          className={`h-full transition-all rounded-full ${
+                          className={`h-full rounded-full animate-[grow-width_0.8s_ease-out_forwards] ${
                             isDark
                               ? 'bg-gradient-to-r from-violet-400 to-purple-400'
                               : ''
@@ -349,6 +349,10 @@ export function TeachingStatsPage() {
                             boxShadow: isDark
                               ? '0 0 8px rgba(167, 139, 250, 0.4)'
                               : '0 1px 3px rgba(0, 0, 0, 0.15)',
+                            animationDelay: `${index * 0.15}s`,
+                            opacity: 0,
+                            transform: 'scaleX(0)',
+                            transformOrigin: 'left',
                           }}
                         />
                       </div>

--- a/src/pages/tu/mypage/TeachingStatsPage.tsx
+++ b/src/pages/tu/mypage/TeachingStatsPage.tsx
@@ -1,20 +1,56 @@
-import { BarChart3, Construction } from 'lucide-react';
+import { BarChart3, Users, BookOpen, GraduationCap, TrendingUp, AlertCircle } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation } from '@/store/common/languageStore';
-import { Card, CardHeader, CardTitle, CardContent, EmptyState } from '@/components/common';
+import { Card, CardHeader, CardTitle, CardContent, Skeleton, EmptyState } from '@/components/common';
+import { Progress } from '@/components/common/Progress';
+import { useMyOwnerStats } from '@/hooks/tu';
 
 export function TeachingStatsPage() {
   const { theme } = useThemeStore();
   const { t } = useTranslation();
   const isDark = theme === 'dark';
 
+  const { data: stats, isLoading, error } = useMyOwnerStats();
+
   const cardClass = isDark
     ? 'bg-white/5 border-white/10'
     : 'bg-white border-gray-200 shadow-sm';
 
+  const statCardClass = isDark
+    ? 'bg-white/5 border border-white/10'
+    : 'bg-white border border-gray-200 shadow-sm';
+
+  // 에러 상태
+  if (error) {
+    return (
+      <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+        <div className="max-w-4xl mx-auto">
+          <div className="mb-8">
+            <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              {t.teaching.stats}
+            </h1>
+            <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
+              {t.teaching.statsDesc}
+            </p>
+          </div>
+          <Card className={cardClass}>
+            <CardContent className="py-12">
+              <div className="flex flex-col items-center justify-center text-center">
+                <AlertCircle className="h-12 w-12 text-red-500 mb-4" />
+                <p className={`text-lg font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                  {t.common.error}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
-      <div className="max-w-3xl mx-auto">
+      <div className="max-w-4xl mx-auto">
         {/* Header */}
         <div className="mb-8">
           <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
@@ -25,24 +61,210 @@ export function TeachingStatsPage() {
           </p>
         </div>
 
-        {/* Stats Card */}
+        {/* Overview Stats Cards */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+          {isLoading ? (
+            <>
+              <Skeleton className="h-28" />
+              <Skeleton className="h-28" />
+              <Skeleton className="h-28" />
+            </>
+          ) : (
+            <>
+              <div className={`p-4 rounded-xl ${statCardClass}`}>
+                <div className="flex items-center gap-3 mb-2">
+                  <div className={isDark ? 'text-purple-400' : 'text-purple-600'}>
+                    <BookOpen className="w-5 h-5" />
+                  </div>
+                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                    {t.teaching.totalPrograms}
+                  </span>
+                </div>
+                <p className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                  {stats?.overview.totalPrograms ?? 0}
+                </p>
+              </div>
+
+              <div className={`p-4 rounded-xl ${statCardClass}`}>
+                <div className="flex items-center gap-3 mb-2">
+                  <div className={isDark ? 'text-blue-400' : 'text-blue-600'}>
+                    <GraduationCap className="w-5 h-5" />
+                  </div>
+                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                    {t.teaching.totalCourseTimes}
+                  </span>
+                </div>
+                <p className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                  {stats?.overview.totalCourseTimes ?? 0}
+                </p>
+              </div>
+
+              <div className={`p-4 rounded-xl ${statCardClass}`}>
+                <div className="flex items-center gap-3 mb-2">
+                  <div className={isDark ? 'text-green-400' : 'text-green-600'}>
+                    <Users className="w-5 h-5" />
+                  </div>
+                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                    {t.teaching.totalStudents}
+                  </span>
+                </div>
+                <p className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                  {stats?.overview.totalStudents ?? 0}
+                </p>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Enrollment Stats Card */}
+        <Card className={`${cardClass} mb-6`}>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <TrendingUp className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+              <CardTitle className={isDark ? 'text-white' : 'text-gray-900'}>
+                {t.teaching.enrollmentStats}
+              </CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="space-y-4">
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+                <Skeleton className="h-6" />
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                    {t.teaching.totalEnrollments}
+                  </span>
+                  <span className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                    {stats?.enrollmentStats.totalEnrollments ?? 0}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                    {t.teaching.completed}
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <Progress
+                      value={
+                        stats?.enrollmentStats.totalEnrollments
+                          ? ((stats?.enrollmentStats.completed ?? 0) / stats.enrollmentStats.totalEnrollments) * 100
+                          : 0
+                      }
+                      className="w-24"
+                    />
+                    <span className={`font-medium w-8 text-right ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                      {stats?.enrollmentStats.completed ?? 0}
+                    </span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                    {t.teaching.inProgress}
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <Progress
+                      value={
+                        stats?.enrollmentStats.totalEnrollments
+                          ? ((stats?.enrollmentStats.inProgress ?? 0) / stats.enrollmentStats.totalEnrollments) * 100
+                          : 0
+                      }
+                      className="w-24"
+                    />
+                    <span className={`font-medium w-8 text-right ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                      {stats?.enrollmentStats.inProgress ?? 0}
+                    </span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                    {t.teaching.dropped}
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <Progress
+                      value={
+                        stats?.enrollmentStats.totalEnrollments
+                          ? ((stats?.enrollmentStats.dropped ?? 0) / stats.enrollmentStats.totalEnrollments) * 100
+                          : 0
+                      }
+                      className="w-24"
+                    />
+                    <span className={`font-medium w-8 text-right ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                      {stats?.enrollmentStats.dropped ?? 0}
+                    </span>
+                  </div>
+                </div>
+                <div className="pt-2 border-t border-gray-200 dark:border-white/10">
+                  <div className="flex items-center justify-between">
+                    <span className={`text-sm font-medium ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                      {t.teaching.averageCompletionRate}
+                    </span>
+                    <span className={`text-lg font-bold ${isDark ? 'text-green-400' : 'text-green-600'}`}>
+                      {stats?.enrollmentStats.averageCompletionRate ?? 0}%
+                    </span>
+                  </div>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Program Stats Card */}
         <Card className={cardClass}>
           <CardHeader>
             <div className="flex items-center gap-3">
               <BarChart3 className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
               <CardTitle className={isDark ? 'text-white' : 'text-gray-900'}>
-                {t.teaching.statsOverview}
+                {t.teaching.programStats}
               </CardTitle>
             </div>
           </CardHeader>
           <CardContent>
-            {/* Under Development Placeholder */}
-            <EmptyState
-              icon={Construction}
-              title={t.common.comingSoon}
-              description={t.teaching.statsComingSoon}
-              className={`border-2 border-dashed rounded-lg ${isDark ? 'border-white/10' : 'border-gray-200'}`}
-            />
+            {isLoading ? (
+              <div className="space-y-3">
+                <Skeleton className="h-16" />
+                <Skeleton className="h-16" />
+                <Skeleton className="h-16" />
+              </div>
+            ) : !stats?.programStats || stats.programStats.length === 0 ? (
+              <EmptyState
+                icon={BookOpen}
+                title={t.teaching.noProgramStats}
+                description={t.teaching.noProgramStatsDesc}
+                className={`border-2 border-dashed rounded-lg ${isDark ? 'border-white/10' : 'border-gray-200'}`}
+              />
+            ) : (
+              <div className="space-y-3">
+                {stats.programStats.map((program) => (
+                  <div
+                    key={program.programId}
+                    className={`p-4 rounded-lg ${isDark ? 'bg-white/5' : 'bg-gray-50'}`}
+                  >
+                    <div className="flex items-start justify-between mb-2">
+                      <h4 className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                        {program.programName}
+                      </h4>
+                      <span className={`text-sm font-medium ${isDark ? 'text-green-400' : 'text-green-600'}`}>
+                        {program.completionRate}%
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-4 text-sm">
+                      <span className={isDark ? 'text-gray-400' : 'text-gray-600'}>
+                        {t.teaching.courseTimes}: {program.courseTimeCount}
+                      </span>
+                      <span className={isDark ? 'text-gray-400' : 'text-gray-600'}>
+                        {t.teaching.students}: {program.totalStudents}
+                      </span>
+                    </div>
+                    <Progress value={program.completionRate} className="mt-2" />
+                  </div>
+                ))}
+              </div>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/src/pages/tu/mypage/TeachingStatsPage.tsx
+++ b/src/pages/tu/mypage/TeachingStatsPage.tsx
@@ -1,11 +1,13 @@
-import { BarChart3, Users, BookOpen, GraduationCap, TrendingUp, AlertCircle } from 'lucide-react';
+import { BarChart3, Users, BookOpen, GraduationCap, TrendingUp, AlertCircle, ChevronRight } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation } from '@/store/common/languageStore';
 import { Card, CardHeader, CardTitle, CardContent, Skeleton, EmptyState } from '@/components/common';
-import { Progress } from '@/components/common/Progress';
 import { useMyOwnerStats } from '@/hooks/tu';
+import { designTokens } from '@/styles/admin-design-tokens';
 
 export function TeachingStatsPage() {
+  const navigate = useNavigate();
   const { theme } = useThemeStore();
   const { t } = useTranslation();
   const isDark = theme === 'dark';
@@ -73,42 +75,42 @@ export function TeachingStatsPage() {
             <>
               <div className={`p-4 rounded-xl ${statCardClass}`}>
                 <div className="flex items-center gap-3 mb-2">
-                  <div className={isDark ? 'text-purple-400' : 'text-purple-600'}>
+                  <div className={isDark ? 'text-violet-400' : 'text-violet-600'}>
                     <BookOpen className="w-5 h-5" />
                   </div>
                   <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
                     {t.teaching.totalPrograms}
                   </span>
                 </div>
-                <p className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                <p className={`text-2xl font-bold tabular-nums ${isDark ? 'text-white' : 'text-gray-900'}`}>
                   {stats?.overview.totalPrograms ?? 0}
                 </p>
               </div>
 
               <div className={`p-4 rounded-xl ${statCardClass}`}>
                 <div className="flex items-center gap-3 mb-2">
-                  <div className={isDark ? 'text-blue-400' : 'text-blue-600'}>
+                  <div className={isDark ? 'text-sky-400' : 'text-sky-600'}>
                     <GraduationCap className="w-5 h-5" />
                   </div>
                   <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
                     {t.teaching.totalCourseTimes}
                   </span>
                 </div>
-                <p className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                <p className={`text-2xl font-bold tabular-nums ${isDark ? 'text-white' : 'text-gray-900'}`}>
                   {stats?.overview.totalCourseTimes ?? 0}
                 </p>
               </div>
 
               <div className={`p-4 rounded-xl ${statCardClass}`}>
                 <div className="flex items-center gap-3 mb-2">
-                  <div className={isDark ? 'text-green-400' : 'text-green-600'}>
+                  <div className={isDark ? 'text-emerald-400' : 'text-emerald-600'}>
                     <Users className="w-5 h-5" />
                   </div>
                   <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
                     {t.teaching.totalStudents}
                   </span>
                 </div>
-                <p className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                <p className={`text-2xl font-bold tabular-nums ${isDark ? 'text-white' : 'text-gray-900'}`}>
                   {stats?.overview.totalStudents ?? 0}
                 </p>
               </div>
@@ -129,81 +131,135 @@ export function TeachingStatsPage() {
           <CardContent>
             {isLoading ? (
               <div className="space-y-4">
-                <Skeleton className="h-6" />
-                <Skeleton className="h-6" />
-                <Skeleton className="h-6" />
-                <Skeleton className="h-6" />
+                <Skeleton className="h-10" />
+                <Skeleton className="h-8" />
               </div>
             ) : (
-              <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-                    {t.teaching.totalEnrollments}
-                  </span>
-                  <span className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              <div className="space-y-6">
+                {/* Total Count Header */}
+                <div className="flex items-baseline gap-2">
+                  <span className={`text-3xl font-bold tabular-nums ${isDark ? 'text-white' : 'text-gray-900'}`}>
                     {stats?.enrollmentStats.totalEnrollments ?? 0}
                   </span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-                    {t.teaching.completed}
+                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                    {t.teaching.totalEnrollments}
                   </span>
-                  <div className="flex items-center gap-2">
-                    <Progress
-                      value={
-                        stats?.enrollmentStats.totalEnrollments
-                          ? ((stats?.enrollmentStats.completed ?? 0) / stats.enrollmentStats.totalEnrollments) * 100
-                          : 0
-                      }
-                      className="w-24"
-                    />
-                    <span className={`font-medium w-8 text-right ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                      {stats?.enrollmentStats.completed ?? 0}
-                    </span>
-                  </div>
                 </div>
-                <div className="flex items-center justify-between">
-                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-                    {t.teaching.inProgress}
-                  </span>
-                  <div className="flex items-center gap-2">
-                    <Progress
-                      value={
-                        stats?.enrollmentStats.totalEnrollments
-                          ? ((stats?.enrollmentStats.inProgress ?? 0) / stats.enrollmentStats.totalEnrollments) * 100
-                          : 0
-                      }
-                      className="w-24"
-                    />
-                    <span className={`font-medium w-8 text-right ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                      {stats?.enrollmentStats.inProgress ?? 0}
-                    </span>
-                  </div>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-                    {t.teaching.dropped}
-                  </span>
-                  <div className="flex items-center gap-2">
-                    <Progress
-                      value={
-                        stats?.enrollmentStats.totalEnrollments
-                          ? ((stats?.enrollmentStats.dropped ?? 0) / stats.enrollmentStats.totalEnrollments) * 100
-                          : 0
-                      }
-                      className="w-24"
-                    />
-                    <span className={`font-medium w-8 text-right ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                      {stats?.enrollmentStats.dropped ?? 0}
-                    </span>
-                  </div>
-                </div>
-                <div className="pt-2 border-t border-gray-200 dark:border-white/10">
+
+                {/* Horizontal Stacked Bar */}
+                {(() => {
+                  // Pastel Neon 톤 색상 팔레트 (Dark Mode 최적화)
+                  const colors = {
+                    completed: isDark ? '#34d399' : '#059669',   // Emerald-400 / Emerald-600
+                    inProgress: isDark ? '#a78bfa' : '#7C3AED',  // Violet-400 / Violet-600
+                    dropped: isDark ? '#fb7185' : '#E11D48',     // Rose-400 / Rose-600
+                    failed: isDark ? '#475569' : '#9CA3AF',      // Slate-600 / Gray-400
+                  };
+
+                  const total = stats?.enrollmentStats.totalEnrollments ?? 0;
+                  const items = [
+                    { key: 'completed', label: t.teaching.completed, value: stats?.enrollmentStats.completed ?? 0, color: colors.completed },
+                    { key: 'inProgress', label: t.teaching.inProgress, value: stats?.enrollmentStats.inProgress ?? 0, color: colors.inProgress },
+                    { key: 'dropped', label: t.teaching.dropped, value: stats?.enrollmentStats.dropped ?? 0, color: colors.dropped },
+                    { key: 'failed', label: t.teaching.failed, value: stats?.enrollmentStats.failed ?? 0, color: colors.failed },
+                  ];
+
+                  // 값이 있는 항목만 필터링
+                  const activeItems = items.filter((item) => item.value > 0);
+
+                  // 그라데이션 색상 (다크모드용)
+                  const gradientColors = {
+                    completed: isDark
+                      ? 'bg-gradient-to-r from-emerald-400 to-teal-400'
+                      : 'bg-emerald-600',
+                    inProgress: isDark
+                      ? 'bg-gradient-to-r from-violet-400 to-purple-400'
+                      : 'bg-violet-600',
+                    dropped: isDark
+                      ? 'bg-gradient-to-r from-rose-400 to-pink-400'
+                      : 'bg-rose-600',
+                    failed: isDark
+                      ? 'bg-gradient-to-r from-slate-500 to-slate-600'
+                      : 'bg-gray-400',
+                  };
+
+                  return (
+                    <div className="space-y-4">
+                      {/* Stacked Bar with Gradients - Entrance Animation */}
+                      <div className="flex h-3 w-full gap-1 overflow-hidden">
+                        {activeItems.length > 0 ? (
+                          activeItems.map((item, index) => {
+                            const percentage = total > 0 ? (item.value / total) * 100 : 0;
+                            const gradientClass = gradientColors[item.key as keyof typeof gradientColors];
+
+                            return (
+                              <div
+                                key={item.key}
+                                className={`h-full rounded-full ${gradientClass} animate-[grow-width_0.8s_ease-out_forwards]`}
+                                style={{
+                                  width: `${percentage}%`,
+                                  animationDelay: `${index * 0.1}s`,
+                                  opacity: 0,
+                                  transform: 'scaleX(0)',
+                                  transformOrigin: 'left',
+                                }}
+                              />
+                            );
+                          })
+                        ) : (
+                          <div
+                            className={`h-full w-full rounded-full ${isDark ? 'bg-white/10' : 'bg-gray-200'}`}
+                          />
+                        )}
+                      </div>
+                      {/* Keyframes for entrance animation */}
+                      <style>{`
+                        @keyframes grow-width {
+                          0% {
+                            opacity: 0;
+                            transform: scaleX(0);
+                          }
+                          100% {
+                            opacity: 1;
+                            transform: scaleX(1);
+                          }
+                        }
+                      `}</style>
+
+                      {/* Legend */}
+                      <div className="flex flex-wrap gap-x-6 gap-y-2">
+                        {items.map((item) => {
+                          const dotGradientClass = gradientColors[item.key as keyof typeof gradientColors];
+                          return (
+                            <div key={item.key} className="flex items-center gap-2 leading-none">
+                              <div
+                                className={`w-2.5 h-2.5 rounded-sm flex-shrink-0 ${isDark ? dotGradientClass : ''}`}
+                                style={!isDark ? { backgroundColor: item.color } : undefined}
+                              />
+                              <span className={`text-sm leading-none ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                                {item.label}
+                              </span>
+                              <span className={`text-sm font-semibold tabular-nums leading-none ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                                {item.value}
+                              </span>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                })()}
+
+                {/* 평균 수료율 */}
+                <div className={`pt-4 border-t ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
                   <div className="flex items-center justify-between">
-                    <span className={`text-sm font-medium ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                    <span className={`text-sm font-medium leading-none ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
                       {t.teaching.averageCompletionRate}
                     </span>
-                    <span className={`text-lg font-bold ${isDark ? 'text-green-400' : 'text-green-600'}`}>
+                    <span
+                      className="text-xl font-bold tabular-nums leading-none"
+                      style={{ color: isDark ? '#34d399' : '#059669' }}
+                    >
                       {stats?.enrollmentStats.averageCompletionRate ?? 0}%
                     </span>
                   </div>
@@ -242,17 +298,20 @@ export function TeachingStatsPage() {
                 {stats.programStats.map((program) => (
                   <div
                     key={program.programId}
-                    className={`p-4 rounded-lg ${isDark ? 'bg-white/5' : 'bg-gray-50'}`}
+                    onClick={() => navigate(`/tu/teaching/programs/${program.programId}`)}
+                    className={`p-4 rounded-lg cursor-pointer transition-all ${
+                      isDark
+                        ? 'bg-white/5 hover:bg-white/10'
+                        : 'bg-gray-50 hover:bg-gray-100'
+                    }`}
                   >
                     <div className="flex items-start justify-between mb-2">
                       <h4 className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
                         {program.programName}
                       </h4>
-                      <span className={`text-sm font-medium ${isDark ? 'text-green-400' : 'text-green-600'}`}>
-                        {program.completionRate}%
-                      </span>
+                      <ChevronRight className={`w-5 h-5 flex-shrink-0 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
                     </div>
-                    <div className="flex items-center gap-4 text-sm">
+                    <div className="flex items-center gap-4 text-sm mb-3">
                       <span className={isDark ? 'text-gray-400' : 'text-gray-600'}>
                         {t.teaching.courseTimes}: {program.courseTimeCount}
                       </span>
@@ -260,7 +319,40 @@ export function TeachingStatsPage() {
                         {t.teaching.students}: {program.totalStudents}
                       </span>
                     </div>
-                    <Progress value={program.completionRate} className="mt-2" />
+                    {/* 수료율 Progress Bar */}
+                    <div className="space-y-1">
+                      <div className="flex items-center justify-between text-sm">
+                        <span className={isDark ? 'text-gray-400' : 'text-gray-500'}>
+                          {t.teaching.completionRate}
+                        </span>
+                        <span
+                          className="font-semibold"
+                          style={{ color: isDark ? '#34d399' : designTokens.status.success_text }}
+                        >
+                          {program.completionRate}%
+                        </span>
+                      </div>
+                      <div
+                        className={`relative h-2 w-full overflow-hidden rounded-full ${
+                          isDark ? 'bg-white/10' : 'bg-gray-200'
+                        }`}
+                      >
+                        <div
+                          className={`h-full transition-all rounded-full ${
+                            isDark
+                              ? 'bg-gradient-to-r from-violet-400 to-purple-400'
+                              : ''
+                          }`}
+                          style={{
+                            width: `${program.completionRate}%`,
+                            ...(!isDark && { backgroundColor: designTokens.button.brand_default }),
+                            boxShadow: isDark
+                              ? '0 0 8px rgba(167, 139, 250, 0.4)'
+                              : '0 1px 3px rgba(0, 0, 0, 0.15)',
+                          }}
+                        />
+                      </div>
+                    </div>
                   </div>
                 ))}
               </div>

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -18,6 +18,7 @@ export const API_ENDPOINTS = {
     ME_PROFILE_IMAGE: '/users/me/profile-image',
     ME_COURSE_ROLES: '/users/me/course-roles',
     ME_COURSE_ROLES_DESIGNER: '/users/me/course-roles/designer',
+    ME_LEARNING_STATS: '/users/me/learning-stats',
     BY_ID: (id: number) => `/users/${id}`,
     ROLE: (id: number) => `/users/${id}/role`,
     STATUS: (id: number) => `/users/${id}/status`,
@@ -26,6 +27,11 @@ export const API_ENDPOINTS = {
     ENROLLMENTS: (id: number) => `/users/${id}/enrollments`,
     ENROLLMENT_STATS: (id: number) => `/users/${id}/enrollments/stats`,
     INSTRUCTOR_STATS: (id: number) => `/users/${id}/instructor-statistics`,
+  },
+
+  // Owners (강사/콘텐츠 소유자)
+  OWNERS: {
+    ME_STATS: '/owners/me/stats',
   },
 
   // Tenants (SA)

--- a/src/services/tu/index.ts
+++ b/src/services/tu/index.ts
@@ -13,3 +13,5 @@ export { communityService } from './communityService';
 export { instructorService } from './instructorService';
 export { courseTimeCatalogService } from './courseTimeCatalogService';
 export { publicBrandingService } from './publicBrandingService';
+export { learningStatsService } from './learningStatsService';
+export { ownerStatsService } from './ownerStatsService';

--- a/src/services/tu/learningStatsService.ts
+++ b/src/services/tu/learningStatsService.ts
@@ -1,0 +1,18 @@
+/**
+ * 내 학습 통계 API 서비스 (TU)
+ * GET /api/users/me/learning-stats
+ */
+import { axiosInstance } from '../common/api';
+import { API_ENDPOINTS } from '../common/api/endpoints';
+import type { LearningStatsResponse } from '@/types/tu';
+
+export const learningStatsService = {
+  /**
+   * 내 학습 통계 조회
+   * @returns 학습 통계 (overview, progress)
+   */
+  getMyLearningStats: async (): Promise<LearningStatsResponse> => {
+    const response = await axiosInstance.get(API_ENDPOINTS.USERS.ME_LEARNING_STATS);
+    return response.data.data;
+  },
+};

--- a/src/services/tu/ownerStatsService.ts
+++ b/src/services/tu/ownerStatsService.ts
@@ -6,13 +6,59 @@ import { axiosInstance } from '../common/api';
 import { API_ENDPOINTS } from '../common/api/endpoints';
 import type { OwnerStatsResponse } from '@/types/tu';
 
+/** 백엔드 API 응답 타입 */
+interface OwnerStatsApiResponse {
+  overview: {
+    totalPrograms: number;
+    totalCourseTimes: number;
+    totalStudents: number;
+  };
+  enrollmentStats: {
+    totalEnrollments: number;
+    byStatus: {
+      enrolled: number;
+      completed: number;
+      dropped: number;
+      failed: number;
+    };
+    completionRate: number;
+  };
+  programStats: Array<{
+    programId: number;
+    title: string;
+    courseTimeCount: number;
+    totalStudents: number;
+    completionRate: number;
+  }>;
+}
+
 export const ownerStatsService = {
   /**
    * 내 강사 통계 조회
    * @returns 강사 통계 (overview, enrollmentStats, programStats)
    */
   getMyOwnerStats: async (): Promise<OwnerStatsResponse> => {
-    const response = await axiosInstance.get(API_ENDPOINTS.OWNERS.ME_STATS);
-    return response.data.data;
+    const response = await axiosInstance.get<{ data: OwnerStatsApiResponse }>(API_ENDPOINTS.OWNERS.ME_STATS);
+    const data = response.data.data;
+
+    // 백엔드 응답 구조를 프론트엔드 타입에 맞게 변환
+    return {
+      overview: data.overview,
+      enrollmentStats: {
+        totalEnrollments: data.enrollmentStats.totalEnrollments,
+        completed: data.enrollmentStats.byStatus.completed,
+        inProgress: data.enrollmentStats.byStatus.enrolled,
+        dropped: data.enrollmentStats.byStatus.dropped,
+        failed: data.enrollmentStats.byStatus.failed,
+        averageCompletionRate: data.enrollmentStats.completionRate,
+      },
+      programStats: data.programStats.map((p) => ({
+        programId: p.programId,
+        programName: p.title,
+        courseTimeCount: p.courseTimeCount,
+        totalStudents: p.totalStudents,
+        completionRate: p.completionRate,
+      })),
+    };
   },
 };

--- a/src/services/tu/ownerStatsService.ts
+++ b/src/services/tu/ownerStatsService.ts
@@ -1,0 +1,18 @@
+/**
+ * 강사(Owner) 통계 API 서비스 (TU)
+ * GET /api/owners/me/stats
+ */
+import { axiosInstance } from '../common/api';
+import { API_ENDPOINTS } from '../common/api/endpoints';
+import type { OwnerStatsResponse } from '@/types/tu';
+
+export const ownerStatsService = {
+  /**
+   * 내 강사 통계 조회
+   * @returns 강사 통계 (overview, enrollmentStats, programStats)
+   */
+  getMyOwnerStats: async (): Promise<OwnerStatsResponse> => {
+    const response = await axiosInstance.get(API_ENDPOINTS.OWNERS.ME_STATS);
+    return response.data.data;
+  },
+};

--- a/src/store/common/languageStore.ts
+++ b/src/store/common/languageStore.ts
@@ -125,7 +125,9 @@ type TranslationKeys = {
     completed: string;
     inProgress: string;
     dropped: string;
+    failed: string;
     averageCompletionRate: string;
+    completionRate: string;
     programStats: string;
     noProgramStats: string;
     noProgramStatsDesc: string;
@@ -425,7 +427,9 @@ const ko: TranslationKeys = {
     completed: '수료 완료',
     inProgress: '진행 중',
     dropped: '중도 포기',
+    failed: '미수료',
     averageCompletionRate: '평균 수료율',
+    completionRate: '수료율',
     programStats: '프로그램별 통계',
     noProgramStats: '프로그램 통계가 없습니다',
     noProgramStatsDesc: '담당 프로그램이 없습니다. 프로그램에 강사로 배정되면 통계를 확인할 수 있습니다.',
@@ -711,7 +715,9 @@ const en: TranslationKeys = {
     completed: 'Completed',
     inProgress: 'In Progress',
     dropped: 'Dropped',
+    failed: 'Failed',
     averageCompletionRate: 'Avg. Completion Rate',
+    completionRate: 'Completion Rate',
     programStats: 'Program Stats',
     noProgramStats: 'No program statistics',
     noProgramStatsDesc: 'No programs assigned. Statistics will be available once you are assigned as an instructor.',

--- a/src/store/common/languageStore.ts
+++ b/src/store/common/languageStore.ts
@@ -62,6 +62,7 @@ type TranslationKeys = {
     completedCourses: string;
     completedComingSoon: string;
     pending: string;
+    dropped: string;
     total: string;
     recentLearning: string;
     viewAll: string;
@@ -115,6 +116,20 @@ type TranslationKeys = {
     courseDesignTitle: string;
     navigateConfirm: string;
     proceed: string;
+    // Owner Stats
+    totalPrograms: string;
+    totalCourseTimes: string;
+    totalStudents: string;
+    enrollmentStats: string;
+    totalEnrollments: string;
+    completed: string;
+    inProgress: string;
+    dropped: string;
+    averageCompletionRate: string;
+    programStats: string;
+    noProgramStats: string;
+    noProgramStatsDesc: string;
+    courseTimes: string;
   };
   // 프로필 및 보안
   profileSecurity: {
@@ -348,6 +363,7 @@ const ko: TranslationKeys = {
     completedCourses: '완료한 강의 목록',
     completedComingSoon: '완료한 강의 기능은 현재 개발 중입니다. 곧 완료한 강의 목록과 수료증을 확인할 수 있습니다.',
     pending: '승인 대기',
+    dropped: '중도 포기',
     total: '전체',
     recentLearning: '최근 학습',
     viewAll: '전체보기',
@@ -400,6 +416,20 @@ const ko: TranslationKeys = {
     courseDesignTitle: '강의 설계 / 개설',
     navigateConfirm: '강의 설계 / 개설 페이지로 이동하시겠습니까?',
     proceed: '이동',
+    // Owner Stats
+    totalPrograms: '총 프로그램',
+    totalCourseTimes: '총 차수',
+    totalStudents: '총 수강생',
+    enrollmentStats: '수강 현황',
+    totalEnrollments: '총 수강 신청',
+    completed: '수료 완료',
+    inProgress: '진행 중',
+    dropped: '중도 포기',
+    averageCompletionRate: '평균 수료율',
+    programStats: '프로그램별 통계',
+    noProgramStats: '프로그램 통계가 없습니다',
+    noProgramStatsDesc: '담당 프로그램이 없습니다. 프로그램에 강사로 배정되면 통계를 확인할 수 있습니다.',
+    courseTimes: '차수',
   },
   profileSecurity: {
     title: '프로필 및 보안',
@@ -619,6 +649,7 @@ const en: TranslationKeys = {
     completedCourses: 'Completed Courses List',
     completedComingSoon: 'Completed courses feature is currently under development. You will soon be able to view your completed courses and certificates.',
     pending: 'Pending',
+    dropped: 'Dropped',
     total: 'Total',
     recentLearning: 'Recent Learning',
     viewAll: 'View All',
@@ -671,6 +702,20 @@ const en: TranslationKeys = {
     courseDesignTitle: 'Course Design / Creation',
     navigateConfirm: 'Would you like to proceed to the course design / creation page?',
     proceed: 'Proceed',
+    // Owner Stats
+    totalPrograms: 'Total Programs',
+    totalCourseTimes: 'Total Sessions',
+    totalStudents: 'Total Students',
+    enrollmentStats: 'Enrollment Stats',
+    totalEnrollments: 'Total Enrollments',
+    completed: 'Completed',
+    inProgress: 'In Progress',
+    dropped: 'Dropped',
+    averageCompletionRate: 'Avg. Completion Rate',
+    programStats: 'Program Stats',
+    noProgramStats: 'No program statistics',
+    noProgramStatsDesc: 'No programs assigned. Statistics will be available once you are assigned as an instructor.',
+    courseTimes: 'Sessions',
   },
   profileSecurity: {
     title: 'Profile & Security',

--- a/src/types/tu/index.ts
+++ b/src/types/tu/index.ts
@@ -241,3 +241,19 @@ export {
   PROGRAM_TYPE_LABELS,
   COURSE_TIME_STATUS_COLORS,
 } from './courseTimeCatalog.types';
+
+// Learning Stats (내 학습 통계)
+export type {
+  LearningStatsByType,
+  LearningStatsOverview,
+  LearningStatsProgress,
+  LearningStatsResponse,
+} from './learningStats.types';
+
+// Owner Stats (강사 통계)
+export type {
+  OwnerStatsOverview,
+  OwnerEnrollmentStats,
+  OwnerProgramStats,
+  OwnerStatsResponse,
+} from './ownerStats.types';

--- a/src/types/tu/learningStats.types.ts
+++ b/src/types/tu/learningStats.types.ts
@@ -1,0 +1,42 @@
+/**
+ * TU 내 학습 통계 타입 정의
+ * GET /api/users/me/learning-stats
+ */
+
+/** 학습 유형별 통계 */
+export interface LearningStatsByType {
+  type: string;
+  count: number;
+}
+
+/** 학습 통계 개요 */
+export interface LearningStatsOverview {
+  /** 전체 수강 과정 수 */
+  totalCourses: number;
+  /** 진행 중 */
+  inProgress: number;
+  /** 수료 완료 */
+  completed: number;
+  /** 중도 포기 */
+  dropped: number;
+  /** 미수료 (기간 만료) */
+  failed: number;
+  /** 수료율 (%) */
+  completionRate: number;
+  /** 유형별 통계 */
+  byType: LearningStatsByType[];
+}
+
+/** 학습 진도 통계 */
+export interface LearningStatsProgress {
+  /** 평균 진도율 (%) */
+  averageProgress: number;
+  /** 평균 점수 */
+  averageScore: number;
+}
+
+/** 내 학습 통계 응답 */
+export interface LearningStatsResponse {
+  overview: LearningStatsOverview;
+  progress: LearningStatsProgress;
+}

--- a/src/types/tu/ownerStats.types.ts
+++ b/src/types/tu/ownerStats.types.ts
@@ -1,0 +1,49 @@
+/**
+ * TU 강사(Owner) 통계 타입 정의
+ * GET /api/owners/me/stats
+ */
+
+/** 강사 통계 개요 */
+export interface OwnerStatsOverview {
+  /** 총 프로그램 수 */
+  totalPrograms: number;
+  /** 총 차수 수 */
+  totalCourseTimes: number;
+  /** 총 수강생 수 */
+  totalStudents: number;
+}
+
+/** 수강 신청 통계 */
+export interface OwnerEnrollmentStats {
+  /** 총 수강 신청 수 */
+  totalEnrollments: number;
+  /** 수료 완료 수 */
+  completed: number;
+  /** 진행 중 수 */
+  inProgress: number;
+  /** 중도 포기 수 */
+  dropped: number;
+  /** 평균 수료율 (%) */
+  averageCompletionRate: number;
+}
+
+/** 프로그램별 통계 */
+export interface OwnerProgramStats {
+  /** 프로그램 ID */
+  programId: number;
+  /** 프로그램명 */
+  programName: string;
+  /** 차수 수 */
+  courseTimeCount: number;
+  /** 총 수강생 */
+  totalStudents: number;
+  /** 수료율 (%) */
+  completionRate: number;
+}
+
+/** 강사(Owner) 통계 응답 */
+export interface OwnerStatsResponse {
+  overview: OwnerStatsOverview;
+  enrollmentStats: OwnerEnrollmentStats;
+  programStats: OwnerProgramStats[];
+}

--- a/src/types/tu/ownerStats.types.ts
+++ b/src/types/tu/ownerStats.types.ts
@@ -23,6 +23,8 @@ export interface OwnerEnrollmentStats {
   inProgress: number;
   /** 중도 포기 수 */
   dropped: number;
+  /** 미수료 (기간 만료) 수 */
+  failed: number;
   /** 평균 수료율 (%) */
   averageCompletionRate: number;
 }


### PR DESCRIPTION
## Summary

TU 마이페이지 학습/강사 통계 API 연동 및 강사 통계 페이지 UI 개선

## Related Issue

- Closes #222
- Closes #223

## Changes

- 내 학습 통계 API 연동 (GET /api/users/me/learning-stats)
- 강사(Owner) 통계 API 연동 (GET /api/owners/me/stats)
- MyPageHome 통계를 API 호출로 변경
- TeachingStatsPage UI 전면 개선
  - Stacked Bar 수강 현황 시각화 (다크모드 Pastel Neon 그라데이션)
  - 왼쪽→오른쪽 엔트리 애니메이션 적용
  - 프로그램별 통계 클릭 시 상세 페이지 네비게이션
- 수강 상태에 failed(미수료) 필드 추가
- 수강/학습 진행 시 통계 캐시 자동 갱신 연동

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)
<img width="1728" height="955" alt="image" src="https://github.com/user-attachments/assets/d16b62b3-b69b-47c5-ac21-75a16cd57f6b" />


## Additional Notes

- React Query 캐시 무효화를 통해 수강 신청/취소/학습 완료 시 통계가 실시간 갱신됩니다
- 다크모드에서 Pastel Neon 그라데이션 적용으로 시각적 구분 강화