### PR TITLE
feat: 로그인 시 테넌트 도메인으로 리다이렉트 기능 #283

### DIFF
--- a/src/contexts/TenantBrandingContext.tsx
+++ b/src/contexts/TenantBrandingContext.tsx
@@ -1,6 +1,10 @@
 import { createContext, useContext, ReactNode } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { usePublicBranding } from '@/hooks/tu/usePublicBranding';
+import { useBrandingApply } from '@/hooks/tu/useBrandingApply';
 import { extractTenantIdentifier } from '@/utils/tenantUtils';
+import { useAuthStore } from '@/store/common/authStore';
+import { tenantSettingsService } from '@/services/ta/tenantSettingsService';
 import type { PublicBrandingResponse } from '@/types/tu/branding.types';
 
 interface TenantBrandingContextValue {
@@ -11,13 +15,48 @@ interface TenantBrandingContextValue {
 
 const TenantBrandingContext = createContext<TenantBrandingContextValue | undefined>(undefined);
 
+/**
+ * 인증된 사용자용 브랜딩 조회 Hook
+ */
+function useAuthenticatedBranding(enabled: boolean) {
+  return useQuery({
+    queryKey: ['tenant-branding', 'authenticated'],
+    queryFn: () => tenantSettingsService.getBranding(),
+    enabled,
+    staleTime: 1000 * 60 * 30, // 30분 캐싱
+    gcTime: 1000 * 60 * 60, // 1시간 가비지 컬렉션
+    retry: 1,
+  });
+}
+
 export function TenantBrandingProvider({ children }: { children: ReactNode }) {
+  const { isAuthenticated, user } = useAuthStore();
   const tenantIdentifier = extractTenantIdentifier();
 
-  const { data: branding, isLoading, error } = usePublicBranding(
+  // 1. 인증된 사용자: tenantId 기반 브랜딩 조회
+  const {
+    data: authBranding,
+    isLoading: authLoading,
+    error: authError,
+  } = useAuthenticatedBranding(isAuthenticated && !!user?.tenantId);
+
+  // 2. 비로그인 사용자: 도메인 기반 브랜딩 조회
+  const {
+    data: publicBranding,
+    isLoading: publicLoading,
+    error: publicError,
+  } = usePublicBranding(
     tenantIdentifier?.identifier,
     tenantIdentifier?.type
   );
+
+  // 인증된 사용자는 authBranding 우선, 아니면 publicBranding
+  const branding = isAuthenticated && user?.tenantId ? authBranding : publicBranding;
+  const isLoading = isAuthenticated && user?.tenantId ? authLoading : publicLoading;
+  const error = isAuthenticated && user?.tenantId ? authError : publicError;
+
+  // 브랜딩을 전역 CSS 변수로 적용
+  useBrandingApply(branding);
 
   return (
     <TenantBrandingContext.Provider value={{ branding, isLoading, error }}>

--- a/src/hooks/common/auth/useAuth.ts
+++ b/src/hooks/common/auth/useAuth.ts
@@ -39,7 +39,7 @@ export const useLogin = () => {
       setAuth(user, tokenResponse.accessToken, tokenResponse.refreshToken);
       toast.success(`${user.name}님, 환영합니다!`);
 
-      // 역할별 리다이렉트
+      // 역할별 리다이렉트 경로
       const redirectPath: Record<string, string> = {
         SYSTEM_ADMIN: '/sa',
         TENANT_ADMIN: '/ta',
@@ -47,7 +47,40 @@ export const useLogin = () => {
         DESIGNER: '/tu/teaching',
         USER: '/tu',
       };
-      navigate(redirectPath[user.role] || '/');
+      const targetPath = redirectPath[user.role] || '/';
+
+      // 테넌트 subdomain/customDomain이 있으면 해당 URL로 리다이렉트
+      const tenantDomain = userDetail.tenantCustomDomain || userDetail.tenantSubdomain;
+      if (tenantDomain && user.role !== 'SYSTEM_ADMIN') {
+        // 현재 호스트가 이미 테넌트 도메인인지 확인
+        const currentHost = window.location.hostname;
+        const isAlreadyOnTenantDomain =
+          currentHost === userDetail.tenantCustomDomain ||
+          currentHost.startsWith(`${userDetail.tenantSubdomain}.`);
+
+        if (!isAlreadyOnTenantDomain) {
+          // 테넌트 도메인으로 리다이렉트 (프로토콜과 포트 유지)
+          const protocol = window.location.protocol;
+          const port = window.location.port ? `:${window.location.port}` : '';
+
+          // customDomain이 있으면 그대로 사용, 없으면 subdomain.baseDomain 형태로 구성
+          let tenantUrl: string;
+          if (userDetail.tenantCustomDomain) {
+            tenantUrl = `${protocol}//${userDetail.tenantCustomDomain}${port}${targetPath}`;
+          } else {
+            // 현재 도메인에서 base domain 추출 (localhost의 경우 그대로 사용)
+            const baseDomain = currentHost === 'localhost'
+              ? 'localhost'
+              : currentHost.split('.').slice(-2).join('.');
+            tenantUrl = `${protocol}//${userDetail.tenantSubdomain}.${baseDomain}${port}${targetPath}`;
+          }
+
+          window.location.href = tenantUrl;
+          return;
+        }
+      }
+
+      navigate(targetPath);
     },
     onError: (error: Error) => {
       toast.error('로그인에 실패했습니다. 이메일과 비밀번호를 확인해주세요.');

--- a/src/hooks/tu/useBrandingApply.ts
+++ b/src/hooks/tu/useBrandingApply.ts
@@ -2,7 +2,21 @@ import { useEffect } from 'react';
 import type { PublicBrandingResponse } from '@/types/tu/branding.types';
 
 /**
+ * 색상을 어둡게 만드는 유틸리티 (hover 상태용)
+ */
+function darkenColor(hex: string, percent: number = 15): string {
+  // hex를 RGB로 변환
+  const num = parseInt(hex.replace('#', ''), 16);
+  const r = Math.max(0, ((num >> 16) & 0xff) - Math.round(255 * percent / 100));
+  const g = Math.max(0, ((num >> 8) & 0xff) - Math.round(255 * percent / 100));
+  const b = Math.max(0, (num & 0xff) - Math.round(255 * percent / 100));
+  return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, '0')}`;
+}
+
+/**
  * 브랜딩을 CSS 변수로 적용하는 Hook
+ * - Landing 페이지용 변수 (--landing-*)
+ * - 전역 애플리케이션 변수 (--primary, --color-tenant-primary, --color-btn-brand)
  */
 export function useBrandingApply(branding: PublicBrandingResponse | null | undefined) {
   useEffect(() => {
@@ -10,7 +24,7 @@ export function useBrandingApply(branding: PublicBrandingResponse | null | undef
 
     const root = document.documentElement;
 
-    // 색상 적용
+    // ===== Landing 페이지용 CSS 변수 =====
     if (branding.primaryColor) {
       root.style.setProperty('--landing-primary-color', branding.primaryColor);
       // gradient-text 업데이트
@@ -37,6 +51,26 @@ export function useBrandingApply(branding: PublicBrandingResponse | null | undef
       root.style.setProperty('--landing-body-font', branding.bodyFont);
     }
 
+    // ===== 전역 애플리케이션 CSS 변수 =====
+    if (branding.primaryColor) {
+      const primaryHover = darkenColor(branding.primaryColor, 15);
+
+      // shadcn/ui 기본 변수
+      root.style.setProperty('--primary', branding.primaryColor);
+      root.style.setProperty('--primary-hover', primaryHover);
+
+      // 테넌트 전용 변수
+      root.style.setProperty('--color-tenant-primary', branding.primaryColor);
+      root.style.setProperty('--color-tenant-primary-hover', primaryHover);
+
+      // 브랜드 버튼 변수
+      root.style.setProperty('--color-btn-brand', branding.primaryColor);
+      root.style.setProperty('--color-btn-brand-hover', primaryHover);
+
+      // Badge indigo (primary 색상과 연동)
+      root.style.setProperty('--color-badge-indigo', branding.primaryColor);
+    }
+
     // Favicon 적용
     if (branding.faviconUrl) {
       let link = document.querySelector("link[rel~='icon']") as HTMLLinkElement;
@@ -52,5 +86,11 @@ export function useBrandingApply(branding: PublicBrandingResponse | null | undef
     if (branding.tenantName) {
       document.title = branding.tenantName;
     }
+
+    // Cleanup: 컴포넌트 언마운트 시 기본값 복원
+    return () => {
+      // 기본값으로 복원 (필요시)
+      // 현재는 SPA이므로 페이지 새로고침 시 자동 복원됨
+    };
   }, [branding]);
 }

--- a/src/pages/sa/tenants/TenantsPage.tsx
+++ b/src/pages/sa/tenants/TenantsPage.tsx
@@ -65,6 +65,13 @@ interface TenantFormData {
   status?: TenantStatus;
 }
 
+interface CreatedTenantInfo {
+  tenantName: string;
+  adminEmail: string;
+  adminName: string;
+  tempPassword: string;
+}
+
 export function TenantsPage() {
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState('');
@@ -74,6 +81,7 @@ export function TenantsPage() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [selectedTenant, setSelectedTenant] = useState<Tenant | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Tenant | null>(null);
+  const [createdTenantInfo, setCreatedTenantInfo] = useState<CreatedTenantInfo | null>(null);
 
   // API Hooks
   const { data: tenantsData, isLoading, isError } = useTenants({
@@ -239,6 +247,7 @@ export function TenantsPage() {
         };
         await updateMutation.mutateAsync({ id: selectedTenant.id, request: updateData });
         toast.success('테넌트가 수정되었습니다.');
+        setIsCreateDialogOpen(false);
       } else {
         // 생성
         const createData: CreateTenantRequest = {
@@ -250,10 +259,16 @@ export function TenantsPage() {
           adminEmail: data.adminEmail,
           adminName: data.adminName,
         };
-        await createMutation.mutateAsync(createData);
-        toast.success('테넌트가 생성되었습니다.');
+        const result = await createMutation.mutateAsync(createData);
+        setIsCreateDialogOpen(false);
+        // 생성 성공 시 관리자 정보 다이얼로그 표시
+        setCreatedTenantInfo({
+          tenantName: result.name,
+          adminEmail: result.admin.email,
+          adminName: result.admin.name,
+          tempPassword: result.admin.tempPassword,
+        });
       }
-      setIsCreateDialogOpen(false);
       reset();
     } catch {
       toast.error(selectedTenant ? '테넌트 수정에 실패했습니다.' : '테넌트 생성에 실패했습니다.');
@@ -533,6 +548,59 @@ export function TenantsPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* 테넌트 생성 완료 다이얼로그 (관리자 계정 정보 표시) */}
+      <Dialog open={!!createdTenantInfo} onOpenChange={() => setCreatedTenantInfo(null)}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>테넌트 생성 완료</DialogTitle>
+            <DialogDescription>
+              '{createdTenantInfo?.tenantName}' 테넌트가 생성되었습니다.
+              <br />
+              아래 관리자 계정 정보를 안전하게 보관하세요.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+              <p className="text-sm font-medium text-yellow-800 mb-3">
+                ⚠️ 임시 비밀번호는 이 창을 닫으면 다시 볼 수 없습니다.
+              </p>
+              <div className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-text-secondary">관리자명:</span>
+                  <span className="font-medium">{createdTenantInfo?.adminName}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-text-secondary">이메일:</span>
+                  <span className="font-medium">{createdTenantInfo?.adminEmail}</span>
+                </div>
+                <div className="flex justify-between items-center">
+                  <span className="text-text-secondary">임시 비밀번호:</span>
+                  <code className="px-2 py-1 bg-white border rounded font-mono text-sm">
+                    {createdTenantInfo?.tempPassword}
+                  </code>
+                </div>
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                if (createdTenantInfo?.tempPassword) {
+                  navigator.clipboard.writeText(createdTenantInfo.tempPassword);
+                  toast.success('임시 비밀번호가 클립보드에 복사되었습니다.');
+                }
+              }}
+            >
+              비밀번호 복사
+            </Button>
+            <Button onClick={() => setCreatedTenantInfo(null)}>
+              확인
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/pages/ta/dashboard/DashboardPage.tsx
+++ b/src/pages/ta/dashboard/DashboardPage.tsx
@@ -391,8 +391,8 @@ export function DashboardPage() {
                 className="h-64"
               />
             ) : (
-              <div className="h-64">
-                <ResponsiveContainer width="100%" height="100%">
+              <div className="w-full" style={{ minHeight: 256 }}>
+                <ResponsiveContainer width="100%" height={256}>
                   <AreaChart
                     data={filteredMonthlyTrend}
                     margin={{ top: 5, right: 30, left: 20, bottom: 5 }}

--- a/src/services/sa/tenantService.ts
+++ b/src/services/sa/tenantService.ts
@@ -4,11 +4,11 @@
 import axiosInstance from '@/services/common/api/axiosInstance';
 import { API_ENDPOINTS } from '@/services/common/api/endpoints';
 import type {
-  Tenant,
   TenantDetail,
   TenantListResponse,
   TenantStats,
   CreateTenantRequest,
+  CreateTenantResponse,
   UpdateTenantDetailRequest,
 } from '@/types/admin';
 
@@ -27,9 +27,9 @@ export const tenantService = {
   // Tenant CRUD
   // ============================================
 
-  /** 테넌트 생성 */
-  async create(request: CreateTenantRequest): Promise<Tenant> {
-    const { data } = await axiosInstance.post<{ data: Tenant }>(
+  /** 테넌트 생성 (관리자 계정도 함께 생성됨) */
+  async create(request: CreateTenantRequest): Promise<CreateTenantResponse> {
+    const { data } = await axiosInstance.post<{ data: CreateTenantResponse }>(
       API_ENDPOINTS.TENANTS.BASE,
       request
     );

--- a/src/services/ta/tenantSettingsService.ts
+++ b/src/services/ta/tenantSettingsService.ts
@@ -9,8 +9,17 @@ import type {
   UpdateBrandingRequest,
   UpdateUserManagementRequest,
 } from '@/types/admin';
+import type { PublicBrandingResponse } from '@/types/tu/branding.types';
 
 export const tenantSettingsService = {
+  /** 현재 테넌트 브랜딩 조회 (로그인 사용자용) */
+  async getBranding(): Promise<PublicBrandingResponse> {
+    const { data } = await axiosInstance.get<{ data: PublicBrandingResponse }>(
+      API_ENDPOINTS.TENANT_SETTINGS.BRANDING
+    );
+    return data.data;
+  },
+
   /** 테넌트 설정 조회 */
   async getSettings(): Promise<TenantSettingsDetail> {
     const { data } = await axiosInstance.get<{ data: TenantSettingsDetail }>(

--- a/src/types/admin/tenant.types.ts
+++ b/src/types/admin/tenant.types.ts
@@ -53,6 +53,25 @@ export interface CreateTenantRequest {
   adminName: string;
 }
 
+/** 테넌트 생성 응답 (관리자 정보 포함) */
+export interface CreateTenantResponse {
+  tenantId: number;
+  code: string;
+  name: string;
+  type: TenantType;
+  status: TenantStatus;
+  plan: PlanType;
+  subdomain: string;
+  customDomain?: string;
+  createdAt: string;
+  admin: {
+    userId: number;
+    email: string;
+    name: string;
+    tempPassword: string;  // 생성 시에만 반환되는 임시 비밀번호
+  };
+}
+
 export interface UpdateTenantRequest {
   name?: string;
   status?: TenantStatus;

--- a/src/types/common/auth.types.ts
+++ b/src/types/common/auth.types.ts
@@ -64,6 +64,8 @@ export interface UserDetailResponse {
   profileImageUrl?: string;
   tenantId?: number;
   tenantName?: string;
+  tenantSubdomain?: string;
+  tenantCustomDomain?: string;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary

사용자 로그인 성공 시 해당 사용자가 속한 테넌트의 subdomain/customDomain URL로 자동 리다이렉트하여 테넌트별 격리된 환경 제공

## Related Issue

- Closes #283

## Changes

- `UserDetailResponse` 타입에 `tenantSubdomain`, `tenantCustomDomain` 필드 추가
- `useLogin` 훅에서 로그인 성공 시 테넌트 도메인 리다이렉트 로직 구현
- customDomain 우선 사용, 없으면 `{subdomain}.{baseDomain}` 형태로 URL 구성
- SYSTEM_ADMIN은 테넌트에 종속되지 않으므로 리다이렉트 제외
- 테넌트 생성 후 관리자 계정 정보 표시 다이얼로그 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 리다이렉트 예시:
  - customDomain 있는 경우: `https://lms.megazone.com/ta`
  - subdomain만 있는 경우: `https://megazone.example.com/ta`
  - localhost 개발 환경: `http://megazone.localhost:5173/ta`