### PR TITLE
fix(mypage): MyTeachingPage CourseRole 기반 권한 체크로 변경 (#251)

### DIFF
--- a/src/pages/tu/mypage/MyTeachingPage.tsx
+++ b/src/pages/tu/mypage/MyTeachingPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import {
@@ -67,16 +67,38 @@ export function MyTeachingPage() {
 
   const [showRoleDialog, setShowRoleDialog] = useState(false);
   const [isGrantingRole, setIsGrantingRole] = useState(false);
+  const [hasDesignerRole, setHasDesignerRole] = useState(false);
+  const [isCheckingRole, setIsCheckingRole] = useState(true);
 
-  // 사용자가 DESIGNER 역할을 가지고 있는지 확인
-  const isDesigner = user?.role === 'DESIGNER' || user?.role === 'OPERATOR' || user?.role === 'TENANT_ADMIN';
+  // CourseRole API로 DESIGNER 역할 확인
+  useEffect(() => {
+    const checkDesignerRole = async () => {
+      try {
+        const roles = await userService.getMyCourseRoles();
+        if (Array.isArray(roles) && roles.length > 0) {
+          const hasDesigner = roles.some((r: { role: string }) => r.role === 'DESIGNER' || r.role === 'OWNER');
+          setHasDesignerRole(hasDesigner);
+        }
+      } catch (error) {
+        console.error('Failed to fetch course roles:', error);
+      } finally {
+        setIsCheckingRole(false);
+      }
+    };
+    checkDesignerRole();
+  }, []);
+
+  // 사용자가 DESIGNER 역할을 가지고 있는지 확인 (시스템 역할 또는 CourseRole)
+  const isDesigner = user?.role === 'OPERATOR' || user?.role === 'TENANT_ADMIN' || hasDesignerRole;
 
   // 내 강의 목록 조회
-  const { data: coursesData, isLoading } = useQuery({
+  const { data: coursesData, isLoading: isLoadingCourses } = useQuery({
     queryKey: ['myCourses'],
     queryFn: () => courseService.getMyCourses(),
-    enabled: isDesigner,
+    enabled: !isCheckingRole && isDesigner,
   });
+
+  const isLoading = isCheckingRole || isLoadingCourses;
   const courses = coursesData?.content || [];
 
   const handleCreateCourse = () => {


### PR DESCRIPTION
## Summary

MyTeachingPage에서 내 강의 목록이 표시되지 않는 버그 수정. user.role 대신 CourseRole API를 사용하여 DESIGNER 권한 확인.

## Related Issue

- Closes #251

## Changes

- MyTeachingPage.tsx: CourseRole API 호출로 DESIGNER/OWNER 역할 확인
- user.role (시스템 역할) 대신 user_course_roles 테이블 기반 권한 체크
- isCheckingRole 상태 추가로 API 호출 순서 제어

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 기존: `user?.role === 'DESIGNER'` → DESIGNER는 시스템 역할이 아니라 CourseRole
- 변경: `/api/users/me/course-roles` API로 DESIGNER/OWNER 역할 확인 후 강의 목록 조회