### PR TITLE
feat(certificate): 수료증 API 연동 및 발급/다운로드 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -125,6 +125,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -399,6 +400,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -3618,6 +3620,7 @@
       "resolved": "https://registry.npmjs.org/@svta/cml-xml/-/cml-xml-1.0.1.tgz",
       "integrity": "sha512-11LkJa5kDEcsRMWkVI1ABH3KLCxGoiSVe4kQ293ItVj8ncTTQ7htmCGiJDjS+Cmy35UgF3e/vc0ysJIiWRTx2g==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -3811,6 +3814,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3821,6 +3825,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3876,6 +3881,7 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -4137,6 +4143,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4451,6 +4458,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5007,7 +5015,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5157,6 +5166,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5959,6 +5969,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6556,6 +6567,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6778,6 +6790,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6808,6 +6821,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6883,6 +6897,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7085,7 +7100,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7584,6 +7600,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7655,6 +7672,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7873,6 +7891,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7966,6 +7985,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/components/domain/tu/certificate/CertificateCard.tsx
+++ b/src/components/domain/tu/certificate/CertificateCard.tsx
@@ -1,7 +1,7 @@
-import { Award, Calendar, User, Eye, Download, CheckCircle } from 'lucide-react';
+import { Award, Calendar, User, Eye, Download, CheckCircle, Loader2 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button, Badge } from '@/components/common';
-import type { Enrollment } from '@/services/tu/enrollmentService';
+import type { CertificateResponse } from '@/types/tu';
 
 // 날짜 포맷팅
 function formatDate(dateString: string | undefined): string {
@@ -20,15 +20,15 @@ export interface CertificateCardLabels {
   preparing: string;
   certificateOf: string;
   completion: string;
+  downloading?: string;
 }
 
 interface CertificateCardProps {
-  enrollment: Enrollment;
-  userName: string;
+  certificate: CertificateResponse;
   labels: CertificateCardLabels;
   onPreview: () => void;
   onDownload?: () => void;
-  isDownloadEnabled?: boolean;
+  isDownloading?: boolean;
   isDark?: boolean;
 }
 
@@ -37,14 +37,15 @@ interface CertificateCardProps {
  * 수료 완료된 강의의 수료증을 인증서 스타일로 표시
  */
 export const CertificateCard = ({
-  enrollment,
-  userName,
+  certificate,
   labels,
   onPreview,
   onDownload,
-  isDownloadEnabled = false,
+  isDownloading = false,
   isDark = false,
 }: Readonly<CertificateCardProps>) => {
+  const isDownloadEnabled = certificate.status === 'ISSUED' || certificate.status === 'VALID';
+
   return (
     <div
       className={cn(
@@ -115,12 +116,12 @@ export const CertificateCard = ({
             isDark ? 'text-white' : 'text-gray-900'
           )}
         >
-          {enrollment.programTitle}
+          {certificate.programTitle}
         </h3>
 
         {/* 차수명 */}
         <p className={cn('text-sm mb-4', isDark ? 'text-gray-400' : 'text-gray-500')}>
-          {enrollment.courseTimeName}
+          {certificate.courseTimeTitle}
         </p>
 
         {/* 구분선 */}
@@ -130,11 +131,11 @@ export const CertificateCard = ({
         <div className="space-y-2 mb-4">
           <div className={cn('flex items-center justify-center gap-2 text-sm', isDark ? 'text-gray-300' : 'text-gray-700')}>
             <User className="w-4 h-4" />
-            <span className="font-medium">{userName}</span>
+            <span className="font-medium">{certificate.userName}</span>
           </div>
           <div className={cn('flex items-center justify-center gap-2 text-xs', isDark ? 'text-gray-400' : 'text-gray-500')}>
             <Calendar className="w-3.5 h-3.5" />
-            <span>{labels.completedOn}: {formatDate(enrollment.completedAt)}</span>
+            <span>{labels.completedOn}: {formatDate(certificate.completedAt)}</span>
           </div>
         </div>
 
@@ -160,10 +161,18 @@ export const CertificateCard = ({
               !isDownloadEnabled && (isDark ? '!text-gray-500' : '!text-gray-400')
             )}
             onClick={isDownloadEnabled ? onDownload : undefined}
-            disabled={!isDownloadEnabled}
+            disabled={!isDownloadEnabled || isDownloading}
           >
-            <Download className="w-4 h-4 mr-1" />
-            {isDownloadEnabled ? labels.download : labels.preparing}
+            {isDownloading ? (
+              <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+            ) : (
+              <Download className="w-4 h-4 mr-1" />
+            )}
+            {isDownloading
+              ? (labels.downloading || 'Downloading...')
+              : isDownloadEnabled
+                ? labels.download
+                : labels.preparing}
           </Button>
         </div>
       </div>

--- a/src/components/domain/tu/certificate/CertificatePreviewModal.tsx
+++ b/src/components/domain/tu/certificate/CertificatePreviewModal.tsx
@@ -1,4 +1,4 @@
-import { Award, Calendar, User, Download, X, Building2, BookOpen } from 'lucide-react';
+import { Award, Calendar, User, Download, X, Building2, BookOpen, Hash, Loader2 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import {
   Dialog,
@@ -7,10 +7,10 @@ import {
   DialogTitle,
   Button,
 } from '@/components/common';
-import type { Enrollment } from '@/services/tu/enrollmentService';
+import type { CertificateResponse, CertificateDetailResponse } from '@/types/tu';
 
 // 날짜 포맷팅
-function formatDate(dateString: string | undefined): string {
+function formatDate(dateString: string | undefined | null): string {
   if (!dateString) return '-';
   return new Date(dateString).toLocaleDateString('ko-KR', {
     year: 'numeric',
@@ -26,9 +26,10 @@ export interface CertificatePreviewLabels {
   certifyThat: string;
   hasCompleted: string;
   issuedOn: string;
-  learningPeriod: string;
+  completedOn: string;
+  certificateNumber: string;
   download: string;
-  preparing: string;
+  downloading?: string;
   close: string;
   organization: string;
 }
@@ -36,11 +37,10 @@ export interface CertificatePreviewLabels {
 interface CertificatePreviewModalProps {
   isOpen: boolean;
   onClose: () => void;
-  enrollment: Enrollment | null;
-  userName: string;
+  certificate: CertificateResponse | CertificateDetailResponse | null;
   labels: CertificatePreviewLabels;
   onDownload?: () => void;
-  isDownloadEnabled?: boolean;
+  isDownloading?: boolean;
   isDark?: boolean;
   organizationName?: string;
 }
@@ -52,15 +52,16 @@ interface CertificatePreviewModalProps {
 export const CertificatePreviewModal = ({
   isOpen,
   onClose,
-  enrollment,
-  userName,
+  certificate,
   labels,
   onDownload,
-  isDownloadEnabled = false,
+  isDownloading = false,
   isDark = false,
   organizationName = 'MZC Learn Platform',
 }: Readonly<CertificatePreviewModalProps>) => {
-  if (!enrollment) return null;
+  if (!certificate) return null;
+
+  const isDownloadEnabled = certificate.status === 'ISSUED' || certificate.status === 'VALID';
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -131,7 +132,7 @@ export const CertificatePreviewModal = ({
               </p>
               <div className={cn('flex items-center justify-center gap-2 text-xl font-bold mb-2', isDark ? 'text-white' : 'text-gray-900')}>
                 <User className="w-5 h-5" />
-                <span>{userName}</span>
+                <span>{certificate.userName}</span>
               </div>
               <p className={cn('text-sm', isDark ? 'text-gray-400' : 'text-gray-500')}>
                 {labels.hasCompleted}
@@ -142,10 +143,10 @@ export const CertificatePreviewModal = ({
             <div className={cn('mb-6 p-4 rounded-lg', isDark ? 'bg-white/5' : 'bg-amber-100/50')}>
               <div className={cn('flex items-center justify-center gap-2 mb-2', isDark ? 'text-gray-300' : 'text-gray-700')}>
                 <BookOpen className="w-4 h-4" />
-                <span className="text-sm font-medium">{enrollment.programTitle}</span>
+                <span className="text-sm font-medium">{certificate.programTitle}</span>
               </div>
               <p className={cn('text-xs', isDark ? 'text-gray-400' : 'text-gray-500')}>
-                {enrollment.courseTimeName}
+                {certificate.courseTimeTitle}
               </p>
             </div>
 
@@ -153,11 +154,19 @@ export const CertificatePreviewModal = ({
             <div className="space-y-2 mb-6">
               <div className={cn('flex items-center justify-center gap-2 text-sm', isDark ? 'text-gray-300' : 'text-gray-600')}>
                 <Calendar className="w-4 h-4" />
-                <span>{labels.learningPeriod}: {formatDate(enrollment.startDate)} ~ {formatDate(enrollment.endDate)}</span>
+                <span>{labels.completedOn}: {formatDate(certificate.completedAt)}</span>
               </div>
               <div className={cn('flex items-center justify-center gap-2 text-sm font-medium', isDark ? 'text-yellow-400' : 'text-amber-700')}>
                 <Award className="w-4 h-4" />
-                <span>{labels.issuedOn}: {formatDate(enrollment.completedAt)}</span>
+                <span>{labels.issuedOn}: {formatDate(certificate.issuedAt)}</span>
+              </div>
+            </div>
+
+            {/* 수료증 번호 */}
+            <div className={cn('mb-4 p-2 rounded', isDark ? 'bg-white/5' : 'bg-amber-50')}>
+              <div className={cn('flex items-center justify-center gap-2 text-xs', isDark ? 'text-gray-400' : 'text-gray-500')}>
+                <Hash className="w-3 h-3" />
+                <span>{labels.certificateNumber}: {certificate.certificateNumber}</span>
               </div>
             </div>
 
@@ -178,10 +187,18 @@ export const CertificatePreviewModal = ({
           <Button
             variant={isDownloadEnabled ? 'brand' : 'ghost'}
             onClick={isDownloadEnabled ? onDownload : undefined}
-            disabled={!isDownloadEnabled}
+            disabled={!isDownloadEnabled || isDownloading}
           >
-            <Download className="w-4 h-4 mr-2" />
-            {isDownloadEnabled ? labels.download : labels.preparing}
+            {isDownloading ? (
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+            ) : (
+              <Download className="w-4 h-4 mr-2" />
+            )}
+            {isDownloading
+              ? (labels.downloading || 'Downloading...')
+              : isDownloadEnabled
+                ? labels.download
+                : labels.close}
           </Button>
         </div>
       </DialogContent>

--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -278,7 +278,7 @@ export const myPageMenuData: MenuItem[] = [
     subItems: [
       { id: 'enrolled-courses', label: { ko: '수강 중인 강의', en: 'Enrolled Courses' }, icon: BookOpen, path: '/tu/b2c/mypage/learning' },
       { id: 'completed-courses', label: { ko: '완료한 강의', en: 'Completed Courses' }, icon: BookCheck, path: '/tu/b2c/mypage/completed' },
-      { id: 'certifications', label: { ko: '인증서', en: 'Certifications' }, icon: Award, path: '/tu/b2c/mypage/certifications' },
+      { id: 'certificates', label: { ko: '수료증', en: 'Certificates' }, icon: Award, path: '/tu/b2c/mypage/certificates' },
     ],
   },
   {

--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -251,3 +251,15 @@ export {
   ownerStatsKeys,
   useMyOwnerStats,
 } from './useOwnerStatsQueries';
+
+// Certificate Hooks (수료증)
+export {
+  certificateKeys,
+  useMyCertificates,
+  useCertificate,
+  useCertificateByEnrollment,
+  useVerifyCertificate,
+  useDownloadCertificate,
+  useIssueCertificate,
+  useReissueCertificate,
+} from './useCertificateQueries';

--- a/src/hooks/tu/useCertificateQueries.ts
+++ b/src/hooks/tu/useCertificateQueries.ts
@@ -1,0 +1,120 @@
+/**
+ * Certificate React Query Hooks
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuthStore } from '@/store/common/authStore';
+import { certificateService } from '@/services/tu/certificateService';
+import type { CertificateFilterParams, CertificateReissueRequest } from '@/types/tu';
+import { enrollmentKeys } from './useEnrollmentQueries';
+
+// Query Keys
+export const certificateKeys = {
+  all: ['certificates'] as const,
+  my: () => [...certificateKeys.all, 'my'] as const,
+  myList: (params?: CertificateFilterParams) => [...certificateKeys.my(), params] as const,
+  detail: (id: number) => [...certificateKeys.all, 'detail', id] as const,
+  byEnrollment: (enrollmentId: number) => [...certificateKeys.all, 'enrollment', enrollmentId] as const,
+  verify: (certificateNumber: string) => [...certificateKeys.all, 'verify', certificateNumber] as const,
+};
+
+/**
+ * 내 수료증 목록 조회 훅
+ */
+export const useMyCertificates = (params?: CertificateFilterParams) => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  return useQuery({
+    queryKey: certificateKeys.myList(params),
+    queryFn: () => certificateService.getMyCertificates(params),
+    enabled: isAuthenticated,
+  });
+};
+
+/**
+ * 수료증 상세 조회 훅
+ */
+export const useCertificate = (id: number, options?: { enabled?: boolean }) => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const externalEnabled = options?.enabled ?? true;
+
+  return useQuery({
+    queryKey: certificateKeys.detail(id),
+    queryFn: () => certificateService.getCertificate(id),
+    enabled: externalEnabled && isAuthenticated && !!id,
+  });
+};
+
+/**
+ * 수강별 수료증 조회 훅
+ */
+export const useCertificateByEnrollment = (enrollmentId: number, options?: { enabled?: boolean }) => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const externalEnabled = options?.enabled ?? true;
+
+  return useQuery({
+    queryKey: certificateKeys.byEnrollment(enrollmentId),
+    queryFn: () => certificateService.getCertificateByEnrollment(enrollmentId),
+    enabled: externalEnabled && isAuthenticated && !!enrollmentId,
+  });
+};
+
+/**
+ * 수료증 검증 훅 (공개 API)
+ */
+export const useVerifyCertificate = (certificateNumber: string, options?: { enabled?: boolean }) => {
+  const externalEnabled = options?.enabled ?? true;
+
+  return useQuery({
+    queryKey: certificateKeys.verify(certificateNumber),
+    queryFn: () => certificateService.verifyCertificate(certificateNumber),
+    enabled: externalEnabled && !!certificateNumber,
+  });
+};
+
+/**
+ * 수료증 PDF 다운로드 뮤테이션 훅
+ */
+export const useDownloadCertificate = () => {
+  return useMutation({
+    mutationFn: async ({ id, fileName }: { id: number; fileName: string }) => {
+      const blob = await certificateService.downloadCertificate(id);
+      certificateService.triggerDownload(blob, fileName);
+      return blob;
+    },
+  });
+};
+
+/**
+ * 수료증 발급 뮤테이션 훅 (수동 발급)
+ */
+export const useIssueCertificate = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (enrollmentId: number) => certificateService.issueCertificate(enrollmentId),
+    onSuccess: () => {
+      // 수료증 목록 갱신
+      queryClient.invalidateQueries({ queryKey: certificateKeys.my() });
+      // 수강 목록 갱신 (수료증 발급 상태 반영)
+      queryClient.invalidateQueries({ queryKey: enrollmentKeys.my() });
+    },
+  });
+};
+
+/**
+ * 수료증 재발급 뮤테이션 훅
+ */
+export const useReissueCertificate = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: { id: number; request: CertificateReissueRequest }) =>
+      certificateService.reissueCertificate(id, request),
+    onSuccess: (_, { id }) => {
+      // 수료증 목록 갱신
+      queryClient.invalidateQueries({ queryKey: certificateKeys.my() });
+      // 해당 수료증 상세 갱신
+      queryClient.invalidateQueries({ queryKey: certificateKeys.detail(id) });
+    },
+  });
+};

--- a/src/pages/tu/mypage/CertificationsPage.tsx
+++ b/src/pages/tu/mypage/CertificationsPage.tsx
@@ -3,7 +3,7 @@ import { Award, Loader2 } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation, useLanguageStore } from '@/store/common/languageStore';
 import { useAuthStore } from '@/store/common/authStore';
-import { useMyEnrollments } from '@/hooks/tu';
+import { useMyCertificates, useDownloadCertificate } from '@/hooks/tu';
 import {
   Button,
   Pagination,
@@ -14,34 +14,41 @@ import {
   PaginationPrevious,
 } from '@/components/common';
 import { CertificateCard, CertificatePreviewModal } from '@/components/domain/tu/certificate';
-import type { Enrollment } from '@/services/tu/enrollmentService';
+import type { CertificateResponse } from '@/types/tu';
 
 export function CertificationsPage() {
   const { theme } = useThemeStore();
   const { language } = useLanguageStore();
   const { t } = useTranslation();
-  const { user } = useAuthStore();
   const isDark = theme === 'dark';
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
   const [page, setPage] = useState(0);
   const pageSize = 12;
 
   // 수료증 미리보기 모달 상태
-  const [selectedEnrollment, setSelectedEnrollment] = useState<Enrollment | null>(null);
+  const [selectedCertificate, setSelectedCertificate] = useState<CertificateResponse | null>(null);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const [downloadingId, setDownloadingId] = useState<number | null>(null);
 
-  // COMPLETED 상태의 수강 목록만 조회
-  const { data, isLoading, isError } = useMyEnrollments({
+  // Certificate API로 수료증 목록 조회
+  const { data, isLoading, isFetching, isError } = useMyCertificates({
     page,
     size: pageSize,
-    status: 'COMPLETED',
   });
+
+  // 실제 로딩 상태 (초기 로딩 또는 페칭 중)
+  const showLoading = isLoading || (isFetching && !data);
+
+  // PDF 다운로드 mutation
+  const downloadMutation = useDownloadCertificate();
 
   // 수료증 카드 라벨
   const cardLabels = {
     completedOn: language === 'ko' ? '수료일' : 'Completed on',
     view: language === 'ko' ? '보기' : 'View',
     download: language === 'ko' ? '다운로드' : 'Download',
+    downloading: language === 'ko' ? '다운로드 중...' : 'Downloading...',
     preparing: language === 'ko' ? '준비 중' : 'Preparing',
     certificateOf: language === 'ko' ? '수료증' : 'Certificate of',
     completion: language === 'ko' ? '수료' : 'Completion',
@@ -54,31 +61,38 @@ export function CertificationsPage() {
     completion: language === 'ko' ? '수료' : 'Completion',
     certifyThat: language === 'ko' ? '다음의 사용자가' : 'This is to certify that',
     hasCompleted: language === 'ko' ? '아래 과정을 성공적으로 수료하였음을 인증합니다.' : 'has successfully completed the following course.',
-    issuedOn: language === 'ko' ? '수료일' : 'Issued on',
-    learningPeriod: language === 'ko' ? '학습 기간' : 'Learning Period',
+    issuedOn: language === 'ko' ? '발급일' : 'Issued on',
+    completedOn: language === 'ko' ? '수료일' : 'Completed on',
+    certificateNumber: language === 'ko' ? '수료증 번호' : 'Certificate No.',
     download: language === 'ko' ? 'PDF 다운로드' : 'Download PDF',
-    preparing: language === 'ko' ? '준비 중' : 'Preparing',
+    downloading: language === 'ko' ? '다운로드 중...' : 'Downloading...',
     close: language === 'ko' ? '닫기' : 'Close',
     organization: language === 'ko' ? '발급 기관' : 'Organization',
   };
 
-  const handlePreview = (enrollment: Enrollment) => {
-    setSelectedEnrollment(enrollment);
+  const handlePreview = (certificate: CertificateResponse) => {
+    setSelectedCertificate(certificate);
     setIsPreviewOpen(true);
   };
 
   const handleClosePreview = () => {
     setIsPreviewOpen(false);
-    setSelectedEnrollment(null);
+    setSelectedCertificate(null);
   };
 
-  // TODO: Phase 2에서 실제 Certificate API 연동 시 구현
-  const handleDownload = () => {
-    // Certificate API: GET /api/certificates/{id}/download
-    console.log('PDF download - Phase 2');
-  };
+  const handleDownload = async (certificate: CertificateResponse) => {
+    if (downloadMutation.isPending) return;
 
-  const userName = user?.name || (language === 'ko' ? '학습자' : 'Learner');
+    setDownloadingId(certificate.id);
+    try {
+      const fileName = `certificate_${certificate.certificateNumber}.pdf`;
+      await downloadMutation.mutateAsync({ id: certificate.id, fileName });
+    } catch (error) {
+      console.error('Failed to download certificate:', error);
+    } finally {
+      setDownloadingId(null);
+    }
+  };
 
   return (
     <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
@@ -101,7 +115,7 @@ export function CertificationsPage() {
         </div>
 
         {/* Results Count */}
-        {data && (
+        {isAuthenticated && data && (
           <p className={`mb-4 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
             {language === 'ko' ? '총 ' : 'Total '}
             <span className={`font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
@@ -112,9 +126,18 @@ export function CertificationsPage() {
         )}
 
         {/* Loading State */}
-        {isLoading && (
+        {showLoading && (
           <div className="flex items-center justify-center py-20">
             <Loader2 className={`w-8 h-8 animate-spin ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+          </div>
+        )}
+
+        {/* Not Authenticated State */}
+        {!isAuthenticated && !showLoading && (
+          <div className="text-center py-20">
+            <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
+              {language === 'ko' ? '로그인이 필요합니다.' : 'Please log in to view certificates.'}
+            </p>
           </div>
         )}
 
@@ -128,7 +151,7 @@ export function CertificationsPage() {
         )}
 
         {/* Empty State */}
-        {data && data.content.length === 0 && (
+        {isAuthenticated && data && data.content.length === 0 && (
           <div
             className={`text-center py-20 rounded-xl ${
               isDark ? 'bg-white/5 border border-white/10' : 'bg-white border border-gray-200'
@@ -150,18 +173,17 @@ export function CertificationsPage() {
         )}
 
         {/* Certificates Grid */}
-        {data && data.content.length > 0 && (
+        {isAuthenticated && data && data.content.length > 0 && (
           <>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mb-8">
-              {data.content.map((enrollment) => (
+              {data.content.map((certificate) => (
                 <CertificateCard
-                  key={enrollment.id}
-                  enrollment={enrollment}
-                  userName={userName}
+                  key={certificate.id}
+                  certificate={certificate}
                   labels={cardLabels}
-                  onPreview={() => handlePreview(enrollment)}
-                  onDownload={handleDownload}
-                  isDownloadEnabled={false} // Phase 2에서 활성화
+                  onPreview={() => handlePreview(certificate)}
+                  onDownload={() => handleDownload(certificate)}
+                  isDownloading={downloadingId === certificate.id}
                   isDark={isDark}
                 />
               ))}
@@ -210,11 +232,10 @@ export function CertificationsPage() {
         <CertificatePreviewModal
           isOpen={isPreviewOpen}
           onClose={handleClosePreview}
-          enrollment={selectedEnrollment}
-          userName={userName}
+          certificate={selectedCertificate}
           labels={modalLabels}
-          onDownload={handleDownload}
-          isDownloadEnabled={false} // Phase 2에서 활성화
+          onDownload={() => selectedCertificate && handleDownload(selectedCertificate)}
+          isDownloading={selectedCertificate ? downloadingId === selectedCertificate.id : false}
           isDark={isDark}
         />
       </div>

--- a/src/pages/tu/mypage/CompletedCoursesPage.tsx
+++ b/src/pages/tu/mypage/CompletedCoursesPage.tsx
@@ -6,10 +6,11 @@ import {
   Loader2,
   Award,
   Calendar,
+  FileText,
 } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation, useLanguageStore } from '@/store/common/languageStore';
-import { useMyEnrollments } from '@/hooks/tu';
+import { useMyEnrollments, useCertificateByEnrollment, useDownloadCertificate, useIssueCertificate } from '@/hooks/tu';
 import {
   Card,
   CardContent,
@@ -22,16 +23,18 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from '@/components/common';
+import { CertificatePreviewModal } from '@/components/domain/tu/certificate';
 import type { Enrollment } from '@/services/tu/enrollmentService';
 
 interface CompletedCourseCardProps {
   enrollment: Enrollment;
   onClick: () => void;
+  onViewCertificate: () => void;
   isDark: boolean;
   language: string;
 }
 
-function CompletedCourseCard({ enrollment, onClick, isDark, language }: CompletedCourseCardProps) {
+function CompletedCourseCard({ enrollment, onClick, onViewCertificate, isDark, language }: CompletedCourseCardProps) {
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr);
     return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`;
@@ -101,19 +104,33 @@ function CompletedCourseCard({ enrollment, onClick, isDark, language }: Complete
           )}
         </div>
 
-        {/* View Details Button */}
-        <Button
-          variant="outline"
-          className={`w-full mt-4 ${isDark ? '!bg-transparent !border-white/20 !text-white hover:!bg-white/10' : ''}`}
-          size="sm"
-          onClick={(e) => {
-            e.stopPropagation();
-            onClick();
-          }}
-        >
-          <BookOpen className="w-4 h-4 mr-2" />
-          {language === 'ko' ? '학습 내용 보기' : 'View Course'}
-        </Button>
+        {/* Action Buttons */}
+        <div className="flex items-center gap-2 mt-4">
+          <Button
+            variant="outline"
+            className={`flex-1 ${isDark ? '!bg-transparent !border-white/20 !text-white hover:!bg-white/10' : ''}`}
+            size="sm"
+            onClick={(e) => {
+              e.stopPropagation();
+              onClick();
+            }}
+          >
+            <BookOpen className="w-4 h-4 mr-2" />
+            {language === 'ko' ? '학습 내용' : 'Course'}
+          </Button>
+          <Button
+            variant="brand"
+            size="sm"
+            className="flex-1"
+            onClick={(e) => {
+              e.stopPropagation();
+              onViewCertificate();
+            }}
+          >
+            <FileText className="w-4 h-4 mr-2" />
+            {language === 'ko' ? '수료증' : 'Certificate'}
+          </Button>
+        </div>
       </CardContent>
     </Card>
   );
@@ -129,6 +146,11 @@ export function CompletedCoursesPage() {
   const [page, setPage] = useState(0);
   const pageSize = 12;
 
+  // 수료증 모달 상태
+  const [selectedEnrollmentId, setSelectedEnrollmentId] = useState<number | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
+
   // COMPLETED 상태의 수강 목록만 조회
   const { data, isLoading, isError } = useMyEnrollments({
     page,
@@ -136,8 +158,72 @@ export function CompletedCoursesPage() {
     status: 'COMPLETED',
   });
 
+  // 선택된 수강의 수료증 조회
+  const { data: certificate, isLoading: isCertificateLoading, isError: isCertificateError, refetch: refetchCertificate } = useCertificateByEnrollment(
+    selectedEnrollmentId ?? 0,
+    { enabled: !!selectedEnrollmentId && isModalOpen }
+  );
+
+  // PDF 다운로드 mutation
+  const downloadMutation = useDownloadCertificate();
+
+  // 수료증 발급 mutation
+  const issueMutation = useIssueCertificate();
+
   const handleCourseClick = (enrollmentId: number) => {
     navigate(`/tu/b2c/mypage/learning/${enrollmentId}`);
+  };
+
+  const handleViewCertificate = (enrollmentId: number) => {
+    setSelectedEnrollmentId(enrollmentId);
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setSelectedEnrollmentId(null);
+  };
+
+  const handleDownload = async () => {
+    if (!certificate || isDownloading) return;
+
+    setIsDownloading(true);
+    try {
+      const fileName = `certificate_${certificate.certificateNumber}.pdf`;
+      await downloadMutation.mutateAsync({ id: certificate.id, fileName });
+    } catch (error) {
+      console.error('Failed to download certificate:', error);
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  const handleIssueCertificate = async () => {
+    if (!selectedEnrollmentId || issueMutation.isPending) return;
+
+    try {
+      await issueMutation.mutateAsync(selectedEnrollmentId);
+      // 발급 성공 후 수료증 다시 조회
+      refetchCertificate();
+    } catch (error) {
+      console.error('Failed to issue certificate:', error);
+    }
+  };
+
+  // 수료증 모달 라벨
+  const modalLabels = {
+    title: language === 'ko' ? '수료증 미리보기' : 'Certificate Preview',
+    certificateOf: language === 'ko' ? '수료증' : 'Certificate of',
+    completion: language === 'ko' ? '수료' : 'Completion',
+    certifyThat: language === 'ko' ? '다음의 사용자가' : 'This is to certify that',
+    hasCompleted: language === 'ko' ? '아래 과정을 성공적으로 수료하였음을 인증합니다.' : 'has successfully completed the following course.',
+    issuedOn: language === 'ko' ? '발급일' : 'Issued on',
+    completedOn: language === 'ko' ? '수료일' : 'Completed on',
+    certificateNumber: language === 'ko' ? '수료증 번호' : 'Certificate No.',
+    download: language === 'ko' ? 'PDF 다운로드' : 'Download PDF',
+    downloading: language === 'ko' ? '다운로드 중...' : 'Downloading...',
+    close: language === 'ko' ? '닫기' : 'Close',
+    organization: language === 'ko' ? '발급 기관' : 'Organization',
   };
 
   return (
@@ -218,6 +304,7 @@ export function CompletedCoursesPage() {
                   key={enrollment.id}
                   enrollment={enrollment}
                   onClick={() => handleCourseClick(enrollment.id)}
+                  onViewCertificate={() => handleViewCertificate(enrollment.id)}
                   isDark={isDark}
                   language={language}
                 />
@@ -261,6 +348,61 @@ export function CompletedCoursesPage() {
               </Pagination>
             )}
           </>
+        )}
+
+        {/* Certificate Modal - 발급 또는 미리보기 */}
+        {isModalOpen && (
+          isCertificateLoading || issueMutation.isPending ? (
+            // 로딩 상태
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+              <div className={`p-8 rounded-xl ${isDark ? 'bg-gray-800' : 'bg-white'}`}>
+                <Loader2 className={`w-8 h-8 animate-spin mx-auto ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+                <p className={`mt-4 text-center ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
+                  {issueMutation.isPending
+                    ? (language === 'ko' ? '수료증 발급 중...' : 'Issuing certificate...')
+                    : (language === 'ko' ? '수료증 조회 중...' : 'Loading certificate...')}
+                </p>
+              </div>
+            </div>
+          ) : isCertificateError && !certificate ? (
+            // 수료증 없음 - 발급 필요
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={handleCloseModal}>
+              <div
+                className={`p-8 rounded-xl max-w-md mx-4 ${isDark ? 'bg-gray-800' : 'bg-white'}`}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Award className={`w-16 h-16 mx-auto mb-4 ${isDark ? 'text-yellow-400' : 'text-amber-500'}`} />
+                <h3 className={`text-lg font-semibold text-center mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                  {language === 'ko' ? '수료증 발급' : 'Issue Certificate'}
+                </h3>
+                <p className={`text-center mb-6 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  {language === 'ko'
+                    ? '아직 수료증이 발급되지 않았습니다. 수료증을 발급하시겠습니까?'
+                    : 'Certificate has not been issued yet. Would you like to issue it?'}
+                </p>
+                <div className="flex gap-3">
+                  <Button variant="outline" className="flex-1" onClick={handleCloseModal}>
+                    {language === 'ko' ? '취소' : 'Cancel'}
+                  </Button>
+                  <Button variant="brand" className="flex-1" onClick={handleIssueCertificate}>
+                    <FileText className="w-4 h-4 mr-2" />
+                    {language === 'ko' ? '발급하기' : 'Issue'}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ) : certificate ? (
+            // 수료증 미리보기
+            <CertificatePreviewModal
+              isOpen={isModalOpen}
+              onClose={handleCloseModal}
+              certificate={certificate}
+              labels={modalLabels}
+              onDownload={handleDownload}
+              isDownloading={isDownloading}
+              isDark={isDark}
+            />
+          ) : null
         )}
       </div>
     </div>

--- a/src/pages/tu/mypage/MyPage.tsx
+++ b/src/pages/tu/mypage/MyPage.tsx
@@ -324,9 +324,9 @@ export function MyPage() {
             />
             <QuickMenuItem
               icon={<Award className="w-5 h-5" />}
-              title="인증서"
-              description="취득한 인증서를 확인하세요"
-              onClick={() => navigate('/tu/b2c/mypage/certifications')}
+              title="수료증"
+              description="취득한 수료증을 확인하세요"
+              onClick={() => navigate('/tu/b2c/mypage/certificates')}
               isDark={isDark}
             />
             <QuickMenuItem

--- a/src/pages/tu/mypage/MyPageHome.tsx
+++ b/src/pages/tu/mypage/MyPageHome.tsx
@@ -437,7 +437,7 @@ export function MyPageHome() {
               icon={<Award className="w-5 h-5" />}
               title={t.mypage.certificates}
               description={t.mypage.certificatesDesc}
-              onClick={() => navigate('/tu/b2c/mypage/certifications')}
+              onClick={() => navigate('/tu/b2c/mypage/certificates')}
               isDark={isDark}
             />
             <QuickMenuItem

--- a/src/routes/tu.mypage.routes.tsx
+++ b/src/routes/tu.mypage.routes.tsx
@@ -49,7 +49,7 @@ export const tuMyPageRoutes = (
     <Route path="learning/:enrollmentId/player" element={<LearningPlayerPage />} />
     <Route path="learning/:enrollmentId/player/:itemId" element={<LearningPlayerPage />} />
     <Route path="completed" element={<CompletedCoursesPage />} />
-    <Route path="certifications" element={<CertificationsPage />} />
+    <Route path="certificates" element={<CertificationsPage />} />
 
     {/* 내 강의 관리 */}
     <Route path="teaching" element={<MyTeachingPage />} />

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -283,4 +283,16 @@ export const API_ENDPOINTS = {
     BASE: '/admin/system/settings',
     TENANT_DEFAULTS: '/admin/system/tenant-defaults',
   },
+
+  // Certificates (수료증) - TU
+  CERTIFICATES: {
+    BASE: '/certificates',
+    MY: '/users/me/certificates',
+    BY_ID: (id: number) => `/certificates/${id}`,
+    DOWNLOAD: (id: number) => `/certificates/${id}/download`,
+    VERIFY: (certificateNumber: string) => `/certificates/verify/${certificateNumber}`,
+    ISSUE: (enrollmentId: number) => `/enrollments/${enrollmentId}/certificate`,
+    BY_ENROLLMENT: (enrollmentId: number) => `/enrollments/${enrollmentId}/certificate`,
+    REISSUE: (id: number) => `/certificates/${id}/reissue`,
+  },
 } as const;

--- a/src/services/tu/certificateService.ts
+++ b/src/services/tu/certificateService.ts
@@ -1,0 +1,108 @@
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type {
+  CertificateDetailResponse,
+  CertificateVerifyResponse,
+  CertificateFilterParams,
+  CertificatePageResponse,
+  CertificateReissueRequest,
+} from '@/types/tu';
+
+/**
+ * 수료증 서비스
+ */
+export const certificateService = {
+  /**
+   * 내 수료증 목록 조회
+   */
+  getMyCertificates: async (params?: CertificateFilterParams): Promise<CertificatePageResponse> => {
+    const response = await axiosInstance.get<CertificatePageResponse>(
+      API_ENDPOINTS.CERTIFICATES.MY,
+      { params }
+    );
+    return response.data;
+  },
+
+  /**
+   * 수료증 상세 조회
+   */
+  getCertificate: async (id: number): Promise<CertificateDetailResponse> => {
+    const response = await axiosInstance.get<CertificateDetailResponse>(
+      API_ENDPOINTS.CERTIFICATES.BY_ID(id)
+    );
+    return response.data;
+  },
+
+  /**
+   * 수료증 PDF 다운로드
+   * Blob으로 반환하여 파일 다운로드 처리
+   */
+  downloadCertificate: async (id: number): Promise<Blob> => {
+    const response = await axiosInstance.get<Blob>(
+      API_ENDPOINTS.CERTIFICATES.DOWNLOAD(id),
+      { responseType: 'blob' }
+    );
+    return response.data;
+  },
+
+  /**
+   * 수료증 검증 (공개 API)
+   */
+  verifyCertificate: async (certificateNumber: string): Promise<CertificateVerifyResponse> => {
+    const response = await axiosInstance.get<CertificateVerifyResponse>(
+      API_ENDPOINTS.CERTIFICATES.VERIFY(certificateNumber)
+    );
+    return response.data;
+  },
+
+  /**
+   * 수강별 수료증 조회
+   */
+  getCertificateByEnrollment: async (enrollmentId: number): Promise<CertificateDetailResponse> => {
+    const response = await axiosInstance.get<CertificateDetailResponse>(
+      API_ENDPOINTS.CERTIFICATES.BY_ENROLLMENT(enrollmentId)
+    );
+    return response.data;
+  },
+
+  /**
+   * 수료증 발급 (수동)
+   */
+  issueCertificate: async (enrollmentId: number): Promise<CertificateDetailResponse> => {
+    const response = await axiosInstance.post<CertificateDetailResponse>(
+      API_ENDPOINTS.CERTIFICATES.ISSUE(enrollmentId)
+    );
+    return response.data;
+  },
+
+  /**
+   * 수료증 재발급
+   */
+  reissueCertificate: async (
+    id: number,
+    request: CertificateReissueRequest
+  ): Promise<CertificateDetailResponse> => {
+    const response = await axiosInstance.post<CertificateDetailResponse>(
+      API_ENDPOINTS.CERTIFICATES.REISSUE(id),
+      request
+    );
+    return response.data;
+  },
+
+  /**
+   * 수료증 PDF 다운로드 트리거
+   * Blob을 파일로 다운로드하는 헬퍼 함수
+   */
+  triggerDownload: (blob: Blob, fileName: string) => {
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+  },
+};
+
+export default certificateService;

--- a/src/services/tu/index.ts
+++ b/src/services/tu/index.ts
@@ -15,3 +15,4 @@ export { courseTimeCatalogService } from './courseTimeCatalogService';
 export { publicBrandingService } from './publicBrandingService';
 export { learningStatsService } from './learningStatsService';
 export { ownerStatsService } from './ownerStatsService';
+export { certificateService } from './certificateService';

--- a/src/types/tu/certificate.types.ts
+++ b/src/types/tu/certificate.types.ts
@@ -1,0 +1,108 @@
+/**
+ * 수료증 관련 타입 정의
+ * Backend: CertificateResponse, CertificateDetailResponse, CertificateVerifyResponse
+ */
+
+/**
+ * 수료증 상태
+ */
+export type CertificateStatus = 'ISSUED' | 'VALID' | 'EXPIRED' | 'REVOKED';
+
+/**
+ * 수료증 상태 라벨
+ */
+export const CERTIFICATE_STATUS_LABELS: Record<CertificateStatus, { ko: string; en: string }> = {
+  ISSUED: { ko: '발급됨', en: 'Issued' },
+  VALID: { ko: '유효', en: 'Valid' },
+  EXPIRED: { ko: '만료됨', en: 'Expired' },
+  REVOKED: { ko: '취소됨', en: 'Revoked' },
+};
+
+/**
+ * 수료증 상태 색상 (Badge variant)
+ */
+export const CERTIFICATE_STATUS_COLORS: Record<CertificateStatus, string> = {
+  ISSUED: 'blue',
+  VALID: 'green',
+  EXPIRED: 'gray',
+  REVOKED: 'red',
+};
+
+/**
+ * 수료증 기본 응답 (목록용)
+ */
+export interface CertificateResponse {
+  id: number;
+  certificateNumber: string;
+  programTitle: string;
+  courseTimeTitle: string;
+  userName: string;
+  completedAt: string;
+  issuedAt: string;
+  status: CertificateStatus;
+}
+
+/**
+ * 수료증 상세 응답
+ */
+export interface CertificateDetailResponse {
+  id: number;
+  certificateNumber: string;
+  enrollmentId: number;
+  courseTimeId: number;
+  programTitle: string;
+  courseTimeTitle: string;
+  userName: string;
+  completedAt: string;
+  issuedAt: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  status: CertificateStatus;
+  reissueCount: number;
+  originalCertificateId: number | null;
+  reissueReason: string | null;
+}
+
+/**
+ * 수료증 검증 응답
+ */
+export interface CertificateVerifyResponse {
+  valid: boolean;
+  certificateNumber: string;
+  userName: string; // 마스킹된 이름 (예: 홍*동)
+  programTitle: string;
+  courseTimeTitle: string;
+  completedAt: string;
+  issuedAt: string;
+  status: CertificateStatus;
+  message: string;
+}
+
+/**
+ * 수료증 재발급 요청
+ */
+export interface CertificateReissueRequest {
+  reason: string;
+}
+
+/**
+ * 수료증 필터 파라미터
+ */
+export interface CertificateFilterParams {
+  page?: number;
+  size?: number;
+  status?: CertificateStatus;
+}
+
+/**
+ * 수료증 페이지 응답
+ */
+export interface CertificatePageResponse {
+  content: CertificateResponse[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+  first: boolean;
+  last: boolean;
+}

--- a/src/types/tu/index.ts
+++ b/src/types/tu/index.ts
@@ -251,3 +251,19 @@ export type {
   OwnerProgramStats,
   OwnerStatsResponse,
 } from './ownerStats.types';
+
+// Certificate (수료증)
+export type {
+  CertificateStatus,
+  CertificateResponse,
+  CertificateDetailResponse,
+  CertificateVerifyResponse,
+  CertificateReissueRequest,
+  CertificateFilterParams,
+  CertificatePageResponse,
+} from './certificate.types';
+
+export {
+  CERTIFICATE_STATUS_LABELS,
+  CERTIFICATE_STATUS_COLORS,
+} from './certificate.types';


### PR DESCRIPTION
## Summary
TU 수료증 페이지의 라우트 경로 불일치 문제를 수정하고, 수료 강의 페이지에서 수료증 발급/미리보기/다운로드 기능을 추가했습니다.

## Related Issue
- Closes #275

## Changes
- **라우트 경로 통일**: `certifications` → `certificates`로 경로 표준화
  - `src/routes/tu.mypage.routes.tsx` - 라우트 경로 수정
  - `src/config/sidebar-menus.ts` - 사이드바 메뉴 경로 수정
  - `src/pages/tu/mypage/MyPageHome.tsx` - 퀵 액션 링크 수정
  - `src/pages/tu/MyPage.tsx` - 네비게이션 링크 수정

- **수료 강의 페이지 수료증 기능 추가**
  - `src/pages/tu/mypage/CompletedCoursesPage.tsx`
    - 수료증 모달 (미리보기/다운로드)
    - 수료증 미발급 시 발급 확인 다이얼로그
    - `useCertificateByEnrollment`, `useIssueCertificate`, `useDownloadCertificate` 훅 연동

## Type of Change
- [x] Bug fix (기존 기능에 영향 없는 버그 수정)
- [x] New feature (기존 기능에 영향 없는 새 기능)

## Checklist
- [x] 코드가 프로젝트 스타일 가이드를 따름
- [x] 셀프 코드 리뷰 완료
- [x] 주요 변경사항에 주석 추가
- [x] 로컬에서 테스트 완료

## Screenshots
N/A

## Additional Notes
- 백엔드에서 PDF 다운로드 시 500 에러 발생 가능 - `resources/fonts/` 폴더에 NotoSansKR-Regular.ttf, NotoSansKR-Bold.ttf 폰트 파일 필요
- 수료증 API는 기존 백엔드 CertificateController 엔드포인트와 연동