### PR TITLE
[Feat] TU 로드맵 페이지 추가

### DIFF
--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -45,6 +45,7 @@ import {
   Briefcase,
   MessageSquare,
   Package,
+  Map,
 } from 'lucide-react';
 import type { MenuItem } from '@/types';
 
@@ -235,6 +236,7 @@ export const tenantUserMenuData: MenuItem[] = [
       { id: 'my-programs', label: { ko: '내 프로그램', en: 'My Programs' }, icon: Package, path: '/tu/teaching/programs' },
       { id: 'my-content', label: { ko: '내 콘텐츠', en: 'My Content' }, icon: PenTool, path: '/tu/teaching/content' },
       { id: 'my-assignments', label: { ko: '내 과제', en: 'My Assignments' }, icon: CheckSquare, path: '/tu/teaching/assignments' },
+      { id: 'my-roadmaps', label: { ko: '로드맵', en: 'Roadmaps' }, icon: Map, path: '/tu/teaching/roadmaps', roles: ['DESIGNER', 'OPERATOR', 'TENANT_ADMIN'] },
     ],
   },
   {

--- a/src/pages/tu/index.ts
+++ b/src/pages/tu/index.ts
@@ -11,6 +11,8 @@ export {
   MyProgramsPage,
   TuProgramDetailPage,
   TuProgramEditPage,
+  RoadmapListPage,
+  RoadmapCreatePage,
 } from './teaching';
 export { SettingsLanguagePage } from './settings';
 export { LandingPage, CoursesExplorePage, RoadmapExplorePage, RoadmapDetailPage, CommunityPage, CommunityDetailPage, CartPage, WishlistPage, NotificationsPage, NotificationDetailPage, CourseDetailPage, InstructorProfilePage } from './main';

--- a/src/pages/tu/teaching/index.ts
+++ b/src/pages/tu/teaching/index.ts
@@ -6,3 +6,4 @@ export {
   ProgramDetailPage as TuProgramDetailPage,
   ProgramEditPage as TuProgramEditPage,
 } from './programs';
+export { RoadmapListPage, RoadmapCreatePage } from './roadmaps';

--- a/src/pages/tu/teaching/roadmaps/RoadmapCreatePage.tsx
+++ b/src/pages/tu/teaching/roadmaps/RoadmapCreatePage.tsx
@@ -1,0 +1,209 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, Plus, GripVertical, X, Search } from 'lucide-react';
+import { Button, Card, CardContent, CardHeader, CardTitle, Input, Textarea, Badge } from '@/components/common';
+
+interface CourseItem {
+  id: string;
+  title: string;
+  category: string;
+  duration: string;
+}
+
+const AVAILABLE_COURSES: CourseItem[] = [
+  { id: '1', title: 'HTML/CSS 기초', category: '프론트엔드', duration: '4시간' },
+  { id: '2', title: 'JavaScript 기초', category: '프론트엔드', duration: '8시간' },
+  { id: '3', title: 'React 입문', category: '프론트엔드', duration: '10시간' },
+  { id: '4', title: 'React 심화', category: '프론트엔드', duration: '12시간' },
+  { id: '5', title: 'TypeScript 기초', category: '프론트엔드', duration: '6시간' },
+  { id: '6', title: 'Node.js 기초', category: '백엔드', duration: '8시간' },
+  { id: '7', title: 'Express.js 실전', category: '백엔드', duration: '10시간' },
+  { id: '8', title: 'MongoDB 기초', category: '데이터베이스', duration: '6시간' },
+];
+
+const t = {
+  createRoadmap: { ko: '로드맵 생성', en: 'Create Roadmap' },
+  editRoadmap: { ko: '로드맵 수정', en: 'Edit Roadmap' },
+  back: { ko: '뒤로', en: 'Back' },
+  basicInfo: { ko: '기본 정보', en: 'Basic Information' },
+  title: { ko: '로드맵 제목', en: 'Roadmap Title' },
+  titlePlaceholder: { ko: '예: 프론트엔드 개발자 로드맵', en: 'e.g., Frontend Developer Roadmap' },
+  description: { ko: '설명', en: 'Description' },
+  descriptionPlaceholder: { ko: '로드맵에 대한 설명을 입력하세요', en: 'Enter a description for this roadmap' },
+  courseList: { ko: '강의 구성', en: 'Course List' },
+  courseListDesc: { ko: '학습 순서대로 강의를 추가하세요. 드래그하여 순서를 변경할 수 있습니다.', en: 'Add courses in learning order. Drag to reorder.' },
+  addCourse: { ko: '강의 추가', en: 'Add Course' },
+  searchCourse: { ko: '강의 검색', en: 'Search courses' },
+  noCourses: { ko: '추가된 강의가 없습니다', en: 'No courses added' },
+  noCoursesDesc: { ko: '아래에서 강의를 검색하여 추가하세요', en: 'Search and add courses below' },
+  availableCourses: { ko: '추가 가능한 강의', en: 'Available Courses' },
+  save: { ko: '저장', en: 'Save' },
+  saveDraft: { ko: '임시 저장', en: 'Save as Draft' },
+  publish: { ko: '공개', en: 'Publish' },
+  cancel: { ko: '취소', en: 'Cancel' },
+  step: { ko: '단계', en: 'Step' },
+};
+
+export function RoadmapCreatePage({ language = 'ko' }: Readonly<{ language?: 'ko' | 'en' }>) {
+  const navigate = useNavigate();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [selectedCourses, setSelectedCourses] = useState<CourseItem[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+
+  const filteredCourses = AVAILABLE_COURSES.filter(
+    (course) =>
+      !selectedCourses.find((c) => c.id === course.id) &&
+      (course.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        course.category.toLowerCase().includes(searchQuery.toLowerCase()))
+  );
+
+  const addCourse = (course: CourseItem) => {
+    setSelectedCourses([...selectedCourses, course]);
+  };
+
+  const removeCourse = (courseId: string) => {
+    setSelectedCourses(selectedCourses.filter((c) => c.id !== courseId));
+  };
+
+  const handleSave = (isDraft: boolean) => {
+    // TODO: API 호출
+    console.log({ title, description, courses: selectedCourses, isDraft });
+    navigate('/tu/teaching/roadmaps');
+  };
+
+  return (
+    <div className="p-8 bg-bg-default min-h-screen">
+      {/* Header */}
+      <div className="mb-8">
+        <Button variant="ghost" onClick={() => navigate('/tu/teaching/roadmaps')} className="mb-4">
+          <ArrowLeft size={20} />
+          <span>{getText('back')}</span>
+        </Button>
+        <h1 className="text-text-primary mb-2">{getText('createRoadmap')}</h1>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Left Column - Basic Info & Course List */}
+        <div className="flex flex-col gap-6">
+          {/* Basic Info */}
+          <Card>
+            <CardHeader>
+              <CardTitle>{getText('basicInfo')}</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-4">
+              <div>
+                <label className="block text-sm font-medium text-text-primary mb-2">
+                  {getText('title')} <span className="text-status-error">*</span>
+                </label>
+                <Input
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder={getText('titlePlaceholder')}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-text-primary mb-2">
+                  {getText('description')}
+                </label>
+                <Textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder={getText('descriptionPlaceholder')}
+                  rows={4}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Selected Courses */}
+          <Card>
+            <CardHeader>
+              <CardTitle>{getText('courseList')}</CardTitle>
+              <p className="text-sm text-text-secondary m-0">{getText('courseListDesc')}</p>
+            </CardHeader>
+            <CardContent>
+              {selectedCourses.length === 0 ? (
+                <div className="text-center py-8 text-text-secondary">
+                  <p className="mb-1">{getText('noCourses')}</p>
+                  <p className="text-sm">{getText('noCoursesDesc')}</p>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-2">
+                  {selectedCourses.map((course, index) => (
+                    <div
+                      key={course.id}
+                      className="flex items-center gap-3 p-3 bg-bg-secondary rounded-lg border border-border"
+                    >
+                      <GripVertical size={18} className="text-text-secondary cursor-grab" />
+                      <Badge variant="outline" className="shrink-0">
+                        {getText('step')} {index + 1}
+                      </Badge>
+                      <div className="flex-1 min-w-0">
+                        <p className="font-medium text-text-primary m-0 truncate">{course.title}</p>
+                        <p className="text-sm text-text-secondary m-0">{course.category} · {course.duration}</p>
+                      </div>
+                      <Button variant="ghost" size="icon" onClick={() => removeCourse(course.id)}>
+                        <X size={18} />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Right Column - Available Courses */}
+        <Card className="h-fit">
+          <CardHeader>
+            <CardTitle>{getText('availableCourses')}</CardTitle>
+            <div className="relative mt-3">
+              <Search size={18} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary" />
+              <Input
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder={getText('searchCourse')}
+                className="pl-10"
+              />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-col gap-2 max-h-[500px] overflow-y-auto">
+              {filteredCourses.map((course) => (
+                <div
+                  key={course.id}
+                  className="flex items-center justify-between p-3 bg-bg-secondary rounded-lg border border-border hover:border-border-hover transition-colors"
+                >
+                  <div>
+                    <p className="font-medium text-text-primary m-0">{course.title}</p>
+                    <p className="text-sm text-text-secondary m-0">{course.category} · {course.duration}</p>
+                  </div>
+                  <Button variant="outline" size="sm" onClick={() => addCourse(course)}>
+                    <Plus size={16} />
+                    {getText('addCourse')}
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Action Buttons */}
+      <div className="flex justify-end gap-3 mt-8">
+        <Button variant="outline" onClick={() => navigate('/tu/teaching/roadmaps')}>
+          {getText('cancel')}
+        </Button>
+        <Button variant="secondary" onClick={() => handleSave(true)}>
+          {getText('saveDraft')}
+        </Button>
+        <Button onClick={() => handleSave(false)} disabled={!title || selectedCourses.length === 0}>
+          {getText('publish')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/teaching/roadmaps/RoadmapListPage.tsx
+++ b/src/pages/tu/teaching/roadmaps/RoadmapListPage.tsx
@@ -1,0 +1,217 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Map, Users, TrendingUp, Plus, Filter, MoreVertical, Edit, Trash2, Copy } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import { Button, IconStatCard, Card, CardContent, Badge } from '@/components/common';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/common/DropdownMenu';
+
+interface Roadmap {
+  id: string;
+  title: string;
+  description: string;
+  courseCount: number;
+  enrolledStudents: number;
+  status: 'published' | 'draft';
+  createdAt: string;
+  updatedAt: string;
+}
+
+const MOCK_ROADMAPS: Roadmap[] = [
+  {
+    id: '1',
+    title: '프론트엔드 개발자 로드맵',
+    description: 'HTML, CSS, JavaScript부터 React까지 프론트엔드 개발의 전체 과정',
+    courseCount: 8,
+    enrolledStudents: 124,
+    status: 'published',
+    createdAt: '2024-01-15',
+    updatedAt: '2024-03-20',
+  },
+  {
+    id: '2',
+    title: '백엔드 개발자 로드맵',
+    description: 'Node.js와 데이터베이스를 활용한 서버 개발 학습 경로',
+    courseCount: 6,
+    enrolledStudents: 89,
+    status: 'published',
+    createdAt: '2024-02-10',
+    updatedAt: '2024-03-18',
+  },
+  {
+    id: '3',
+    title: 'DevOps 엔지니어 로드맵',
+    description: 'CI/CD, Docker, Kubernetes 등 DevOps 핵심 기술 학습',
+    courseCount: 5,
+    enrolledStudents: 0,
+    status: 'draft',
+    createdAt: '2024-03-01',
+    updatedAt: '2024-03-22',
+  },
+];
+
+const t = {
+  title: { ko: '로드맵', en: 'Roadmaps' },
+  subtitle: { ko: '학습 경로를 설계하고 수강생의 성장을 이끌어주세요', en: 'Design learning paths and guide student growth' },
+  createRoadmap: { ko: '로드맵 생성', en: 'Create Roadmap' },
+  all: { ko: '전체', en: 'All' },
+  published: { ko: '공개', en: 'Published' },
+  draft: { ko: '임시 저장', en: 'Draft' },
+  sortBy: { ko: '정렬', en: 'Sort By' },
+  recent: { ko: '최신순', en: 'Recent' },
+  studentCount: { ko: '수강생 순', en: 'Students' },
+  titleSort: { ko: '제목순', en: 'Title' },
+  totalRoadmaps: { ko: '전체 로드맵', en: 'Total Roadmaps' },
+  totalStudents: { ko: '총 수강생', en: 'Total Students' },
+  avgCourses: { ko: '평균 강의 수', en: 'Avg. Courses' },
+  courses: { ko: '개 강의', en: ' courses' },
+  students: { ko: '명 수강 중', en: ' students' },
+  edit: { ko: '수정', en: 'Edit' },
+  duplicate: { ko: '복제', en: 'Duplicate' },
+  delete: { ko: '삭제', en: 'Delete' },
+  noRoadmaps: { ko: '생성된 로드맵이 없습니다', en: 'No roadmaps created yet' },
+  noRoadmapsDesc: { ko: '새로운 로드맵을 만들어 학습 경로를 설계하세요', en: 'Create a new roadmap to design learning paths' },
+};
+
+export function RoadmapListPage({ language = 'ko' }: Readonly<{ language?: 'ko' | 'en' }>) {
+  const navigate = useNavigate();
+  const [filterStatus, setFilterStatus] = useState<'all' | 'published' | 'draft'>('all');
+  const [sortBy, setSortBy] = useState<'recent' | 'students' | 'title'>('recent');
+
+  const filteredRoadmaps = MOCK_ROADMAPS.filter((roadmap) => {
+    if (filterStatus === 'all') return true;
+    return roadmap.status === filterStatus;
+  });
+
+  const sortedRoadmaps = [...filteredRoadmaps].sort((a, b) => {
+    if (sortBy === 'students') return b.enrolledStudents - a.enrolledStudents;
+    if (sortBy === 'title') return a.title.localeCompare(b.title);
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+  });
+
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+
+  const totalStudents = MOCK_ROADMAPS.reduce((acc, r) => acc + r.enrolledStudents, 0);
+  const avgCourses = Math.round(MOCK_ROADMAPS.reduce((acc, r) => acc + r.courseCount, 0) / MOCK_ROADMAPS.length);
+
+  return (
+    <div className="p-8 bg-bg-default min-h-screen">
+      {/* Header */}
+      <div className="mb-8 flex justify-between items-start">
+        <div>
+          <h1 className="text-text-primary mb-2">{getText('title')}</h1>
+          <p className="text-text-secondary m-0">{getText('subtitle')}</p>
+        </div>
+        <Button onClick={() => navigate('/tu/teaching/roadmaps/create')}>
+          <Plus size={20} />
+          <span>{getText('createRoadmap')}</span>
+        </Button>
+      </div>
+
+      {/* Statistics Summary */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-8">
+        <IconStatCard icon={<Map size={20} />} label={getText('totalRoadmaps')} value={MOCK_ROADMAPS.length} />
+        <IconStatCard icon={<Users size={20} />} label={getText('totalStudents')} value={totalStudents} />
+        <IconStatCard icon={<TrendingUp size={20} className="text-status-success" />} label={getText('avgCourses')} value={avgCourses} />
+      </div>
+
+      {/* Filters and Sort */}
+      <div className="mb-6 flex gap-4 items-center flex-wrap">
+        <div className="flex gap-2 items-center">
+          <Filter size={18} className="text-text-secondary" />
+          <div className="flex gap-1 bg-bg-secondary p-1 rounded-lg">
+            {(['all', 'published', 'draft'] as const).map((status) => (
+              <button
+                key={status}
+                onClick={() => setFilterStatus(status)}
+                className={cn(
+                  'px-4 py-1.5 rounded-md text-sm transition-colors',
+                  filterStatus === status
+                    ? 'bg-btn-neutral text-white font-medium'
+                    : 'bg-transparent text-text-secondary hover:bg-bg-secondary'
+                )}
+              >
+                {getText(status)}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex gap-2 items-center ml-auto">
+          <span className="text-sm text-text-secondary">{getText('sortBy')}:</span>
+          <select
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value as 'recent' | 'students' | 'title')}
+            className="px-3 py-2 bg-bg-secondary text-text-primary border border-border rounded-md text-sm cursor-pointer"
+          >
+            <option value="recent">{getText('recent')}</option>
+            <option value="students">{getText('studentCount')}</option>
+            <option value="title">{getText('titleSort')}</option>
+          </select>
+        </div>
+      </div>
+
+      {/* Roadmap List */}
+      <div className="flex flex-col gap-4">
+        {sortedRoadmaps.map((roadmap) => (
+          <Card key={roadmap.id} className="hover:shadow-md transition-shadow cursor-pointer" onClick={() => navigate(`/tu/teaching/roadmaps/${roadmap.id}`)}>
+            <CardContent className="p-5">
+              <div className="flex justify-between items-start">
+                <div className="flex-1">
+                  <div className="flex items-center gap-3 mb-2">
+                    <h3 className="text-lg font-semibold text-text-primary m-0">{roadmap.title}</h3>
+                    <Badge variant={roadmap.status === 'published' ? 'default' : 'secondary'}>
+                      {getText(roadmap.status)}
+                    </Badge>
+                  </div>
+                  <p className="text-text-secondary text-sm mb-3 m-0">{roadmap.description}</p>
+                  <div className="flex gap-4 text-sm text-text-secondary">
+                    <span>{roadmap.courseCount}{getText('courses')}</span>
+                    <span>{roadmap.enrolledStudents}{getText('students')}</span>
+                  </div>
+                </div>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon" onClick={(e) => e.stopPropagation()}>
+                      <MoreVertical size={18} />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={(e) => { e.stopPropagation(); navigate(`/tu/teaching/roadmaps/${roadmap.id}/edit`); }}>
+                      <Edit size={16} className="mr-2" />
+                      {getText('edit')}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={(e) => e.stopPropagation()}>
+                      <Copy size={16} className="mr-2" />
+                      {getText('duplicate')}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={(e) => e.stopPropagation()} className="text-status-error">
+                      <Trash2 size={16} className="mr-2" />
+                      {getText('delete')}
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Empty State */}
+      {sortedRoadmaps.length === 0 && (
+        <div className="text-center py-20 px-5 bg-bg-secondary rounded-xl border border-border">
+          <Map size={64} className="text-text-secondary mb-4 opacity-30 mx-auto" />
+          <h3 className="text-text-primary mb-2">{getText('noRoadmaps')}</h3>
+          <p className="text-text-secondary mb-6">{getText('noRoadmapsDesc')}</p>
+          <Button onClick={() => navigate('/tu/teaching/roadmaps/create')}>
+            {getText('createRoadmap')}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/tu/teaching/roadmaps/index.ts
+++ b/src/pages/tu/teaching/roadmaps/index.ts
@@ -1,0 +1,2 @@
+export { RoadmapListPage } from './RoadmapListPage';
+export { RoadmapCreatePage } from './RoadmapCreatePage';

--- a/src/routes/tu.teaching.routes.tsx
+++ b/src/routes/tu.teaching.routes.tsx
@@ -14,6 +14,8 @@ import {
   MyProgramsPage,
   TuProgramDetailPage,
   TuProgramEditPage,
+  RoadmapListPage,
+  RoadmapCreatePage,
 } from '@/pages/tu';
 import { DashboardPage, PlaceholderPage } from './pages';
 
@@ -57,6 +59,12 @@ export const tuTeachingRoutes = (
     {/* 내 과제 */}
     <Route path="teaching/assignments" element={<MyAssignmentsPage />} />
     <Route path="teaching/assignments/:id" element={<AssignmentDetailPage />} />
+
+    {/* 로드맵 */}
+    <Route path="teaching/roadmaps" element={<RoadmapListPage />} />
+    <Route path="teaching/roadmaps/create" element={<RoadmapCreatePage />} />
+    <Route path="teaching/roadmaps/:id" element={<PlaceholderPage title="로드맵 상세" />} />
+    <Route path="teaching/roadmaps/:id/edit" element={<RoadmapCreatePage />} />
 
     {/* 교육 과정 탐색 */}
     <Route path="catalog" element={<PlaceholderPage title="과정 둘러보기" />} />


### PR DESCRIPTION
## Summary
- TU(Tenant User)에서 코스 디자인 권한(DESIGNER 이상)을 가진 사용자가 학습 로드맵을 생성/관리할 수 있는 페이지 추가
<img width="1496" height="858" alt="스크린샷 2026-01-05 오후 5 49 48" src="https://github.com/user-attachments/assets/f9f73981-2d25-41d6-82a9-8d9382803481" />
<img width="1503" height="851" alt="스크린샷 2026-01-05 오후 5 49 54" src="https://github.com/user-attachments/assets/f6adcc72-6056-4761-8353-2dccd40f6dcd" />

## Related Issue
- Closes #257

## Changes
- 로드맵 목록 페이지 (RoadmapListPage) 구현
- 로드맵 생성 페이지 (RoadmapCreatePage) 구현
- 라우트 추가 (/tu/teaching/roadmaps)
- 사이드바 메뉴에 로드맵 추가 (DESIGNER 권한 이상)

## Type of Change
- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist
- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)
N/A

## Additional Notes
- Mock 데이터로 구현되어 있으며, 추후 API 연동 필요