### PR TITLE
feat(program): add snapshot edit form to ProgramEditPage

### DIFF
--- a/src/pages/tu/teaching/programs/ProgramEditPage.tsx
+++ b/src/pages/tu/teaching/programs/ProgramEditPage.tsx
@@ -4,11 +4,14 @@ import { ArrowLeft, Send, Loader2, AlertCircle, Save } from 'lucide-react';
 import { Button, Card, Badge } from '@/components/common';
 import {
   useMyProgram,
+  useMyProgramSnapshot,
   useUpdateMyProgram,
+  useUpdateSnapshot,
   useSubmitMyProgram,
 } from '@/hooks/tu';
 import type { ProgramStatus } from '@/types/common';
 import { ProgramBasicInfoForm, type ProgramFormData } from './components/ProgramBasicInfoForm';
+import { SnapshotEditForm, type SnapshotFormData } from './components/SnapshotEditForm';
 
 interface ProgramEditPageProps {
   language?: 'ko' | 'en';
@@ -55,7 +58,7 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
 
   const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
 
-  // Form state
+  // Form state - Program
   const [formData, setFormData] = useState<ProgramFormData>({
     title: '',
     description: '',
@@ -66,9 +69,19 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
   });
   const [hasChanges, setHasChanges] = useState(false);
 
+  // Form state - Snapshot
+  const [snapshotFormData, setSnapshotFormData] = useState<SnapshotFormData>({
+    snapshotName: '',
+    description: '',
+    hashtags: '',
+  });
+  const [hasSnapshotChanges, setHasSnapshotChanges] = useState(false);
+
   // API hooks
   const { data: program, isLoading, error } = useMyProgram(id);
+  const { data: snapshot } = useMyProgramSnapshot(program?.snapshotId || 0);
   const updateProgramMutation = useUpdateMyProgram();
+  const updateSnapshotMutation = useUpdateSnapshot();
   const submitProgramMutation = useSubmitMyProgram();
 
   // 프로그램 데이터로 폼 초기화
@@ -86,10 +99,28 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
     }
   }, [program]);
 
+  // 스냅샷 데이터로 폼 초기화
+  useEffect(() => {
+    if (snapshot) {
+      setSnapshotFormData({
+        snapshotName: snapshot.snapshotName || '',
+        description: snapshot.description || '',
+        hashtags: snapshot.hashtags || '',
+      });
+      setHasSnapshotChanges(false);
+    }
+  }, [snapshot]);
+
   // 폼 데이터 변경 핸들러
   const handleFormDataChange = (data: Partial<ProgramFormData>) => {
     setFormData((prev) => ({ ...prev, ...data }));
     setHasChanges(true);
+  };
+
+  // 스냅샷 폼 데이터 변경 핸들러
+  const handleSnapshotFormDataChange = (data: Partial<SnapshotFormData>) => {
+    setSnapshotFormData((prev) => ({ ...prev, ...data }));
+    setHasSnapshotChanges(true);
   };
 
   // 저장 핸들러
@@ -100,18 +131,35 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
     }
 
     try {
-      await updateProgramMutation.mutateAsync({
-        id,
-        request: {
-          title: formData.title.trim(),
-          description: formData.description.trim() || undefined,
-          thumbnailUrl: formData.thumbnailUrl.trim() || undefined,
-          level: formData.level || undefined,
-          type: formData.type || undefined,
-          estimatedHours: formData.estimatedHours || undefined,
-        },
-      });
-      setHasChanges(false);
+      // 프로그램 저장
+      if (hasChanges) {
+        await updateProgramMutation.mutateAsync({
+          id,
+          request: {
+            title: formData.title.trim(),
+            description: formData.description.trim() || undefined,
+            thumbnailUrl: formData.thumbnailUrl.trim() || undefined,
+            level: formData.level || undefined,
+            type: formData.type || undefined,
+            estimatedHours: formData.estimatedHours || undefined,
+          },
+        });
+        setHasChanges(false);
+      }
+
+      // 스냅샷 저장 (수정 가능한 상태이고 변경사항이 있을 때만)
+      if (hasSnapshotChanges && snapshot && isSnapshotModifiable) {
+        await updateSnapshotMutation.mutateAsync({
+          id: snapshot.snapshotId,
+          request: {
+            snapshotName: snapshotFormData.snapshotName.trim() || undefined,
+            description: snapshotFormData.description.trim() || undefined,
+            hashtags: snapshotFormData.hashtags.trim() || undefined,
+          },
+        });
+        setHasSnapshotChanges(false);
+      }
+
       return true;
     } catch (err) {
       console.error('Save failed:', err);
@@ -143,7 +191,7 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
 
     try {
       // 변경사항이 있으면 먼저 저장
-      if (hasChanges) {
+      if (hasAnyChanges) {
         const saveSuccess = await handleSave();
         if (!saveSuccess) return;
       }
@@ -158,9 +206,11 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
     }
   };
 
-  const isSaving = updateProgramMutation.isPending;
+  const isSaving = updateProgramMutation.isPending || updateSnapshotMutation.isPending;
   const isSubmitting = submitProgramMutation.isPending;
   const isProcessing = isSaving || isSubmitting;
+  const isSnapshotModifiable = snapshot?.status === 'DRAFT' || snapshot?.status === 'ACTIVE';
+  const hasAnyChanges = hasChanges || hasSnapshotChanges;
 
   // 로딩 상태
   if (isLoading) {
@@ -237,7 +287,7 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
                 <div className="flex items-center gap-2">
                   <h1 className="text-text-primary text-xl mb-0">{getText('pageTitle')}</h1>
                   <Badge variant={statusVariant}>{statusLabel}</Badge>
-                  {hasChanges && (
+                  {hasAnyChanges && (
                     <span className="text-xs text-status-warning">({getText('hasChanges')})</span>
                   )}
                 </div>
@@ -247,7 +297,7 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
 
             {/* Action Buttons */}
             <div className="flex items-center gap-2">
-              {hasChanges && (
+              {hasAnyChanges && (
                 <Button
                   variant="outline"
                   onClick={handleSaveOnly}
@@ -267,7 +317,7 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
                 ) : (
                   <Send size={16} />
                 )}
-                {isSubmitting ? getText('submitting') : hasChanges ? getText('saveAndSubmit') : getText('submit')}
+                {isSubmitting ? getText('submitting') : hasAnyChanges ? getText('saveAndSubmit') : getText('submit')}
               </Button>
             </div>
           </div>
@@ -295,6 +345,16 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
             language={language}
           />
 
+          {/* 스냅샷(커리큘럼) 정보 폼 */}
+          {snapshot && (
+            <SnapshotEditForm
+              formData={snapshotFormData}
+              onFormDataChange={handleSnapshotFormDataChange}
+              status={snapshot.status}
+              language={language}
+            />
+          )}
+
           {/* 하단 신청 버튼 (모바일 대응) */}
           <div className="pt-4 pb-8">
             <Button
@@ -308,7 +368,7 @@ export function ProgramEditPage({ language = 'ko' }: Readonly<ProgramEditPagePro
               ) : (
                 <Send size={16} />
               )}
-              {isSubmitting ? getText('submitting') : hasChanges ? getText('saveAndSubmit') : getText('submit')}
+              {isSubmitting ? getText('submitting') : hasAnyChanges ? getText('saveAndSubmit') : getText('submit')}
             </Button>
           </div>
         </div>

--- a/src/pages/tu/teaching/programs/components/SnapshotEditForm.tsx
+++ b/src/pages/tu/teaching/programs/components/SnapshotEditForm.tsx
@@ -1,0 +1,128 @@
+import { Card, Label, Input, Textarea, Badge } from '@/components/common';
+import type { SnapshotStatus } from '@/types/common';
+
+export interface SnapshotFormData {
+  snapshotName: string;
+  description: string;
+  hashtags: string;
+}
+
+interface SnapshotEditFormProps {
+  formData: SnapshotFormData;
+  onFormDataChange: (data: Partial<SnapshotFormData>) => void;
+  status: SnapshotStatus;
+  language?: 'ko' | 'en';
+}
+
+const t = {
+  curriculumInfo: { ko: '커리큘럼 정보', en: 'Curriculum Information' },
+  snapshotName: { ko: '커리큘럼 이름', en: 'Curriculum Name' },
+  snapshotNamePlaceholder: { ko: '커리큘럼 이름을 입력하세요', en: 'Enter curriculum name' },
+  description: { ko: '설명', en: 'Description' },
+  descriptionPlaceholder: { ko: '커리큘럼에 대한 설명을 입력하세요', en: 'Enter curriculum description' },
+  hashtags: { ko: '해시태그', en: 'Hashtags' },
+  hashtagsPlaceholder: { ko: '예: #클라우드 #AWS #입문', en: 'e.g., #cloud #AWS #beginner' },
+  readOnly: { ko: '(읽기 전용)', en: '(Read-only)' },
+  statusDraft: { ko: '준비중', en: 'Draft' },
+  statusActive: { ko: '강의중', en: 'Active' },
+  statusCompleted: { ko: '종료', en: 'Completed' },
+  statusArchived: { ko: '보관됨', en: 'Archived' },
+};
+
+const isModifiable = (status: SnapshotStatus) => status === 'DRAFT' || status === 'ACTIVE';
+
+const getStatusLabel = (status: SnapshotStatus, language: 'ko' | 'en') => {
+  const labels: Record<SnapshotStatus, { ko: string; en: string }> = {
+    DRAFT: t.statusDraft,
+    ACTIVE: t.statusActive,
+    COMPLETED: t.statusCompleted,
+    ARCHIVED: t.statusArchived,
+  };
+  return language === 'ko' ? labels[status].ko : labels[status].en;
+};
+
+const getStatusVariant = (status: SnapshotStatus) => {
+  switch (status) {
+    case 'DRAFT':
+      return 'secondary';
+    case 'ACTIVE':
+      return 'success';
+    case 'COMPLETED':
+      return 'default';
+    case 'ARCHIVED':
+      return 'outline';
+    default:
+      return 'default';
+  }
+};
+
+export function SnapshotEditForm({
+  formData,
+  onFormDataChange,
+  status,
+  language = 'ko',
+}: Readonly<SnapshotEditFormProps>) {
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+  const canEdit = isModifiable(status);
+
+  const handleChange = (field: keyof SnapshotFormData, value: string) => {
+    if (canEdit) {
+      onFormDataChange({ [field]: value });
+    }
+  };
+
+  return (
+    <Card>
+      <div className="p-5">
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-base font-medium text-text-primary">{getText('curriculumInfo')}</h2>
+          <div className="flex items-center gap-2">
+            <Badge variant={getStatusVariant(status)}>{getStatusLabel(status, language)}</Badge>
+            {!canEdit && (
+              <span className="text-xs text-text-secondary">{getText('readOnly')}</span>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-5">
+          {/* 커리큘럼 이름 */}
+          <div>
+            <Label className="text-text-primary mb-2">{getText('snapshotName')}</Label>
+            <Input
+              value={formData.snapshotName}
+              onChange={(e) => handleChange('snapshotName', e.target.value)}
+              placeholder={getText('snapshotNamePlaceholder')}
+              disabled={!canEdit}
+              className={!canEdit ? 'bg-bg-secondary cursor-not-allowed' : ''}
+            />
+          </div>
+
+          {/* 설명 */}
+          <div>
+            <Label className="text-text-primary mb-2">{getText('description')}</Label>
+            <Textarea
+              value={formData.description}
+              onChange={(e) => handleChange('description', e.target.value)}
+              placeholder={getText('descriptionPlaceholder')}
+              rows={3}
+              disabled={!canEdit}
+              className={!canEdit ? 'bg-bg-secondary cursor-not-allowed' : ''}
+            />
+          </div>
+
+          {/* 해시태그 */}
+          <div>
+            <Label className="text-text-primary mb-2">{getText('hashtags')}</Label>
+            <Input
+              value={formData.hashtags}
+              onChange={(e) => handleChange('hashtags', e.target.value)}
+              placeholder={getText('hashtagsPlaceholder')}
+              disabled={!canEdit}
+              className={!canEdit ? 'bg-bg-secondary cursor-not-allowed' : ''}
+            />
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- 프로그램 편집 페이지에 스냅샷(커리큘럼) 수정 기능 추가
- SnapshotEditForm 컴포넌트 신규 생성

## Changes

### 신규 파일
- `src/pages/tu/teaching/programs/components/SnapshotEditForm.tsx`

### 수정 파일
- `src/pages/tu/teaching/programs/ProgramEditPage.tsx`

## Features
- 스냅샷 기본정보 수정: 이름, 설명, 해시태그
- 상태에 따른 수정 가능 여부 제어 (DRAFT/ACTIVE만 수정 가능)
- 프로그램과 스냅샷 변경사항 동시 저장
- 읽기 전용 모드 지원 (COMPLETED/ARCHIVED 상태)

## UI
```
┌─────────────────────────────────────────────┐
│ 프로그램 편집                                │
├─────────────────────────────────────────────┤
│ 기본 정보 (기존)                             │
│ └─ 제목, 설명, 썸네일, 난이도, 유형, 시간    │
├─────────────────────────────────────────────┤
│ 커리큘럼 정보 (신규)                         │
│ └─ 커리큘럼 이름, 설명, 해시태그             │
│ └─ 상태 Badge + 읽기전용 표시                │
└─────────────────────────────────────────────┘
```

## Test plan
- [ ] 스냅샷이 있는 프로그램 편집 시 커리큘럼 정보 표시 확인
- [ ] DRAFT/ACTIVE 상태 스냅샷 수정 후 저장 확인
- [ ] COMPLETED/ARCHIVED 상태 스냅샷은 읽기 전용 확인
- [ ] 스냅샷이 없는 프로그램은 커리큘럼 섹션 미표시 확인

## Related Backend Issues
- mzcATU/mzc-lp-backend#305 (countBySnapshotId)
- mzcATU/mzc-lp-backend#307 (delete snapshot with program)

Closes #285