### PR TITLE
fix: 강의 수정 페이지 커리큘럼 로드 버그 수정 및 텍스트 통일

### DIFF
--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -231,7 +231,7 @@ export const tenantUserMenuData: MenuItem[] = [
     label: { ko: '내 강의', en: 'My Teaching' },
     icon: Briefcase,
     subItems: [
-      { id: 'my-courses', label: { ko: '내 강의계획', en: 'My Course Plans' }, icon: BookOpen, path: '/tu/teaching/courses' },
+      { id: 'my-courses', label: { ko: '내 강의 계획', en: 'My Course Plans' }, icon: BookOpen, path: '/tu/teaching/courses' },
       { id: 'my-programs', label: { ko: '내 프로그램', en: 'My Programs' }, icon: Package, path: '/tu/teaching/programs' },
       { id: 'my-content', label: { ko: '내 콘텐츠', en: 'My Content' }, icon: PenTool, path: '/tu/teaching/content' },
       { id: 'my-assignments', label: { ko: '내 과제', en: 'My Assignments' }, icon: CheckSquare, path: '/tu/teaching/assignments' },

--- a/src/pages/tu/teaching/courses/CourseEditPage.tsx
+++ b/src/pages/tu/teaching/courses/CourseEditPage.tsx
@@ -11,9 +11,10 @@ import { ArrowLeft, ArrowRight, Save, Upload, Loader2 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button } from '@/components/common';
 import { categoryService } from '@/services/common';
-import { useCourse, useUpdateCourse } from '@/hooks/tu/useCourseQueries';
+import { useCourse, useCourseItemsHierarchy, useUpdateCourse } from '@/hooks/tu/useCourseQueries';
 import type { CourseFormData } from '@/types';
 import type { CategoryResponse, UpdateCourseRequest } from '@/types/common';
+import { convertHierarchyToCurriculumItems } from '@/types/tu/curriculum.types';
 import { Step1BasicInfo, Step3Review, translations } from './components';
 import { Step2CurriculumTree } from './components/Step2CurriculumTree';
 import type { TranslationKey } from './components';
@@ -28,6 +29,7 @@ export function CourseEditPage({ language = 'ko' }: Readonly<CourseEditPageProps
   const courseIdNum = Number(courseId);
 
   const { data: courseData, isLoading, isError } = useCourse(courseIdNum);
+  const { data: hierarchyData } = useCourseItemsHierarchy(courseIdNum);
   const updateCourseMutation = useUpdateCourse();
 
   const [currentStep, setCurrentStep] = useState(1);
@@ -71,7 +73,7 @@ export function CourseEditPage({ language = 'ko' }: Readonly<CourseEditPageProps
 
   // 기존 강의 데이터 로드
   useEffect(() => {
-    if (courseData && !isInitialized) {
+    if (courseData && hierarchyData && !isInitialized) {
       setFormData({
         title: courseData.title,
         description: courseData.description || '',
@@ -83,7 +85,7 @@ export function CourseEditPage({ language = 'ko' }: Readonly<CourseEditPageProps
         level: courseData.level || '',
         type: courseData.type || '',
         lessons: [], // deprecated
-        curriculumItems: [], // TODO: items를 curriculumItems로 변환하는 로직 필요
+        curriculumItems: convertHierarchyToCurriculumItems(hierarchyData),
         isDraft: false,
         multiLanguage: {
           enabled: false,
@@ -92,7 +94,7 @@ export function CourseEditPage({ language = 'ko' }: Readonly<CourseEditPageProps
       });
       setIsInitialized(true);
     }
-  }, [courseData, isInitialized]);
+  }, [courseData, hierarchyData, isInitialized]);
 
   // 네비게이션 핸들러
   const handleNext = () => currentStep < totalSteps && setCurrentStep(currentStep + 1);

--- a/src/pages/tu/teaching/courses/MyCoursesPage.tsx
+++ b/src/pages/tu/teaching/courses/MyCoursesPage.tsx
@@ -32,7 +32,7 @@ function mapCourseResponseToCourse(response: CourseResponse): Course {
 }
 
 const t = {
-  title: { ko: '내 강의', en: 'My Courses' },
+  title: { ko: '내 강의 계획', en: 'My Course Plans' },
   subtitle: { ko: '개설한 강의를 관리하고 수강생을 확인하세요', en: 'Manage your courses and track student progress' },
   createCourse: { ko: '강의 생성', en: 'Create Course' },
   all: { ko: '전체', en: 'All' },

--- a/src/types/tu/curriculum.types.ts
+++ b/src/types/tu/curriculum.types.ts
@@ -6,6 +6,8 @@
  * - 콘텐츠: learningObjectId가 있는 CourseItem
  */
 
+import type { CourseItemHierarchyResponse } from '@/types/common/course.types';
+
 // ============================================
 // Curriculum Tree Types (계층구조 지원)
 // ============================================
@@ -147,4 +149,41 @@ export function findParentInTree(
     }
   }
   return null;
+}
+
+// ============================================
+// Conversion Functions (백엔드 ↔ 프론트엔드)
+// ============================================
+
+/** 백엔드 계층 응답을 프론트엔드 CurriculumItem으로 변환 */
+export function convertHierarchyToCurriculumItems(
+  items: CourseItemHierarchyResponse[],
+  depth: number = 0
+): CurriculumItem[] {
+  return items.map((item, index): CurriculumItem => {
+    if (item.isFolder) {
+      return {
+        id: `folder-${item.itemId}`,
+        name: item.itemName,
+        type: 'folder',
+        depth,
+        order: index,
+        isExpanded: true,
+        children: convertHierarchyToCurriculumItems(item.children, depth + 1),
+      };
+    } else {
+      return {
+        id: `content-${item.itemId}`,
+        name: item.itemName,
+        type: 'content',
+        depth,
+        order: index,
+        contentId: item.learningObjectId!,
+        originalFileName: item.itemName,
+        contentType: '',
+        displayName: item.displayName ?? undefined,
+        description: item.description ?? undefined,
+      };
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- 강의 수정 페이지에서 커리큘럼이 제대로 로드되지 않는 버그 수정
- '내 강의 계획' 텍스트 통일 (사이드바, 페이지 타이틀)

## Changes
- `CourseEditPage.tsx`: 커리큘럼 로드 로직 수정
- `curriculum.types.ts`: 커리큘럼 관련 타입 추가
- `sidebar-menus.ts`: '내 강의계획' → '내 강의 계획'
- `MyCoursesPage.tsx`: '내 강의' → '내 강의 계획'

## Test Plan
- [ ] 강의 수정 페이지에서 커리큘럼이 정상 로드되는지 확인
- [ ] 사이드바 메뉴 텍스트 확인
- [ ] 내 강의 계획 페이지 타이틀 확인

Closes #200