### PR TITLE
[Feat] 프로그램 신청 중간 페이지 구현 (#268)

### DIFF
--- a/src/pages/tu/index.ts
+++ b/src/pages/tu/index.ts
@@ -4,6 +4,7 @@ export {
   CourseCreatePage,
   CourseEditPage,
   CourseDetailPage as TeachingCourseDetailPage,
+  CourseApplyPage,
   TuContentCreatePage,
   ContentDetailPage,
   MyAssignmentsPage,

--- a/src/pages/tu/teaching/courses/CourseApplyPage.tsx
+++ b/src/pages/tu/teaching/courses/CourseApplyPage.tsx
@@ -1,0 +1,236 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { ArrowLeft, Send, Loader2, AlertCircle } from 'lucide-react';
+import { Button, Card } from '@/components/common';
+import { useCourse } from '@/hooks/tu';
+import { snapshotService } from '@/services/to/snapshotService';
+import { programService } from '@/services/to/programService';
+import { ProgramBasicInfoForm, type ProgramFormData } from '../programs/components/ProgramBasicInfoForm';
+import type { ProgramLevel, ProgramType } from '@/types/common';
+
+interface CourseApplyPageProps {
+  language?: 'ko' | 'en';
+}
+
+const t = {
+  pageTitle: { ko: '프로그램 신청', en: 'Apply for Program' },
+  pageSubtitle: { ko: '강의를 프로그램으로 신청합니다. 정보를 확인하고 수정할 수 있습니다.', en: 'Apply this course as a program. Review and edit information.' },
+  back: { ko: '취소', en: 'Cancel' },
+  loading: { ko: '강의 정보를 불러오는 중...', en: 'Loading course information...' },
+  error: { ko: '강의를 불러오는데 실패했습니다.', en: 'Failed to load course.' },
+  notFound: { ko: '강의를 찾을 수 없습니다.', en: 'Course not found.' },
+  apply: { ko: '프로그램 신청', en: 'Apply for Program' },
+  applying: { ko: '신청 중...', en: 'Applying...' },
+  applySuccess: { ko: '프로그램 신청이 완료되었습니다. 관리자 검토 후 승인됩니다.', en: 'Program submitted for review. It will be approved after admin review.' },
+  applyFailed: { ko: '프로그램 신청에 실패했습니다.', en: 'Failed to apply for program.' },
+  titleRequired: { ko: '프로그램명을 입력해주세요.', en: 'Please enter a program title.' },
+  confirmApply: {
+    ko: '이 강의를 프로그램으로 신청하시겠습니까?\n신청 후 관리자 검토를 거쳐 승인됩니다.',
+    en: 'Apply this course as a program?\nIt will be reviewed and approved by an administrator.'
+  },
+  courseInfo: { ko: '원본 강의 정보', en: 'Original Course Information' },
+  courseName: { ko: '강의명', en: 'Course Name' },
+};
+
+export function CourseApplyPage({ language = 'ko' }: Readonly<CourseApplyPageProps>) {
+  const { courseId } = useParams<{ courseId: string }>();
+  const navigate = useNavigate();
+  const id = courseId ? parseInt(courseId, 10) : 0;
+
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+
+  // Form state
+  const [formData, setFormData] = useState<ProgramFormData>({
+    title: '',
+    description: '',
+    thumbnailUrl: '',
+    level: '',
+    type: '',
+    estimatedHours: null,
+  });
+  const [isApplying, setIsApplying] = useState(false);
+
+  // API hooks
+  const { data: course, isLoading, error } = useCourse(id);
+
+  // Course 데이터로 폼 초기화 (prefill)
+  useEffect(() => {
+    if (course) {
+      setFormData({
+        title: course.title || '',
+        description: course.description || '',
+        thumbnailUrl: course.thumbnailUrl || '',
+        level: (course.level as ProgramLevel) || '',
+        type: (course.type as ProgramType) || '',
+        estimatedHours: course.estimatedHours || null,
+      });
+    }
+  }, [course]);
+
+  // 폼 데이터 변경 핸들러
+  const handleFormDataChange = (data: Partial<ProgramFormData>) => {
+    setFormData((prev) => ({ ...prev, ...data }));
+  };
+
+  // 프로그램 신청 핸들러 (생성 후 바로 PENDING 상태로 제출)
+  const handleApply = async () => {
+    // 유효성 검사
+    if (!formData.title.trim()) {
+      alert(getText('titleRequired'));
+      return;
+    }
+
+    // 확인
+    if (!window.confirm(getText('confirmApply'))) {
+      return;
+    }
+
+    setIsApplying(true);
+
+    try {
+      // 1. Snapshot 생성
+      const snapshot = await snapshotService.createFromCourse(id, {
+        snapshotName: formData.title.trim(),
+        description: formData.description.trim() || undefined,
+      });
+
+      // 2. Program 생성
+      const program = await programService.createProgram({
+        title: formData.title.trim(),
+        description: formData.description.trim() || undefined,
+        thumbnailUrl: formData.thumbnailUrl.trim() || undefined,
+        level: formData.level || undefined,
+        type: formData.type || undefined,
+        estimatedHours: formData.estimatedHours || undefined,
+        snapshotId: snapshot.snapshotId,
+      });
+
+      // 3. Program 제출 (PENDING 상태로)
+      await programService.submitProgram(program.id);
+
+      alert(getText('applySuccess'));
+      // 프로그램 목록 페이지로 이동
+      navigate('/tu/teaching/programs');
+    } catch (err) {
+      console.error('Apply failed:', err);
+      alert(getText('applyFailed'));
+    } finally {
+      setIsApplying(false);
+    }
+  };
+
+  // 로딩 상태
+  if (isLoading) {
+    return (
+      <div className="h-full flex items-center justify-center bg-bg-app">
+        <Loader2 size={32} className="animate-spin text-text-secondary" />
+        <span className="ml-2 text-text-secondary">{getText('loading')}</span>
+      </div>
+    );
+  }
+
+  // 에러 상태
+  if (error || !course) {
+    return (
+      <div className="h-full flex items-center justify-center bg-bg-app">
+        <div className="text-center">
+          <AlertCircle size={48} className="mx-auto mb-3 text-status-error" />
+          <p className="text-text-secondary">
+            {error ? getText('error') : getText('notFound')}
+          </p>
+          <Button
+            variant="ghost"
+            className="mt-4 border border-border"
+            onClick={() => navigate('/tu/teaching/courses')}
+          >
+            <ArrowLeft size={16} />
+            목록으로
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col bg-bg-app">
+      {/* Header */}
+      <div className="border-b border-border bg-bg-default sticky top-0 z-10">
+        <div className="p-6 px-8">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="border border-border"
+                onClick={() => navigate(`/tu/teaching/courses/${id}`)}
+              >
+                <ArrowLeft size={16} />
+                {getText('back')}
+              </Button>
+              <div>
+                <h1 className="text-text-primary text-xl mb-0">{getText('pageTitle')}</h1>
+                <p className="text-text-secondary text-sm mt-1">{getText('pageSubtitle')}</p>
+              </div>
+            </div>
+
+            {/* Action Button */}
+            <Button onClick={handleApply} disabled={isApplying}>
+              {isApplying ? (
+                <Loader2 size={16} className="animate-spin" />
+              ) : (
+                <Send size={16} />
+              )}
+              {isApplying ? getText('applying') : getText('apply')}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto">
+        <div className="p-6 px-8 max-w-3xl space-y-6">
+          {/* 원본 강의 정보 안내 */}
+          <Card className="bg-bg-subtle border-border">
+            <div className="p-4">
+              <p className="text-sm text-text-secondary mb-2">
+                {getText('courseInfo')}
+              </p>
+              <p className="text-text-primary font-medium">
+                {getText('courseName')}: {course.title}
+              </p>
+              <p className="text-xs text-text-tertiary mt-2">
+                {language === 'ko'
+                  ? '아래 정보는 강의에서 가져온 기본값입니다. 필요에 따라 수정할 수 있습니다.'
+                  : 'The information below is pre-filled from the course. You can modify it as needed.'}
+              </p>
+            </div>
+          </Card>
+
+          {/* 기본 정보 폼 */}
+          <ProgramBasicInfoForm
+            formData={formData}
+            onFormDataChange={handleFormDataChange}
+            language={language}
+          />
+
+          {/* 하단 신청 버튼 (모바일 대응) */}
+          <div className="pt-4 pb-8">
+            <Button
+              onClick={handleApply}
+              disabled={isApplying}
+              className="w-full"
+              size="lg"
+            >
+              {isApplying ? (
+                <Loader2 size={16} className="animate-spin" />
+              ) : (
+                <Send size={16} />
+              )}
+              {isApplying ? getText('applying') : getText('apply')}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/teaching/courses/CourseDetailPage.tsx
+++ b/src/pages/tu/teaching/courses/CourseDetailPage.tsx
@@ -14,8 +14,6 @@ import {
   useCourse,
   useCourseItemsHierarchy,
   useDeleteCourse,
-  useApplyProgram,
-  toCourseForApplication,
 } from '@/hooks/tu';
 import { categoryService } from '@/services/common';
 import { CourseInfoSection } from './components/CourseInfoSection';
@@ -61,7 +59,6 @@ export function CourseDetailPage() {
   const { data: course, isLoading, error } = useCourse(id);
   const { data: curriculum } = useCourseItemsHierarchy(id);
   const deleteCourseMutation = useDeleteCourse();
-  const applyProgramMutation = useApplyProgram();
 
   // 카테고리 목록 조회
   useEffect(() => {
@@ -87,27 +84,6 @@ export function CourseDetailPage() {
     } catch (err) {
       console.error('Delete failed:', err);
       alert('삭제에 실패했습니다.');
-    }
-  };
-
-  // 프로그램 신청 핸들러
-  const handleApplyProgram = async () => {
-    if (!course) return;
-    if (!confirm('이 강의를 프로그램으로 신청하시겠습니까?')) return;
-
-    try {
-      const result = await applyProgramMutation.mutateAsync(
-        toCourseForApplication(course)
-      );
-
-      if (result.success) {
-        alert('프로그램 신청이 완료되었습니다. 관리자 검토 후 승인됩니다.');
-      } else {
-        alert(`신청 실패: ${result.error}`);
-      }
-    } catch (err) {
-      console.error('Apply program failed:', err);
-      alert('프로그램 신청에 실패했습니다.');
     }
   };
 
@@ -183,14 +159,9 @@ export function CourseDetailPage() {
             <div className="flex items-center gap-2">
               <Button
                 size="sm"
-                onClick={handleApplyProgram}
-                disabled={applyProgramMutation.isPending}
+                onClick={() => navigate(`/tu/teaching/courses/${id}/apply`)}
               >
-                {applyProgramMutation.isPending ? (
-                  <Loader2 size={16} className="animate-spin" />
-                ) : (
-                  <Send size={16} />
-                )}
+                <Send size={16} />
                 프로그램 신청
               </Button>
               <Button

--- a/src/pages/tu/teaching/courses/MyCoursesPage.tsx
+++ b/src/pages/tu/teaching/courses/MyCoursesPage.tsx
@@ -4,7 +4,7 @@ import { BookOpen, Users, TrendingUp, Award, Plus, Filter, Loader2, AlertCircle,
 import { cn } from '@/utils/cn';
 import { Button, IconStatCard } from '@/components/common';
 import { CourseCard } from '@/components/domain/tu/course';
-import { useMyCourses, useApplyProgram, useApplyProgramsBulk, toCourseForApplication } from '@/hooks/tu';
+import { useMyCourses, useApplyProgramsBulk, toCourseForApplication } from '@/hooks/tu';
 import type { Course, CourseStatus } from '@/types';
 import type { CourseResponse } from '@/types/common/course.types';
 
@@ -77,7 +77,6 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
 
   // API 연동
   const { data: coursesData, isLoading, error, refetch } = useMyCourses();
-  const applyProgramMutation = useApplyProgram();
   const applyProgramsBulkMutation = useApplyProgramsBulk();
 
   const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
@@ -101,26 +100,6 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
       setSelectedCourseIds(new Set());
     } else {
       setSelectedCourseIds(new Set(courses.map((c) => c.id)));
-    }
-  };
-
-  // 개별 신청
-  const handleApplySingle = async (courseResponse: CourseResponse) => {
-    if (!confirm(`"${courseResponse.title}" 강의를 프로그램으로 신청하시겠습니까?`)) return;
-
-    try {
-      const result = await applyProgramMutation.mutateAsync(
-        toCourseForApplication(courseResponse)
-      );
-
-      if (result.success) {
-        alert('프로그램 신청이 완료되었습니다. 관리자 검토 후 승인됩니다.');
-      } else {
-        alert(`신청 실패: ${result.error}`);
-      }
-    } catch (err) {
-      console.error('Apply program failed:', err);
-      alert('프로그램 신청에 실패했습니다.');
     }
   };
 
@@ -213,7 +192,7 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
     ? Math.round(courses.reduce((acc, c) => acc + c.progress, 0) / courses.length)
     : 0;
 
-  const isApplying = applyProgramMutation.isPending || applyProgramsBulkMutation.isPending;
+  const isApplying = applyProgramsBulkMutation.isPending;
 
   return (
     <div className="p-8 bg-bg-app_default min-h-screen">
@@ -367,14 +346,9 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
                       size="sm"
                       variant="ghost"
                       className="flex-1 border border-border"
-                      onClick={() => handleApplySingle(courseResponse)}
-                      disabled={isApplying}
+                      onClick={() => navigate(`/tu/teaching/courses/${course.id}/apply`)}
                     >
-                      {applyProgramMutation.isPending ? (
-                        <Loader2 size={14} className="animate-spin" />
-                      ) : (
-                        <Send size={14} />
-                      )}
+                      <Send size={14} />
                       {getText('applyProgram')}
                     </Button>
                   ) : (

--- a/src/pages/tu/teaching/courses/index.ts
+++ b/src/pages/tu/teaching/courses/index.ts
@@ -2,3 +2,4 @@ export { MyCoursesPage } from './MyCoursesPage';
 export { CourseCreatePage } from './CourseCreatePage';
 export { CourseEditPage } from './CourseEditPage';
 export { CourseDetailPage } from './CourseDetailPage';
+export { CourseApplyPage } from './CourseApplyPage';

--- a/src/pages/tu/teaching/index.ts
+++ b/src/pages/tu/teaching/index.ts
@@ -1,4 +1,4 @@
-export { MyCoursesPage, CourseCreatePage, CourseEditPage, CourseDetailPage } from './courses';
+export { MyCoursesPage, CourseCreatePage, CourseEditPage, CourseDetailPage, CourseApplyPage } from './courses';
 export { MyContentPage, ContentCreatePage as TuContentCreatePage, ContentDetailPage } from './content';
 export { MyAssignmentsPage, AssignmentDetailPage } from './assignments';
 export {

--- a/src/pages/tu/teaching/programs/MyProgramsPage.tsx
+++ b/src/pages/tu/teaching/programs/MyProgramsPage.tsx
@@ -16,7 +16,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button, Badge, Card } from '@/components/common';
-import { useMyPrograms, useSubmitMyProgram, useDeleteMyProgram } from '@/hooks/tu';
+import { useMyPrograms, useDeleteMyProgram } from '@/hooks/tu';
 import type { ProgramStatus, ProgramResponse } from '@/types/common';
 import {
   PROGRAM_STATUS_LABELS,
@@ -115,21 +115,7 @@ export function MyProgramsPage({ language = 'ko' }: Readonly<MyProgramsPageProps
     refetch,
   } = useMyPrograms(filterStatus === 'all' ? undefined : { status: filterStatus });
 
-  const submitMutation = useSubmitMyProgram();
   const deleteMutation = useDeleteMyProgram();
-
-  // 신청 핸들러
-  const handleSubmit = async (program: ProgramResponse) => {
-    if (!confirm(getText('confirmSubmit'))) return;
-
-    try {
-      await submitMutation.mutateAsync(program.id);
-      alert(getText('submitSuccess'));
-    } catch (err) {
-      console.error('Submit failed:', err);
-      alert('신청에 실패했습니다.');
-    }
-  };
 
   // 삭제 핸들러
   const handleDelete = async (program: ProgramResponse) => {
@@ -178,7 +164,7 @@ export function MyProgramsPage({ language = 'ko' }: Readonly<MyProgramsPageProps
     return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
   });
 
-  const isActionPending = submitMutation.isPending || deleteMutation.isPending;
+  const isActionPending = deleteMutation.isPending;
 
   return (
     <div className="p-8 bg-bg-app_default min-h-screen">
@@ -309,14 +295,9 @@ export function MyProgramsPage({ language = 'ko' }: Readonly<MyProgramsPageProps
                     <Button
                       size="sm"
                       className="flex-1"
-                      onClick={() => handleSubmit(program)}
-                      disabled={isActionPending}
+                      onClick={() => navigate(`/tu/teaching/programs/${program.id}/edit`)}
                     >
-                      {submitMutation.isPending ? (
-                        <Loader2 size={14} className="animate-spin" />
-                      ) : (
-                        <Send size={14} />
-                      )}
+                      <Send size={14} />
                       {getText('submit')}
                     </Button>
                   )}

--- a/src/pages/tu/teaching/programs/ProgramEditPage.tsx
+++ b/src/pages/tu/teaching/programs/ProgramEditPage.tsx
@@ -1,22 +1,22 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Save, Loader2, AlertCircle } from 'lucide-react';
-import { Button } from '@/components/common';
+import { ArrowLeft, Send, Loader2, AlertCircle, Save } from 'lucide-react';
+import { Button, Card, Badge } from '@/components/common';
 import {
   useMyProgram,
-  useSnapshotItems,
   useUpdateMyProgram,
-  useUpdateSnapshot,
+  useSubmitMyProgram,
 } from '@/hooks/tu';
 import type { ProgramStatus } from '@/types/common';
 import { ProgramBasicInfoForm, type ProgramFormData } from './components/ProgramBasicInfoForm';
-import { SnapshotItemTree } from './components/SnapshotItemTree';
 
 interface ProgramEditPageProps {
   language?: 'ko' | 'en';
 }
 
 const t = {
+  pageTitle: { ko: '프로그램 수정', en: 'Edit Program' },
+  pageSubtitle: { ko: '프로그램 정보를 수정하고 검토 신청할 수 있습니다', en: 'Edit program information and submit for review' },
   back: { ko: '취소', en: 'Cancel' },
   loading: { ko: '로딩 중...', en: 'Loading...' },
   error: { ko: '프로그램을 불러오는데 실패했습니다.', en: 'Failed to load program.' },
@@ -25,12 +25,24 @@ const t = {
     ko: '이 프로그램은 수정할 수 없는 상태입니다.',
     en: 'This program cannot be edited.',
   },
-  save: { ko: '저장', en: 'Save' },
+  saveAndSubmit: { ko: '저장 후 신청', en: 'Save & Submit' },
+  submit: { ko: '신청하기', en: 'Submit' },
+  submitting: { ko: '신청 중...', en: 'Submitting...' },
   saving: { ko: '저장 중...', en: 'Saving...' },
+  submitSuccess: { ko: '프로그램이 검토 신청되었습니다.', en: 'Program submitted for review.' },
+  submitFailed: { ko: '신청에 실패했습니다.', en: 'Failed to submit.' },
+  titleRequired: { ko: '프로그램명을 입력해주세요.', en: 'Please enter a program title.' },
+  currentStatus: { ko: '현재 상태', en: 'Current Status' },
+  statusDraft: { ko: '임시저장', en: 'Draft' },
+  statusRejected: { ko: '반려됨', en: 'Rejected' },
+  confirmSubmit: {
+    ko: '프로그램을 검토 신청하시겠습니까?\n신청 후에는 승인 전까지 수정이 불가능합니다.',
+    en: 'Submit this program for review?\nYou cannot edit it until it is approved.'
+  },
+  saveFirst: { ko: '저장', en: 'Save' },
   saveSuccess: { ko: '저장되었습니다.', en: 'Saved successfully.' },
   saveFailed: { ko: '저장에 실패했습니다.', en: 'Failed to save.' },
-  titleRequired: { ko: '프로그램명을 입력해주세요.', en: 'Please enter a program title.' },
-  editProgram: { ko: '프로그램 수정', en: 'Edit Program' },
+  hasChanges: { ko: '수정사항이 있습니다', en: 'You have unsaved changes' },
 };
 
 // 수정 가능한 상태
@@ -52,16 +64,12 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
     type: '',
     estimatedHours: null,
   });
+  const [hasChanges, setHasChanges] = useState(false);
 
   // API hooks
-  const { data: program, isLoading, error, refetch: refetchProgram } = useMyProgram(id);
-  const {
-    data: snapshotItems,
-    refetch: refetchItems,
-  } = useSnapshotItems(program?.snapshotId || 0);
-
+  const { data: program, isLoading, error } = useMyProgram(id);
   const updateProgramMutation = useUpdateMyProgram();
-  const updateSnapshotMutation = useUpdateSnapshot();
+  const submitProgramMutation = useSubmitMyProgram();
 
   // 프로그램 데이터로 폼 초기화
   useEffect(() => {
@@ -74,24 +82,24 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
         type: program.type || '',
         estimatedHours: program.estimatedHours || null,
       });
+      setHasChanges(false);
     }
   }, [program]);
 
   // 폼 데이터 변경 핸들러
   const handleFormDataChange = (data: Partial<ProgramFormData>) => {
     setFormData((prev) => ({ ...prev, ...data }));
+    setHasChanges(true);
   };
 
   // 저장 핸들러
   const handleSave = async () => {
-    // 유효성 검사
     if (!formData.title.trim()) {
       alert(getText('titleRequired'));
-      return;
+      return false;
     }
 
     try {
-      // 프로그램 기본 정보 저장
       await updateProgramMutation.mutateAsync({
         id,
         request: {
@@ -103,32 +111,56 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
           estimatedHours: formData.estimatedHours || undefined,
         },
       });
-
-      // 스냅샷 기본 정보도 업데이트 (이름 동기화)
-      if (program?.snapshotId) {
-        await updateSnapshotMutation.mutateAsync({
-          id: program.snapshotId,
-          request: {
-            snapshotName: formData.title.trim(),
-            description: formData.description.trim() || undefined,
-          },
-        });
-      }
-
-      alert(getText('saveSuccess'));
-      refetchProgram();
+      setHasChanges(false);
+      return true;
     } catch (err) {
       console.error('Save failed:', err);
       alert(getText('saveFailed'));
+      return false;
     }
   };
 
-  // 스냅샷 아이템 변경 시 리프레시
-  const handleItemsChange = () => {
-    refetchItems();
+  // 저장만 하기
+  const handleSaveOnly = async () => {
+    const success = await handleSave();
+    if (success) {
+      alert(getText('saveSuccess'));
+    }
   };
 
-  const isSaving = updateProgramMutation.isPending || updateSnapshotMutation.isPending;
+  // 신청 핸들러
+  const handleSubmit = async () => {
+    // 유효성 검사
+    if (!formData.title.trim()) {
+      alert(getText('titleRequired'));
+      return;
+    }
+
+    // 확인
+    if (!window.confirm(getText('confirmSubmit'))) {
+      return;
+    }
+
+    try {
+      // 변경사항이 있으면 먼저 저장
+      if (hasChanges) {
+        const saveSuccess = await handleSave();
+        if (!saveSuccess) return;
+      }
+
+      // 신청
+      await submitProgramMutation.mutateAsync(id);
+      alert(getText('submitSuccess'));
+      navigate('/tu/teaching/programs');
+    } catch (err) {
+      console.error('Submit failed:', err);
+      alert(getText('submitFailed'));
+    }
+  };
+
+  const isSaving = updateProgramMutation.isPending;
+  const isSubmitting = submitProgramMutation.isPending;
+  const isProcessing = isSaving || isSubmitting;
 
   // 로딩 상태
   if (isLoading) {
@@ -182,6 +214,9 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
     );
   }
 
+  const statusLabel = program.status === 'DRAFT' ? getText('statusDraft') : getText('statusRejected');
+  const statusVariant = program.status === 'DRAFT' ? 'secondary' : 'destructive';
+
   return (
     <div className="h-full flex flex-col bg-bg-app">
       {/* Header */}
@@ -193,33 +228,66 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
                 variant="ghost"
                 size="sm"
                 className="border border-border"
-                onClick={() => navigate(`/tu/teaching/programs/${id}`)}
+                onClick={() => navigate('/tu/teaching/programs')}
               >
                 <ArrowLeft size={16} />
                 {getText('back')}
               </Button>
               <div>
-                <h1 className="text-text-primary text-xl mb-0">{getText('editProgram')}</h1>
-                <p className="text-text-secondary text-sm mt-1">{program.title}</p>
+                <div className="flex items-center gap-2">
+                  <h1 className="text-text-primary text-xl mb-0">{getText('pageTitle')}</h1>
+                  <Badge variant={statusVariant}>{statusLabel}</Badge>
+                  {hasChanges && (
+                    <span className="text-xs text-status-warning">({getText('hasChanges')})</span>
+                  )}
+                </div>
+                <p className="text-text-secondary text-sm mt-1">{getText('pageSubtitle')}</p>
               </div>
             </div>
 
-            {/* Save Button */}
-            <Button onClick={handleSave} disabled={isSaving}>
-              {isSaving ? (
-                <Loader2 size={16} className="animate-spin" />
-              ) : (
-                <Save size={16} />
+            {/* Action Buttons */}
+            <div className="flex items-center gap-2">
+              {hasChanges && (
+                <Button
+                  variant="outline"
+                  onClick={handleSaveOnly}
+                  disabled={isProcessing}
+                >
+                  {isSaving ? (
+                    <Loader2 size={16} className="animate-spin" />
+                  ) : (
+                    <Save size={16} />
+                  )}
+                  {isSaving ? getText('saving') : getText('saveFirst')}
+                </Button>
               )}
-              {isSaving ? getText('saving') : getText('save')}
-            </Button>
+              <Button onClick={handleSubmit} disabled={isProcessing}>
+                {isSubmitting ? (
+                  <Loader2 size={16} className="animate-spin" />
+                ) : (
+                  <Send size={16} />
+                )}
+                {isSubmitting ? getText('submitting') : hasChanges ? getText('saveAndSubmit') : getText('submit')}
+              </Button>
+            </div>
           </div>
         </div>
       </div>
 
       {/* Content */}
       <div className="flex-1 overflow-auto">
-        <div className="p-6 px-8 max-w-5xl space-y-6">
+        <div className="p-6 px-8 max-w-3xl space-y-6">
+          {/* 안내 카드 */}
+          <Card className="bg-bg-subtle border-border">
+            <div className="p-4">
+              <p className="text-sm text-text-secondary">
+                {language === 'ko'
+                  ? '아래 정보를 확인하고 필요한 경우 수정한 후 신청해주세요. 신청 후에는 검토 완료 전까지 수정이 불가능합니다.'
+                  : 'Review and edit the information below if needed. Once submitted, you cannot edit until the review is complete.'}
+              </p>
+            </div>
+          </Card>
+
           {/* 기본 정보 폼 */}
           <ProgramBasicInfoForm
             formData={formData}
@@ -227,15 +295,22 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
             language={language}
           />
 
-          {/* 스냅샷 아이템 트리 */}
-          {program.snapshotId && (
-            <SnapshotItemTree
-              snapshotId={program.snapshotId}
-              items={snapshotItems || []}
-              onItemsChange={handleItemsChange}
-              language={language}
-            />
-          )}
+          {/* 하단 신청 버튼 (모바일 대응) */}
+          <div className="pt-4 pb-8">
+            <Button
+              onClick={handleSubmit}
+              disabled={isProcessing}
+              className="w-full"
+              size="lg"
+            >
+              {isSubmitting ? (
+                <Loader2 size={16} className="animate-spin" />
+              ) : (
+                <Send size={16} />
+              )}
+              {isSubmitting ? getText('submitting') : hasChanges ? getText('saveAndSubmit') : getText('submit')}
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/routes/tu.teaching.routes.tsx
+++ b/src/routes/tu.teaching.routes.tsx
@@ -7,6 +7,7 @@ import {
   CourseCreatePage,
   CourseEditPage,
   TeachingCourseDetailPage,
+  CourseApplyPage,
   TuContentCreatePage,
   ContentDetailPage,
   MyAssignmentsPage,
@@ -45,6 +46,7 @@ export const tuTeachingRoutes = (
     <Route path="teaching/courses/create" element={<CourseCreatePage />} />
     <Route path="teaching/courses/:courseId" element={<TeachingCourseDetailPage />} />
     <Route path="teaching/courses/:courseId/edit" element={<CourseEditPage />} />
+    <Route path="teaching/courses/:courseId/apply" element={<CourseApplyPage />} />
 
     {/* 내 프로그램 */}
     <Route path="teaching/programs" element={<MyProgramsPage />} />


### PR DESCRIPTION
## Summary
- CourseApplyPage 신규 생성: Course에서 Program으로 신청하는 중간 페이지
  - Course 정보를 폼에 prefill하여 유저가 확인/수정 가능
  - 신청 시 Snapshot 생성 → Program 생성 → 제출 (PENDING 상태)
  - 완료 후 프로그램 목록 페이지(/tu/teaching/programs)로 이동
- ProgramSubmitPage → ProgramEditPage 이름 변경 (기존 프로그램 수정/재신청 용도)
- CourseDetailPage, MyCoursesPage의 "프로그램 신청" 버튼 → /apply 페이지로 이동하도록 변경
- MyProgramsPage의 "신청" 버튼 → /edit 페이지로 이동하도록 변경

## 플로우

```
[코스에서 프로그램 신청]
MyCoursesPage 또는 CourseDetailPage
    ↓ "프로그램 신청" 버튼 클릭
/tu/teaching/courses/:courseId/apply (CourseApplyPage)
    - Course 정보를 폼에 prefill
    - 유저가 정보 확인/수정
    ↓ "프로그램 신청" 버튼 클릭
Snapshot 생성 → Program 생성 → Program 제출 (PENDING)
    ↓
/tu/teaching/programs (MyProgramsPage) - 승인 대기 상태로 확인 가능

[기존 프로그램 수정/재신청]
MyProgramsPage에서 DRAFT/REJECTED 프로그램
    ↓ "신청" 버튼 클릭
/tu/teaching/programs/:programId/edit (ProgramEditPage)
    - 정보 수정 가능
    ↓ "신청하기" 버튼 클릭
Program 제출 (PENDING)
```

## Changed Files
| 파일 | 상태 | 설명 |
|-----|------|------|
| CourseApplyPage.tsx | 신규 | Course → Program 신청 페이지 |
| ProgramEditPage.tsx | 이름변경 | 프로그램 수정/신청 페이지 |
| CourseDetailPage.tsx | 수정 | /apply로 이동하도록 변경 |
| MyCoursesPage.tsx | 수정 | /apply로 이동하도록 변경 |
| MyProgramsPage.tsx | 수정 | /edit으로 이동하도록 변경 |
| tu.teaching.routes.tsx | 수정 | 라우트 추가/수정 |

## Test plan
- [ ] 코스 목록 페이지에서 "프로그램 신청" 버튼 클릭 → CourseApplyPage로 이동 확인
- [ ] 코스 상세 페이지에서 "프로그램 신청" 버튼 클릭 → CourseApplyPage로 이동 확인
- [ ] CourseApplyPage에서 Course 정보가 폼에 prefill 되는지 확인
- [ ] CourseApplyPage에서 "프로그램 신청" 클릭 → PENDING 상태로 제출, 프로그램 목록으로 이동 확인
- [ ] MyProgramsPage에서 DRAFT/REJECTED 프로그램의 "신청" 버튼 → ProgramEditPage로 이동 확인

Closes #268