### PR TITLE
feat(tu): 수료증 페이지 Phase 1 구현

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npx tsc:*)"
+    ]
+  }
+}

--- a/src/components/domain/tu/certificate/CertificateCard.tsx
+++ b/src/components/domain/tu/certificate/CertificateCard.tsx
@@ -1,0 +1,174 @@
+import { Award, Calendar, User, Eye, Download, CheckCircle } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import { Button, Badge } from '@/components/common';
+import type { Enrollment } from '@/services/tu/enrollmentService';
+
+// 날짜 포맷팅
+function formatDate(dateString: string | undefined): string {
+  if (!dateString) return '-';
+  return new Date(dateString).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export interface CertificateCardLabels {
+  completedOn: string;
+  view: string;
+  download: string;
+  preparing: string;
+  certificateOf: string;
+  completion: string;
+}
+
+interface CertificateCardProps {
+  enrollment: Enrollment;
+  userName: string;
+  labels: CertificateCardLabels;
+  onPreview: () => void;
+  onDownload?: () => void;
+  isDownloadEnabled?: boolean;
+  isDark?: boolean;
+}
+
+/**
+ * 수료증 카드 컴포넌트
+ * 수료 완료된 강의의 수료증을 인증서 스타일로 표시
+ */
+export const CertificateCard = ({
+  enrollment,
+  userName,
+  labels,
+  onPreview,
+  onDownload,
+  isDownloadEnabled = false,
+  isDark = false,
+}: Readonly<CertificateCardProps>) => {
+  return (
+    <div
+      className={cn(
+        'relative overflow-hidden rounded-xl border-2 transition-all hover:shadow-lg cursor-pointer',
+        isDark
+          ? 'bg-gradient-to-br from-gray-800 via-gray-900 to-gray-800 border-yellow-500/30 hover:border-yellow-500/50'
+          : 'bg-gradient-to-br from-amber-50 via-white to-amber-50 border-amber-300 hover:border-amber-400'
+      )}
+      onClick={onPreview}
+    >
+      {/* 장식용 코너 디자인 */}
+      <div
+        className={cn(
+          'absolute top-0 left-0 w-16 h-16 border-t-4 border-l-4 rounded-tl-xl',
+          isDark ? 'border-yellow-500/40' : 'border-amber-400'
+        )}
+      />
+      <div
+        className={cn(
+          'absolute top-0 right-0 w-16 h-16 border-t-4 border-r-4 rounded-tr-xl',
+          isDark ? 'border-yellow-500/40' : 'border-amber-400'
+        )}
+      />
+      <div
+        className={cn(
+          'absolute bottom-0 left-0 w-16 h-16 border-b-4 border-l-4 rounded-bl-xl',
+          isDark ? 'border-yellow-500/40' : 'border-amber-400'
+        )}
+      />
+      <div
+        className={cn(
+          'absolute bottom-0 right-0 w-16 h-16 border-b-4 border-r-4 rounded-br-xl',
+          isDark ? 'border-yellow-500/40' : 'border-amber-400'
+        )}
+      />
+
+      <div className="p-6 text-center">
+        {/* 헤더: 수료증 아이콘 & 타이틀 */}
+        <div className="mb-4">
+          <div
+            className={cn(
+              'inline-flex items-center justify-center w-14 h-14 rounded-full mb-3',
+              isDark ? 'bg-yellow-500/20' : 'bg-amber-100'
+            )}
+          >
+            <Award className={cn('w-7 h-7', isDark ? 'text-yellow-400' : 'text-amber-600')} />
+          </div>
+          <div className={cn('text-xs font-medium tracking-widest uppercase mb-1', isDark ? 'text-yellow-400/80' : 'text-amber-600')}>
+            {labels.certificateOf}
+          </div>
+          <div className={cn('text-lg font-bold', isDark ? 'text-yellow-400' : 'text-amber-700')}>
+            {labels.completion}
+          </div>
+        </div>
+
+        {/* 수료 배지 */}
+        <div className="mb-4">
+          <Badge variant="green" className="text-xs">
+            <CheckCircle className="w-3 h-3 mr-1" />
+            100% {labels.completion}
+          </Badge>
+        </div>
+
+        {/* 프로그램/강의명 */}
+        <h3
+          className={cn(
+            'text-base font-semibold mb-2 line-clamp-2 min-h-[3rem]',
+            isDark ? 'text-white' : 'text-gray-900'
+          )}
+        >
+          {enrollment.programTitle}
+        </h3>
+
+        {/* 차수명 */}
+        <p className={cn('text-sm mb-4', isDark ? 'text-gray-400' : 'text-gray-500')}>
+          {enrollment.courseTimeName}
+        </p>
+
+        {/* 구분선 */}
+        <div className={cn('border-t my-4', isDark ? 'border-white/10' : 'border-amber-200')} />
+
+        {/* 수료자 정보 */}
+        <div className="space-y-2 mb-4">
+          <div className={cn('flex items-center justify-center gap-2 text-sm', isDark ? 'text-gray-300' : 'text-gray-700')}>
+            <User className="w-4 h-4" />
+            <span className="font-medium">{userName}</span>
+          </div>
+          <div className={cn('flex items-center justify-center gap-2 text-xs', isDark ? 'text-gray-400' : 'text-gray-500')}>
+            <Calendar className="w-3.5 h-3.5" />
+            <span>{labels.completedOn}: {formatDate(enrollment.completedAt)}</span>
+          </div>
+        </div>
+
+        {/* 액션 버튼 */}
+        <div className="flex items-center gap-2 mt-4" onClick={(e) => e.stopPropagation()}>
+          <Button
+            variant="outline"
+            size="sm"
+            className={cn(
+              'flex-1',
+              isDark && '!bg-transparent !border-white/20 !text-white hover:!bg-white/10'
+            )}
+            onClick={onPreview}
+          >
+            <Eye className="w-4 h-4 mr-1" />
+            {labels.view}
+          </Button>
+          <Button
+            variant={isDownloadEnabled ? 'brand' : 'ghost'}
+            size="sm"
+            className={cn(
+              'flex-1',
+              !isDownloadEnabled && (isDark ? '!text-gray-500' : '!text-gray-400')
+            )}
+            onClick={isDownloadEnabled ? onDownload : undefined}
+            disabled={!isDownloadEnabled}
+          >
+            <Download className="w-4 h-4 mr-1" />
+            {isDownloadEnabled ? labels.download : labels.preparing}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CertificateCard;

--- a/src/components/domain/tu/certificate/CertificatePreviewModal.tsx
+++ b/src/components/domain/tu/certificate/CertificatePreviewModal.tsx
@@ -1,0 +1,192 @@
+import { Award, Calendar, User, Download, X, Building2, BookOpen } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Button,
+} from '@/components/common';
+import type { Enrollment } from '@/services/tu/enrollmentService';
+
+// 날짜 포맷팅
+function formatDate(dateString: string | undefined): string {
+  if (!dateString) return '-';
+  return new Date(dateString).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export interface CertificatePreviewLabels {
+  title: string;
+  certificateOf: string;
+  completion: string;
+  certifyThat: string;
+  hasCompleted: string;
+  issuedOn: string;
+  learningPeriod: string;
+  download: string;
+  preparing: string;
+  close: string;
+  organization: string;
+}
+
+interface CertificatePreviewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  enrollment: Enrollment | null;
+  userName: string;
+  labels: CertificatePreviewLabels;
+  onDownload?: () => void;
+  isDownloadEnabled?: boolean;
+  isDark?: boolean;
+  organizationName?: string;
+}
+
+/**
+ * 수료증 미리보기 모달
+ * 수료증을 상세하게 표시하는 모달 컴포넌트
+ */
+export const CertificatePreviewModal = ({
+  isOpen,
+  onClose,
+  enrollment,
+  userName,
+  labels,
+  onDownload,
+  isDownloadEnabled = false,
+  isDark = false,
+  organizationName = 'MZC Learn Platform',
+}: Readonly<CertificatePreviewModalProps>) => {
+  if (!enrollment) return null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent
+        className={cn(
+          'max-w-2xl p-0 overflow-hidden',
+          isDark ? 'bg-gray-900 border-gray-700' : 'bg-white'
+        )}
+      >
+        {/* 헤더 */}
+        <DialogHeader className={cn('p-4 border-b', isDark ? 'border-gray-700' : 'border-gray-200')}>
+          <div className="flex items-center justify-between">
+            <DialogTitle className={isDark ? 'text-white' : 'text-gray-900'}>
+              {labels.title}
+            </DialogTitle>
+            <Button variant="ghost" size="sm" onClick={onClose}>
+              <X className="w-4 h-4" />
+            </Button>
+          </div>
+        </DialogHeader>
+
+        {/* 수료증 본문 */}
+        <div className="p-6">
+          <div
+            className={cn(
+              'relative border-4 rounded-lg p-8 text-center',
+              isDark
+                ? 'bg-gradient-to-br from-gray-800 via-gray-900 to-gray-800 border-yellow-500/50'
+                : 'bg-gradient-to-br from-amber-50 via-white to-amber-50 border-amber-400'
+            )}
+          >
+            {/* 장식용 코너 */}
+            <div className={cn('absolute top-2 left-2 w-8 h-8 border-t-2 border-l-2', isDark ? 'border-yellow-500/40' : 'border-amber-300')} />
+            <div className={cn('absolute top-2 right-2 w-8 h-8 border-t-2 border-r-2', isDark ? 'border-yellow-500/40' : 'border-amber-300')} />
+            <div className={cn('absolute bottom-2 left-2 w-8 h-8 border-b-2 border-l-2', isDark ? 'border-yellow-500/40' : 'border-amber-300')} />
+            <div className={cn('absolute bottom-2 right-2 w-8 h-8 border-b-2 border-r-2', isDark ? 'border-yellow-500/40' : 'border-amber-300')} />
+
+            {/* 기관 로고/이름 */}
+            <div className="mb-6">
+              <div className={cn('flex items-center justify-center gap-2 text-sm', isDark ? 'text-gray-400' : 'text-gray-500')}>
+                <Building2 className="w-4 h-4" />
+                <span>{organizationName}</span>
+              </div>
+            </div>
+
+            {/* 수료증 타이틀 */}
+            <div className="mb-6">
+              <div
+                className={cn(
+                  'inline-flex items-center justify-center w-16 h-16 rounded-full mb-4',
+                  isDark ? 'bg-yellow-500/20' : 'bg-amber-100'
+                )}
+              >
+                <Award className={cn('w-8 h-8', isDark ? 'text-yellow-400' : 'text-amber-600')} />
+              </div>
+              <div className={cn('text-sm font-medium tracking-widest uppercase mb-2', isDark ? 'text-yellow-400/80' : 'text-amber-600')}>
+                {labels.certificateOf}
+              </div>
+              <div className={cn('text-2xl font-bold', isDark ? 'text-yellow-400' : 'text-amber-700')}>
+                {labels.completion}
+              </div>
+            </div>
+
+            {/* 수료자 정보 */}
+            <div className="mb-6">
+              <p className={cn('text-sm mb-2', isDark ? 'text-gray-400' : 'text-gray-500')}>
+                {labels.certifyThat}
+              </p>
+              <div className={cn('flex items-center justify-center gap-2 text-xl font-bold mb-2', isDark ? 'text-white' : 'text-gray-900')}>
+                <User className="w-5 h-5" />
+                <span>{userName}</span>
+              </div>
+              <p className={cn('text-sm', isDark ? 'text-gray-400' : 'text-gray-500')}>
+                {labels.hasCompleted}
+              </p>
+            </div>
+
+            {/* 강의 정보 */}
+            <div className={cn('mb-6 p-4 rounded-lg', isDark ? 'bg-white/5' : 'bg-amber-100/50')}>
+              <div className={cn('flex items-center justify-center gap-2 mb-2', isDark ? 'text-gray-300' : 'text-gray-700')}>
+                <BookOpen className="w-4 h-4" />
+                <span className="text-sm font-medium">{enrollment.programTitle}</span>
+              </div>
+              <p className={cn('text-xs', isDark ? 'text-gray-400' : 'text-gray-500')}>
+                {enrollment.courseTimeName}
+              </p>
+            </div>
+
+            {/* 날짜 정보 */}
+            <div className="space-y-2 mb-6">
+              <div className={cn('flex items-center justify-center gap-2 text-sm', isDark ? 'text-gray-300' : 'text-gray-600')}>
+                <Calendar className="w-4 h-4" />
+                <span>{labels.learningPeriod}: {formatDate(enrollment.startDate)} ~ {formatDate(enrollment.endDate)}</span>
+              </div>
+              <div className={cn('flex items-center justify-center gap-2 text-sm font-medium', isDark ? 'text-yellow-400' : 'text-amber-700')}>
+                <Award className="w-4 h-4" />
+                <span>{labels.issuedOn}: {formatDate(enrollment.completedAt)}</span>
+              </div>
+            </div>
+
+            {/* 서명란 (장식용) */}
+            <div className={cn('border-t pt-4', isDark ? 'border-white/10' : 'border-amber-200')}>
+              <div className={cn('text-xs', isDark ? 'text-gray-500' : 'text-gray-400')}>
+                {organizationName}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* 푸터: 다운로드 버튼 */}
+        <div className={cn('p-4 border-t flex justify-end gap-2', isDark ? 'border-gray-700 bg-gray-800/50' : 'border-gray-200 bg-gray-50')}>
+          <Button variant="outline" onClick={onClose}>
+            {labels.close}
+          </Button>
+          <Button
+            variant={isDownloadEnabled ? 'brand' : 'ghost'}
+            onClick={isDownloadEnabled ? onDownload : undefined}
+            disabled={!isDownloadEnabled}
+          >
+            <Download className="w-4 h-4 mr-2" />
+            {isDownloadEnabled ? labels.download : labels.preparing}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CertificatePreviewModal;

--- a/src/components/domain/tu/certificate/index.ts
+++ b/src/components/domain/tu/certificate/index.ts
@@ -1,0 +1,4 @@
+export { CertificateCard } from './CertificateCard';
+export { CertificatePreviewModal } from './CertificatePreviewModal';
+export type { CertificateCardLabels } from './CertificateCard';
+export type { CertificatePreviewLabels } from './CertificatePreviewModal';

--- a/src/pages/tu/mypage/CertificationsPage.tsx
+++ b/src/pages/tu/mypage/CertificationsPage.tsx
@@ -1,50 +1,222 @@
-import { Award, Construction } from 'lucide-react';
+import { useState } from 'react';
+import { Award, Loader2 } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
-import { useTranslation } from '@/store/common/languageStore';
-import { Card, CardHeader, CardTitle, CardContent, EmptyState } from '@/components/common';
+import { useTranslation, useLanguageStore } from '@/store/common/languageStore';
+import { useAuthStore } from '@/store/common/authStore';
+import { useMyEnrollments } from '@/hooks/tu';
+import {
+  Button,
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/common';
+import { CertificateCard, CertificatePreviewModal } from '@/components/domain/tu/certificate';
+import type { Enrollment } from '@/services/tu/enrollmentService';
 
 export function CertificationsPage() {
   const { theme } = useThemeStore();
+  const { language } = useLanguageStore();
   const { t } = useTranslation();
+  const { user } = useAuthStore();
   const isDark = theme === 'dark';
 
-  const cardClass = isDark
-    ? 'bg-white/5 border-white/10'
-    : 'bg-white border-gray-200 shadow-sm';
+  const [page, setPage] = useState(0);
+  const pageSize = 12;
+
+  // 수료증 미리보기 모달 상태
+  const [selectedEnrollment, setSelectedEnrollment] = useState<Enrollment | null>(null);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+
+  // COMPLETED 상태의 수강 목록만 조회
+  const { data, isLoading, isError } = useMyEnrollments({
+    page,
+    size: pageSize,
+    status: 'COMPLETED',
+  });
+
+  // 수료증 카드 라벨
+  const cardLabels = {
+    completedOn: language === 'ko' ? '수료일' : 'Completed on',
+    view: language === 'ko' ? '보기' : 'View',
+    download: language === 'ko' ? '다운로드' : 'Download',
+    preparing: language === 'ko' ? '준비 중' : 'Preparing',
+    certificateOf: language === 'ko' ? '수료증' : 'Certificate of',
+    completion: language === 'ko' ? '수료' : 'Completion',
+  };
+
+  // 수료증 모달 라벨
+  const modalLabels = {
+    title: language === 'ko' ? '수료증 미리보기' : 'Certificate Preview',
+    certificateOf: language === 'ko' ? '수료증' : 'Certificate of',
+    completion: language === 'ko' ? '수료' : 'Completion',
+    certifyThat: language === 'ko' ? '다음의 사용자가' : 'This is to certify that',
+    hasCompleted: language === 'ko' ? '아래 과정을 성공적으로 수료하였음을 인증합니다.' : 'has successfully completed the following course.',
+    issuedOn: language === 'ko' ? '수료일' : 'Issued on',
+    learningPeriod: language === 'ko' ? '학습 기간' : 'Learning Period',
+    download: language === 'ko' ? 'PDF 다운로드' : 'Download PDF',
+    preparing: language === 'ko' ? '준비 중' : 'Preparing',
+    close: language === 'ko' ? '닫기' : 'Close',
+    organization: language === 'ko' ? '발급 기관' : 'Organization',
+  };
+
+  const handlePreview = (enrollment: Enrollment) => {
+    setSelectedEnrollment(enrollment);
+    setIsPreviewOpen(true);
+  };
+
+  const handleClosePreview = () => {
+    setIsPreviewOpen(false);
+    setSelectedEnrollment(null);
+  };
+
+  // TODO: Phase 2에서 실제 Certificate API 연동 시 구현
+  const handleDownload = () => {
+    // Certificate API: GET /api/certificates/{id}/download
+    console.log('PDF download - Phase 2');
+  };
+
+  const userName = user?.name || (language === 'ko' ? '학습자' : 'Learner');
 
   return (
     <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
-      <div className="max-w-3xl mx-auto">
+      <div className="max-w-[1400px] mx-auto">
         {/* Header */}
         <div className="mb-8">
-          <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            {t.mypage.certificates}
-          </h1>
+          <div className="flex items-center gap-3 mb-2">
+            <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${
+              isDark ? 'bg-yellow-500/20' : 'bg-amber-100'
+            }`}>
+              <Award className={`w-5 h-5 ${isDark ? 'text-yellow-400' : 'text-amber-600'}`} />
+            </div>
+            <h1 className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              {t.mypage.certificates}
+            </h1>
+          </div>
           <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
             {t.mypage.certificatesDesc}
           </p>
         </div>
 
-        {/* Certifications Card */}
-        <Card className={cardClass}>
-          <CardHeader>
-            <div className="flex items-center gap-3">
-              <Award className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
-              <CardTitle className={isDark ? 'text-white' : 'text-gray-900'}>
-                {t.mypage.certificatesList}
-              </CardTitle>
+        {/* Results Count */}
+        {data && (
+          <p className={`mb-4 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+            {language === 'ko' ? '총 ' : 'Total '}
+            <span className={`font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              {data.totalElements}
+            </span>
+            {language === 'ko' ? '개의 수료증' : ' certificates'}
+          </p>
+        )}
+
+        {/* Loading State */}
+        {isLoading && (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className={`w-8 h-8 animate-spin ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+          </div>
+        )}
+
+        {/* Error State */}
+        {isError && (
+          <div className="text-center py-20">
+            <p className="text-red-500">
+              {language === 'ko' ? '데이터를 불러오는데 실패했습니다.' : 'Failed to load data.'}
+            </p>
+          </div>
+        )}
+
+        {/* Empty State */}
+        {data && data.content.length === 0 && (
+          <div
+            className={`text-center py-20 rounded-xl ${
+              isDark ? 'bg-white/5 border border-white/10' : 'bg-white border border-gray-200'
+            }`}
+          >
+            <Award className={`w-16 h-16 mx-auto mb-4 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
+            <h3 className={`text-lg font-medium mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              {language === 'ko' ? '발급된 수료증이 없습니다' : 'No certificates issued'}
+            </h3>
+            <p className={`mb-4 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+              {language === 'ko'
+                ? '강의를 수료하면 수료증이 여기에 표시됩니다.'
+                : 'Certificates will appear here when you complete courses.'}
+            </p>
+            <Button variant="brand" onClick={() => window.location.href = '/tu/b2c/mypage/learning'}>
+              {language === 'ko' ? '학습 중인 강의 보기' : 'View Current Courses'}
+            </Button>
+          </div>
+        )}
+
+        {/* Certificates Grid */}
+        {data && data.content.length > 0 && (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mb-8">
+              {data.content.map((enrollment) => (
+                <CertificateCard
+                  key={enrollment.id}
+                  enrollment={enrollment}
+                  userName={userName}
+                  labels={cardLabels}
+                  onPreview={() => handlePreview(enrollment)}
+                  onDownload={handleDownload}
+                  isDownloadEnabled={false} // Phase 2에서 활성화
+                  isDark={isDark}
+                />
+              ))}
             </div>
-          </CardHeader>
-          <CardContent>
-            {/* Under Development Placeholder */}
-            <EmptyState
-              icon={Construction}
-              title={t.common.comingSoon}
-              description={t.mypage.certificatesComingSoon}
-              className={`border-2 border-dashed rounded-lg ${isDark ? 'border-white/10' : 'border-gray-200'}`}
-            />
-          </CardContent>
-        </Card>
+
+            {/* Pagination */}
+            {data.totalPages > 1 && (
+              <Pagination>
+                <PaginationContent>
+                  <PaginationItem>
+                    <PaginationPrevious
+                      onClick={() => setPage(Math.max(0, page - 1))}
+                      className={page === 0 ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
+                    />
+                  </PaginationItem>
+
+                  {Array.from({ length: Math.min(5, data.totalPages) }, (_, i) => {
+                    const pageNum = Math.max(0, Math.min(page - 2, data.totalPages - 5)) + i;
+                    if (pageNum >= data.totalPages) return null;
+                    return (
+                      <PaginationItem key={pageNum}>
+                        <PaginationLink
+                          onClick={() => setPage(pageNum)}
+                          isActive={pageNum === page}
+                          className="cursor-pointer"
+                        >
+                          {pageNum + 1}
+                        </PaginationLink>
+                      </PaginationItem>
+                    );
+                  })}
+
+                  <PaginationItem>
+                    <PaginationNext
+                      onClick={() => setPage(Math.min(data.totalPages - 1, page + 1))}
+                      className={page >= data.totalPages - 1 ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
+                    />
+                  </PaginationItem>
+                </PaginationContent>
+              </Pagination>
+            )}
+          </>
+        )}
+
+        {/* Certificate Preview Modal */}
+        <CertificatePreviewModal
+          isOpen={isPreviewOpen}
+          onClose={handleClosePreview}
+          enrollment={selectedEnrollment}
+          userName={userName}
+          labels={modalLabels}
+          onDownload={handleDownload}
+          isDownloadEnabled={false} // Phase 2에서 활성화
+          isDark={isDark}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

마이페이지의 수료증 페이지(`/tu/b2c/mypage/certifications`)를 구현합니다.
Phase 1에서는 Enrollment API를 활용하여 수료 완료된 강의의 수료증 목록을 표시합니다.

## Related Issue

- Closes #239

## Changes

- `CertificateCard` 컴포넌트 생성 (인증서 스타일 카드 디자인)
- `CertificatePreviewModal` 컴포넌트 생성 (수료증 미리보기 모달)
- `CertificationsPage` 수정: Coming Soon → 실제 데이터 연동
  - `useMyEnrollments({ status: 'COMPLETED' })` 연동
  - 수료증 목록 그리드 표시
  - 빈 상태 처리
  - 페이지네이션
- 다크/라이트 테마 및 다국어(ko/en) 지원
- PDF 다운로드는 Phase 2 대기 (비활성화)

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

- Phase 2에서 백엔드 Certificate API 연동 예정
  - PDF 다운로드 기능 활성화
  - 수료증 번호/상세 정보 표시
- 현재는 Enrollment의 COMPLETED 상태를 기반으로 수료증 목록 표시