### PR TITLE
feat(mypage): CourseRole API 연동으로 역할 Badge 표시 (#248)

### DIFF
--- a/src/pages/tu/mypage/MyPageHome.tsx
+++ b/src/pages/tu/mypage/MyPageHome.tsx
@@ -20,6 +20,7 @@ import { toast } from 'sonner';
 import { useAuth } from '@/hooks/common/auth';
 import { useMyProfile, useUploadProfileImage } from '@/hooks/common';
 import { useMyEnrollments, useMyLearningStats } from '@/hooks/tu';
+import { userService } from '@/services/common/userService';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation, useLanguageStore } from '@/store/common/languageStore';
 import { Button, Card, CardContent, Badge } from '@/components/common';
@@ -80,6 +81,8 @@ export function MyPageHome() {
   const isDark = theme === 'dark';
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [profileImagePreview, setProfileImagePreview] = useState<string | null>(null);
+  // USER: 일반 회원, CAN_CREATE: 강의 개설 가능, DESIGNER: 강의 설계자, OWNER: 강의 소유자
+  const [courseRoleStatus, setCourseRoleStatus] = useState<'USER' | 'CAN_CREATE' | 'DESIGNER' | 'OWNER'>('USER');
 
   // 프로필 이미지 URL 생성
   const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api').replace('/api', '');
@@ -93,6 +96,40 @@ export function MyPageHome() {
       setProfileImagePreview(imageUrl);
     }
   }, [profile, apiBaseUrl]);
+
+  // Fetch course roles on mount
+  useEffect(() => {
+    const fetchCourseRoles = async () => {
+      try {
+        const roles = await userService.getMyCourseRoles();
+        console.log('MyPageHome - CourseRoles API response:', roles);
+
+        if (Array.isArray(roles) && roles.length > 0) {
+          // OWNER가 있으면 → 강의 소유자 (승인된 강의 있음)
+          const hasOwner = roles.some((r: { role: string }) => r.role === 'OWNER');
+          // DESIGNER 중 programId가 있는 것 → 강의 설계자 (생성했지만 미승인)
+          const hasDesignerWithProgram = roles.some(
+            (r: { role: string; programId?: number | null }) => r.role === 'DESIGNER' && r.programId != null
+          );
+          // DESIGNER 중 programId가 없는 것 → 강의 개설 가능 (권한만 있음)
+          const hasDesignerOnly = roles.some(
+            (r: { role: string; programId?: number | null }) => r.role === 'DESIGNER' && r.programId == null
+          );
+
+          if (hasOwner) {
+            setCourseRoleStatus('OWNER');
+          } else if (hasDesignerWithProgram) {
+            setCourseRoleStatus('DESIGNER');
+          } else if (hasDesignerOnly) {
+            setCourseRoleStatus('CAN_CREATE');
+          }
+        }
+      } catch (error) {
+        console.error('Failed to fetch course roles:', error);
+      }
+    };
+    fetchCourseRoles();
+  }, []);
 
   // 상태 라벨 (다국어)
   const statusLabels: Record<EnrollmentStatus, string> = {
@@ -209,8 +246,21 @@ export function MyPageHome() {
                 <p className={`text-sm mb-3 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
                   {user?.email}
                 </p>
-                <Badge variant="blue" className="text-xs">
-                  {user?.role === 'USER' ? t.mypage.generalMember : user?.role}
+                <Badge
+                  variant={
+                    courseRoleStatus === 'USER' ? 'gray' :
+                    courseRoleStatus === 'CAN_CREATE' ? 'blue' :
+                    courseRoleStatus === 'DESIGNER' ? 'indigo' : 'orange'
+                  }
+                  className="text-xs"
+                >
+                  {courseRoleStatus === 'USER'
+                    ? t.mypage.generalMember
+                    : courseRoleStatus === 'CAN_CREATE'
+                      ? (language === 'ko' ? '강의 개설 가능' : 'Can Create Course')
+                      : courseRoleStatus === 'DESIGNER'
+                        ? (language === 'ko' ? '강의 설계자' : 'Course Designer')
+                        : (language === 'ko' ? '강의 소유자' : 'Course Owner')}
                 </Badge>
               </div>
 

--- a/src/pages/tu/mypage/ProfilePage.tsx
+++ b/src/pages/tu/mypage/ProfilePage.tsx
@@ -31,6 +31,7 @@ import {
   useUploadProfileImage,
   useWithdraw,
 } from '@/hooks/common';
+import { userService } from '@/services/common/userService';
 
 export function ProfilePage() {
   const { theme } = useThemeStore();
@@ -73,6 +74,31 @@ export function ProfilePage() {
       }
     }
   }, [profile, apiBaseUrl]);
+
+  // Fetch course roles on mount
+  useEffect(() => {
+    const fetchCourseRoles = async () => {
+      try {
+        const roles = await userService.getMyCourseRoles();
+        console.log('CourseRoles API response:', roles);
+
+        if (Array.isArray(roles) && roles.length > 0) {
+          // OWNER > DESIGNER 우선순위로 체크
+          const hasOwner = roles.some((r: { role: string }) => r.role === 'OWNER');
+          const hasDesigner = roles.some((r: { role: string }) => r.role === 'DESIGNER');
+
+          if (hasOwner) {
+            setDesignAuthStatus('OWNER');
+          } else if (hasDesigner) {
+            setDesignAuthStatus('DESIGNER');
+          }
+        }
+      } catch (error) {
+        console.error('Failed to fetch course roles:', error);
+      }
+    };
+    fetchCourseRoles();
+  }, []);
 
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -143,13 +169,25 @@ export function ProfilePage() {
     }
   };
 
-  const handleRequestDesignAuth = () => {
+  const handleRequestDesignAuth = async () => {
     setIsRequestPending(true);
-    setTimeout(() => {
+    try {
+      await userService.applyDesignerRole();
       setDesignAuthStatus('DESIGNER');
+      toast.success('강의 개설 권한이 부여되었습니다.');
+    } catch (error) {
+      const axiosError = error as { response?: { status?: number } };
+      if (axiosError.response?.status === 409) {
+        // 이미 권한이 있음
+        setDesignAuthStatus('DESIGNER');
+        toast.info('이미 강의 개설 권한이 있습니다.');
+      } else {
+        console.error('Failed to apply designer role:', error);
+        toast.error('권한 신청에 실패했습니다.');
+      }
+    } finally {
       setIsRequestPending(false);
-      toast.success('권한이 승인되었습니다.');
-    }, 1500);
+    }
   };
 
   const handleWithdraw = async () => {


### PR DESCRIPTION
## Summary

마이페이지에서 사용자의 과정 역할(CourseRole)을 API를 통해 조회하여 Badge로 표시하는 기능 구현

## Related Issue

- Closes #248

## Changes

- MyPageHome.tsx: CourseRole API 호출 및 역할 Badge 표시 로직 추가
- ProfilePage.tsx: CourseRole API 호출 및 권한 신청 버튼 실제 API 연동
- 역할별 Badge 표시:
  - 일반 회원 (gray): 역할 없음
  - 강의 개설 가능 (blue): DESIGNER 역할, programId 없음
  - 강의 설계자 (indigo): DESIGNER 역할, programId 있음
  - 강의 소유자 (orange): OWNER 역할

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

| 역할 | Badge |
|------|-------|
| 일반 회원 | `일반 회원` (gray) |
| 강의 개설 가능 | `강의 개설 가능` (blue) |
| 강의 설계자 | `강의 설계자` (indigo) |
| 강의 소유자 | `강의 소유자` (orange) |

## Additional Notes

- `/api/users/me/course-roles` API 응답 기반으로 역할 판단
- 다국어 지원 (한국어/영어)