### PR TITLE
fix: axios 인터셉터와 서비스 data.data 중복 접근 수정

### DIFF
--- a/src/services/common/categoryService.ts
+++ b/src/services/common/categoryService.ts
@@ -21,10 +21,10 @@ export const categoryService = {
 
   /** 카테고리 목록 조회 */
   async getCategories(): Promise<CategoryResponse[]> {
-    const { data } = await axiosInstance.get<{ data: CategoryResponse[] }>(
+    const { data } = await axiosInstance.get<CategoryResponse[]>(
       API_ENDPOINTS.CATEGORIES.BASE
     );
-    return data.data;
+    return data;
   },
 
   /** 카테고리 상세 조회 */

--- a/src/services/common/courseService.ts
+++ b/src/services/common/courseService.ts
@@ -43,41 +43,41 @@ export const courseService = {
 
   /** 강의 생성 */
   async create(request: CreateCourseRequest): Promise<CourseResponse> {
-    const { data } = await axiosInstance.post<{ data: CourseResponse }>(
+    const { data } = await axiosInstance.post<CourseResponse>(
       API_ENDPOINTS.COURSES.BASE,
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 강의 목록 조회 */
   async getCourses(
     params?: CourseFilterParams
   ): Promise<PageResponse<CourseResponse>> {
-    const { data } = await axiosInstance.get<{ data: PageResponse<CourseResponse> }>(
+    const { data } = await axiosInstance.get<PageResponse<CourseResponse>>(
       API_ENDPOINTS.COURSES.BASE,
       { params }
     );
-    return data.data;
+    return data;
   },
 
   /** 내 강의 목록 조회 */
   async getMyCourses(
     params?: CourseFilterParams
   ): Promise<PageResponse<CourseResponse>> {
-    const { data } = await axiosInstance.get<{ data: PageResponse<CourseResponse> }>(
+    const { data } = await axiosInstance.get<PageResponse<CourseResponse>>(
       API_ENDPOINTS.COURSES.MY,
       { params }
     );
-    return data.data;
+    return data;
   },
 
   /** 강의 상세 조회 */
   async getCourse(id: number): Promise<CourseDetailResponse> {
-    const { data } = await axiosInstance.get<{ data: CourseDetailResponse }>(
+    const { data } = await axiosInstance.get<CourseDetailResponse>(
       API_ENDPOINTS.COURSES.BY_ID(id)
     );
-    return data.data;
+    return data;
   },
 
   /** 강의 수정 */
@@ -85,11 +85,11 @@ export const courseService = {
     id: number,
     request: UpdateCourseRequest
   ): Promise<CourseResponse> {
-    const { data } = await axiosInstance.put<{ data: CourseResponse }>(
+    const { data } = await axiosInstance.put<CourseResponse>(
       API_ENDPOINTS.COURSES.BY_ID(id),
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 강의 삭제 */
@@ -118,21 +118,21 @@ export const courseService = {
     courseId: number,
     request: CreateFolderRequest
   ): Promise<CourseItemResponse> {
-    const { data } = await axiosInstance.post<{ data: CourseItemResponse }>(
+    const { data } = await axiosInstance.post<CourseItemResponse>(
       API_ENDPOINTS.COURSES.FOLDERS(courseId),
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 계층 구조 조회 */
   async getItemsHierarchy(
     courseId: number
   ): Promise<CourseItemHierarchyResponse[]> {
-    const { data } = await axiosInstance.get<{ data: CourseItemHierarchyResponse[] }>(
+    const { data } = await axiosInstance.get<CourseItemHierarchyResponse[]>(
       API_ENDPOINTS.COURSES.ITEMS_HIERARCHY(courseId)
     );
-    return data.data;
+    return data;
   },
 
   /** 순서대로 차시 조회 */
@@ -194,10 +194,10 @@ export const courseService = {
     itemId: number,
     request: UpdateDisplayInfoRequest
   ): Promise<CourseItemResponse> {
-    const { data } = await axiosInstance.patch<{ data: CourseItemResponse }>(
+    const { data } = await axiosInstance.patch<CourseItemResponse>(
       API_ENDPOINTS.COURSES.ITEM_DISPLAY_INFO(courseId, itemId),
       request
     );
-    return data.data;
+    return data;
   },
 };

--- a/src/services/sa/analyticsService.ts
+++ b/src/services/sa/analyticsService.ts
@@ -93,27 +93,27 @@ export interface ActivityLogsParams {
 export const saAnalyticsService = {
   /** 전체 시스템 활동 로그 목록 조회 */
   async getLogs(params?: ActivityLogsParams): Promise<Page<ActivityLogResponse>> {
-    const { data } = await axiosInstance.get<{ data: Page<ActivityLogResponse> }>(
+    const { data } = await axiosInstance.get<Page<ActivityLogResponse>>(
       API_ENDPOINTS.ANALYTICS.SA_LOGS,
       { params }
     );
-    return data.data;
+    return data;
   },
 
   /** 전체 시스템 활동 통계 조회 */
   async getStats(days: number = 30): Promise<ActivityStatsResponse> {
-    const { data } = await axiosInstance.get<{ data: ActivityStatsResponse }>(
+    const { data } = await axiosInstance.get<ActivityStatsResponse>(
       API_ENDPOINTS.ANALYTICS.SA_STATS,
       { params: { days } }
     );
-    return data.data;
+    return data;
   },
 
   /** 전체 시스템 최근 활동 목록 조회 */
   async getRecentActivities(): Promise<ActivityLogResponse[]> {
-    const { data } = await axiosInstance.get<{ data: ActivityLogResponse[] }>(
+    const { data } = await axiosInstance.get<ActivityLogResponse[]>(
       API_ENDPOINTS.ANALYTICS.SA_RECENT
     );
-    return data.data;
+    return data;
   },
 };

--- a/src/services/sa/dashboardService.ts
+++ b/src/services/sa/dashboardService.ts
@@ -9,9 +9,9 @@ import type { SaDashboardResponse } from '@/types/admin';
 export const saDashboardService = {
   /** SA 대시보드 통계 조회 */
   async getDashboard(): Promise<SaDashboardResponse> {
-    const { data } = await axiosInstance.get<{ data: SaDashboardResponse }>(
+    const { data } = await axiosInstance.get<SaDashboardResponse>(
       API_ENDPOINTS.SA_DASHBOARD.BASE
     );
-    return data.data;
+    return data;
   },
 };

--- a/src/services/sa/noticeService.ts
+++ b/src/services/sa/noticeService.ts
@@ -15,37 +15,37 @@ import type {
 export const noticeService = {
   /** 공지사항 목록 조회 */
   async getNotices(params?: NoticeListParams): Promise<NoticeListResponse> {
-    const { data } = await axiosInstance.get<{ data: NoticeListResponse }>(
+    const { data } = await axiosInstance.get<NoticeListResponse>(
       API_ENDPOINTS.NOTICES.BASE,
       { params }
     );
-    return data.data;
+    return data;
   },
 
   /** 공지사항 상세 조회 */
   async getNotice(id: number): Promise<Notice> {
-    const { data } = await axiosInstance.get<{ data: Notice }>(
+    const { data } = await axiosInstance.get<Notice>(
       API_ENDPOINTS.NOTICES.BY_ID(id)
     );
-    return data.data;
+    return data;
   },
 
   /** 공지사항 생성 */
   async create(request: CreateNoticeRequest): Promise<Notice> {
-    const { data } = await axiosInstance.post<{ data: Notice }>(
+    const { data } = await axiosInstance.post<Notice>(
       API_ENDPOINTS.NOTICES.BASE,
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 공지사항 수정 */
   async update(id: number, request: UpdateNoticeRequest): Promise<Notice> {
-    const { data } = await axiosInstance.put<{ data: Notice }>(
+    const { data } = await axiosInstance.put<Notice>(
       API_ENDPOINTS.NOTICES.BY_ID(id),
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 공지사항 삭제 */
@@ -55,18 +55,18 @@ export const noticeService = {
 
   /** 공지사항 발행 */
   async publish(id: number): Promise<Notice> {
-    const { data } = await axiosInstance.post<{ data: Notice }>(
+    const { data } = await axiosInstance.post<Notice>(
       API_ENDPOINTS.NOTICES.PUBLISH(id)
     );
-    return data.data;
+    return data;
   },
 
   /** 공지사항 보관 */
   async archive(id: number): Promise<Notice> {
-    const { data } = await axiosInstance.post<{ data: Notice }>(
+    const { data } = await axiosInstance.post<Notice>(
       API_ENDPOINTS.NOTICES.ARCHIVE(id)
     );
-    return data.data;
+    return data;
   },
 
   /** 특정 테넌트에 배포 */
@@ -81,9 +81,9 @@ export const noticeService = {
 
   /** 배포된 테넌트 ID 목록 조회 */
   async getDistributedTenants(id: number): Promise<number[]> {
-    const { data } = await axiosInstance.get<{ data: number[] }>(
+    const { data } = await axiosInstance.get<number[]>(
       API_ENDPOINTS.NOTICES.TENANTS(id)
     );
-    return data.data;
+    return data;
   },
 };

--- a/src/services/sa/systemSettingsService.ts
+++ b/src/services/sa/systemSettingsService.ts
@@ -156,19 +156,19 @@ export const systemSettingsService = {
 
   /** 시스템 설정 조회 */
   async getSystemSettings(): Promise<SystemSettingsResponse> {
-    const { data } = await axiosInstance.get<{ data: SystemSettingsResponse }>(
+    const { data } = await axiosInstance.get<SystemSettingsResponse>(
       API_ENDPOINTS.SYSTEM_SETTINGS.BASE
     );
-    return data.data;
+    return data;
   },
 
   /** 시스템 설정 업데이트 */
   async updateSystemSettings(request: UpdateSystemSettingsRequest): Promise<SystemSettingsResponse> {
-    const { data } = await axiosInstance.put<{ data: SystemSettingsResponse }>(
+    const { data } = await axiosInstance.put<SystemSettingsResponse>(
       API_ENDPOINTS.SYSTEM_SETTINGS.BASE,
       request
     );
-    return data.data;
+    return data;
   },
 
   // ============================================
@@ -177,18 +177,18 @@ export const systemSettingsService = {
 
   /** 테넌트 기본값 조회 */
   async getTenantDefaults(): Promise<TenantDefaultsResponse> {
-    const { data } = await axiosInstance.get<{ data: TenantDefaultsResponse }>(
+    const { data } = await axiosInstance.get<TenantDefaultsResponse>(
       API_ENDPOINTS.SYSTEM_SETTINGS.TENANT_DEFAULTS
     );
-    return data.data;
+    return data;
   },
 
   /** 테넌트 기본값 업데이트 */
   async updateTenantDefaults(request: UpdateTenantDefaultsRequest): Promise<TenantDefaultsResponse> {
-    const { data } = await axiosInstance.put<{ data: TenantDefaultsResponse }>(
+    const { data } = await axiosInstance.put<TenantDefaultsResponse>(
       API_ENDPOINTS.SYSTEM_SETTINGS.TENANT_DEFAULTS,
       request
     );
-    return data.data;
+    return data;
   },
 };

--- a/src/services/sa/tenantService.ts
+++ b/src/services/sa/tenantService.ts
@@ -29,11 +29,11 @@ export const tenantService = {
 
   /** 테넌트 생성 */
   async create(request: CreateTenantRequest): Promise<Tenant> {
-    const { data } = await axiosInstance.post<{ data: Tenant }>(
+    const { data } = await axiosInstance.post<Tenant>(
       API_ENDPOINTS.TENANTS.BASE,
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 테넌트 목록 조회 */
@@ -47,19 +47,19 @@ export const tenantService = {
 
   /** 테넌트 상세 조회 */
   async getTenant(id: number): Promise<TenantDetail> {
-    const { data } = await axiosInstance.get<{ data: TenantDetail }>(
+    const { data } = await axiosInstance.get<TenantDetail>(
       API_ENDPOINTS.TENANTS.BY_ID(id)
     );
-    return data.data;
+    return data;
   },
 
   /** 테넌트 수정 */
   async update(id: number, request: UpdateTenantDetailRequest): Promise<TenantDetail> {
-    const { data } = await axiosInstance.put<{ data: TenantDetail }>(
+    const { data } = await axiosInstance.put<TenantDetail>(
       API_ENDPOINTS.TENANTS.BY_ID(id),
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 테넌트 삭제 */
@@ -73,9 +73,9 @@ export const tenantService = {
 
   /** 테넌트 통계 조회 */
   async getStats(): Promise<TenantStats> {
-    const { data } = await axiosInstance.get<{ data: TenantStats }>(
+    const { data } = await axiosInstance.get<TenantStats>(
       `${API_ENDPOINTS.TENANTS.BASE}/stats`
     );
-    return data.data;
+    return data;
   },
 };

--- a/src/services/ta/analyticsService.ts
+++ b/src/services/ta/analyticsService.ts
@@ -93,27 +93,27 @@ export interface ActivityLogsParams {
 export const analyticsService = {
   /** 활동 로그 목록 조회 */
   async getLogs(params?: ActivityLogsParams): Promise<Page<ActivityLogResponse>> {
-    const { data } = await axiosInstance.get<{ data: Page<ActivityLogResponse> }>(
+    const { data } = await axiosInstance.get<Page<ActivityLogResponse>>(
       API_ENDPOINTS.ANALYTICS.TA_LOGS,
       { params }
     );
-    return data.data;
+    return data;
   },
 
   /** 활동 통계 조회 */
   async getStats(days: number = 30): Promise<ActivityStatsResponse> {
-    const { data } = await axiosInstance.get<{ data: ActivityStatsResponse }>(
+    const { data } = await axiosInstance.get<ActivityStatsResponse>(
       API_ENDPOINTS.ANALYTICS.TA_STATS,
       { params: { days } }
     );
-    return data.data;
+    return data;
   },
 
   /** 최근 활동 목록 조회 */
   async getRecentActivities(): Promise<ActivityLogResponse[]> {
-    const { data } = await axiosInstance.get<{ data: ActivityLogResponse[] }>(
+    const { data } = await axiosInstance.get<ActivityLogResponse[]>(
       API_ENDPOINTS.ANALYTICS.TA_RECENT
     );
-    return data.data;
+    return data;
   },
 };

--- a/src/services/ta/brandingService.ts
+++ b/src/services/ta/brandingService.ts
@@ -121,28 +121,28 @@ export const brandingService = {
 
   /** 테넌트 설정 전체 조회 */
   async getSettings(): Promise<TenantSettingsResponse> {
-    const { data } = await axiosInstance.get<{ data: TenantSettingsResponse }>(
+    const { data } = await axiosInstance.get<TenantSettingsResponse>(
       API_ENDPOINTS.TENANT_SETTINGS.BASE
     );
-    return data.data;
+    return data;
   },
 
   /** 디자인 설정 업데이트 */
   async updateDesignSettings(request: UpdateDesignSettingsRequest): Promise<TenantSettingsResponse> {
-    const { data } = await axiosInstance.put<{ data: TenantSettingsResponse }>(
+    const { data } = await axiosInstance.put<TenantSettingsResponse>(
       API_ENDPOINTS.TENANT_SETTINGS.DESIGN,
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 레이아웃 설정 업데이트 */
   async updateLayoutSettings(request: UpdateLayoutSettingsRequest): Promise<TenantSettingsResponse> {
-    const { data } = await axiosInstance.put<{ data: TenantSettingsResponse }>(
+    const { data } = await axiosInstance.put<TenantSettingsResponse>(
       API_ENDPOINTS.TENANT_SETTINGS.LAYOUT,
       request
     );
-    return data.data;
+    return data;
   },
 
   // ============================================
@@ -151,28 +151,28 @@ export const brandingService = {
 
   /** 네비게이션 항목 목록 조회 */
   async getNavigationItems(): Promise<NavigationItemResponse[]> {
-    const { data } = await axiosInstance.get<{ data: NavigationItemResponse[] }>(
+    const { data } = await axiosInstance.get<NavigationItemResponse[]>(
       API_ENDPOINTS.TENANT_SETTINGS.NAVIGATION
     );
-    return data.data;
+    return data;
   },
 
   /** 네비게이션 항목 생성 */
   async createNavigationItem(request: NavigationItemRequest): Promise<NavigationItemResponse> {
-    const { data } = await axiosInstance.post<{ data: NavigationItemResponse }>(
+    const { data } = await axiosInstance.post<NavigationItemResponse>(
       API_ENDPOINTS.TENANT_SETTINGS.NAVIGATION,
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 네비게이션 항목 수정 */
   async updateNavigationItem(id: number, request: NavigationItemRequest): Promise<NavigationItemResponse> {
-    const { data } = await axiosInstance.put<{ data: NavigationItemResponse }>(
+    const { data } = await axiosInstance.put<NavigationItemResponse>(
       API_ENDPOINTS.TENANT_SETTINGS.NAVIGATION_ITEM(id),
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 네비게이션 항목 삭제 */
@@ -182,18 +182,18 @@ export const brandingService = {
 
   /** 네비게이션 항목 순서 변경 */
   async reorderNavigationItems(itemIds: number[]): Promise<NavigationItemResponse[]> {
-    const { data } = await axiosInstance.put<{ data: NavigationItemResponse[] }>(
+    const { data } = await axiosInstance.put<NavigationItemResponse[]>(
       API_ENDPOINTS.TENANT_SETTINGS.NAVIGATION_REORDER,
       itemIds
     );
-    return data.data;
+    return data;
   },
 
   /** 네비게이션 초기화 */
   async resetNavigationItems(): Promise<NavigationItemResponse[]> {
-    const { data } = await axiosInstance.post<{ data: NavigationItemResponse[] }>(
+    const { data } = await axiosInstance.post<NavigationItemResponse[]>(
       API_ENDPOINTS.TENANT_SETTINGS.NAVIGATION_RESET
     );
-    return data.data;
+    return data;
   },
 };

--- a/src/services/ta/dashboardService.ts
+++ b/src/services/ta/dashboardService.ts
@@ -9,9 +9,9 @@ import type { TaKpiDashboardResponse } from '@/types/admin';
 export const taDashboardService = {
   /** TA KPI 대시보드 통계 조회 */
   async getKpiDashboard(): Promise<TaKpiDashboardResponse> {
-    const { data } = await axiosInstance.get<{ data: TaKpiDashboardResponse }>(
+    const { data } = await axiosInstance.get<TaKpiDashboardResponse>(
       API_ENDPOINTS.TA_DASHBOARD.KPI
     );
-    return data.data;
+    return data;
   },
 };

--- a/src/services/ta/groupService.ts
+++ b/src/services/ta/groupService.ts
@@ -14,45 +14,45 @@ import type {
 export const groupService = {
   /** 그룹 목록 조회 */
   async getGroups(params?: UserGroupListParams): Promise<UserGroupListResponse> {
-    const { data } = await axiosInstance.get<{ data: UserGroupListResponse }>(
+    const { data } = await axiosInstance.get<UserGroupListResponse>(
       API_ENDPOINTS.GROUPS.BASE,
       { params }
     );
-    return data.data;
+    return data;
   },
 
   /** 활성 그룹 목록 조회 */
   async getActiveGroups(): Promise<UserGroup[]> {
-    const { data } = await axiosInstance.get<{ data: UserGroup[] }>(
+    const { data } = await axiosInstance.get<UserGroup[]>(
       API_ENDPOINTS.GROUPS.ACTIVE
     );
-    return data.data;
+    return data;
   },
 
   /** 그룹 상세 조회 */
   async getGroup(id: number): Promise<UserGroup> {
-    const { data } = await axiosInstance.get<{ data: UserGroup }>(
+    const { data } = await axiosInstance.get<UserGroup>(
       API_ENDPOINTS.GROUPS.BY_ID(id)
     );
-    return data.data;
+    return data;
   },
 
   /** 그룹 생성 */
   async create(request: CreateUserGroupRequest): Promise<UserGroup> {
-    const { data } = await axiosInstance.post<{ data: UserGroup }>(
+    const { data } = await axiosInstance.post<UserGroup>(
       API_ENDPOINTS.GROUPS.BASE,
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 그룹 수정 */
   async update(id: number, request: UpdateUserGroupRequest): Promise<UserGroup> {
-    const { data } = await axiosInstance.put<{ data: UserGroup }>(
+    const { data } = await axiosInstance.put<UserGroup>(
       API_ENDPOINTS.GROUPS.BY_ID(id),
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 그룹 삭제 */

--- a/src/services/ta/tenantSettingsService.ts
+++ b/src/services/ta/tenantSettingsService.ts
@@ -13,36 +13,36 @@ import type {
 export const tenantSettingsService = {
   /** 테넌트 설정 조회 */
   async getSettings(): Promise<TenantSettingsDetail> {
-    const { data } = await axiosInstance.get<{ data: TenantSettingsDetail }>(
+    const { data } = await axiosInstance.get<TenantSettingsDetail>(
       API_ENDPOINTS.TENANT_SETTINGS.BASE
     );
-    return data.data;
+    return data;
   },
 
   /** 테넌트 설정 전체 수정 */
   async update(request: UpdateTenantSettingsRequest): Promise<TenantSettingsDetail> {
-    const { data } = await axiosInstance.put<{ data: TenantSettingsDetail }>(
+    const { data } = await axiosInstance.put<TenantSettingsDetail>(
       API_ENDPOINTS.TENANT_SETTINGS.BASE,
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 브랜딩 설정 수정 */
   async updateBranding(request: UpdateBrandingRequest): Promise<TenantSettingsDetail> {
-    const { data } = await axiosInstance.patch<{ data: TenantSettingsDetail }>(
+    const { data } = await axiosInstance.patch<TenantSettingsDetail>(
       API_ENDPOINTS.TENANT_SETTINGS.BRANDING,
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 사용자 관리 설정 수정 */
   async updateUserManagement(request: UpdateUserManagementRequest): Promise<TenantSettingsDetail> {
-    const { data } = await axiosInstance.patch<{ data: TenantSettingsDetail }>(
+    const { data } = await axiosInstance.patch<TenantSettingsDetail>(
       API_ENDPOINTS.TENANT_SETTINGS.USER_MANAGEMENT,
       request
     );
-    return data.data;
+    return data;
   },
 };

--- a/src/services/ta/userService.ts
+++ b/src/services/ta/userService.ts
@@ -31,37 +31,37 @@ export const userService = {
 
   /** 사용자 상세 조회 */
   async getUser(id: number): Promise<UserDetail> {
-    const { data } = await axiosInstance.get<{ data: UserDetail }>(
+    const { data } = await axiosInstance.get<UserDetail>(
       API_ENDPOINTS.USERS.BY_ID(id)
     );
-    return data.data;
+    return data;
   },
 
   /** 사용자 정보 수정 */
   async update(id: number, request: UpdateUserDetailRequest): Promise<UserDetail> {
-    const { data } = await axiosInstance.put<{ data: UserDetail }>(
+    const { data } = await axiosInstance.put<UserDetail>(
       API_ENDPOINTS.USERS.BY_ID(id),
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 사용자 역할 변경 */
   async updateRole(id: number, request: UpdateUserRoleRequest): Promise<AdminUser> {
-    const { data } = await axiosInstance.patch<{ data: AdminUser }>(
+    const { data } = await axiosInstance.patch<AdminUser>(
       API_ENDPOINTS.USERS.ROLE(id),
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 사용자 상태 변경 */
   async updateStatus(id: number, status: string): Promise<AdminUser> {
-    const { data } = await axiosInstance.patch<{ data: AdminUser }>(
+    const { data } = await axiosInstance.patch<AdminUser>(
       API_ENDPOINTS.USERS.STATUS(id),
       { status }
     );
-    return data.data;
+    return data;
   },
 
   /** 사용자 삭제 */
@@ -75,10 +75,10 @@ export const userService = {
 
   /** 사용자 통계 조회 */
   async getStats(): Promise<UserStats> {
-    const { data } = await axiosInstance.get<{ data: UserStats }>(
+    const { data } = await axiosInstance.get<UserStats>(
       `${API_ENDPOINTS.USERS.BASE}/stats`
     );
-    return data.data;
+    return data;
   },
 
   // ============================================
@@ -87,10 +87,10 @@ export const userService = {
 
   /** 단체 계정 생성 */
   async bulkCreateUsers(request: BulkCreateUsersRequest): Promise<BulkCreateUsersResponse> {
-    const { data } = await axiosInstance.post<{ data: BulkCreateUsersResponse }>(
+    const { data } = await axiosInstance.post<BulkCreateUsersResponse>(
       API_ENDPOINTS.USERS.BULK,
       request
     );
-    return data.data;
+    return data;
   },
 };

--- a/src/services/to/dashboardService.ts
+++ b/src/services/to/dashboardService.ts
@@ -9,9 +9,9 @@ import type { ToOperatorDashboardResponse } from '@/types/to';
 export const toDashboardService = {
   /** TO 운영 대시보드 통계 조회 */
   async getDashboard(): Promise<ToOperatorDashboardResponse> {
-    const { data } = await axiosInstance.get<{ data: ToOperatorDashboardResponse }>(
+    const { data } = await axiosInstance.get<ToOperatorDashboardResponse>(
       API_ENDPOINTS.TO_DASHBOARD.TASKS
     );
-    return data.data;
+    return data;
   },
 };

--- a/src/services/to/instructorAssignmentService.ts
+++ b/src/services/to/instructorAssignmentService.ts
@@ -23,11 +23,11 @@ export const instructorAssignmentService = {
   async getAssignments(
     params?: InstructorAssignmentFilterParams
   ): Promise<PageResponse<InstructorAssignmentListResponse>> {
-    const { data } = await axiosInstance.get<{ data: PageResponse<InstructorAssignmentListResponse> }>(
+    const { data } = await axiosInstance.get<PageResponse<InstructorAssignmentListResponse>>(
       API_ENDPOINTS.INSTRUCTOR_ASSIGNMENTS.BASE,
       { params }
     );
-    return data.data;
+    return data;
   },
 
   // ============================================
@@ -39,11 +39,11 @@ export const instructorAssignmentService = {
     timeId: number,
     request: AssignInstructorRequest
   ): Promise<InstructorAssignmentResponse> {
-    const { data } = await axiosInstance.post<{ data: InstructorAssignmentResponse }>(
+    const { data } = await axiosInstance.post<InstructorAssignmentResponse>(
       API_ENDPOINTS.TIMES.INSTRUCTORS(timeId),
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 차수별 강사 목록 조회 */
@@ -51,11 +51,11 @@ export const instructorAssignmentService = {
     timeId: number,
     params?: InstructorAssignmentFilterParams
   ): Promise<InstructorAssignmentResponse[]> {
-    const { data } = await axiosInstance.get<{ data: InstructorAssignmentResponse[] }>(
+    const { data } = await axiosInstance.get<InstructorAssignmentResponse[]>(
       API_ENDPOINTS.TIMES.INSTRUCTORS(timeId),
       { params }
     );
-    return data.data;
+    return data;
   },
 
   /** 강사 역할 변경 */
@@ -64,11 +64,11 @@ export const instructorAssignmentService = {
     assignmentId: number,
     request: UpdateInstructorRoleRequest
   ): Promise<InstructorAssignmentResponse> {
-    const { data } = await axiosInstance.put<{ data: InstructorAssignmentResponse }>(
+    const { data } = await axiosInstance.put<InstructorAssignmentResponse>(
       API_ENDPOINTS.TIMES.INSTRUCTOR_BY_ID(timeId, assignmentId),
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 강사 교체 */
@@ -77,11 +77,11 @@ export const instructorAssignmentService = {
     assignmentId: number,
     request: ReplaceInstructorRequest
   ): Promise<InstructorAssignmentResponse> {
-    const { data } = await axiosInstance.post<{ data: InstructorAssignmentResponse }>(
+    const { data } = await axiosInstance.post<InstructorAssignmentResponse>(
       API_ENDPOINTS.TIMES.INSTRUCTOR_REPLACE(timeId, assignmentId),
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 배정 취소 */

--- a/src/services/to/programService.ts
+++ b/src/services/to/programService.ts
@@ -41,30 +41,30 @@ export const programService = {
   async createProgram(
     request: CreateProgramRequest
   ): Promise<ProgramResponse> {
-    const { data } = await axiosInstance.post<{ data: ProgramResponse }>(
+    const { data } = await axiosInstance.post<ProgramResponse>(
       API_ENDPOINTS.PROGRAMS.BASE,
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 프로그램 목록 조회 */
   async getPrograms(
     params?: ProgramFilterParams
   ): Promise<PageResponse<ProgramResponse>> {
-    const { data } = await axiosInstance.get<{ data: PageResponse<ProgramResponse> }>(
+    const { data } = await axiosInstance.get<PageResponse<ProgramResponse>>(
       API_ENDPOINTS.PROGRAMS.BASE,
       { params }
     );
-    return data.data;
+    return data;
   },
 
   /** 프로그램 상세 조회 */
   async getProgram(id: number): Promise<ProgramDetailResponse> {
-    const { data } = await axiosInstance.get<{ data: ProgramDetailResponse }>(
+    const { data } = await axiosInstance.get<ProgramDetailResponse>(
       API_ENDPOINTS.PROGRAMS.BY_ID(id)
     );
-    return data.data;
+    return data;
   },
 
   /** 프로그램 수정 */
@@ -72,11 +72,11 @@ export const programService = {
     id: number,
     request: UpdateProgramRequest
   ): Promise<ProgramResponse> {
-    const { data } = await axiosInstance.put<{ data: ProgramResponse }>(
+    const { data } = await axiosInstance.put<ProgramResponse>(
       API_ENDPOINTS.PROGRAMS.BY_ID(id),
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 프로그램 삭제 */
@@ -90,20 +90,21 @@ export const programService = {
 
   /** 프로그램 개설 신청 (DRAFT/REJECTED → PENDING) */
   async submitProgram(id: number): Promise<ProgramResponse> {
-    const { data } = await axiosInstance.post<{ data: ProgramResponse }>(
+    const { data } = await axiosInstance.post<ProgramResponse>(
       API_ENDPOINTS.PROGRAMS.SUBMIT(id)
     );
-    return data.data;
+    return data;
   },
 
   /** 검토 대기 프로그램 목록 조회 (OPERATOR용) */
   async getPendingPrograms(
     params?: Pick<ProgramFilterParams, 'page' | 'size' | 'sort'>
   ): Promise<PageResponse<PendingProgramResponse>> {
-    const { data } = await axiosInstance.get<{
-      data: PageResponse<PendingProgramResponse>;
-    }>(API_ENDPOINTS.PROGRAMS.PENDING, { params });
-    return data.data;
+    const { data } = await axiosInstance.get<PageResponse<PendingProgramResponse>>(
+      API_ENDPOINTS.PROGRAMS.PENDING,
+      { params }
+    );
+    return data;
   },
 
   /** 프로그램 승인 (PENDING → APPROVED) */
@@ -111,11 +112,11 @@ export const programService = {
     id: number,
     request?: ApproveRequest
   ): Promise<ProgramDetailResponse> {
-    const { data } = await axiosInstance.post<{ data: ProgramDetailResponse }>(
+    const { data } = await axiosInstance.post<ProgramDetailResponse>(
       API_ENDPOINTS.PROGRAMS.APPROVE(id),
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 프로그램 반려 (PENDING → REJECTED) */
@@ -123,19 +124,19 @@ export const programService = {
     id: number,
     request: RejectRequest
   ): Promise<ProgramDetailResponse> {
-    const { data } = await axiosInstance.post<{ data: ProgramDetailResponse }>(
+    const { data } = await axiosInstance.post<ProgramDetailResponse>(
       API_ENDPOINTS.PROGRAMS.REJECT(id),
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 프로그램 종료 (APPROVED/DRAFT → CLOSED) */
   async closeProgram(id: number): Promise<ProgramResponse> {
-    const { data } = await axiosInstance.post<{ data: ProgramResponse }>(
+    const { data } = await axiosInstance.post<ProgramResponse>(
       API_ENDPOINTS.PROGRAMS.CLOSE(id)
     );
-    return data.data;
+    return data;
   },
 
   // ============================================
@@ -147,11 +148,11 @@ export const programService = {
     programId: number,
     snapshotId: number
   ): Promise<ProgramResponse> {
-    const { data } = await axiosInstance.post<{ data: ProgramResponse }>(
+    const { data } = await axiosInstance.post<ProgramResponse>(
       API_ENDPOINTS.PROGRAMS.SNAPSHOT(programId),
       null,
       { params: { snapshotId } }
     );
-    return data.data;
+    return data;
   },
 };

--- a/src/services/tu/contentService.ts
+++ b/src/services/tu/contentService.ts
@@ -68,7 +68,7 @@ export const contentService = {
       formData.append('downloadable', String(options.downloadable));
     }
 
-    const { data } = await axiosInstance.post<{ data: ContentResponse }>(
+    const { data } = await axiosInstance.post<ContentResponse>(
       API_ENDPOINTS.CONTENTS.UPLOAD,
       formData,
       {
@@ -78,53 +78,51 @@ export const contentService = {
         timeout: 300000, // 5분 (대용량 파일 업로드용)
       }
     );
-    return data.data;
+    return data;
   },
 
   // 외부 링크 생성
   async createExternalLink(request: CreateExternalLinkRequest): Promise<ContentResponse> {
-    const { data } = await axiosInstance.post<{ data: ContentResponse }>(
+    const { data } = await axiosInstance.post<ContentResponse>(
       API_ENDPOINTS.CONTENTS.EXTERNAL_LINK,
       request
     );
-    return data.data;
+    return data;
   },
 
   // 콘텐츠 목록 조회
   async getContents(params?: ContentFilterParams): Promise<PageResponse<ContentListResponse>> {
-    const { data } = await axiosInstance.get<{ data: PageResponse<ContentListResponse> }>(
+    const { data } = await axiosInstance.get<PageResponse<ContentListResponse>>(
       API_ENDPOINTS.CONTENTS.BASE,
       { params }
     );
-    return data.data;
+    return data;
   },
 
   // 내 콘텐츠 목록 조회 (DESIGNER용)
   async getMyContents(params?: ContentFilterParams): Promise<PageResponse<ContentListResponse>> {
-    const { data } = await axiosInstance.get<{ data: PageResponse<ContentListResponse> }>(
+    const { data } = await axiosInstance.get<PageResponse<ContentListResponse>>(
       API_ENDPOINTS.CONTENTS.MY,
       { params }
     );
-    return data.data;
+    return data;
   },
 
   // 콘텐츠 상세 조회
   async getContent(id: number): Promise<ContentResponse> {
-    const { data } = await axiosInstance.get<{ data: ContentResponse }>(
+    const { data } = await axiosInstance.get<ContentResponse>(
       API_ENDPOINTS.CONTENTS.BY_ID(id)
     );
-    return data.data;
+    return data;
   },
 
   // 콘텐츠 메타데이터 수정
   async updateContent(id: number, request: UpdateContentRequest): Promise<ContentResponse> {
-    const response = await axiosInstance.put(
+    const { data } = await axiosInstance.put<ContentResponse>(
       API_ENDPOINTS.CONTENTS.BY_ID(id),
       request
     );
-    // API 응답 형식에 따라 처리
-    const result = response.data;
-    return result.data ?? result;
+    return data;
   },
 
   // 파일 교체
@@ -132,7 +130,7 @@ export const contentService = {
     const formData = new FormData();
     formData.append('file', file);
 
-    const response = await axiosInstance.put(
+    const { data } = await axiosInstance.put<ContentResponse>(
       API_ENDPOINTS.CONTENTS.FILE(id),
       formData,
       {
@@ -142,8 +140,7 @@ export const contentService = {
         timeout: 300000, // 5분 (대용량 파일 업로드용)
       }
     );
-    const result = response.data;
-    return result.data ?? result;
+    return data;
   },
 
   // 콘텐츠 삭제
@@ -153,18 +150,18 @@ export const contentService = {
 
   // 콘텐츠 보관 (Archive)
   async archiveContent(id: number): Promise<ContentResponse> {
-    const { data } = await axiosInstance.post<{ data: ContentResponse }>(
+    const { data } = await axiosInstance.post<ContentResponse>(
       API_ENDPOINTS.CONTENTS.ARCHIVE(id)
     );
-    return data.data;
+    return data;
   },
 
   // 콘텐츠 복원
   async restoreContent(id: number): Promise<ContentResponse> {
-    const { data } = await axiosInstance.post<{ data: ContentResponse }>(
+    const { data } = await axiosInstance.post<ContentResponse>(
       API_ENDPOINTS.CONTENTS.RESTORE(id)
     );
-    return data.data;
+    return data;
   },
 
   // 스트리밍 URL 반환
@@ -219,18 +216,18 @@ export const contentService = {
 
   // 버전 히스토리 조회
   async getVersions(id: number): Promise<ContentVersionResponse[]> {
-    const { data } = await axiosInstance.get<{ data: ContentVersionResponse[] }>(
+    const { data } = await axiosInstance.get<ContentVersionResponse[]>(
       API_ENDPOINTS.CONTENTS.VERSIONS(id)
     );
-    return data.data;
+    return data;
   },
 
   // 특정 버전 조회
   async getVersion(id: number, versionNumber: number): Promise<ContentVersionResponse> {
-    const { data } = await axiosInstance.get<{ data: ContentVersionResponse }>(
+    const { data } = await axiosInstance.get<ContentVersionResponse>(
       API_ENDPOINTS.CONTENTS.VERSION_BY_NUMBER(id, versionNumber)
     );
-    return data.data;
+    return data;
   },
 
   // 버전 복원
@@ -239,10 +236,10 @@ export const contentService = {
     versionNumber: number,
     request?: RestoreVersionRequest
   ): Promise<ContentResponse> {
-    const { data } = await axiosInstance.post<{ data: ContentResponse }>(
+    const { data } = await axiosInstance.post<ContentResponse>(
       API_ENDPOINTS.CONTENTS.VERSION_RESTORE(id, versionNumber),
       request
     );
-    return data.data;
+    return data;
   },
 };

--- a/src/services/tu/learningObjectService.ts
+++ b/src/services/tu/learningObjectService.ts
@@ -23,56 +23,56 @@ interface PageResponse<T> {
 export const learningObjectService = {
   // 학습객체 생성
   async create(request: CreateLearningObjectRequest): Promise<LearningObjectResponse> {
-    const { data } = await axiosInstance.post<{ data: LearningObjectResponse }>(
+    const { data } = await axiosInstance.post<LearningObjectResponse>(
       API_ENDPOINTS.LEARNING_OBJECTS.BASE,
       request
     );
-    return data.data;
+    return data;
   },
 
   // 학습객체 목록 조회
   async getLearningObjects(
     params?: LearningObjectFilterParams
   ): Promise<PageResponse<LearningObjectResponse>> {
-    const { data } = await axiosInstance.get<{ data: PageResponse<LearningObjectResponse> }>(
+    const { data } = await axiosInstance.get<PageResponse<LearningObjectResponse>>(
       API_ENDPOINTS.LEARNING_OBJECTS.BASE,
       { params }
     );
-    return data.data;
+    return data;
   },
 
   // 학습객체 상세 조회
   async getLearningObject(id: number): Promise<LearningObjectResponse> {
-    const { data } = await axiosInstance.get<{ data: LearningObjectResponse }>(
+    const { data } = await axiosInstance.get<LearningObjectResponse>(
       API_ENDPOINTS.LEARNING_OBJECTS.BY_ID(id)
     );
-    return data.data;
+    return data;
   },
 
   // Content ID로 학습객체 조회
   async getLearningObjectByContentId(contentId: number): Promise<LearningObjectResponse> {
-    const { data } = await axiosInstance.get<{ data: LearningObjectResponse }>(
+    const { data } = await axiosInstance.get<LearningObjectResponse>(
       API_ENDPOINTS.LEARNING_OBJECTS.BY_CONTENT_ID(contentId)
     );
-    return data.data;
+    return data;
   },
 
   // 학습객체 수정
   async update(id: number, request: UpdateLearningObjectRequest): Promise<LearningObjectResponse> {
-    const { data } = await axiosInstance.put<{ data: LearningObjectResponse }>(
+    const { data } = await axiosInstance.put<LearningObjectResponse>(
       API_ENDPOINTS.LEARNING_OBJECTS.BY_ID(id),
       request
     );
-    return data.data;
+    return data;
   },
 
   // 학습객체 폴더 이동
   async moveToFolder(id: number, request: MoveFolderRequest): Promise<LearningObjectResponse> {
-    const { data } = await axiosInstance.put<{ data: LearningObjectResponse }>(
+    const { data } = await axiosInstance.put<LearningObjectResponse>(
       API_ENDPOINTS.LEARNING_OBJECTS.FOLDER(id),
       request
     );
-    return data.data;
+    return data;
   },
 
   // 학습객체 삭제

--- a/src/services/tu/publicBrandingService.ts
+++ b/src/services/tu/publicBrandingService.ts
@@ -15,12 +15,12 @@ export const publicBrandingService = {
     identifier: string,
     type: 'subdomain' | 'customDomain' = 'subdomain'
   ): Promise<PublicBrandingResponse> {
-    const { data } = await axiosInstance.get<{ data: PublicBrandingResponse }>(
+    const { data } = await axiosInstance.get<PublicBrandingResponse>(
       '/api/public/tenants/branding',
       {
         params: { identifier, type },
       }
     );
-    return data.data;
+    return data;
   },
 };


### PR DESCRIPTION
## Summary

- axios 인터셉터에서 이미 `response.data.data`를 추출하고 있어, 서비스에서 다시 `data.data` 접근 시 `undefined` 반환되는 문제 수정
- React Query "Query data cannot be undefined" 오류 해결

## Changes

모든 서비스에서:
- 타입: `<{ data: T }>` → `<T>`
- 반환: `return data.data` → `return data`

### 수정 파일 (19개)
| 폴더 | 파일 |
|------|------|
| common | courseService, categoryService |
| tu | contentService, learningObjectService, publicBrandingService |
| to | programService, instructorAssignmentService, dashboardService |
| sa | tenantService, noticeService, analyticsService, dashboardService, systemSettingsService |
| ta | groupService, userService, analyticsService, dashboardService, tenantSettingsService, brandingService |

## Test plan

- [ ] 프로그램 목록 페이지 정상 로드 확인
- [ ] 콘텐츠 목록 페이지 정상 로드 확인
- [ ] 강의 목록 페이지 정상 로드 확인
- [ ] React Query 에러 없음 확인

Closes #278