### PR TITLE
feat: 어드민 로그인/회원가입 페이지 추가

### DIFF
--- a/src/pages/admin/auth/AdminLoginPage.tsx
+++ b/src/pages/admin/auth/AdminLoginPage.tsx
@@ -1,0 +1,248 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Eye, EyeOff, LogIn, Shield } from 'lucide-react';
+import { Checkbox } from '@/components/common/Checkbox';
+import { useLogin } from '@/hooks/common';
+import { ROLE_REDIRECT_PATH } from '@/types/common/auth.types';
+import { designTokens } from '@/styles/admin-design-tokens';
+
+/**
+ * 어드민 로그인 페이지
+ * 어드민 디자인 토큰 사용
+ */
+export const AdminLoginPage = () => {
+  const navigate = useNavigate();
+  const loginMutation = useLogin();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [rememberMe, setRememberMe] = useState(false);
+  const [errors, setErrors] = useState<{ email?: string; password?: string; general?: string }>({});
+
+  const validateForm = (): boolean => {
+    const newErrors: typeof errors = {};
+
+    if (!email) {
+      newErrors.email = '이메일을 입력해주세요.';
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      newErrors.email = '올바른 이메일 형식이 아닙니다.';
+    }
+
+    if (!password) {
+      newErrors.password = '비밀번호를 입력해주세요.';
+    } else if (password.length < 8) {
+      newErrors.password = '비밀번호는 8자 이상이어야 합니다.';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) return;
+
+    setErrors({});
+
+    try {
+      const user = await loginMutation.mutateAsync({ email, password });
+
+      // Role에 따른 리다이렉트
+      const redirectPath = ROLE_REDIRECT_PATH[user.role] || '/';
+      navigate(redirectPath);
+    } catch {
+      setErrors({ general: '이메일 또는 비밀번호가 올바르지 않습니다.' });
+    }
+  };
+
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center p-4"
+      style={{ backgroundColor: designTokens.bg.app_default }}
+    >
+      <div
+        className="w-full max-w-[400px] rounded-xl p-8 border shadow-lg"
+        style={{
+          backgroundColor: designTokens.bg.default,
+          borderColor: designTokens.bg.border,
+        }}
+      >
+        {/* 로고 영역 */}
+        <div className="text-center mb-8">
+          <div
+            className="w-12 h-12 rounded-lg mx-auto mb-4 flex items-center justify-center"
+            style={{ backgroundColor: designTokens.button.brand_default }}
+          >
+            <Shield className="w-6 h-6 text-white" />
+          </div>
+          <h1
+            className="text-2xl font-semibold"
+            style={{ color: designTokens.text.primary }}
+          >
+            관리자 로그인
+          </h1>
+          <p
+            className="text-sm mt-2"
+            style={{ color: designTokens.text.secondary }}
+          >
+            Super Admin / Tenant Admin 전용 로그인
+          </p>
+        </div>
+
+        {/* 에러 메시지 */}
+        {errors.general && (
+          <div
+            className="mb-4 p-3 rounded-md text-sm"
+            style={{
+              backgroundColor: designTokens.status.error_background,
+              color: designTokens.status.error_text,
+            }}
+          >
+            {errors.general}
+          </div>
+        )}
+
+        {/* 로그인 폼 */}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* 이메일 입력 */}
+          <div>
+            <label
+              className="block text-sm font-medium mb-1"
+              style={{ color: designTokens.text.primary }}
+            >
+              이메일
+            </label>
+            <input
+              type="email"
+              placeholder="admin@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              disabled={loginMutation.isPending}
+              className="w-full h-10 px-3 rounded-lg border text-sm transition-colors outline-none focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{
+                backgroundColor: designTokens.bg.default,
+                borderColor: errors.email ? designTokens.status.error_text : designTokens.bg.border,
+                color: designTokens.text.primary,
+              }}
+            />
+            {errors.email && (
+              <p className="text-sm mt-1" style={{ color: designTokens.status.error_text }}>
+                {errors.email}
+              </p>
+            )}
+          </div>
+
+          {/* 비밀번호 입력 */}
+          <div>
+            <label
+              className="block text-sm font-medium mb-1"
+              style={{ color: designTokens.text.primary }}
+            >
+              비밀번호
+            </label>
+            <div className="relative">
+              <input
+                type={showPassword ? 'text' : 'password'}
+                placeholder="비밀번호를 입력하세요"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                disabled={loginMutation.isPending}
+                className="w-full h-10 px-3 pr-10 rounded-lg border text-sm transition-colors outline-none focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                style={{
+                  backgroundColor: designTokens.bg.default,
+                  borderColor: errors.password ? designTokens.status.error_text : designTokens.bg.border,
+                  color: designTokens.text.primary,
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 p-0.5"
+                style={{ color: designTokens.text.placeholder }}
+                tabIndex={-1}
+              >
+                {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+              </button>
+            </div>
+            {errors.password && (
+              <p className="text-sm mt-1" style={{ color: designTokens.status.error_text }}>
+                {errors.password}
+              </p>
+            )}
+          </div>
+
+          {/* 로그인 유지 & 비밀번호 찾기 */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="remember"
+                checked={rememberMe}
+                onCheckedChange={(checked) => setRememberMe(checked === true)}
+                disabled={loginMutation.isPending}
+              />
+              <label
+                htmlFor="remember"
+                className="text-sm cursor-pointer"
+                style={{ color: designTokens.text.secondary }}
+              >
+                로그인 유지
+              </label>
+            </div>
+            <Link
+              to="/auth/forgot-password"
+              className="text-sm hover:underline"
+              style={{ color: designTokens.button.brand_default }}
+            >
+              비밀번호 찾기
+            </Link>
+          </div>
+
+          {/* 로그인 버튼 */}
+          <button
+            type="submit"
+            disabled={loginMutation.isPending}
+            className="w-full py-3 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            style={{
+              backgroundColor: designTokens.button.neutral_default,
+              color: designTokens.button.neutral_text,
+            }}
+            onMouseEnter={(e) => {
+              if (!loginMutation.isPending) {
+                e.currentTarget.style.backgroundColor = designTokens.button.neutral_hover;
+              }
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = designTokens.button.neutral_default;
+            }}
+          >
+            {loginMutation.isPending ? (
+              '로그인 중...'
+            ) : (
+              <>
+                <LogIn className="w-4 h-4" />
+                관리자 로그인
+              </>
+            )}
+          </button>
+        </form>
+
+        {/* 회원가입 링크 */}
+        <div className="mt-6 text-center">
+          <p className="text-sm" style={{ color: designTokens.text.secondary }}>
+            계정이 없으신가요?{' '}
+            <Link
+              to="/admin/register"
+              className="font-medium hover:underline"
+              style={{ color: designTokens.button.brand_default }}
+            >
+              관리자 가입 신청
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminLoginPage;

--- a/src/pages/admin/auth/AdminRegisterPage.tsx
+++ b/src/pages/admin/auth/AdminRegisterPage.tsx
@@ -1,0 +1,368 @@
+import { useState } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+import { useAuth } from '@/hooks/common/auth';
+import { ROLE_REDIRECT_PATH } from '@/types/common/auth.types';
+import { Eye, EyeOff, Loader2, Check, X, UserPlus, Shield } from 'lucide-react';
+import { designTokens } from '@/styles/admin-design-tokens';
+
+interface FormErrors {
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+  name?: string;
+  phone?: string;
+}
+
+/**
+ * 어드민 회원가입 페이지
+ * 어드민 디자인 토큰 사용
+ */
+export function AdminRegisterPage() {
+  const { isAuthenticated, user, register, isRegistering } = useAuth();
+  const [formData, setFormData] = useState({
+    email: '',
+    password: '',
+    confirmPassword: '',
+    name: '',
+    phone: '',
+  });
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [errors, setErrors] = useState<FormErrors>({});
+
+  // 이미 로그인된 경우 역할별 페이지로 리다이렉트
+  if (isAuthenticated && user) {
+    return <Navigate to={ROLE_REDIRECT_PATH[user.role]} replace />;
+  }
+
+  const passwordRequirements = [
+    { label: '8자 이상', test: (p: string) => p.length >= 8 },
+    { label: '영문 포함', test: (p: string) => /[A-Za-z]/.test(p) },
+    { label: '숫자 포함', test: (p: string) => /\d/.test(p) },
+    { label: '특수문자 포함', test: (p: string) => /[@$!%*#?&]/.test(p) },
+  ];
+
+  const validate = (): boolean => {
+    const newErrors: FormErrors = {};
+
+    // 이메일 검증
+    if (!formData.email) {
+      newErrors.email = '이메일을 입력해주세요.';
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+      newErrors.email = '올바른 이메일 형식이 아닙니다.';
+    }
+
+    // 비밀번호 검증
+    if (!formData.password) {
+      newErrors.password = '비밀번호를 입력해주세요.';
+    } else if (
+      !/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/.test(formData.password)
+    ) {
+      newErrors.password = '비밀번호 요구사항을 모두 충족해야 합니다.';
+    }
+
+    // 비밀번호 확인 검증
+    if (!formData.confirmPassword) {
+      newErrors.confirmPassword = '비밀번호 확인을 입력해주세요.';
+    } else if (formData.password !== formData.confirmPassword) {
+      newErrors.confirmPassword = '비밀번호가 일치하지 않습니다.';
+    }
+
+    // 이름 검증
+    if (!formData.name) {
+      newErrors.name = '이름을 입력해주세요.';
+    } else if (formData.name.length > 50) {
+      newErrors.name = '이름은 50자 이하여야 합니다.';
+    }
+
+    // 전화번호 검증 (선택)
+    if (formData.phone && !/^01[0-9]-\d{3,4}-\d{4}$/.test(formData.phone)) {
+      newErrors.phone = '올바른 전화번호 형식이 아닙니다. (예: 010-1234-5678)';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+    // 입력 시 해당 필드 에러 제거
+    if (errors[name as keyof FormErrors]) {
+      setErrors((prev) => ({ ...prev, [name]: undefined }));
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (validate()) {
+      register({
+        email: formData.email,
+        password: formData.password,
+        name: formData.name,
+        phone: formData.phone || undefined,
+      });
+    }
+  };
+
+  const inputStyle = (hasError: boolean) => ({
+    backgroundColor: designTokens.bg.default,
+    borderColor: hasError ? designTokens.status.error_text : designTokens.bg.border,
+    color: designTokens.text.primary,
+  });
+
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center p-4 py-8"
+      style={{ backgroundColor: designTokens.bg.app_default }}
+    >
+      <div
+        className="w-full max-w-[400px] rounded-xl p-8 border shadow-lg"
+        style={{
+          backgroundColor: designTokens.bg.default,
+          borderColor: designTokens.bg.border,
+        }}
+      >
+        {/* 로고 영역 */}
+        <div className="text-center mb-8">
+          <div
+            className="w-12 h-12 rounded-lg mx-auto mb-4 flex items-center justify-center"
+            style={{ backgroundColor: designTokens.button.brand_default }}
+          >
+            <Shield className="w-6 h-6 text-white" />
+          </div>
+          <h1
+            className="text-2xl font-semibold"
+            style={{ color: designTokens.text.primary }}
+          >
+            관리자 가입 신청
+          </h1>
+          <p
+            className="text-sm mt-2"
+            style={{ color: designTokens.text.secondary }}
+          >
+            Super Admin / Tenant Admin 전용 가입
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* 이메일 필드 */}
+          <div>
+            <label
+              className="block text-sm font-medium mb-1"
+              style={{ color: designTokens.text.primary }}
+            >
+              이메일 <span style={{ color: designTokens.status.error_text }}>*</span>
+            </label>
+            <input
+              name="email"
+              type="email"
+              placeholder="admin@example.com"
+              value={formData.email}
+              onChange={handleChange}
+              disabled={isRegistering}
+              className="w-full h-10 px-3 rounded-lg border text-sm transition-colors outline-none focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed"
+              style={inputStyle(!!errors.email)}
+            />
+            {errors.email && (
+              <p className="text-sm mt-1" style={{ color: designTokens.status.error_text }}>
+                {errors.email}
+              </p>
+            )}
+          </div>
+
+          {/* 이름 필드 */}
+          <div>
+            <label
+              className="block text-sm font-medium mb-1"
+              style={{ color: designTokens.text.primary }}
+            >
+              이름 <span style={{ color: designTokens.status.error_text }}>*</span>
+            </label>
+            <input
+              name="name"
+              type="text"
+              placeholder="홍길동"
+              value={formData.name}
+              onChange={handleChange}
+              disabled={isRegistering}
+              className="w-full h-10 px-3 rounded-lg border text-sm transition-colors outline-none focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed"
+              style={inputStyle(!!errors.name)}
+            />
+            {errors.name && (
+              <p className="text-sm mt-1" style={{ color: designTokens.status.error_text }}>
+                {errors.name}
+              </p>
+            )}
+          </div>
+
+          {/* 전화번호 필드 */}
+          <div>
+            <label
+              className="block text-sm font-medium mb-1"
+              style={{ color: designTokens.text.primary }}
+            >
+              전화번호 <span style={{ color: designTokens.text.placeholder }}>(선택)</span>
+            </label>
+            <input
+              name="phone"
+              type="tel"
+              placeholder="010-1234-5678"
+              value={formData.phone}
+              onChange={handleChange}
+              disabled={isRegistering}
+              className="w-full h-10 px-3 rounded-lg border text-sm transition-colors outline-none focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed"
+              style={inputStyle(!!errors.phone)}
+            />
+            {errors.phone && (
+              <p className="text-sm mt-1" style={{ color: designTokens.status.error_text }}>
+                {errors.phone}
+              </p>
+            )}
+          </div>
+
+          {/* 비밀번호 필드 */}
+          <div>
+            <label
+              className="block text-sm font-medium mb-1"
+              style={{ color: designTokens.text.primary }}
+            >
+              비밀번호 <span style={{ color: designTokens.status.error_text }}>*</span>
+            </label>
+            <div className="relative">
+              <input
+                name="password"
+                type={showPassword ? 'text' : 'password'}
+                placeholder="비밀번호를 입력하세요"
+                value={formData.password}
+                onChange={handleChange}
+                disabled={isRegistering}
+                className="w-full h-10 px-3 pr-10 rounded-lg border text-sm transition-colors outline-none focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                style={inputStyle(!!errors.password)}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 p-0.5"
+                style={{ color: designTokens.text.placeholder }}
+                tabIndex={-1}
+              >
+                {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+              </button>
+            </div>
+            {/* 비밀번호 요구사항 */}
+            {formData.password && (
+              <div className="mt-2 space-y-1">
+                {passwordRequirements.map((req) => {
+                  const passed = req.test(formData.password);
+                  return (
+                    <div
+                      key={req.label}
+                      className="flex items-center gap-2 text-xs"
+                      style={{
+                        color: passed
+                          ? designTokens.status.success_text
+                          : designTokens.text.placeholder,
+                      }}
+                    >
+                      {passed ? <Check size={12} /> : <X size={12} />}
+                      {req.label}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+            {errors.password && (
+              <p className="text-sm mt-1" style={{ color: designTokens.status.error_text }}>
+                {errors.password}
+              </p>
+            )}
+          </div>
+
+          {/* 비밀번호 확인 필드 */}
+          <div>
+            <label
+              className="block text-sm font-medium mb-1"
+              style={{ color: designTokens.text.primary }}
+            >
+              비밀번호 확인 <span style={{ color: designTokens.status.error_text }}>*</span>
+            </label>
+            <div className="relative">
+              <input
+                name="confirmPassword"
+                type={showConfirmPassword ? 'text' : 'password'}
+                placeholder="비밀번호를 다시 입력하세요"
+                value={formData.confirmPassword}
+                onChange={handleChange}
+                disabled={isRegistering}
+                className="w-full h-10 px-3 pr-10 rounded-lg border text-sm transition-colors outline-none focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                style={inputStyle(!!errors.confirmPassword)}
+              />
+              <button
+                type="button"
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 p-0.5"
+                style={{ color: designTokens.text.placeholder }}
+                tabIndex={-1}
+              >
+                {showConfirmPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+              </button>
+            </div>
+            {errors.confirmPassword && (
+              <p className="text-sm mt-1" style={{ color: designTokens.status.error_text }}>
+                {errors.confirmPassword}
+              </p>
+            )}
+          </div>
+
+          {/* 회원가입 버튼 */}
+          <button
+            type="submit"
+            disabled={isRegistering}
+            className="w-full py-3 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            style={{
+              backgroundColor: designTokens.button.neutral_default,
+              color: designTokens.button.neutral_text,
+            }}
+            onMouseEnter={(e) => {
+              if (!isRegistering) {
+                e.currentTarget.style.backgroundColor = designTokens.button.neutral_hover;
+              }
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = designTokens.button.neutral_default;
+            }}
+          >
+            {isRegistering ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" />
+                신청 중...
+              </>
+            ) : (
+              <>
+                <UserPlus className="w-4 h-4" />
+                관리자 가입 신청
+              </>
+            )}
+          </button>
+        </form>
+
+        {/* 로그인 링크 */}
+        <div className="mt-6 text-center">
+          <p className="text-sm" style={{ color: designTokens.text.secondary }}>
+            이미 계정이 있으신가요?{' '}
+            <Link
+              to="/admin/login"
+              className="font-medium hover:underline"
+              style={{ color: designTokens.button.brand_default }}
+            >
+              관리자 로그인
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AdminRegisterPage;

--- a/src/pages/admin/auth/index.ts
+++ b/src/pages/admin/auth/index.ts
@@ -1,0 +1,2 @@
+export { AdminLoginPage } from './AdminLoginPage';
+export { AdminRegisterPage } from './AdminRegisterPage';

--- a/src/pages/admin/index.ts
+++ b/src/pages/admin/index.ts
@@ -1,0 +1,1 @@
+export * from './auth';

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -208,6 +208,19 @@ export const LoginPage = () => {
             </Link>
           </p>
         </div>
+
+        {/* 관리자 로그인 링크 */}
+        <div className={`mt-4 pt-4 text-center border-t ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
+          <p className={`text-sm ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
+            관리자이신가요?{' '}
+            <Link
+              to="/admin/login"
+              className={`font-medium hover:underline ${isDark ? 'text-gray-400' : 'text-gray-500'}`}
+            >
+              관리자 로그인
+            </Link>
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/routes/auth.routes.tsx
+++ b/src/routes/auth.routes.tsx
@@ -1,9 +1,15 @@
 import { Route } from 'react-router-dom';
 import { LoginPage, RegisterPage } from '@/pages/auth';
+import { AdminLoginPage, AdminRegisterPage } from '@/pages/admin';
 
 export const authRoutes = (
   <>
+    {/* 일반 사용자 인증 */}
     <Route path="/login" element={<LoginPage />} />
     <Route path="/register" element={<RegisterPage />} />
+
+    {/* 어드민 인증 */}
+    <Route path="/admin/login" element={<AdminLoginPage />} />
+    <Route path="/admin/register" element={<AdminRegisterPage />} />
   </>
 );


### PR DESCRIPTION
## Summary
- SA/TA 전용 로그인 페이지 (`/admin/login`) 추가
- SA/TA 전용 회원가입 페이지 (`/admin/register`) 추가
- 어드민 디자인 토큰 적용으로 일반 사용자 페이지와 차별화
- 일반 로그인 페이지에 "관리자이신가요?" 링크 추가

Closes #281

## Test plan
- [x] `/admin/login` 페이지 접근 확인
- [x] `/admin/register` 페이지 접근 확인
- [x] 관리자 로그인 후 역할별 리다이렉트 확인
- [x] `/login` 페이지에서 관리자 로그인 링크 표시 확인
- [x] 다크모드/라이트모드 스타일 확인