### PR TITLE
fix: axios 인터셉터에서 ApiResponse wrapper 자동 추출 처리

### DIFF
--- a/src/pages/tu/learning/components/CurriculumSidebar.tsx
+++ b/src/pages/tu/learning/components/CurriculumSidebar.tsx
@@ -49,21 +49,15 @@ const contentTypeIcons: Record<string, React.ReactNode> = {
   EXTERNAL_LINK: <LinkIcon className="w-4 h-4" />,
 };
 
-// API 응답 타입
-interface ApiResponse<T> {
-  success: boolean;
-  data: T;
-}
-
 // 스냅샷 아이템 조회 훅
 function useSnapshotItems(snapshotId: number, enabled: boolean = true) {
   return useQuery({
     queryKey: ['snapshot', 'items', snapshotId],
     queryFn: async () => {
-      const response = await axiosInstance.get<ApiResponse<SnapshotItemResponse[]>>(
+      const response = await axiosInstance.get<SnapshotItemResponse[]>(
         API_ENDPOINTS.SNAPSHOTS.ITEMS(snapshotId)
       );
-      return response.data.data;
+      return response.data;
     },
     enabled: enabled && !!snapshotId && snapshotId !== 999, // 999는 데모 모드
   });
@@ -74,10 +68,10 @@ function useSnapshotRelationsOrdered(snapshotId: number, enabled: boolean = true
   return useQuery({
     queryKey: ['snapshot', 'relations', 'ordered', snapshotId],
     queryFn: async () => {
-      const response = await axiosInstance.get<ApiResponse<SnapshotRelationsResponse>>(
+      const response = await axiosInstance.get<SnapshotRelationsResponse>(
         API_ENDPOINTS.SNAPSHOTS.RELATIONS_ORDERED(snapshotId)
       );
-      return response.data.data;
+      return response.data;
     },
     enabled: enabled && !!snapshotId && snapshotId !== 999, // 999는 데모 모드
   });

--- a/src/services/common/api/axiosInstance.ts
+++ b/src/services/common/api/axiosInstance.ts
@@ -43,9 +43,21 @@ axiosInstance.interceptors.request.use(
   }
 );
 
-// Response interceptor: 에러 처리 및 토큰 갱신
+// Response interceptor: ApiResponse wrapper 처리 및 토큰 갱신
 axiosInstance.interceptors.response.use(
-  (response) => response,
+  (response) => {
+    // ApiResponse wrapper에서 data 추출
+    // 서버 응답: { success: boolean, data: T, error?: {...} }
+    if (
+      response.data &&
+      typeof response.data === 'object' &&
+      'success' in response.data &&
+      'data' in response.data
+    ) {
+      response.data = response.data.data;
+    }
+    return response;
+  },
   async (error: AxiosError) => {
     const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
 

--- a/src/services/common/authService.ts
+++ b/src/services/common/authService.ts
@@ -7,8 +7,6 @@ import type {
   TokenResponse,
   UserResponse,
 } from '@/types/common/auth.types';
-import type { ApiResponse } from '@/types/common/api.types';
-
 /**
  * 인증 관련 API 서비스
  */
@@ -17,22 +15,22 @@ export const authService = {
    * 회원가입
    */
   register: async (request: RegisterRequest): Promise<UserResponse> => {
-    const response = await axiosInstance.post<ApiResponse<UserResponse>>(
+    const response = await axiosInstance.post<UserResponse>(
       API_ENDPOINTS.AUTH.REGISTER,
       request
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
    * 로그인
    */
   login: async (request: LoginRequest): Promise<TokenResponse> => {
-    const response = await axiosInstance.post<ApiResponse<TokenResponse>>(
+    const response = await axiosInstance.post<TokenResponse>(
       API_ENDPOINTS.AUTH.LOGIN,
       request
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -40,11 +38,11 @@ export const authService = {
    */
   refresh: async (refreshToken: string): Promise<TokenResponse> => {
     const request: RefreshTokenRequest = { refreshToken };
-    const response = await axiosInstance.post<ApiResponse<TokenResponse>>(
+    const response = await axiosInstance.post<TokenResponse>(
       API_ENDPOINTS.AUTH.REFRESH,
       request
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**

--- a/src/services/common/userService.ts
+++ b/src/services/common/userService.ts
@@ -5,8 +5,6 @@ import type {
   ChangePasswordRequest,
   UpdateProfileRequest,
 } from '@/types/common/auth.types';
-import type { ApiResponse } from '@/types/common/api.types';
-
 /**
  * 사용자 관련 API 서비스
  */
@@ -15,21 +13,21 @@ export const userService = {
    * 내 정보 조회
    */
   getMe: async (): Promise<UserDetailResponse> => {
-    const response = await axiosInstance.get<ApiResponse<UserDetailResponse>>(
+    const response = await axiosInstance.get<UserDetailResponse>(
       API_ENDPOINTS.USERS.ME
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
    * 프로필 수정
    */
   updateProfile: async (request: UpdateProfileRequest): Promise<UserDetailResponse> => {
-    const response = await axiosInstance.put<ApiResponse<UserDetailResponse>>(
+    const response = await axiosInstance.put<UserDetailResponse>(
       API_ENDPOINTS.USERS.ME,
       request
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -47,11 +45,11 @@ export const userService = {
     formData.append('file', file);
 
     // FormData 전송 시 headers를 생략하여 브라우저가 boundary 포함한 Content-Type 자동 설정
-    const response = await axiosInstance.postForm<ApiResponse<{ profileImageUrl: string }>>(
+    const response = await axiosInstance.postForm<{ profileImageUrl: string }>(
       API_ENDPOINTS.USERS.ME_PROFILE_IMAGE,
       formData
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -75,7 +73,7 @@ export const userService = {
    */
   getMyCourseRoles: async () => {
     const response = await axiosInstance.get(API_ENDPOINTS.USERS.ME_COURSE_ROLES);
-    return response.data.data;
+    return response.data;
   },
 };
 

--- a/src/services/to/enrollmentService.ts
+++ b/src/services/to/enrollmentService.ts
@@ -33,27 +33,27 @@ export const adminEnrollmentService = {
     courseTimeId: number,
     params?: EnrollmentFilterParams
   ): Promise<PageResponse<EnrollmentResponse>> {
-    const response = await axiosInstance.get<{ data: PageResponse<EnrollmentResponse> }>(
+    const response = await axiosInstance.get<PageResponse<EnrollmentResponse>>(
       API_ENDPOINTS.TIMES.ENROLLMENTS(courseTimeId),
       { params }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /** 수강 상세 조회 */
   async getEnrollment(id: number): Promise<EnrollmentDetailResponse> {
-    const { data } = await axiosInstance.get<{ data: EnrollmentDetailResponse }>(
+    const { data } = await axiosInstance.get<EnrollmentDetailResponse>(
       API_ENDPOINTS.ENROLLMENTS.BY_ID(id)
     );
-    return data.data;
+    return data;
   },
 
   /** 차수별 수강 통계 조회 */
   async getCourseTimeStats(courseTimeId: number): Promise<CourseTimeEnrollmentStatsResponse> {
-    const { data } = await axiosInstance.get<{ data: CourseTimeEnrollmentStatsResponse }>(
+    const { data } = await axiosInstance.get<CourseTimeEnrollmentStatsResponse>(
       `${API_ENDPOINTS.TIMES.ENROLLMENTS(courseTimeId)}/stats`
     );
-    return data.data;
+    return data;
   },
 
   // ============================================
@@ -65,11 +65,11 @@ export const adminEnrollmentService = {
     courseTimeId: number,
     request: ForceEnrollRequest
   ): Promise<ForceEnrollResultResponse> {
-    const { data } = await axiosInstance.post<{ data: ForceEnrollResultResponse }>(
+    const { data } = await axiosInstance.post<ForceEnrollResultResponse>(
       `${API_ENDPOINTS.TIMES.ENROLLMENTS(courseTimeId)}/force`,
       request
     );
-    return data.data;
+    return data;
   },
 
   // ============================================
@@ -81,11 +81,11 @@ export const adminEnrollmentService = {
     id: number,
     request: CompleteEnrollmentRequest
   ): Promise<EnrollmentDetailResponse> {
-    const { data } = await axiosInstance.patch<{ data: EnrollmentDetailResponse }>(
+    const { data } = await axiosInstance.patch<EnrollmentDetailResponse>(
       `${API_ENDPOINTS.ENROLLMENTS.BY_ID(id)}/complete`,
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 상태 변경 */
@@ -93,11 +93,11 @@ export const adminEnrollmentService = {
     id: number,
     request: UpdateEnrollmentStatusRequest
   ): Promise<EnrollmentDetailResponse> {
-    const { data } = await axiosInstance.patch<{ data: EnrollmentDetailResponse }>(
+    const { data } = await axiosInstance.patch<EnrollmentDetailResponse>(
       `${API_ENDPOINTS.ENROLLMENTS.BY_ID(id)}/status`,
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 수강 취소 */

--- a/src/services/to/timeService.ts
+++ b/src/services/to/timeService.ts
@@ -30,37 +30,37 @@ export const timeService = {
 
   /** 차수 생성 */
   async createTime(request: CreateCourseTimeRequest): Promise<CourseTimeResponse> {
-    const { data } = await axiosInstance.post<{ data: CourseTimeResponse }>(
+    const { data } = await axiosInstance.post<CourseTimeResponse>(
       API_ENDPOINTS.TIMES.BASE,
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 차수 목록 조회 */
   async getTimes(params?: CourseTimeFilterParams): Promise<PageResponse<CourseTimeResponse>> {
-    const response = await axiosInstance.get<{ data: PageResponse<CourseTimeResponse> }>(
+    const response = await axiosInstance.get<PageResponse<CourseTimeResponse>>(
       API_ENDPOINTS.TIMES.BASE,
       { params }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /** 차수 상세 조회 */
   async getTime(id: number): Promise<CourseTimeDetailResponse> {
-    const { data } = await axiosInstance.get<{ data: CourseTimeDetailResponse }>(
+    const { data } = await axiosInstance.get<CourseTimeDetailResponse>(
       API_ENDPOINTS.TIMES.BY_ID(id)
     );
-    return data.data;
+    return data;
   },
 
   /** 차수 수정 */
   async updateTime(id: number, request: UpdateCourseTimeRequest): Promise<CourseTimeResponse> {
-    const { data } = await axiosInstance.patch<{ data: CourseTimeResponse }>(
+    const { data } = await axiosInstance.patch<CourseTimeResponse>(
       API_ENDPOINTS.TIMES.BY_ID(id),
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 차수 삭제 */
@@ -70,11 +70,11 @@ export const timeService = {
 
   /** 차수 복제 */
   async cloneTime(id: number, request: CloneCourseTimeRequest): Promise<CourseTimeResponse> {
-    const { data } = await axiosInstance.post<{ data: CourseTimeResponse }>(
+    const { data } = await axiosInstance.post<CourseTimeResponse>(
       API_ENDPOINTS.TIMES.CLONE(id),
       request
     );
-    return data.data;
+    return data;
   },
 
   // ============================================
@@ -83,34 +83,34 @@ export const timeService = {
 
   /** 모집 개시 (DRAFT → RECRUITING) */
   async openTime(id: number): Promise<CourseTimeResponse> {
-    const { data } = await axiosInstance.post<{ data: CourseTimeResponse }>(
+    const { data } = await axiosInstance.post<CourseTimeResponse>(
       API_ENDPOINTS.TIMES.OPEN(id)
     );
-    return data.data;
+    return data;
   },
 
   /** 수업 시작 (RECRUITING → ONGOING) */
   async startTime(id: number): Promise<CourseTimeResponse> {
-    const { data } = await axiosInstance.post<{ data: CourseTimeResponse }>(
+    const { data } = await axiosInstance.post<CourseTimeResponse>(
       API_ENDPOINTS.TIMES.START(id)
     );
-    return data.data;
+    return data;
   },
 
   /** 수업 종료 (ONGOING → CLOSED) */
   async closeTime(id: number): Promise<CourseTimeResponse> {
-    const { data } = await axiosInstance.post<{ data: CourseTimeResponse }>(
+    const { data } = await axiosInstance.post<CourseTimeResponse>(
       API_ENDPOINTS.TIMES.CLOSE(id)
     );
-    return data.data;
+    return data;
   },
 
   /** 보관 처리 (CLOSED → ARCHIVED) */
   async archiveTime(id: number): Promise<CourseTimeResponse> {
-    const { data } = await axiosInstance.post<{ data: CourseTimeResponse }>(
+    const { data } = await axiosInstance.post<CourseTimeResponse>(
       API_ENDPOINTS.TIMES.ARCHIVE(id)
     );
-    return data.data;
+    return data;
   },
 
   // ============================================
@@ -119,17 +119,17 @@ export const timeService = {
 
   /** 정원 정보 조회 */
   async getCapacity(id: number): Promise<CapacityResponse> {
-    const { data } = await axiosInstance.get<{ data: CapacityResponse }>(
+    const { data } = await axiosInstance.get<CapacityResponse>(
       API_ENDPOINTS.TIMES.CAPACITY(id)
     );
-    return data.data;
+    return data;
   },
 
   /** 가격 정보 조회 */
   async getPrice(id: number): Promise<PriceResponse> {
-    const { data } = await axiosInstance.get<{ data: PriceResponse }>(
+    const { data } = await axiosInstance.get<PriceResponse>(
       API_ENDPOINTS.TIMES.PRICE(id)
     );
-    return data.data;
+    return data;
   },
 };

--- a/src/services/to/userService.ts
+++ b/src/services/to/userService.ts
@@ -32,19 +32,19 @@ export const userService = {
 
   /** 사용자 목록 조회 */
   async getUsers(params?: UserFilterParams): Promise<PageResponse<UserListResponse>> {
-    const response = await axiosInstance.get<{ data: PageResponse<UserListResponse> }>(
+    const response = await axiosInstance.get<PageResponse<UserListResponse>>(
       API_ENDPOINTS.USERS.BASE,
       { params }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /** 사용자 상세 조회 */
   async getUser(id: number): Promise<TOUserDetailResponse> {
-    const { data } = await axiosInstance.get<{ data: TOUserDetailResponse }>(
+    const { data } = await axiosInstance.get<TOUserDetailResponse>(
       API_ENDPOINTS.USERS.BY_ID(id)
     );
-    return data.data;
+    return data;
   },
 
   // ============================================
@@ -53,11 +53,11 @@ export const userService = {
 
   /** 사용자 상태 변경 */
   async changeStatus(id: number, request: ChangeStatusRequest): Promise<TOUserDetailResponse> {
-    const { data } = await axiosInstance.put<{ data: TOUserDetailResponse }>(
+    const { data } = await axiosInstance.put<TOUserDetailResponse>(
       API_ENDPOINTS.USERS.STATUS(id),
       request
     );
-    return data.data;
+    return data;
   },
 
   // ============================================
@@ -69,26 +69,26 @@ export const userService = {
     userId: number,
     params?: EnrollmentFilterParams
   ): Promise<PageResponse<EnrollmentResponse>> {
-    const response = await axiosInstance.get<{ data: PageResponse<EnrollmentResponse> }>(
+    const response = await axiosInstance.get<PageResponse<EnrollmentResponse>>(
       API_ENDPOINTS.USERS.ENROLLMENTS(userId),
       { params }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /** 사용자별 수강 통계 조회 */
   async getUserEnrollmentStats(userId: number): Promise<UserEnrollmentStatsResponse> {
-    const { data } = await axiosInstance.get<{ data: UserEnrollmentStatsResponse }>(
+    const { data } = await axiosInstance.get<UserEnrollmentStatsResponse>(
       API_ENDPOINTS.USERS.ENROLLMENT_STATS(userId)
     );
-    return data.data;
+    return data;
   },
 
   /** 사용자별 강사 통계 조회 (DESIGNER 역할용) */
   async getUserInstructorStats(userId: number): Promise<InstructorDetailStatResponse> {
-    const { data } = await axiosInstance.get<{ data: InstructorDetailStatResponse }>(
+    const { data } = await axiosInstance.get<InstructorDetailStatResponse>(
       API_ENDPOINTS.USERS.INSTRUCTOR_STATS(userId)
     );
-    return data.data;
+    return data;
   },
 };

--- a/src/services/tu/cartService.ts
+++ b/src/services/tu/cartService.ts
@@ -5,7 +5,6 @@
 
 import axiosInstance from '@/services/common/api/axiosInstance';
 import { API_ENDPOINTS } from '@/services/common/api/endpoints';
-import type { ApiResponse } from '@/types/common/api.types';
 import type {
   CartItemResponse,
   CartAddRequest,
@@ -18,21 +17,21 @@ export const cartService = {
    * 장바구니 목록 조회
    */
   getCart: async (): Promise<CartItemResponse[]> => {
-    const response = await axiosInstance.get<ApiResponse<CartItemResponse[]>>(
+    const response = await axiosInstance.get<CartItemResponse[]>(
       API_ENDPOINTS.CART.BASE
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
    * 장바구니에 CourseTime 추가
    */
   addToCart: async (request: CartAddRequest): Promise<CartItemResponse> => {
-    const response = await axiosInstance.post<ApiResponse<CartItemResponse>>(
+    const response = await axiosInstance.post<CartItemResponse>(
       API_ENDPOINTS.CART.ITEMS,
       request
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -53,19 +52,19 @@ export const cartService = {
    * 장바구니 개수 조회
    */
   getCartCount: async (): Promise<CartCountResponse> => {
-    const response = await axiosInstance.get<ApiResponse<CartCountResponse>>(
+    const response = await axiosInstance.get<CartCountResponse>(
       API_ENDPOINTS.CART.COUNT
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
    * 특정 CourseTime 장바구니 여부 확인
    */
   checkCartStatus: async (courseTimeId: number): Promise<boolean> => {
-    const response = await axiosInstance.get<ApiResponse<boolean>>(
+    const response = await axiosInstance.get<boolean>(
       API_ENDPOINTS.CART.ITEM_CHECK(courseTimeId)
     );
-    return response.data.data;
+    return response.data;
   },
 };

--- a/src/services/tu/catalogService.ts
+++ b/src/services/tu/catalogService.ts
@@ -65,18 +65,6 @@ export interface PageResponse<T> {
 }
 
 /**
- * API 응답 래퍼 타입
- */
-interface ApiResponse<T> {
-  success: boolean;
-  data: T;
-  error?: {
-    code: string;
-    message: string;
-  };
-}
-
-/**
  * 카탈로그 서비스
  */
 export const catalogService = {
@@ -84,42 +72,42 @@ export const catalogService = {
    * 프로그램 목록 조회 (카탈로그)
    */
   getPrograms: async (params?: CatalogFilterParams): Promise<PageResponse<CatalogProgram>> => {
-    const response = await axiosInstance.get<ApiResponse<PageResponse<CatalogProgram>>>(
+    const response = await axiosInstance.get<PageResponse<CatalogProgram>>(
       API_ENDPOINTS.PROGRAMS.BASE,
       { params: { ...params, status: 'APPROVED' } }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
    * 프로그램 상세 조회
    */
   getProgram: async (id: number): Promise<CatalogProgram> => {
-    const response = await axiosInstance.get<ApiResponse<CatalogProgram>>(
+    const response = await axiosInstance.get<CatalogProgram>(
       API_ENDPOINTS.PROGRAMS.BY_ID(id)
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
    * 프로그램의 차수 목록 조회
    */
   getCourseTimes: async (programId: number): Promise<CatalogCourseTime[]> => {
-    const response = await axiosInstance.get<ApiResponse<CatalogCourseTime[]>>(
+    const response = await axiosInstance.get<CatalogCourseTime[]>(
       API_ENDPOINTS.TIMES.BASE,
       { params: { programId, status: 'OPEN' } }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
    * 차수 상세 조회
    */
   getCourseTime: async (id: number): Promise<CatalogCourseTime> => {
-    const response = await axiosInstance.get<ApiResponse<CatalogCourseTime>>(
+    const response = await axiosInstance.get<CatalogCourseTime>(
       API_ENDPOINTS.TIMES.BY_ID(id)
     );
-    return response.data.data;
+    return response.data;
   },
 };
 

--- a/src/services/tu/communityService.ts
+++ b/src/services/tu/communityService.ts
@@ -16,7 +16,6 @@ import type {
   CreateCommentRequest,
   UpdateCommentRequest,
 } from '@/types/tu/community.types';
-import type { ApiResponse } from '@/types/common';
 
 const BASE_URL = '/community';
 
@@ -48,32 +47,32 @@ export const communityService = {
 
     const query = params.toString();
     const url = query ? `${BASE_URL}/posts?${query}` : `${BASE_URL}/posts`;
-    const response = await axiosInstance.get<ApiResponse<CommunityPostListResponse>>(url);
-    return response.data.data;
+    const response = await axiosInstance.get<CommunityPostListResponse>(url);
+    return response.data;
   },
 
   /**
    * 게시글 상세 조회
    */
   getPost: async (postId: number): Promise<CommunityPostDetail> => {
-    const response = await axiosInstance.get<ApiResponse<CommunityPostDetail>>(`${BASE_URL}/posts/${postId}`);
-    return response.data.data;
+    const response = await axiosInstance.get<CommunityPostDetail>(`${BASE_URL}/posts/${postId}`);
+    return response.data;
   },
 
   /**
    * 게시글 작성
    */
   createPost: async (data: CreatePostRequest): Promise<CommunityPost> => {
-    const response = await axiosInstance.post<ApiResponse<CommunityPost>>(`${BASE_URL}/posts`, data);
-    return response.data.data;
+    const response = await axiosInstance.post<CommunityPost>(`${BASE_URL}/posts`, data);
+    return response.data;
   },
 
   /**
    * 게시글 수정
    */
   updatePost: async (postId: number, data: UpdatePostRequest): Promise<CommunityPost> => {
-    const response = await axiosInstance.patch<ApiResponse<CommunityPost>>(`${BASE_URL}/posts/${postId}`, data);
-    return response.data.data;
+    const response = await axiosInstance.patch<CommunityPost>(`${BASE_URL}/posts/${postId}`, data);
+    return response.data;
   },
 
   /**
@@ -101,8 +100,8 @@ export const communityService = {
    * 카테고리 목록 조회
    */
   getCategories: async (): Promise<CommunityCategoryResponse> => {
-    const response = await axiosInstance.get<ApiResponse<CommunityCategoryResponse>>(`${BASE_URL}/categories`);
-    return response.data.data;
+    const response = await axiosInstance.get<CommunityCategoryResponse>(`${BASE_URL}/categories`);
+    return response.data;
   },
 
   /**
@@ -110,28 +109,28 @@ export const communityService = {
    */
   getPopularPosts: async (limit?: number): Promise<CommunityPostListResponse> => {
     const params = limit ? `?limit=${limit}` : '';
-    const response = await axiosInstance.get<ApiResponse<CommunityPostListResponse>>(`${BASE_URL}/posts/popular${params}`);
-    return response.data.data;
+    const response = await axiosInstance.get<CommunityPostListResponse>(`${BASE_URL}/posts/popular${params}`);
+    return response.data;
   },
 
   /**
    * 내 게시글 목록 조회
    */
   getMyPosts: async (page = 0, pageSize = 20): Promise<CommunityPostListResponse> => {
-    const response = await axiosInstance.get<ApiResponse<CommunityPostListResponse>>(
+    const response = await axiosInstance.get<CommunityPostListResponse>(
       `${BASE_URL}/posts/my?page=${page}&pageSize=${pageSize}`
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
    * 내가 댓글 단 게시글 목록 조회
    */
   getCommentedPosts: async (page = 0, pageSize = 20): Promise<CommunityPostListResponse> => {
-    const response = await axiosInstance.get<ApiResponse<CommunityPostListResponse>>(
+    const response = await axiosInstance.get<CommunityPostListResponse>(
       `${BASE_URL}/posts/commented?page=${page}&pageSize=${pageSize}`
     );
-    return response.data.data;
+    return response.data;
   },
 
   // ========== 댓글 관련 API ==========
@@ -140,32 +139,32 @@ export const communityService = {
    * 댓글 목록 조회
    */
   getComments: async (postId: number, page = 0, pageSize = 20): Promise<CommentListResponse> => {
-    const response = await axiosInstance.get<ApiResponse<CommentListResponse>>(
+    const response = await axiosInstance.get<CommentListResponse>(
       `${BASE_URL}/posts/${postId}/comments?page=${page}&pageSize=${pageSize}`
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
    * 댓글 작성
    */
   createComment: async (data: CreateCommentRequest): Promise<Comment> => {
-    const response = await axiosInstance.post<ApiResponse<Comment>>(
+    const response = await axiosInstance.post<Comment>(
       `${BASE_URL}/posts/${data.postId}/comments`,
       { content: data.content, parentId: data.parentId }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
    * 댓글 수정
    */
   updateComment: async (postId: number, commentId: number, data: UpdateCommentRequest): Promise<Comment> => {
-    const response = await axiosInstance.patch<ApiResponse<Comment>>(
+    const response = await axiosInstance.patch<Comment>(
       `${BASE_URL}/posts/${postId}/comments/${commentId}`,
       data
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -198,7 +197,7 @@ export const communityService = {
     const formData = new FormData();
     formData.append('file', file);
 
-    const response = await axiosInstance.post<ApiResponse<{ url: string }>>(
+    const response = await axiosInstance.post<{ url: string }>(
       `${BASE_URL}/images/upload`,
       formData,
       {
@@ -207,7 +206,7 @@ export const communityService = {
         },
       }
     );
-    return response.data.data.url;
+    return response.data.url;
   },
 
   /**
@@ -219,7 +218,7 @@ export const communityService = {
       formData.append('files', file);
     });
 
-    const response = await axiosInstance.post<ApiResponse<{ urls: string[] }>>(
+    const response = await axiosInstance.post<{ urls: string[] }>(
       `${BASE_URL}/images/upload/multiple`,
       formData,
       {
@@ -228,6 +227,6 @@ export const communityService = {
         },
       }
     );
-    return response.data.data.urls;
+    return response.data.urls;
   },
 };

--- a/src/services/tu/courseDetailService.ts
+++ b/src/services/tu/courseDetailService.ts
@@ -13,16 +13,6 @@ import type { PageResponse } from '@/services/tu/catalogService';
  * 강의 상세 정보 조회 및 관련 API 호출
  */
 
-// API 응답 래퍼 타입
-interface ApiResponse<T> {
-  success: boolean;
-  data: T;
-  error?: {
-    code: string;
-    message: string;
-  };
-}
-
 // 백엔드 CourseItem 응답 타입
 interface BackendCourseItemResponse {
   itemId: number;
@@ -178,10 +168,10 @@ export const courseDetailService = {
    * @param id 강의 ID
    */
   getCourseDetail: async (id: number): Promise<CourseDetail> => {
-    const response = await axiosInstance.get<ApiResponse<BackendCourseDetailResponse>>(
+    const response = await axiosInstance.get<BackendCourseDetailResponse>(
       `/courses/${id}`
     );
-    return transformCourseDetail(response.data.data);
+    return transformCourseDetail(response.data);
   },
 
   /**
@@ -189,11 +179,11 @@ export const courseDetailService = {
    * @param params 필터 파라미터
    */
   getCourses: async (params?: CourseFilterParams): Promise<PageResponse<CourseCard>> => {
-    const response = await axiosInstance.get<ApiResponse<PageResponse<CourseCard>>>(
+    const response = await axiosInstance.get<PageResponse<CourseCard>>(
       '/courses/explore',
       { params }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -201,11 +191,11 @@ export const courseDetailService = {
    * @param limit 조회 개수
    */
   getPopularCourses: async (limit: number = 10): Promise<CourseCard[]> => {
-    const response = await axiosInstance.get<ApiResponse<CourseCard[]>>(
+    const response = await axiosInstance.get<CourseCard[]>(
       '/courses/popular',
       { params: { limit } }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -213,11 +203,11 @@ export const courseDetailService = {
    * @param limit 조회 개수
    */
   getRecommendedCourses: async (limit: number = 10): Promise<CourseCard[]> => {
-    const response = await axiosInstance.get<ApiResponse<CourseCard[]>>(
+    const response = await axiosInstance.get<CourseCard[]>(
       '/courses/recommended',
       { params: { limit } }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -226,11 +216,11 @@ export const courseDetailService = {
    * @param limit 조회 개수
    */
   getRelatedCourses: async (courseId: number, limit: number = 4): Promise<CourseCard[]> => {
-    const response = await axiosInstance.get<ApiResponse<CourseCard[]>>(
+    const response = await axiosInstance.get<CourseCard[]>(
       `/courses/${courseId}/related`,
       { params: { limit } }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**

--- a/src/services/tu/courseExploreService.ts
+++ b/src/services/tu/courseExploreService.ts
@@ -9,7 +9,7 @@ import type {
   CourseExploreFilter,
   CourseExploreItem,
 } from '@/types/tu/courseExplore.types';
-import type { ApiResponse, PageResponse } from '@/types/common';
+import type { PageResponse } from '@/types/common';
 
 const BASE_URL = '/courses';
 
@@ -70,9 +70,9 @@ export const courseExploreService = {
 
     const query = params.toString();
     const url = query ? `${BASE_URL}?${query}` : BASE_URL;
-    const response = await axiosInstance.get<ApiResponse<PageResponse<BackendCourseResponse>>>(url);
+    const response = await axiosInstance.get<PageResponse<BackendCourseResponse>>(url);
 
-    const pageData = response.data.data;
+    const pageData = response.data;
     return {
       courses: pageData.content.map(transformCourse),
       totalCount: pageData.totalElements,
@@ -103,8 +103,8 @@ export const courseExploreService = {
    */
   getPopularCourses: async (limit?: number): Promise<CourseExploreResponse> => {
     const size = limit || 10;
-    const response = await axiosInstance.get<ApiResponse<PageResponse<BackendCourseResponse>>>(`${BASE_URL}?size=${size}`);
-    const pageData = response.data.data;
+    const response = await axiosInstance.get<PageResponse<BackendCourseResponse>>(`${BASE_URL}?size=${size}`);
+    const pageData = response.data;
     return {
       courses: pageData.content.map(transformCourse),
       totalCount: pageData.totalElements,
@@ -119,8 +119,8 @@ export const courseExploreService = {
    */
   getNewCourses: async (limit?: number): Promise<CourseExploreResponse> => {
     const size = limit || 10;
-    const response = await axiosInstance.get<ApiResponse<PageResponse<BackendCourseResponse>>>(`${BASE_URL}?size=${size}`);
-    const pageData = response.data.data;
+    const response = await axiosInstance.get<PageResponse<BackendCourseResponse>>(`${BASE_URL}?size=${size}`);
+    const pageData = response.data;
     return {
       courses: pageData.content.map(transformCourse),
       totalCount: pageData.totalElements,
@@ -135,8 +135,8 @@ export const courseExploreService = {
    */
   getRecommendedCourses: async (limit?: number): Promise<CourseExploreResponse> => {
     const size = limit || 10;
-    const response = await axiosInstance.get<ApiResponse<PageResponse<BackendCourseResponse>>>(`${BASE_URL}?size=${size}`);
-    const pageData = response.data.data;
+    const response = await axiosInstance.get<PageResponse<BackendCourseResponse>>(`${BASE_URL}?size=${size}`);
+    const pageData = response.data;
     return {
       courses: pageData.content.map(transformCourse),
       totalCount: pageData.totalElements,

--- a/src/services/tu/enrollmentService.ts
+++ b/src/services/tu/enrollmentService.ts
@@ -78,18 +78,6 @@ export interface PageResponse<T> {
 }
 
 /**
- * API 응답 래퍼 타입
- */
-interface ApiResponse<T> {
-  success: boolean;
-  data: T;
-  error?: {
-    code: string;
-    message: string;
-  };
-}
-
-/**
  * 백엔드 상태를 프론트엔드 상태로 매핑
  */
 const mapEnrollmentStatus = (status: string): EnrollmentStatus => {
@@ -148,21 +136,21 @@ export const enrollmentService = {
    * 수강 신청
    */
   enroll: async (courseTimeId: number): Promise<Enrollment> => {
-    const response = await axiosInstance.post<ApiResponse<Enrollment>>(
+    const response = await axiosInstance.post<Enrollment>(
       API_ENDPOINTS.TIMES.ENROLLMENTS(courseTimeId)
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
    * 일괄 수강 신청
    */
   enrollBulk: async (courseTimeIds: number[]): Promise<BulkEnrollmentResponse> => {
-    const response = await axiosInstance.post<ApiResponse<BulkEnrollmentResponse>>(
+    const response = await axiosInstance.post<BulkEnrollmentResponse>(
       API_ENDPOINTS.ENROLLMENTS.BULK,
       { courseTimeIds }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -172,11 +160,11 @@ export const enrollmentService = {
    */
   getMyEnrollments: async (params?: EnrollmentFilterParams): Promise<PageResponse<Enrollment>> => {
     // 1. 수강 목록 조회
-    const response = await axiosInstance.get<ApiResponse<PageResponse<BackendEnrollmentResponse>>>(
+    const response = await axiosInstance.get<PageResponse<BackendEnrollmentResponse>>(
       API_ENDPOINTS.ENROLLMENTS.MY,
       { params }
     );
-    const pageData = response.data.data;
+    const pageData = response.data;
 
     // 2. 고유한 courseTimeId 목록 추출
     const courseTimeIds = [...new Set(pageData.content.map((e) => e.courseTimeId))];
@@ -186,10 +174,10 @@ export const enrollmentService = {
     if (courseTimeIds.length > 0) {
       const courseTimePromises = courseTimeIds.map(async (id) => {
         try {
-          const res = await axiosInstance.get<ApiResponse<BackendCourseTimeResponse>>(
+          const res = await axiosInstance.get<BackendCourseTimeResponse>(
             API_ENDPOINTS.TIMES.BY_ID(id)
           );
-          return { id, data: res.data.data };
+          return { id, data: res.data };
         } catch {
           return { id, data: null };
         }
@@ -216,18 +204,18 @@ export const enrollmentService = {
    */
   getEnrollment: async (id: number): Promise<Enrollment> => {
     // 1. 수강 정보 조회
-    const response = await axiosInstance.get<ApiResponse<BackendEnrollmentResponse>>(
+    const response = await axiosInstance.get<BackendEnrollmentResponse>(
       API_ENDPOINTS.ENROLLMENTS.BY_ID(id)
     );
-    const enrollment = response.data.data;
+    const enrollment = response.data;
 
     // 2. 차수 정보 조회
     let courseTimeInfo: BackendCourseTimeResponse | undefined;
     try {
-      const courseTimeRes = await axiosInstance.get<ApiResponse<BackendCourseTimeResponse>>(
+      const courseTimeRes = await axiosInstance.get<BackendCourseTimeResponse>(
         API_ENDPOINTS.TIMES.BY_ID(enrollment.courseTimeId)
       );
-      courseTimeInfo = courseTimeRes.data.data;
+      courseTimeInfo = courseTimeRes.data;
     } catch {
       // 차수 정보 조회 실패 시 빈 값 사용
     }
@@ -247,10 +235,10 @@ export const enrollmentService = {
    * 수강 상세 + 커리큘럼 조회 (학습 플레이어용)
    */
   getEnrollmentWithCurriculum: async (id: number): Promise<EnrollmentWithCurriculumResponse> => {
-    const response = await axiosInstance.get<ApiResponse<EnrollmentWithCurriculumResponse>>(
+    const response = await axiosInstance.get<EnrollmentWithCurriculumResponse>(
       API_ENDPOINTS.ENROLLMENTS.CURRICULUM(id)
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**

--- a/src/services/tu/learningStatsService.ts
+++ b/src/services/tu/learningStatsService.ts
@@ -13,6 +13,6 @@ export const learningStatsService = {
    */
   getMyLearningStats: async (): Promise<LearningStatsResponse> => {
     const response = await axiosInstance.get(API_ENDPOINTS.USERS.ME_LEARNING_STATS);
-    return response.data.data;
+    return response.data;
   },
 };

--- a/src/services/tu/myAssignmentService.ts
+++ b/src/services/tu/myAssignmentService.ts
@@ -41,7 +41,7 @@ export const myAssignmentService = {
    */
   getMyAssignments: async (): Promise<InstructorAssignmentResponse[]> => {
     const response = await axiosInstance.get(API_ENDPOINTS.INSTRUCTOR_ASSIGNMENTS.MY);
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -62,7 +62,7 @@ export const myAssignmentService = {
       API_ENDPOINTS.INSTRUCTOR_ASSIGNMENTS.MY_STATISTICS,
       { params }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -75,11 +75,11 @@ export const myAssignmentService = {
     const enrollmentsRes = await axiosInstance.get(API_ENDPOINTS.TIMES.ENROLLMENTS(timeId), {
       params: { size: 1000 },
     });
-    const pageData: PageResponse<BackendEnrollmentResponse> = enrollmentsRes.data.data;
+    const pageData: PageResponse<BackendEnrollmentResponse> = enrollmentsRes.data;
 
     // 2. 차수 정보 조회
     const timeRes = await axiosInstance.get(API_ENDPOINTS.TIMES.BY_ID(timeId));
-    const timeData = timeRes.data.data;
+    const timeData = timeRes.data;
 
     // 3. 백엔드 상태를 프론트엔드 상태로 매핑
     const mapStatus = (status: string): StudentEnrollmentStatus => {

--- a/src/services/tu/notificationService.ts
+++ b/src/services/tu/notificationService.ts
@@ -12,13 +12,6 @@ import type {
 
 const BASE_URL = '/tu/notifications';
 
-// API 응답 래퍼 타입
-interface ApiResponse<T> {
-  success: boolean;
-  data: T;
-  error?: string;
-}
-
 export const notificationService = {
   /**
    * 알림 목록 조회
@@ -40,18 +33,18 @@ export const notificationService = {
 
     const query = params.toString();
     const url = query ? `${BASE_URL}?${query}` : BASE_URL;
-    const response = await axiosInstance.get<ApiResponse<NotificationListResponse>>(url);
-    return response.data.data;
+    const response = await axiosInstance.get<NotificationListResponse>(url);
+    return response.data;
   },
 
   /**
    * 알림 상세 조회
    */
   getNotification: async (notificationId: number): Promise<NotificationItem> => {
-    const response = await axiosInstance.get<ApiResponse<NotificationItem>>(
+    const response = await axiosInstance.get<NotificationItem>(
       `${BASE_URL}/${notificationId}`
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -86,9 +79,9 @@ export const notificationService = {
    * 읽지 않은 알림 개수 조회
    */
   getUnreadCount: async (): Promise<UnreadCountResponse> => {
-    const response = await axiosInstance.get<ApiResponse<UnreadCountResponse>>(
+    const response = await axiosInstance.get<UnreadCountResponse>(
       `${BASE_URL}/unread-count`
     );
-    return response.data.data;
+    return response.data;
   },
 };

--- a/src/services/tu/ownerStatsService.ts
+++ b/src/services/tu/ownerStatsService.ts
@@ -38,8 +38,8 @@ export const ownerStatsService = {
    * @returns 강사 통계 (overview, enrollmentStats, programStats)
    */
   getMyOwnerStats: async (): Promise<OwnerStatsResponse> => {
-    const response = await axiosInstance.get<{ data: OwnerStatsApiResponse }>(API_ENDPOINTS.OWNERS.ME_STATS);
-    const data = response.data.data;
+    const response = await axiosInstance.get<OwnerStatsApiResponse>(API_ENDPOINTS.OWNERS.ME_STATS);
+    const data = response.data;
 
     // 백엔드 응답 구조를 프론트엔드 타입에 맞게 변환
     return {

--- a/src/services/tu/roadmapDetailService.ts
+++ b/src/services/tu/roadmapDetailService.ts
@@ -14,16 +14,6 @@ import type { PageResponse } from '@/services/tu/catalogService';
  * 로드맵 상세 정보 조회 및 관련 API 호출
  */
 
-// API 응답 래퍼 타입
-interface ApiResponse<T> {
-  success: boolean;
-  data: T;
-  error?: {
-    code: string;
-    message: string;
-  };
-}
-
 /**
  * 로드맵 상세 서비스
  */
@@ -33,10 +23,10 @@ export const roadmapDetailService = {
    * @param id 로드맵 ID
    */
   getRoadmapDetail: async (id: number): Promise<RoadmapDetail> => {
-    const response = await axiosInstance.get<ApiResponse<RoadmapDetail>>(
+    const response = await axiosInstance.get<RoadmapDetail>(
       `/roadmaps/${id}`
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -44,11 +34,11 @@ export const roadmapDetailService = {
    * @param params 필터 파라미터
    */
   getRoadmaps: async (params?: RoadmapFilterParams): Promise<PageResponse<RoadmapCard>> => {
-    const response = await axiosInstance.get<ApiResponse<PageResponse<RoadmapCard>>>(
+    const response = await axiosInstance.get<PageResponse<RoadmapCard>>(
       '/roadmaps',
       { params }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -56,11 +46,11 @@ export const roadmapDetailService = {
    * @param limit 조회 개수
    */
   getPopularRoadmaps: async (limit: number = 10): Promise<RoadmapCard[]> => {
-    const response = await axiosInstance.get<ApiResponse<RoadmapCard[]>>(
+    const response = await axiosInstance.get<RoadmapCard[]>(
       '/roadmaps/popular',
       { params: { limit } }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -68,11 +58,11 @@ export const roadmapDetailService = {
    * @param limit 조회 개수
    */
   getRecommendedRoadmaps: async (limit: number = 10): Promise<RoadmapCard[]> => {
-    const response = await axiosInstance.get<ApiResponse<RoadmapCard[]>>(
+    const response = await axiosInstance.get<RoadmapCard[]>(
       '/roadmaps/recommended',
       { params: { limit } }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -86,11 +76,11 @@ export const roadmapDetailService = {
     page: number = 0,
     size: number = 10
   ): Promise<ReviewPageResponse> => {
-    const response = await axiosInstance.get<ApiResponse<ReviewPageResponse>>(
+    const response = await axiosInstance.get<ReviewPageResponse>(
       `/roadmaps/${roadmapId}/reviews`,
       { params: { page, size } }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -98,11 +88,11 @@ export const roadmapDetailService = {
    * @param request 수강평 작성 요청
    */
   createReview: async (request: CreateReviewRequest): Promise<RoadmapReview> => {
-    const response = await axiosInstance.post<ApiResponse<RoadmapReview>>(
+    const response = await axiosInstance.post<RoadmapReview>(
       `/roadmaps/${request.roadmapId}/reviews`,
       { rating: request.rating, content: request.content }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -119,10 +109,10 @@ export const roadmapDetailService = {
    * @param roadmapId 로드맵 ID
    */
   enrollRoadmap: async (roadmapId: number): Promise<{ enrollmentId: number }> => {
-    const response = await axiosInstance.post<ApiResponse<{ enrollmentId: number }>>(
+    const response = await axiosInstance.post<{ enrollmentId: number }>(
       `/roadmaps/${roadmapId}/enroll`
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -133,11 +123,11 @@ export const roadmapDetailService = {
     completedCourses: number;
     totalProgress: number;
   }> => {
-    const response = await axiosInstance.get<ApiResponse<{
+    const response = await axiosInstance.get<{
       completedCourses: number;
       totalProgress: number;
-    }>>(`/roadmaps/${roadmapId}/progress`);
-    return response.data.data;
+    }>(`/roadmaps/${roadmapId}/progress`);
+    return response.data;
   },
 };
 

--- a/src/services/tu/wishlistService.ts
+++ b/src/services/tu/wishlistService.ts
@@ -5,7 +5,7 @@
 
 import axiosInstance from '@/services/common/api/axiosInstance';
 import { API_ENDPOINTS } from '@/services/common/api/endpoints';
-import type { ApiResponse, PageResponse } from '@/types/common/api.types';
+import type { PageResponse } from '@/types/common/api.types';
 import type {
   WishlistItemResponse,
   WishlistAddRequest,
@@ -19,11 +19,11 @@ export const wishlistService = {
    * 찜 추가
    */
   addToWishlist: async (request: WishlistAddRequest): Promise<WishlistItemResponse> => {
-    const response = await axiosInstance.post<ApiResponse<WishlistItemResponse>>(
+    const response = await axiosInstance.post<WishlistItemResponse>(
       API_ENDPOINTS.WISHLIST.BASE,
       request
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
@@ -40,41 +40,41 @@ export const wishlistService = {
     page: number = 0,
     size: number = 20
   ): Promise<PageResponse<WishlistItemResponse>> => {
-    const response = await axiosInstance.get<ApiResponse<PageResponse<WishlistItemResponse>>>(
+    const response = await axiosInstance.get<PageResponse<WishlistItemResponse>>(
       API_ENDPOINTS.WISHLIST.BASE,
       { params: { page, size } }
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
    * 특정 CourseTime 찜 여부 확인
    */
   checkWishlistStatus: async (courseTimeId: number): Promise<boolean> => {
-    const response = await axiosInstance.get<ApiResponse<boolean>>(
+    const response = await axiosInstance.get<boolean>(
       API_ENDPOINTS.WISHLIST.COURSE_TIME_CHECK(courseTimeId)
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
    * 여러 CourseTime 찜 여부 일괄 확인
    */
   checkWishlistStatusBulk: async (request: WishlistCheckRequest): Promise<WishlistCheckResponse> => {
-    const response = await axiosInstance.post<ApiResponse<WishlistCheckResponse>>(
+    const response = await axiosInstance.post<WishlistCheckResponse>(
       API_ENDPOINTS.WISHLIST.CHECK_BULK,
       request
     );
-    return response.data.data;
+    return response.data;
   },
 
   /**
    * 내 찜 개수 조회
    */
   getMyWishlistCount: async (): Promise<WishlistCountResponse> => {
-    const response = await axiosInstance.get<ApiResponse<WishlistCountResponse>>(
+    const response = await axiosInstance.get<WishlistCountResponse>(
       API_ENDPOINTS.WISHLIST.COUNT
     );
-    return response.data.data;
+    return response.data;
   },
 };


### PR DESCRIPTION
## Summary
- axios response interceptor에서 `ApiResponse<T>` 래퍼의 `data` 필드를 자동으로 추출하도록 수정
- 모든 서비스 파일에서 `.data.data` 패턴을 `.data`로 일괄 변경
- 사용하지 않는 `ApiResponse` 인터페이스/타입 선언 제거

## 변경 사항
### 핵심 변경: axiosInstance.ts
```typescript
// Response interceptor에서 ApiResponse wrapper 처리
if (
  response.data &&
  typeof response.data === 'object' &&
  'success' in response.data &&
  'data' in response.data
) {
  response.data = response.data.data;
}
```

### 영향받는 파일 (19개)
- `src/services/common/api/axiosInstance.ts`
- `src/services/common/authService.ts`, `userService.ts`
- `src/services/tu/` - 모든 서비스 파일
- `src/services/to/` - enrollmentService, timeService, userService
- `src/pages/tu/learning/components/CurriculumSidebar.tsx`

## 배경
프로그램 신청 시 백엔드에서 스냅샷이 생성되어 `{ success: true, data: { snapshotId: 123, ... } }` 형태로 응답하지만, 프론트엔드에서 `.data.data.snapshotId` 대신 `.data.snapshotId`로 접근하여 `undefined`가 반환되는 문제가 있었습니다.

이 PR은 axios interceptor에서 일괄적으로 ApiResponse wrapper를 처리하여 모든 서비스에서 일관된 방식으로 데이터에 접근할 수 있도록 수정합니다.

## Test plan
- [ ] 프로그램 신청 후 스냅샷 정보가 정상적으로 표시되는지 확인
- [ ] 로그인/로그아웃 정상 동작 확인
- [ ] 수강 신청/취소 정상 동작 확인
- [ ] 알림 목록 조회 정상 동작 확인
- [ ] 빌드 성공 확인 ✅

Closes #272