### PR TITLE
[Bug] 강의 생성/수정 3단계 검토에서 콘텐츠 displayName이 표시되지 않음

### DIFF
--- a/src/pages/tu/teaching/courses/components/Step3Review.tsx
+++ b/src/pages/tu/teaching/courses/components/Step3Review.tsx
@@ -22,7 +22,7 @@ import { Button, Label, Card, CardHeader, CardContent, Alert, AlertDescription }
 import type { CourseFormData } from '@/types';
 import type { CategoryResponse } from '@/types/common';
 import type { CurriculumItem } from '@/types/tu';
-import { isCurriculumFolder } from '@/types/tu';
+import { isCurriculumFolder, isCurriculumContent } from '@/types/tu';
 import { translations, levelOptions, type TranslationKey } from './courseCreate.constants';
 
 /** 커리큘럼 아이템 수 계산 (폴더/콘텐츠 분리) */
@@ -55,6 +55,7 @@ function CurriculumTreeItem({
   onToggle: (id: string) => void;
 }) {
   const isFolder = isCurriculumFolder(item);
+  const isContent = isCurriculumContent(item);
   const isExpanded = expandedIds.has(item.id);
 
   return (
@@ -83,7 +84,16 @@ function CurriculumTreeItem({
         ) : (
           <File size={16} className="text-blue-500 shrink-0" />
         )}
-        <span className="text-text-primary text-sm truncate">{item.name}</span>
+        <span className="text-text-primary text-sm truncate">
+          {isContent && item.displayName ? (
+            <>
+              {item.displayName}
+              <span className="text-text-placeholder ml-1 text-xs">({item.originalFileName})</span>
+            </>
+          ) : (
+            item.name
+          )}
+        </span>
       </div>
       {isFolder && isExpanded && item.children.length > 0 && (
         <div>


### PR DESCRIPTION
## Summary
- Step3Review 컴포넌트에서 콘텐츠 `displayName` 우선 표시 로직 추가
- 원본 파일명(`originalFileName`)은 괄호 안에 보조 표시
- `isCurriculumContent` 타입 가드를 활용하여 콘텐츠 타입 확인

## Changes
- `src/pages/tu/teaching/courses/components/Step3Review.tsx`
  - `isCurriculumContent` import 추가
  - `CurriculumTreeItem` 컴포넌트에 `isContent` 변수 추가
  - 이름 표시 로직을 CurriculumItemCard와 동일하게 수정

## Test plan
- [ ] 강의 생성 페이지 진입
- [ ] Step 2에서 콘텐츠 추가 후 "강의 내 표시 이름" 입력
- [ ] Step 3에서 입력한 표시 이름이 정상 표시되는지 확인
- [ ] 원본 파일명이 괄호 안에 표시되는지 확인

Closes #201