### PR TITLE
feat(course): 강의 계획 임시저장 기능 및 목록 필터 개선

### DIFF
--- a/src/pages/tu/teaching/courses/CourseCreatePage.tsx
+++ b/src/pages/tu/teaching/courses/CourseCreatePage.tsx
@@ -8,8 +8,8 @@
  * - Step3Review: 검토 및 저장
  */
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, ArrowRight, Save, FileText, Upload } from 'lucide-react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { ArrowLeft, ArrowRight, Save, FileText, Upload, Loader2 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button } from '@/components/common';
 import { courseService, categoryService } from '@/services/common';
@@ -63,9 +63,17 @@ async function createCurriculumItemsRecursively(
 
 export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageProps>) {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const courseIdParam = searchParams.get('courseId');
+
   const [currentStep, setCurrentStep] = useState(1);
   const [categories, setCategories] = useState<CategoryResponse[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [courseId, setCourseId] = useState<number | null>(
+    courseIdParam ? Number(courseIdParam) : null
+  );
   const [formData, setFormData] = useState<CourseFormData>({
     title: '',
     description: '',
@@ -102,15 +110,88 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
     fetchCategories();
   }, []);
 
+  // 기존 강의 불러오기 (courseId가 있는 경우)
+  useEffect(() => {
+    const loadExistingCourse = async () => {
+      if (!courseId) return;
+
+      setIsLoading(true);
+      try {
+        const course = await courseService.getCourse(courseId);
+        setFormData((prev) => ({
+          ...prev,
+          title: course.title,
+          description: course.description || '',
+          thumbnailUrl: course.thumbnailUrl || undefined,
+          level: course.level || '',
+          type: course.type || '',
+          categoryId: course.categoryId,
+          startDate: course.startDate || '',
+          endDate: course.endDate || '',
+          tags: course.tags || [],
+          isDraft: !course.isComplete,
+          lastSaved: course.updatedAt,
+        }));
+      } catch (error) {
+        console.error('강의 불러오기 실패:', error);
+        alert('강의를 불러오는데 실패했습니다.');
+        navigate('/tu/teaching/courses');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadExistingCourse();
+  }, [courseId, navigate]);
+
   // 네비게이션 핸들러
   const handleNext = () => currentStep < totalSteps && setCurrentStep(currentStep + 1);
   const handlePrevious = () => currentStep > 1 && setCurrentStep(currentStep - 1);
   const handleGoToStep = (step: number) => setCurrentStep(step);
   const handleClose = () => navigate('/tu/teaching/courses');
 
-  const handleSaveDraft = () => {
-    setFormData({ ...formData, isDraft: true, lastSaved: new Date().toISOString() });
-    alert('임시저장되었습니다.');
+  const handleSaveDraft = async () => {
+    if (!formData.title) {
+      alert('강의명을 입력해주세요.');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const request: CreateCourseRequest = {
+        title: formData.title,
+        description: formData.description || undefined,
+        thumbnailUrl: formData.thumbnailUrl || undefined,
+        level: formData.level || undefined,
+        type: formData.type || undefined,
+        categoryId: formData.categoryId ?? undefined,
+        startDate: formData.startDate || undefined,
+        endDate: formData.endDate || undefined,
+        tags: formData.tags.length > 0 ? formData.tags : undefined,
+      };
+
+      if (courseId) {
+        // 기존 강의 수정
+        await courseService.update(courseId, request);
+      } else {
+        // 새 강의 생성
+        const response = await courseService.create(request);
+        setCourseId(response.courseId);
+        // URL 업데이트 (뒤로가기 시에도 courseId 유지)
+        navigate(`/tu/teaching/courses/create?courseId=${response.courseId}`, { replace: true });
+      }
+
+      setFormData((prev) => ({
+        ...prev,
+        isDraft: true,
+        lastSaved: new Date().toISOString(),
+      }));
+      alert('저장되었습니다.');
+    } catch (error) {
+      console.error('저장 실패:', error);
+      alert('저장에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const handleSubmit = async () => {
@@ -133,14 +214,22 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
         tags: formData.tags.length > 0 ? formData.tags : undefined,
       };
 
-      // 1. 강의 생성
-      const courseResponse = await courseService.create(request);
-      const courseId = courseResponse.courseId;
+      let targetCourseId = courseId;
 
-      // 2. 커리큘럼 항목 생성 (트리 구조 재귀 처리)
-      if (formData.curriculumItems.length > 0) {
+      if (courseId) {
+        // 기존 강의 수정
+        await courseService.update(courseId, request);
+      } else {
+        // 새 강의 생성
+        const courseResponse = await courseService.create(request);
+        targetCourseId = courseResponse.courseId;
+      }
+
+      // 커리큘럼 항목 생성 (트리 구조 재귀 처리)
+      // 참고: 기존 강의 수정 시에는 이미 저장된 커리큘럼이 있을 수 있음
+      if (targetCourseId && formData.curriculumItems.length > 0) {
         await createCurriculumItemsRecursively(
-          courseId,
+          targetCourseId,
           formData.curriculumItems,
           null
         );
@@ -162,6 +251,18 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
   };
 
   const stepLabels = [getText('step1'), getText('step2'), getText('step3')];
+
+  // 로딩 중일 때
+  if (isLoading) {
+    return (
+      <div className="bg-bg-app min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <Loader2 size={32} className="animate-spin text-text-secondary mx-auto mb-4" />
+          <p className="text-text-secondary">강의 정보를 불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="bg-bg-app min-h-screen">
@@ -266,9 +367,14 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
                 {getText('previous')}
               </Button>
             )}
-            <Button variant="ghost" onClick={handleSaveDraft} className="border border-border">
-              <Save size={18} />
-              {getText('saveDraft')}
+            <Button
+              variant="ghost"
+              onClick={handleSaveDraft}
+              disabled={isSaving}
+              className="border border-border"
+            >
+              {isSaving ? <Loader2 size={18} className="animate-spin" /> : <Save size={18} />}
+              {isSaving ? '저장 중...' : getText('saveDraft')}
             </Button>
           </div>
 

--- a/src/pages/tu/teaching/courses/MyCoursesPage.tsx
+++ b/src/pages/tu/teaching/courses/MyCoursesPage.tsx
@@ -1,12 +1,15 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { BookOpen, Users, TrendingUp, Award, Plus, Filter, Loader2, AlertCircle, Send, CheckSquare, Square } from 'lucide-react';
+import { BookOpen, Users, TrendingUp, Award, Plus, Filter, Loader2, AlertCircle, Send, CheckSquare, Square, Edit, AlertTriangle } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button, IconStatCard } from '@/components/common';
 import { CourseCard } from '@/components/domain/tu/course';
 import { useMyCourses, useApplyProgram, useApplyProgramsBulk, toCourseForApplication } from '@/hooks/tu';
 import type { Course, CourseStatus } from '@/types';
 import type { CourseResponse } from '@/types/common/course.types';
+
+/** 완성 상태 필터 타입 */
+type CompletionFilter = 'all' | 'complete' | 'incomplete';
 
 interface MyCoursesPageProps {
   language?: 'ko' | 'en';
@@ -15,19 +18,20 @@ interface MyCoursesPageProps {
 const DEFAULT_THUMBNAIL = 'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=400&h=250&fit=crop';
 
 /** CourseResponse를 UI용 Course 타입으로 변환 */
-function mapCourseResponseToCourse(response: CourseResponse): Course {
+function mapCourseResponseToCourse(response: CourseResponse): Course & { isComplete: boolean } {
   return {
     id: String(response.courseId),
     title: response.title,
     instructor: '나',
-    progress: 100,
-    totalLessons: 0,
-    completedLessons: 0,
+    progress: response.isComplete ? 100 : 0,
+    totalLessons: response.itemCount,
+    completedLessons: response.itemCount,
     thumbnail: response.thumbnailUrl || DEFAULT_THUMBNAIL,
     category: response.tags?.[0] || '미분류',
     students: 0,
     lastAccessed: new Date(response.updatedAt).toLocaleDateString('ko-KR'),
-    status: 'active' as CourseStatus,
+    status: response.isComplete ? 'active' as CourseStatus : 'draft' as CourseStatus,
+    isComplete: response.isComplete,
   };
 }
 
@@ -36,9 +40,8 @@ const t = {
   subtitle: { ko: '개설한 강의를 관리하고 수강생을 확인하세요', en: 'Manage your courses and track student progress' },
   createCourse: { ko: '강의 생성', en: 'Create Course' },
   all: { ko: '전체', en: 'All' },
-  active: { ko: '진행 중', en: 'Active' },
-  completed: { ko: '완료', en: 'Completed' },
-  draft: { ko: '임시 저장', en: 'Draft' },
+  complete: { ko: '작성완료', en: 'Complete' },
+  incomplete: { ko: '작성중', en: 'In Progress' },
   sortBy: { ko: '정렬', en: 'Sort By' },
   recent: { ko: '최신순', en: 'Recent' },
   studentCount: { ko: '수강생 순', en: 'Students' },
@@ -62,11 +65,13 @@ const t = {
   selected: { ko: '개 선택됨', en: ' selected' },
   selectAll: { ko: '전체 선택', en: 'Select All' },
   deselectAll: { ko: '선택 해제', en: 'Deselect All' },
+  incompleteWarning: { ko: '작성을 완료해야 신청할 수 있습니다', en: 'Complete the course to apply' },
+  continueEditing: { ko: '이어서 작성', en: 'Continue Editing' },
 };
 
 export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>) {
   const navigate = useNavigate();
-  const [filterStatus, setFilterStatus] = useState<'all' | CourseStatus>('all');
+  const [filterStatus, setFilterStatus] = useState<CompletionFilter>('all');
   const [sortBy, setSortBy] = useState<'recent' | 'students' | 'title'>('recent');
   const [selectedCourseIds, setSelectedCourseIds] = useState<Set<string>>(new Set());
 
@@ -188,11 +193,13 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
   const courseResponses = coursesData?.content || [];
 
   // API 응답을 UI용 Course 타입으로 변환
-  const courses: Course[] = courseResponses.map(mapCourseResponseToCourse);
+  const courses = courseResponses.map(mapCourseResponseToCourse);
 
   const filteredCourses = courses.filter((course) => {
     if (filterStatus === 'all') return true;
-    return course.status === filterStatus;
+    if (filterStatus === 'complete') return course.isComplete;
+    if (filterStatus === 'incomplete') return !course.isComplete;
+    return true;
   });
 
   const sortedCourses = [...filteredCourses].sort((a, b) => {
@@ -234,7 +241,7 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
         <div className="flex gap-2 items-center">
           <Filter size={18} className="text-text-secondary" />
           <div className="flex gap-1 bg-bg-secondary p-1 rounded-lg">
-            {(['all', 'active', 'completed', 'draft'] as const).map((status) => (
+            {(['all', 'complete', 'incomplete'] as const).map((status) => (
               <button
                 key={status}
                 onClick={() => setFilterStatus(status)}
@@ -313,6 +320,14 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
 
           return (
             <div key={course.id} className="relative">
+              {/* Status Badge */}
+              {!course.isComplete && (
+                <div className="absolute top-3 left-3 z-10 px-2 py-1 rounded-md bg-status-warning/20 text-status-warning text-xs font-medium flex items-center gap-1">
+                  <AlertTriangle size={12} />
+                  {getText('incomplete')}
+                </div>
+              )}
+
               {/* Checkbox */}
               <button
                 onClick={() => toggleSelect(course.id)}
@@ -329,7 +344,8 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
               {/* Course Card */}
               <div className={cn(
                 'transition-all',
-                isSelected && 'ring-2 ring-btn-primary rounded-xl'
+                isSelected && 'ring-2 ring-btn-primary rounded-xl',
+                !course.isComplete && 'opacity-80'
               )}>
                 <CourseCard
                   course={course}
@@ -343,23 +359,46 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
                 />
               </div>
 
-              {/* Apply Button */}
+              {/* Action Buttons */}
               {courseResponse && (
-                <div className="mt-2">
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    className="w-full border border-border"
-                    onClick={() => handleApplySingle(courseResponse)}
-                    disabled={isApplying}
-                  >
-                    {applyProgramMutation.isPending ? (
-                      <Loader2 size={14} className="animate-spin" />
-                    ) : (
-                      <Send size={14} />
-                    )}
-                    {getText('applyProgram')}
-                  </Button>
+                <div className="mt-2 flex gap-2">
+                  {course.isComplete ? (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="flex-1 border border-border"
+                      onClick={() => handleApplySingle(courseResponse)}
+                      disabled={isApplying}
+                    >
+                      {applyProgramMutation.isPending ? (
+                        <Loader2 size={14} className="animate-spin" />
+                      ) : (
+                        <Send size={14} />
+                      )}
+                      {getText('applyProgram')}
+                    </Button>
+                  ) : (
+                    <>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="flex-1 border border-border"
+                        onClick={() => navigate(`/tu/teaching/courses/create?courseId=${course.id}`)}
+                      >
+                        <Edit size={14} />
+                        {getText('continueEditing')}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="border border-border opacity-50 cursor-not-allowed"
+                        disabled
+                        title={getText('incompleteWarning')}
+                      >
+                        <Send size={14} />
+                      </Button>
+                    </>
+                  )}
                 </div>
               )}
             </div>

--- a/src/types/common/course.types.ts
+++ b/src/types/common/course.types.ts
@@ -32,6 +32,10 @@ export interface CourseResponse {
   tags: string[];
   createdAt: string;
   updatedAt: string;
+  /** 완성 여부 (title, description, categoryId, items 1개 이상) */
+  isComplete: boolean;
+  /** 커리큘럼 아이템 개수 */
+  itemCount: number;
 }
 
 /** 강의 아이템 응답 (CourseDetailResponse에서 사용) */
@@ -75,6 +79,8 @@ export interface CourseDetailResponse {
   tags: string[];
   items: CourseItemResponse[];
   itemCount: number;
+  /** 완성 여부 (title, description, categoryId, items 1개 이상) */
+  isComplete: boolean;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- 강의 계획 작성 시 임시저장 기능을 서버 연동 방식으로 개선
- 목록 페이지에서 작성완료/작성중 상태 구분 및 필터링

## 주요 변경 사항

### CourseCreatePage
- 임시저장 버튼 클릭 시 서버 API 호출 (기존: 로컬 state만)
- `?courseId=xxx` 파라미터로 기존 강의 불러오기 지원
- 저장 중 로딩 상태 표시

### MyCoursesPage
- 필터 변경: `전체 | 진행중 | 완료 | 임시저장` → `전체 | 작성완료 | 작성중`
- 작성중 강의에 경고 배지 표시
- 작성중 강의: 프로그램 신청 버튼 비활성화, "이어서 작성" 버튼 추가

### Types (course.types.ts)
- `CourseResponse`에 `isComplete`, `itemCount` 필드 추가
- `CourseDetailResponse`에 `isComplete` 필드 추가

## 의존성
- **백엔드 PR 필요**: mzcATU/mzc-lp-backend#280 (CourseResponse에 isComplete 필드)

## Test plan
- [ ] 새 강의 생성 후 임시저장 → 서버에 저장 확인
- [ ] 목록에서 작성중 강의 클릭 → "이어서 작성" → 기존 데이터 불러오기 확인
- [ ] 작성완료/작성중 필터 동작 확인
- [ ] 작성중 강의 프로그램 신청 버튼 비활성화 확인

Closes #253