### PR TITLE
refactor: 디테일 페이지 상단 레이아웃을 목록 페이지와 통일

### DIFF
--- a/src/pages/to/program/ProgramDetailPage.tsx
+++ b/src/pages/to/program/ProgramDetailPage.tsx
@@ -180,76 +180,69 @@ export function ProgramDetailPage({ language = 'ko' }: Readonly<ProgramDetailPag
   }
 
   return (
-    <div className="h-full flex flex-col bg-bg-app">
-      {/* Header */}
-      <div className="sticky top-0 z-10 bg-bg-default border-b border-border px-6 py-4">
-        <div className="max-w-4xl mx-auto">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
-              <Button variant="ghost" size="sm" onClick={() => navigate('/to/courses')}>
-                <ArrowLeft size={18} />
-                {getText('back')}
-              </Button>
-            </div>
+    <div className="h-full overflow-auto bg-bg-app">
+      <div className="p-8">
+        {/* 뒤로가기 버튼 */}
+        <div className="mb-4">
+          <Button variant="ghost" size="sm" onClick={() => navigate('/to/courses')} className="border border-border">
+            <ArrowLeft size={18} />
+            {getText('back')}
+          </Button>
+        </div>
 
-            {/* Action Buttons */}
-            <div className="flex items-center gap-2">
-              {program.status === 'PENDING' && (
-                <>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setShowRejectModal(true)}
-                    disabled={rejectProgram.isPending}
-                    className="border border-status-error text-status-error hover:bg-status-error-bg"
-                  >
-                    <XCircle size={16} />
-                    {rejectProgram.isPending ? getText('rejecting') : getText('reject')}
-                  </Button>
-                  <Button
-                    size="sm"
-                    onClick={() => setShowApproveModal(true)}
-                    disabled={approveProgram.isPending}
-                  >
-                    <CheckCircle size={16} />
-                    {approveProgram.isPending ? getText('approving') : getText('approve')}
-                  </Button>
-                </>
-              )}
-              {(program.status === 'APPROVED' || program.status === 'DRAFT') && (
+        {/* Header Section - 목록 페이지와 동일한 스타일 */}
+        <div className="flex items-start justify-between mb-8">
+          <div>
+            <div className="flex items-center gap-3 mb-2">
+              <h1 className="text-text-primary mb-0">{program.title}</h1>
+              <Badge variant={statusBadgeVariant[program.status]} className="text-sm">
+                {PROGRAM_STATUS_LABELS[program.status]}
+              </Badge>
+            </div>
+            <p className="text-text-secondary m-0">ID: {program.id}</p>
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex items-center gap-2">
+            {program.status === 'PENDING' && (
+              <>
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={handleClose}
-                  disabled={closeProgram.isPending}
-                  className="border border-border"
+                  onClick={() => setShowRejectModal(true)}
+                  disabled={rejectProgram.isPending}
+                  className="border border-status-error text-status-error hover:bg-status-error-bg"
                 >
-                  <Archive size={16} />
-                  {closeProgram.isPending ? getText('closing') : getText('close')}
+                  <XCircle size={16} />
+                  {rejectProgram.isPending ? getText('rejecting') : getText('reject')}
                 </Button>
-              )}
-            </div>
+                <Button
+                  size="sm"
+                  onClick={() => setShowApproveModal(true)}
+                  disabled={approveProgram.isPending}
+                >
+                  <CheckCircle size={16} />
+                  {approveProgram.isPending ? getText('approving') : getText('approve')}
+                </Button>
+              </>
+            )}
+            {(program.status === 'APPROVED' || program.status === 'DRAFT') && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleClose}
+                disabled={closeProgram.isPending}
+                className="border border-border"
+              >
+                <Archive size={16} />
+                {closeProgram.isPending ? getText('closing') : getText('close')}
+              </Button>
+            )}
           </div>
         </div>
-      </div>
 
-      {/* Content */}
-      <div className="flex-1 overflow-auto">
-        <div className="max-w-4xl mx-auto p-6 space-y-6">
-          {/* Title Section */}
-          <div className="flex items-start justify-between">
-            <div className="space-y-2">
-              <div className="flex items-center gap-3">
-                <h1 className="text-2xl font-semibold text-text-primary m-0">
-                  {program.title}
-                </h1>
-                <Badge variant={statusBadgeVariant[program.status]} className="text-sm">
-                  {PROGRAM_STATUS_LABELS[program.status]}
-                </Badge>
-              </div>
-              <p className="text-text-secondary text-sm">ID: {program.id}</p>
-            </div>
-          </div>
+        {/* Content */}
+        <div className="space-y-6">
 
           {/* Description */}
           {program.description && (

--- a/src/pages/tu/teaching/courses/CourseDetailPage.tsx
+++ b/src/pages/tu/teaching/courses/CourseDetailPage.tsx
@@ -120,76 +120,74 @@ export function CourseDetailPage() {
   }
 
   return (
-    <div className="h-full flex flex-col bg-bg-app">
-      {/* Header */}
-      <div className="border-b border-border bg-bg-default sticky top-0 z-10">
-        <div className="p-6 px-8">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="border border-border"
-                onClick={() => navigate('/tu/teaching/courses')}
-              >
-                <ArrowLeft size={16} />
-                목록으로
-              </Button>
-              <div>
-                <h1 className="text-text-primary text-xl mb-1">{course.title}</h1>
-                <div className="flex items-center gap-2">
-                  {course.level && (
-                    <Badge variant={levelBadgeColor[course.level]}>
-                      {LEVEL_LABELS[course.level]}
-                    </Badge>
-                  )}
-                  {course.type && (
-                    <Badge variant={typeBadgeColor[course.type]}>
-                      {TYPE_LABELS[course.type]}
-                    </Badge>
-                  )}
-                  <span className="text-text-secondary text-sm">
-                    {course.itemCount}차시
-                  </span>
-                </div>
-              </div>
-            </div>
+    <div className="h-full overflow-auto bg-bg-app">
+      <div className="p-8">
+        {/* 뒤로가기 버튼 */}
+        <div className="mb-4">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="border border-border"
+            onClick={() => navigate('/tu/teaching/courses')}
+          >
+            <ArrowLeft size={16} />
+            목록으로
+          </Button>
+        </div>
 
-            {/* Action Buttons */}
+        {/* Header Section - 목록 페이지와 동일한 스타일 */}
+        <div className="flex items-start justify-between mb-8">
+          <div>
+            <h1 className="text-text-primary mb-2">{course.title}</h1>
             <div className="flex items-center gap-2">
-              <Button
-                size="sm"
-                onClick={() => navigate(`/tu/teaching/courses/${id}/apply`)}
-              >
-                <Send size={16} />
-                프로그램 신청
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="border border-border"
-                onClick={() => navigate(`/tu/teaching/courses/${id}/edit`)}
-              >
-                <Edit2 size={16} />
-                수정
-              </Button>
-              <Button
-                variant="destructive"
-                size="sm"
-                onClick={handleDelete}
-                disabled={deleteCourseMutation.isPending}
-              >
-                <Trash2 size={16} />
-                삭제
-              </Button>
+              {course.level && (
+                <Badge variant={levelBadgeColor[course.level]}>
+                  {LEVEL_LABELS[course.level]}
+                </Badge>
+              )}
+              {course.type && (
+                <Badge variant={typeBadgeColor[course.type]}>
+                  {TYPE_LABELS[course.type]}
+                </Badge>
+              )}
+              <span className="text-text-secondary text-sm">
+                {course.itemCount}차시
+              </span>
             </div>
           </div>
-        </div>
-      </div>
 
-      {/* Content */}
-      <div className="flex-1 overflow-auto">
-        <div className="p-6 px-8 max-w-5xl space-y-6">
+          {/* Action Buttons */}
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              onClick={() => navigate(`/tu/teaching/courses/${id}/apply`)}
+            >
+              <Send size={16} />
+              프로그램 신청
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="border border-border"
+              onClick={() => navigate(`/tu/teaching/courses/${id}/edit`)}
+            >
+              <Edit2 size={16} />
+              수정
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={handleDelete}
+              disabled={deleteCourseMutation.isPending}
+            >
+              <Trash2 size={16} />
+              삭제
+            </Button>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="space-y-6">
           {/* 기본 정보 섹션 */}
           <CourseInfoSection course={course} categories={categories} />
 

--- a/src/pages/tu/teaching/programs/ProgramDetailPage.tsx
+++ b/src/pages/tu/teaching/programs/ProgramDetailPage.tsx
@@ -149,84 +149,82 @@ export function ProgramDetailPage({ language = 'ko' }: Readonly<ProgramDetailPag
   }
 
   return (
-    <div className="h-full flex flex-col bg-bg-app">
-      {/* Header */}
-      <div className="border-b border-border bg-bg-default sticky top-0 z-10">
-        <div className="p-6 px-8">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
+    <div className="h-full overflow-auto bg-bg-app">
+      <div className="p-8">
+        {/* 뒤로가기 버튼 */}
+        <div className="mb-4">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="border border-border"
+            onClick={() => navigate('/tu/teaching/programs')}
+          >
+            <ArrowLeft size={16} />
+            {getText('back')}
+          </Button>
+        </div>
+
+        {/* Header Section - 목록 페이지와 동일한 스타일 */}
+        <div className="flex items-start justify-between mb-8">
+          <div>
+            <div className="flex items-center gap-3 mb-2">
+              <h1 className="text-text-primary mb-0">{program.title}</h1>
+              <Badge
+                variant={statusBadgeVariant[program.status]}
+                className="flex items-center gap-1"
+              >
+                {statusIcons[program.status]}
+                {PROGRAM_STATUS_LABELS[program.status]}
+              </Badge>
+            </div>
+            <p className="text-text-secondary m-0">ID: {program.id}</p>
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex items-center gap-2">
+            {canSubmit(program.status) && (
+              <Button size="sm" onClick={handleSubmit} disabled={isActionPending}>
+                {submitMutation.isPending ? (
+                  <Loader2 size={16} className="animate-spin" />
+                ) : (
+                  <Send size={16} />
+                )}
+                {getText('submit')}
+              </Button>
+            )}
+
+            {canEdit(program.status) && (
               <Button
                 variant="ghost"
                 size="sm"
                 className="border border-border"
-                onClick={() => navigate('/tu/teaching/programs')}
+                onClick={() => navigate(`/tu/teaching/programs/${id}/edit`)}
               >
-                <ArrowLeft size={16} />
-                {getText('back')}
+                <Edit2 size={16} />
+                {getText('edit')}
               </Button>
-              <div>
-                <div className="flex items-center gap-3">
-                  <h1 className="text-text-primary text-xl mb-0">{program.title}</h1>
-                  <Badge
-                    variant={statusBadgeVariant[program.status]}
-                    className="flex items-center gap-1"
-                  >
-                    {statusIcons[program.status]}
-                    {PROGRAM_STATUS_LABELS[program.status]}
-                  </Badge>
-                </div>
-                <p className="text-text-secondary text-sm mt-1">ID: {program.id}</p>
-              </div>
-            </div>
+            )}
 
-            {/* Action Buttons */}
-            <div className="flex items-center gap-2">
-              {canSubmit(program.status) && (
-                <Button size="sm" onClick={handleSubmit} disabled={isActionPending}>
-                  {submitMutation.isPending ? (
-                    <Loader2 size={16} className="animate-spin" />
-                  ) : (
-                    <Send size={16} />
-                  )}
-                  {getText('submit')}
-                </Button>
-              )}
-
-              {canEdit(program.status) && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="border border-border"
-                  onClick={() => navigate(`/tu/teaching/programs/${id}/edit`)}
-                >
-                  <Edit2 size={16} />
-                  {getText('edit')}
-                </Button>
-              )}
-
-              {canDelete(program.status) && (
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={handleDelete}
-                  disabled={isActionPending}
-                >
-                  {deleteMutation.isPending ? (
-                    <Loader2 size={16} className="animate-spin" />
-                  ) : (
-                    <Trash2 size={16} />
-                  )}
-                  {getText('delete')}
-                </Button>
-              )}
-            </div>
+            {canDelete(program.status) && (
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={handleDelete}
+                disabled={isActionPending}
+              >
+                {deleteMutation.isPending ? (
+                  <Loader2 size={16} className="animate-spin" />
+                ) : (
+                  <Trash2 size={16} />
+                )}
+                {getText('delete')}
+              </Button>
+            )}
           </div>
         </div>
-      </div>
 
-      {/* Content */}
-      <div className="flex-1 overflow-auto">
-        <div className="p-6 px-8 max-w-5xl space-y-6">
+        {/* Content */}
+        <div className="space-y-6">
           {/* 기본 정보 섹션 */}
           <ProgramInfoSection program={program} language={language} />
 


### PR DESCRIPTION
## Summary
- 디테일 페이지의 상단 헤더 디자인이 목록 페이지와 이질감이 있어 통일
- sticky 헤더 제거하고 자연스러운 스크롤 레이아웃으로 변경
- 3개 디테일 페이지에 동일한 레이아웃 패턴 적용

## Changes
| Before | After |
|--------|-------|
| `sticky top-0 z-10` 헤더 | sticky 제거, 자연스러운 스크롤 |
| `bg-bg-default border-b` | `bg-bg-app` (목록과 동일) |
| 뒤로가기+제목 같은 줄 | 뒤로가기 별도 줄, 제목+액션버튼 같은 줄 |
| `max-w-4xl/5xl` 제한 | 전체 너비 사용 |

## 변경 파일
- `to/program/ProgramDetailPage.tsx` - 강의 개설 디테일
- `tu/teaching/programs/ProgramDetailPage.tsx` - 강의계획 디테일
- `tu/teaching/courses/CourseDetailPage.tsx` - 강의 디테일

## 레이아웃 구조
```
┌──────────────────────────────────────────┐
│ [← 목록으로]                             │
├──────────────────────────────────────────┤
│ 제목 [배지]            [액션버튼들]      │
│ 부제목                                   │
├──────────────────────────────────────────┤
│ [카드 컨텐츠...]                         │
└──────────────────────────────────────────┘
```

## Test plan
- [ ] TO 강의 개설 디테일 페이지 (`/to/courses/:id`) 레이아웃 확인
- [ ] TU 강의계획 디테일 페이지 (`/tu/teaching/programs/:id`) 레이아웃 확인
- [ ] TU 강의 디테일 페이지 (`/tu/teaching/courses/:id`) 레이아웃 확인
- [ ] 목록 페이지와 디자인 일관성 확인