### PR TITLE
feat(tu): B2B 환경에 맞게 가격 표시 방식 변경 및 강의 카드 내용 일관성 유지 #276

### DIFF
--- a/src/components/landing/LandingCourseCard.tsx
+++ b/src/components/landing/LandingCourseCard.tsx
@@ -65,7 +65,6 @@ export function LandingCourseCard({
     if (tag === '할인중') return t.landing.tagSale;
     if (tag === '상시모집') return '상시모집';
     if (tag === '모집중') return '모집중';
-    if (tag === '자기부담') return '자기부담';
     return tag;
   };
 
@@ -100,9 +99,7 @@ export function LandingCourseCard({
                           ? 'bg-gradient-to-r from-[#70f2a0] to-[#6bc2f0]'
                           : tag === '모집중'
                             ? 'bg-gradient-to-r from-[#6778ff] to-[#a855f7]'
-                            : tag === '자기부담'
-                              ? 'bg-gradient-to-r from-[#f59e0b] to-[#f97316]'
-                              : 'bg-gradient-to-r from-[#ff7867] to-[#ff9a5a]'
+                            : 'bg-gradient-to-r from-[#ff7867] to-[#ff9a5a]'
                   }`}
                 >
                   {getTagLabel(tag)}
@@ -152,7 +149,7 @@ export function LandingCourseCard({
 
           <div className="pt-2 flex items-center justify-between">
             {price && (
-              <span className="font-bold text-[#f59e0b] text-lg">{price}</span>
+              <span className="font-bold text-[#6778ff] text-lg">{price}</span>
             )}
             <div className={`flex gap-1.5 ${!price ? 'ml-auto' : ''}`}>
               <span className="landing-badge-bg landing-text-muted text-[10px] px-2 py-1 rounded-full">

--- a/src/components/landing/LandingCourseCard.tsx
+++ b/src/components/landing/LandingCourseCard.tsx
@@ -1,6 +1,5 @@
 import { Link, useNavigate } from 'react-router-dom';
-import { Star, Heart, Loader2 } from 'lucide-react';
-import { useTranslation } from '@/store/common/languageStore';
+import { Star, Heart, Loader2, Calendar, Users } from 'lucide-react';
 import { useAuthStore } from '@/store/common/authStore';
 import { useCheckWishlistStatus, useToggleWishlist } from '@/hooks/tu';
 import { toast } from 'sonner';
@@ -9,12 +8,27 @@ interface LandingCourseCardProps {
   id: number;
   title: string;
   instructor: string;
-  price: string | null; // B2B: null이면 표시 안함
+  price: string | null; // null이면 표시 안함 (무료)
   rating: number;
-  reviewCount: number;
+  reviewCount: number; // 리뷰 수
+  studentCount: number; // 참여자 수
   image: string;
   tags: string[];
   category: string;
+  // 추가 정보
+  deliveryType?: string; // 운영 방식 (온라인, 오프라인 등)
+  level?: string; // 레벨 (입문, 초급 등)
+  classStartDate?: string; // 개강일
+  availableSeats?: number | null; // 잔여석
+  isOnDemand?: boolean; // 상시모집 여부
+}
+
+/**
+ * 날짜 포맷팅 (M/D)
+ */
+function formatShortDate(dateString: string): string {
+  const date = new Date(dateString);
+  return `${date.getMonth() + 1}/${date.getDate()}`;
 }
 
 export function LandingCourseCard({
@@ -24,10 +38,15 @@ export function LandingCourseCard({
   price,
   rating,
   reviewCount,
+  studentCount,
   image,
   tags,
+  deliveryType,
+  level,
+  classStartDate,
+  availableSeats,
+  isOnDemand,
 }: LandingCourseCardProps) {
-  const { t, language } = useTranslation();
   const navigate = useNavigate();
   const { isAuthenticated } = useAuthStore();
 
@@ -58,56 +77,51 @@ export function LandingCourseCard({
 
   const isWishlistLoading = isWishlistChecking || isWishlistToggling;
 
-  // 태그 번역 매핑
-  const getTagLabel = (tag: string) => {
-    if (tag === 'NEW') return t.landing.tagNew;
-    if (tag === '베스트') return t.landing.tagBest;
-    if (tag === '할인중') return t.landing.tagSale;
-    if (tag === '상시모집') return '상시모집';
-    if (tag === '모집중') return '모집중';
-    return tag;
-  };
-
-  // 수강생 수 포맷
-  const formatStudentCount = (count: number) => {
-    const displayCount = count > 100 ? '100+' : count.toString();
-    return language === 'ko' ? `+${displayCount}명` : `${displayCount}+ students`;
+  // 태그 스타일 매핑
+  const getTagStyle = (tag: string) => {
+    switch (tag) {
+      case '상시모집':
+        return 'bg-gradient-to-r from-[#70f2a0] to-[#6bc2f0]';
+      case '모집중':
+        return 'bg-gradient-to-r from-[#6778ff] to-[#a855f7]';
+      case '진행중':
+        return 'bg-gray-500';
+      case 'NEW':
+        return 'bg-gradient-to-r from-[#70f2a0] to-[#6bc2f0]';
+      case '베스트':
+        return 'bg-gradient-to-r from-[#6778ff] to-[#a855f7]';
+      default:
+        return 'bg-gradient-to-r from-[#ff7867] to-[#ff9a5a]';
+    }
   };
 
   return (
     <Link to={`/tu/b2c/courses/${id}`} className="group block h-full">
       <div className="h-full card-hover rounded-xl overflow-hidden landing-card-bg border landing-card-border">
-        {/* Image Container */}
+        {/* 썸네일 영역 */}
         <div className="relative aspect-[16/10] overflow-hidden">
           <img
             src={image}
             alt={title}
             className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
           />
-          <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+          <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+
+          {/* 좌측 상단: 상태 뱃지 */}
           {tags.length > 0 && (
             <div className="absolute top-3 left-3 flex gap-1.5">
               {tags.map((tag) => (
                 <span
                   key={tag}
-                  className={`text-white text-[10px] font-bold px-2.5 py-1 rounded-full shadow-lg ${
-                    tag === 'NEW'
-                      ? 'bg-gradient-to-r from-[#70f2a0] to-[#6bc2f0]'
-                      : tag === '베스트'
-                        ? 'bg-gradient-to-r from-[#6778ff] to-[#a855f7]'
-                        : tag === '상시모집'
-                          ? 'bg-gradient-to-r from-[#70f2a0] to-[#6bc2f0]'
-                          : tag === '모집중'
-                            ? 'bg-gradient-to-r from-[#6778ff] to-[#a855f7]'
-                            : 'bg-gradient-to-r from-[#ff7867] to-[#ff9a5a]'
-                  }`}
+                  className={`text-white text-[10px] font-bold px-2.5 py-1 rounded-full shadow-lg ${getTagStyle(tag)}`}
                 >
-                  {getTagLabel(tag)}
+                  {tag}
                 </span>
               ))}
             </div>
           )}
-          {/* 찜 버튼 */}
+
+          {/* 우측 상단: 찜 버튼 */}
           <button
             onClick={handleWishlistToggle}
             disabled={isWishlistLoading}
@@ -126,14 +140,17 @@ export function LandingCourseCard({
           </button>
         </div>
 
-        {/* Content */}
+        {/* 정보 영역 */}
         <div className="p-4 space-y-2">
+          {/* 제목 (2줄 말줄임) */}
           <h3 className="font-bold landing-text-primary line-clamp-2 text-[15px] group-hover:text-[#6778ff] transition-colors h-11">
             {title}
           </h3>
 
+          {/* 강사명 */}
           <div className="text-xs landing-text-muted">{instructor}</div>
 
+          {/* 별점 + 리뷰 수 (항상 표시) */}
           <div className="flex items-center gap-1.5 text-xs">
             <div className="flex">
               {[...Array(5)].map((_, i) => (
@@ -147,15 +164,42 @@ export function LandingCourseCard({
             <span className="landing-text-muted">({reviewCount.toLocaleString()})</span>
           </div>
 
-          <div className="pt-2 flex items-center justify-between">
-            {price && (
-              <span className="font-bold text-[#6778ff] text-lg">{price}</span>
-            )}
-            <div className={`flex gap-1.5 ${!price ? 'ml-auto' : ''}`}>
-              <span className="landing-badge-bg landing-text-muted text-[10px] px-2 py-1 rounded-full">
-                {formatStudentCount(reviewCount)}
+          {/* 메타 정보 (운영방식 · 레벨) */}
+          <div className="flex items-center gap-2 text-xs">
+            {deliveryType && (
+              <span className="landing-badge-bg landing-text-muted px-2 py-0.5 rounded">
+                {deliveryType}
               </span>
+            )}
+            {level && (
+              <span className="landing-text-muted">{level}</span>
+            )}
+          </div>
+
+          {/* 개강일 및 잔여석 (상시모집이 아닌 경우만) */}
+          {!isOnDemand && classStartDate && (
+            <div className="flex items-center gap-1 text-xs landing-text-muted">
+              <Calendar className="w-3 h-3" />
+              <span>{formatShortDate(classStartDate)} 개강</span>
+              {availableSeats !== null && availableSeats !== undefined && (
+                <span className="ml-2 text-orange-500 font-medium">
+                  잔여 {availableSeats}석
+                </span>
+              )}
             </div>
+          )}
+        </div>
+
+        {/* 하단 푸터 (가격 + 참여자 수) */}
+        <div className="px-4 pb-4 flex items-center justify-between">
+          {price ? (
+            <span className="font-bold text-[#6778ff] text-lg">{price}</span>
+          ) : (
+            <span />
+          )}
+          <div className="flex items-center gap-1 text-xs landing-text-muted">
+            <Users className="w-3.5 h-3.5" />
+            <span>{studentCount.toLocaleString()}명</span>
           </div>
         </div>
       </div>

--- a/src/components/landing/LandingCourseCard.tsx
+++ b/src/components/landing/LandingCourseCard.tsx
@@ -9,7 +9,7 @@ interface LandingCourseCardProps {
   id: number;
   title: string;
   instructor: string;
-  price: string;
+  price: string | null; // B2B: null이면 표시 안함
   rating: number;
   reviewCount: number;
   image: string;
@@ -65,7 +65,7 @@ export function LandingCourseCard({
     if (tag === '할인중') return t.landing.tagSale;
     if (tag === '상시모집') return '상시모집';
     if (tag === '모집중') return '모집중';
-    if (tag === '무료') return '무료';
+    if (tag === '자기부담') return '자기부담';
     return tag;
   };
 
@@ -100,8 +100,8 @@ export function LandingCourseCard({
                           ? 'bg-gradient-to-r from-[#70f2a0] to-[#6bc2f0]'
                           : tag === '모집중'
                             ? 'bg-gradient-to-r from-[#6778ff] to-[#a855f7]'
-                            : tag === '무료'
-                              ? 'bg-gradient-to-r from-[#ff7867] to-[#ff9a5a]'
+                            : tag === '자기부담'
+                              ? 'bg-gradient-to-r from-[#f59e0b] to-[#f97316]'
                               : 'bg-gradient-to-r from-[#ff7867] to-[#ff9a5a]'
                   }`}
                 >
@@ -151,8 +151,10 @@ export function LandingCourseCard({
           </div>
 
           <div className="pt-2 flex items-center justify-between">
-            <span className="font-bold text-[#6778ff] text-lg">{price}</span>
-            <div className="flex gap-1.5">
+            {price && (
+              <span className="font-bold text-[#f59e0b] text-lg">{price}</span>
+            )}
+            <div className={`flex gap-1.5 ${!price ? 'ml-auto' : ''}`}>
               <span className="landing-badge-bg landing-text-muted text-[10px] px-2 py-1 rounded-full">
                 {formatStudentCount(reviewCount)}
               </span>

--- a/src/pages/tu/main/CartPage.tsx
+++ b/src/pages/tu/main/CartPage.tsx
@@ -10,13 +10,14 @@ import type { CartItemResponse } from '@/types/tu/cart.types';
 import type { WishlistItemResponse } from '@/types/tu/wishlist.types';
 
 /**
- * 가격 포맷팅 (₩180,000 형식)
+ * B2B 가격 표시 (유료 → 자기부담, 무료 → 표시 안함)
  */
-function formatPrice(price: string | null | undefined): string {
-  if (!price) return '';
+function formatB2BPrice(price: string | null | undefined, isFree: boolean): string | null {
+  if (isFree) return null; // 무료는 표시 안함
+  if (!price) return null;
   const numPrice = parseFloat(price);
-  if (isNaN(numPrice)) return price;
-  return `₩${numPrice.toLocaleString()}`;
+  if (isNaN(numPrice) || numPrice === 0) return null;
+  return '자기부담';
 }
 
 export function CartPage() {
@@ -175,11 +176,6 @@ export function CartPage() {
     }, 0);
   }, [selectedCartItems]);
 
-  // 무료 강의 개수
-  const freeCoursesCount = useMemo(() => {
-    return selectedCartItems.filter(item => item.isFree).length;
-  }, [selectedCartItems]);
-
   // 로딩 상태
   if (isCartLoading) {
     return (
@@ -326,15 +322,11 @@ export function CartPage() {
                                   {item.estimatedHours}시간
                                 </span>
                               )}
-                              {item.isFree ? (
+                              {formatB2BPrice(item.price, item.isFree) && (
                                 <span className={`text-xs px-2 py-0.5 rounded ${
-                                  isDark ? 'bg-green-500/20 text-green-400' : 'bg-green-100 text-green-600'
+                                  isDark ? 'bg-orange-500/20 text-orange-400' : 'bg-orange-100 text-orange-600'
                                 }`}>
-                                  무료
-                                </span>
-                              ) : item.price && (
-                                <span className={`text-xs font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                                  {formatPrice(item.price)}
+                                  {formatB2BPrice(item.price, item.isFree)}
                                 </span>
                               )}
                             </div>
@@ -424,15 +416,11 @@ export function CartPage() {
                                   {item.estimatedHours}시간
                                 </span>
                               )}
-                              {item.isFree ? (
+                              {formatB2BPrice(item.price, item.isFree) && (
                                 <span className={`text-xs px-2 py-0.5 rounded ${
-                                  isDark ? 'bg-green-500/20 text-green-400' : 'bg-green-100 text-green-600'
+                                  isDark ? 'bg-orange-500/20 text-orange-400' : 'bg-orange-100 text-orange-600'
                                 }`}>
-                                  무료
-                                </span>
-                              ) : item.price && (
-                                <span className={`text-xs font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                                  {formatPrice(item.price)}
+                                  {formatB2BPrice(item.price, item.isFree)}
                                 </span>
                               )}
                             </div>
@@ -499,20 +487,14 @@ export function CartPage() {
                   )}
                 </div>
 
-                {/* Total Price */}
+                {/* 자기부담 강의 수 */}
                 <div className={`space-y-3 mb-6 pb-6 border-b ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
-                  {freeCoursesCount > 0 && (
+                  {totalPrice > 0 && (
                     <div className={`flex justify-between ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-                      <span>무료 강의</span>
-                      <span>{freeCoursesCount}개</span>
+                      <span>자기부담 강의</span>
+                      <span>{selectedCartItems.filter(item => !item.isFree && item.price && parseFloat(item.price) > 0).length}개</span>
                     </div>
                   )}
-                  <div className={`flex justify-between items-center`}>
-                    <span className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>총 결제금액</span>
-                    <span className={`text-2xl font-bold ${isDark ? 'text-[#6bc2f0]' : 'text-[#6778ff]'}`}>
-                      {totalPrice === 0 ? '무료' : `₩${totalPrice.toLocaleString()}`}
-                    </span>
-                  </div>
                 </div>
 
                 {/* Checkout Button */}

--- a/src/pages/tu/main/CartPage.tsx
+++ b/src/pages/tu/main/CartPage.tsx
@@ -10,14 +10,14 @@ import type { CartItemResponse } from '@/types/tu/cart.types';
 import type { WishlistItemResponse } from '@/types/tu/wishlist.types';
 
 /**
- * B2B 가격 표시 (유료 → 자기부담, 무료 → 표시 안함)
+ * 가격 표시 (유료 → 금액, 무료 → 표시 안함)
  */
-function formatB2BPrice(price: string | null | undefined, isFree: boolean): string | null {
+function formatPrice(price: string | null | undefined, isFree: boolean): string | null {
   if (isFree) return null; // 무료는 표시 안함
   if (!price) return null;
   const numPrice = parseFloat(price);
   if (isNaN(numPrice) || numPrice === 0) return null;
-  return '자기부담';
+  return `₩${numPrice.toLocaleString()}`;
 }
 
 export function CartPage() {
@@ -322,11 +322,11 @@ export function CartPage() {
                                   {item.estimatedHours}시간
                                 </span>
                               )}
-                              {formatB2BPrice(item.price, item.isFree) && (
+                              {formatPrice(item.price, item.isFree) && (
                                 <span className={`text-xs px-2 py-0.5 rounded ${
-                                  isDark ? 'bg-orange-500/20 text-orange-400' : 'bg-orange-100 text-orange-600'
+                                  isDark ? 'bg-blue-500/20 text-blue-400' : 'bg-blue-100 text-blue-600'
                                 }`}>
-                                  {formatB2BPrice(item.price, item.isFree)}
+                                  {formatPrice(item.price, item.isFree)}
                                 </span>
                               )}
                             </div>
@@ -416,11 +416,11 @@ export function CartPage() {
                                   {item.estimatedHours}시간
                                 </span>
                               )}
-                              {formatB2BPrice(item.price, item.isFree) && (
+                              {formatPrice(item.price, item.isFree) && (
                                 <span className={`text-xs px-2 py-0.5 rounded ${
-                                  isDark ? 'bg-orange-500/20 text-orange-400' : 'bg-orange-100 text-orange-600'
+                                  isDark ? 'bg-blue-500/20 text-blue-400' : 'bg-blue-100 text-blue-600'
                                 }`}>
-                                  {formatB2BPrice(item.price, item.isFree)}
+                                  {formatPrice(item.price, item.isFree)}
                                 </span>
                               )}
                             </div>
@@ -487,13 +487,19 @@ export function CartPage() {
                   )}
                 </div>
 
-                {/* 자기부담 강의 수 */}
+                {/* 유료 강의 수 및 총 금액 */}
                 <div className={`space-y-3 mb-6 pb-6 border-b ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
                   {totalPrice > 0 && (
-                    <div className={`flex justify-between ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-                      <span>자기부담 강의</span>
-                      <span>{selectedCartItems.filter(item => !item.isFree && item.price && parseFloat(item.price) > 0).length}개</span>
-                    </div>
+                    <>
+                      <div className={`flex justify-between ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                        <span>유료 강의</span>
+                        <span>{selectedCartItems.filter(item => !item.isFree && item.price && parseFloat(item.price) > 0).length}개</span>
+                      </div>
+                      <div className={`flex justify-between font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                        <span>총 금액</span>
+                        <span className="text-[#6778ff]">₩{totalPrice.toLocaleString()}</span>
+                      </div>
+                    </>
                   )}
                 </div>
 

--- a/src/pages/tu/main/CoursesExplorePage.tsx
+++ b/src/pages/tu/main/CoursesExplorePage.tsx
@@ -103,7 +103,7 @@ function CourseTimeCard({ courseTime, isDark }: CourseTimeCardProps) {
     }
   };
 
-  // 태그 생성 (B2B: 무료 태그 제거)
+  // 태그 생성 (무료 태그 제거, 유료는 금액 표시)
   const tags: string[] = [];
   if (courseTime.isOnDemand) {
     tags.push('상시모집');
@@ -112,17 +112,14 @@ function CourseTimeCard({ courseTime, isDark }: CourseTimeCardProps) {
   } else if (courseTime.status === 'ONGOING') {
     tags.push('진행중');
   }
-  // B2B 환경: 유료 강의만 '자기부담' 표시
-  if (!courseTime.isFree && parseFloat(courseTime.price) > 0) {
-    tags.push('자기부담');
-  }
 
   // 주강사 찾기
   const mainInstructor = courseTime.instructors.find((i) => i.role === 'MAIN');
   const instructorName = mainInstructor?.name || courseTime.instructors[0]?.name || '';
 
-  // B2B 가격 표시: 유료 → 자기부담, 무료 → 표시 안함
-  const priceDisplay = (!courseTime.isFree && parseFloat(courseTime.price) > 0) ? '자기부담' : null;
+  // 가격 표시: 유료 → 금액, 무료 → 표시 안함
+  const price = parseFloat(courseTime.price);
+  const priceDisplay = (!courseTime.isFree && price > 0) ? `₩${price.toLocaleString()}` : null;
 
   // 썸네일
   const thumbnailUrl =
@@ -161,9 +158,7 @@ function CourseTimeCard({ courseTime, isDark }: CourseTimeCardProps) {
                       ? 'bg-gradient-to-r from-[#70f2a0] to-[#6bc2f0]'
                       : tag === '모집중'
                         ? 'bg-gradient-to-r from-[#6778ff] to-[#a855f7]'
-                        : tag === '자기부담'
-                          ? 'bg-gradient-to-r from-[#f59e0b] to-[#f97316]'
-                          : 'bg-gray-500'
+                        : 'bg-gray-500'
                   }`}
                 >
                   {tag}
@@ -260,11 +255,13 @@ function CourseTimeCard({ courseTime, isDark }: CourseTimeCardProps) {
           )}
 
           {/* 가격 */}
-          <div className="pt-2 flex items-center justify-between">
-            <span className={`font-bold text-lg ${isDark ? 'text-[#6bc2f0]' : 'text-[#4C2D9A]'}`}>
-              {priceDisplay}
-            </span>
-          </div>
+          {priceDisplay && (
+            <div className="pt-2 flex items-center justify-between">
+              <span className={`font-bold text-lg ${isDark ? 'text-[#6bc2f0]' : 'text-[#6778ff]'}`}>
+                {priceDisplay}
+              </span>
+            </div>
+          )}
         </div>
       </div>
     </Link>

--- a/src/pages/tu/main/CoursesExplorePage.tsx
+++ b/src/pages/tu/main/CoursesExplorePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useSearchParams, Link, useNavigate } from 'react-router-dom';
-import { Search, SlidersHorizontal, Loader2, Heart, Clock, Users, Calendar, X } from 'lucide-react';
+import { Search, SlidersHorizontal, Loader2, Heart, Calendar, X, Star, Users } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
@@ -186,9 +186,9 @@ function CourseTimeCard({ courseTime, isDark }: CourseTimeCardProps) {
           </button>
         </div>
 
-        {/* Content */}
+        {/* 정보 영역 */}
         <div className="p-4 space-y-2">
-          {/* 제목 */}
+          {/* 제목 (2줄 말줄임) */}
           <h3
             className={`font-bold line-clamp-2 text-[15px] transition-colors h-11 ${
               isDark
@@ -206,8 +206,22 @@ function CourseTimeCard({ courseTime, isDark }: CourseTimeCardProps) {
             </div>
           )}
 
-          {/* 메타 정보 */}
-          <div className="flex items-center gap-3 text-xs">
+          {/* 별점 + 리뷰 수 (항상 표시) */}
+          <div className="flex items-center gap-1.5 text-xs">
+            <div className="flex">
+              {[...Array(5)].map((_, i) => (
+                <Star
+                  key={i}
+                  className={`w-3 h-3 ${i < 4 ? 'fill-yellow-400 text-yellow-400' : isDark ? 'text-gray-600' : 'text-gray-300'}`}
+                />
+              ))}
+            </div>
+            <span className={`font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>4.5</span>
+            <span className={isDark ? 'text-gray-500' : 'text-gray-400'}>({courseTime.currentEnrollment.toLocaleString()})</span>
+          </div>
+
+          {/* 메타 정보 (운영방식 · 레벨) */}
+          <div className="flex items-center gap-2 text-xs">
             {/* 운영 방식 */}
             <span
               className={`px-2 py-0.5 rounded ${
@@ -221,47 +235,37 @@ function CourseTimeCard({ courseTime, isDark }: CourseTimeCardProps) {
             {levelLabel && (
               <span className={isDark ? 'text-gray-500' : 'text-gray-500'}>{levelLabel}</span>
             )}
-
-            {/* 예상 시간 */}
-            {courseTime.program?.estimatedHours && (
-              <span className={`flex items-center gap-1 ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
-                <Clock className="w-3 h-3" />
-                {courseTime.program.estimatedHours}시간
-              </span>
-            )}
           </div>
 
-          {/* 모집/수강 기간 (상시모집이 아닌 경우만) */}
+          {/* 개강일 및 잔여석 (상시모집이 아닌 경우만) */}
           {!courseTime.isOnDemand && (
             <div className={`flex items-center gap-1 text-xs ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
               <Calendar className="w-3 h-3" />
               <span>
                 {formatShortDate(courseTime.classStartDate)} 개강
               </span>
-              {courseTime.availableSeats !== null && courseTime.capacity !== null && (
-                <span className="ml-2 text-orange-500">
+              {courseTime.availableSeats !== null && courseTime.availableSeats !== undefined && (
+                <span className="ml-2 text-orange-500 font-medium">
                   잔여 {courseTime.availableSeats}석
                 </span>
               )}
             </div>
           )}
+        </div>
 
-          {/* 수강생 수 (상시모집인 경우) */}
-          {courseTime.isOnDemand && courseTime.currentEnrollment > 0 && (
-            <div className={`flex items-center gap-1 text-xs ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
-              <Users className="w-3 h-3" />
-              <span>{courseTime.currentEnrollment.toLocaleString()}명 수강중</span>
-            </div>
+        {/* 하단 푸터 (가격 + 참여자 수) */}
+        <div className="px-4 pb-4 flex items-center justify-between">
+          {priceDisplay ? (
+            <span className={`font-bold text-lg ${isDark ? 'text-[#6bc2f0]' : 'text-[#6778ff]'}`}>
+              {priceDisplay}
+            </span>
+          ) : (
+            <span />
           )}
-
-          {/* 가격 */}
-          {priceDisplay && (
-            <div className="pt-2 flex items-center justify-between">
-              <span className={`font-bold text-lg ${isDark ? 'text-[#6bc2f0]' : 'text-[#6778ff]'}`}>
-                {priceDisplay}
-              </span>
-            </div>
-          )}
+          <div className={`flex items-center gap-1 text-xs ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
+            <Users className="w-3.5 h-3.5" />
+            <span>{courseTime.currentEnrollment.toLocaleString()}명</span>
+          </div>
         </div>
       </div>
     </Link>

--- a/src/pages/tu/main/CoursesExplorePage.tsx
+++ b/src/pages/tu/main/CoursesExplorePage.tsx
@@ -103,7 +103,7 @@ function CourseTimeCard({ courseTime, isDark }: CourseTimeCardProps) {
     }
   };
 
-  // 태그 생성
+  // 태그 생성 (B2B: 무료 태그 제거)
   const tags: string[] = [];
   if (courseTime.isOnDemand) {
     tags.push('상시모집');
@@ -112,17 +112,17 @@ function CourseTimeCard({ courseTime, isDark }: CourseTimeCardProps) {
   } else if (courseTime.status === 'ONGOING') {
     tags.push('진행중');
   }
-  if (courseTime.isFree) {
-    tags.push('무료');
+  // B2B 환경: 유료 강의만 '자기부담' 표시
+  if (!courseTime.isFree && parseFloat(courseTime.price) > 0) {
+    tags.push('자기부담');
   }
 
   // 주강사 찾기
   const mainInstructor = courseTime.instructors.find((i) => i.role === 'MAIN');
   const instructorName = mainInstructor?.name || courseTime.instructors[0]?.name || '';
 
-  // 가격 포맷팅
-  const price = courseTime.isFree ? 0 : parseFloat(courseTime.price);
-  const priceDisplay = courseTime.isFree ? '무료' : `₩${price.toLocaleString()}`;
+  // B2B 가격 표시: 유료 → 자기부담, 무료 → 표시 안함
+  const priceDisplay = (!courseTime.isFree && parseFloat(courseTime.price) > 0) ? '자기부담' : null;
 
   // 썸네일
   const thumbnailUrl =
@@ -161,8 +161,8 @@ function CourseTimeCard({ courseTime, isDark }: CourseTimeCardProps) {
                       ? 'bg-gradient-to-r from-[#70f2a0] to-[#6bc2f0]'
                       : tag === '모집중'
                         ? 'bg-gradient-to-r from-[#6778ff] to-[#a855f7]'
-                        : tag === '무료'
-                          ? 'bg-gradient-to-r from-[#ff7867] to-[#ff9a5a]'
+                        : tag === '자기부담'
+                          ? 'bg-gradient-to-r from-[#f59e0b] to-[#f97316]'
                           : 'bg-gray-500'
                   }`}
                 >

--- a/src/pages/tu/main/LandingPage.tsx
+++ b/src/pages/tu/main/LandingPage.tsx
@@ -93,11 +93,11 @@ function convertCourseTimeToCardProps(courseTime: CourseTimeCatalogResponse) {
   const mainInstructor = courseTime.instructors.find((i) => i.role === 'MAIN');
   const instructorName = mainInstructor?.name || courseTime.instructors[0]?.name || '';
 
-  // 가격 포맷팅
+  // B2B 가격 포맷팅 (유료 → 자기부담, 무료 → 표시 안함)
   const price = courseTime.isFree ? 0 : parseFloat(courseTime.price);
-  const priceDisplay = courseTime.isFree ? '무료' : `₩${price.toLocaleString()}`;
+  const priceDisplay = (!courseTime.isFree && price > 0) ? '자기부담' : null;
 
-  // 태그 생성
+  // 태그 생성 (B2B: 무료 태그 제거)
   const tags: string[] = [];
   if (courseTime.isOnDemand) {
     tags.push('상시모집');
@@ -106,8 +106,9 @@ function convertCourseTimeToCardProps(courseTime: CourseTimeCatalogResponse) {
   } else if (courseTime.status === 'ONGOING') {
     tags.push('진행중');
   }
-  if (courseTime.isFree) {
-    tags.push('무료');
+  // B2B 환경: 유료 강의만 '자기부담' 표시
+  if (!courseTime.isFree && price > 0) {
+    tags.push('자기부담');
   }
 
   // 썸네일
@@ -166,9 +167,9 @@ export function LandingPage() {
   // 최신 강의 (createdAt 기준 정렬이므로 처음 5개)
   const newCourses = courses.slice(0, 5);
 
-  // 추천 강의 (무료 강의 우선)
+  // 추천 강의 (상시모집 우선, B2B에서는 무료 태그 없음)
   const featuredCourses = courses
-    .filter((c) => c.tags.includes('무료') || c.tags.includes('상시모집'))
+    .filter((c) => c.tags.includes('상시모집') || !c.tags.includes('자기부담'))
     .slice(0, 5);
   const recommendedCourses = featuredCourses.length > 0 ? featuredCourses : courses.slice(0, 5);
 

--- a/src/pages/tu/main/LandingPage.tsx
+++ b/src/pages/tu/main/LandingPage.tsx
@@ -93,11 +93,11 @@ function convertCourseTimeToCardProps(courseTime: CourseTimeCatalogResponse) {
   const mainInstructor = courseTime.instructors.find((i) => i.role === 'MAIN');
   const instructorName = mainInstructor?.name || courseTime.instructors[0]?.name || '';
 
-  // B2B 가격 포맷팅 (유료 → 자기부담, 무료 → 표시 안함)
+  // 가격 포맷팅 (유료 → 금액, 무료 → 표시 안함)
   const price = courseTime.isFree ? 0 : parseFloat(courseTime.price);
-  const priceDisplay = (!courseTime.isFree && price > 0) ? '자기부담' : null;
+  const priceDisplay = (!courseTime.isFree && price > 0) ? `₩${price.toLocaleString()}` : null;
 
-  // 태그 생성 (B2B: 무료 태그 제거)
+  // 태그 생성 (무료 태그 제거)
   const tags: string[] = [];
   if (courseTime.isOnDemand) {
     tags.push('상시모집');
@@ -105,10 +105,6 @@ function convertCourseTimeToCardProps(courseTime: CourseTimeCatalogResponse) {
     tags.push('모집중');
   } else if (courseTime.status === 'ONGOING') {
     tags.push('진행중');
-  }
-  // B2B 환경: 유료 강의만 '자기부담' 표시
-  if (!courseTime.isFree && price > 0) {
-    tags.push('자기부담');
   }
 
   // 썸네일
@@ -167,9 +163,9 @@ export function LandingPage() {
   // 최신 강의 (createdAt 기준 정렬이므로 처음 5개)
   const newCourses = courses.slice(0, 5);
 
-  // 추천 강의 (상시모집 우선, B2B에서는 무료 태그 없음)
+  // 추천 강의 (상시모집 우선)
   const featuredCourses = courses
-    .filter((c) => c.tags.includes('상시모집') || !c.tags.includes('자기부담'))
+    .filter((c) => c.tags.includes('상시모집'))
     .slice(0, 5);
   const recommendedCourses = featuredCourses.length > 0 ? featuredCourses : courses.slice(0, 5);
 

--- a/src/pages/tu/main/LandingPage.tsx
+++ b/src/pages/tu/main/LandingPage.tsx
@@ -14,6 +14,7 @@ import { useTenantBranding } from '@/contexts/TenantBrandingContext';
 import { useBrandingApply } from '@/hooks/tu/useBrandingApply';
 import type { InstructorSummary } from '@/types/tu';
 import type { CourseTimeCatalogResponse } from '@/types/tu/courseTimeCatalog.types';
+import { DELIVERY_TYPE_LABELS, PROGRAM_LEVEL_LABELS } from '@/types/tu/courseTimeCatalog.types';
 
 // API 사용 여부 플래그
 const USE_INSTRUCTOR_API = false; // 강사 API 연동 시 true로 변경
@@ -118,10 +119,17 @@ function convertCourseTimeToCardProps(courseTime: CourseTimeCatalogResponse) {
     instructor: instructorName,
     price: priceDisplay,
     rating: 4.5, // CourseTime API에 rating이 없으므로 기본값
-    reviewCount: courseTime.currentEnrollment, // 수강생 수로 대체
+    reviewCount: courseTime.currentEnrollment, // 리뷰 수 (수강생 수로 대체)
+    studentCount: courseTime.currentEnrollment, // 참여자 수
     image: thumbnailUrl,
     tags,
     category: courseTime.program?.categoryName || 'all',
+    // 추가 정보
+    deliveryType: DELIVERY_TYPE_LABELS[courseTime.deliveryType] || courseTime.deliveryType,
+    level: courseTime.program?.level ? PROGRAM_LEVEL_LABELS[courseTime.program.level] : undefined,
+    classStartDate: courseTime.classStartDate,
+    availableSeats: courseTime.availableSeats,
+    isOnDemand: courseTime.isOnDemand,
   };
 }
 

--- a/src/pages/tu/main/WishlistPage.tsx
+++ b/src/pages/tu/main/WishlistPage.tsx
@@ -17,14 +17,14 @@ const LEVEL_LABELS: Record<string, string> = {
 };
 
 /**
- * B2B 가격 표시 (유료 → 자기부담, 무료 → 표시 안함)
+ * 가격 표시 (유료 → 금액, 무료 → 표시 안함)
  */
-function formatB2BPrice(price: string | null | undefined, isFree: boolean): string | null {
+function formatPrice(price: string | null | undefined, isFree: boolean): string | null {
   if (isFree) return null; // 무료는 표시 안함
   if (!price) return null;
   const numPrice = parseFloat(price);
   if (isNaN(numPrice) || numPrice === 0) return null;
-  return '자기부담';
+  return `₩${numPrice.toLocaleString()}`;
 }
 
 export function WishlistPage() {
@@ -200,9 +200,9 @@ export function WishlistPage() {
                           {item.estimatedHours}시간
                         </span>
                       )}
-                      {formatB2BPrice(item.price, item.isFree) && (
-                        <span className={`px-2 py-0.5 rounded text-xs ${isDark ? 'bg-orange-500/20 text-orange-400' : 'bg-orange-100 text-orange-600'}`}>
-                          {formatB2BPrice(item.price, item.isFree)}
+                      {formatPrice(item.price, item.isFree) && (
+                        <span className={`px-2 py-0.5 rounded text-xs ${isDark ? 'bg-blue-500/20 text-blue-400' : 'bg-blue-100 text-blue-600'}`}>
+                          {formatPrice(item.price, item.isFree)}
                         </span>
                       )}
                     </div>

--- a/src/pages/tu/main/WishlistPage.tsx
+++ b/src/pages/tu/main/WishlistPage.tsx
@@ -17,13 +17,14 @@ const LEVEL_LABELS: Record<string, string> = {
 };
 
 /**
- * 가격 포맷팅 (₩180,000 형식)
+ * B2B 가격 표시 (유료 → 자기부담, 무료 → 표시 안함)
  */
-function formatPrice(price: string | null | undefined): string {
-  if (!price) return '';
+function formatB2BPrice(price: string | null | undefined, isFree: boolean): string | null {
+  if (isFree) return null; // 무료는 표시 안함
+  if (!price) return null;
   const numPrice = parseFloat(price);
-  if (isNaN(numPrice)) return price;
-  return `₩${numPrice.toLocaleString()}`;
+  if (isNaN(numPrice) || numPrice === 0) return null;
+  return '자기부담';
 }
 
 export function WishlistPage() {
@@ -199,13 +200,9 @@ export function WishlistPage() {
                           {item.estimatedHours}시간
                         </span>
                       )}
-                      {item.isFree ? (
-                        <span className={`px-2 py-0.5 rounded ${isDark ? 'bg-green-500/20 text-green-400' : 'bg-green-100 text-green-600'}`}>
-                          무료
-                        </span>
-                      ) : item.price && (
-                        <span className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                          {formatPrice(item.price)}
+                      {formatB2BPrice(item.price, item.isFree) && (
+                        <span className={`px-2 py-0.5 rounded text-xs ${isDark ? 'bg-orange-500/20 text-orange-400' : 'bg-orange-100 text-orange-600'}`}>
+                          {formatB2BPrice(item.price, item.isFree)}
                         </span>
                       )}
                     </div>


### PR DESCRIPTION
## Summary

강의 카드 통합 디자인 적용 및 B2B/B2C 가격 표시 정책 변경

## Related Issue

- Closes #276

## Changes

- **가격 표시 정책 변경**: 무료 강의는 가격 미표시, 유료 강의만 금액 표시
- **강의 카드 통합 디자인 (Universal Card Layout)** 적용
  - 3섹션 구조: 썸네일 → 정보 → 푸터
  - 썸네일: 상태 뱃지(모집중/상시모집/진행중), 찜 버튼
  - 정보: 제목, 강사명, 별점+리뷰수, 운영방식+레벨, 개강일+잔여석
  - 푸터: 가격(좌측), 참여자수+Users아이콘(우측)
- **적용 파일**
  - `LandingCourseCard.tsx`: reviewCount, studentCount, deliveryType, level 등 props 추가
  - `LandingPage.tsx`: convertCourseTimeToCardProps 함수 업데이트
  - `CoursesExplorePage.tsx`: CourseTimeCard 통합 디자인 적용
  - `CartPage.tsx`, `WishlistPage.tsx`: formatPrice 함수 적용

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 별점/리뷰수는 현재 API에 없어 기본값(4.5) 및 수강생수로 대체
- 추후 리뷰 API 연동 시 실제 데이터로 교체 필요