### PR TITLE
[Feat] TU 사이드바 모드 스위처 및 설정 페이지 UI 개선

### DIFF
--- a/src/components/layout/common/AdminLayout.tsx
+++ b/src/components/layout/common/AdminLayout.tsx
@@ -2,7 +2,7 @@ import { type ReactNode } from 'react';
 import { BaseSidebar } from './BaseSidebar';
 import type { MenuItem } from '@/types';
 import { designTokens } from '@/styles/admin-design-tokens';
-import { useUIStore } from '@/store/common/uiStore';
+import { useUIStore, useIsDarkMode } from '@/store/common/uiStore';
 
 interface AdminLayoutProps {
   children: ReactNode;
@@ -17,7 +17,8 @@ export function AdminLayout({
   roleLabel,
   onMenuItemClick,
 }: AdminLayoutProps) {
-  const { isSidebarExpanded, isDarkMode, language, toggleSidebar } = useUIStore();
+  const { isSidebarExpanded, language, toggleSidebar } = useUIStore();
+  const isDarkMode = useIsDarkMode();
 
   return (
     <div

--- a/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
+++ b/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
@@ -6,130 +6,15 @@ import {
   PanelLeftClose,
   PanelLeft,
   GraduationCap,
-  Briefcase,
-  BookOpen,
-  Check,
 } from 'lucide-react';
 import type { BaseSidebarProps, SidebarColors } from '@/types';
 import { designTokens } from '@/styles/admin-design-tokens';
 import { cn } from '@/utils/cn';
+import { useTenantBranding } from '@/contexts/TenantBrandingContext';
+import { ModeSwitcher, type ViewMode } from '../ModeSwitcher';
 
-// 역할 전환 모드 타입
-type ViewMode = 'instructor' | 'learner';
-
-interface ModeSwitcherProps {
-  currentMode: ViewMode;
-  isExpanded: boolean;
-  language: 'ko' | 'en';
-  colors: SidebarColors;
-  onModeChange: (mode: ViewMode) => void;
-}
-
-function ModeSwitcher({ currentMode, isExpanded, language, colors, onModeChange }: ModeSwitcherProps) {
-  const [isOpen, setIsOpen] = useState(false);
-
-  const modes = [
-    {
-      id: 'instructor' as ViewMode,
-      label: { ko: '강사 모드', en: 'Instructor Mode' },
-      icon: Briefcase,
-    },
-    {
-      id: 'learner' as ViewMode,
-      label: { ko: '학습자 모드', en: 'Learner Mode' },
-      icon: BookOpen,
-    },
-  ];
-
-  const currentModeData = modes.find(m => m.id === currentMode)!;
-  const CurrentIcon = currentModeData.icon;
-
-  if (!isExpanded) {
-    return (
-      <button
-        onClick={() => onModeChange(currentMode === 'instructor' ? 'learner' : 'instructor')}
-        className="w-[44px] h-[44px] rounded-xl flex items-center justify-center transition-all mx-auto"
-        style={{ backgroundColor: colors.hover }}
-        title={currentModeData.label[language]}
-      >
-        <CurrentIcon className="w-5 h-5" style={{ color: colors.textPrimary }} />
-      </button>
-    );
-  }
-
-  return (
-    <div className="relative">
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex items-center gap-3 px-4 py-3 rounded-xl transition-all"
-        style={{
-          backgroundColor: colors.hover,
-          color: colors.textPrimary,
-        }}
-      >
-        <CurrentIcon className="w-5 h-5" style={{ color: colors.textSecondary }} />
-        <span className="flex-1 text-left text-sm font-medium">
-          {currentModeData.label[language]}
-        </span>
-        <ChevronDown
-          className={cn("w-4 h-4 transition-transform", isOpen && "rotate-180")}
-          style={{ color: colors.textSecondary }}
-        />
-      </button>
-
-      {isOpen && (
-        <>
-          {/* Backdrop */}
-          <div
-            className="fixed inset-0 z-40"
-            onClick={() => setIsOpen(false)}
-          />
-          {/* Dropdown */}
-          <div
-            className="absolute left-0 right-0 top-full mt-1 rounded-xl border shadow-lg z-50 py-1"
-            style={{
-              backgroundColor: colors.tooltipBg,
-              borderColor: colors.border,
-            }}
-          >
-            {modes.map((mode) => {
-              const Icon = mode.icon;
-              const isActive = mode.id === currentMode;
-              return (
-                <button
-                  key={mode.id}
-                  onClick={() => {
-                    onModeChange(mode.id);
-                    setIsOpen(false);
-                  }}
-                  className="w-full flex items-center gap-3 px-4 py-2.5 transition-all"
-                  style={{
-                    backgroundColor: isActive ? colors.activeBg : 'transparent',
-                    color: isActive ? colors.activeText : colors.textPrimary,
-                  }}
-                  onMouseEnter={(e) => {
-                    if (!isActive) {
-                      e.currentTarget.style.backgroundColor = colors.hover;
-                    }
-                  }}
-                  onMouseLeave={(e) => {
-                    if (!isActive) {
-                      e.currentTarget.style.backgroundColor = 'transparent';
-                    }
-                  }}
-                >
-                  <Icon className="w-5 h-5" style={{ color: isActive ? colors.activeText : colors.textSecondary }} />
-                  <span className="flex-1 text-left text-sm">{mode.label[language]}</span>
-                  {isActive && <Check className="w-4 h-4" />}
-                </button>
-              );
-            })}
-          </div>
-        </>
-      )}
-    </div>
-  );
-}
+// 역할 타입
+type RoleType = 'sa' | 'ta' | 'to' | 'tu';
 
 export function BaseSidebar({
   isExpanded,
@@ -141,10 +26,19 @@ export function BaseSidebar({
   roleLabel,
   showModeSwitcher = false,
   currentMode = 'instructor',
-}: BaseSidebarProps & { showModeSwitcher?: boolean; currentMode?: ViewMode }) {
+  roleType = 'tu',
+}: BaseSidebarProps & { showModeSwitcher?: boolean; currentMode?: ViewMode; roleType?: RoleType }) {
   const navigate = useNavigate();
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
   const [activeItem, setActiveItem] = useState<string>('dashboard');
+
+  // 테넌트 브랜딩 (SA 제외)
+  const { branding } = useTenantBranding();
+
+  // SA는 플랫폼 기본 로고, 나머지는 테넌트 브랜딩
+  const isSuperAdmin = roleType === 'sa';
+  const logoUrl = isSuperAdmin ? null : (isDarkMode ? branding?.darkLogoUrl : branding?.logoUrl) || branding?.logoUrl;
+  const platformName = isSuperAdmin ? 'Learning Hub' : (branding?.tenantName || 'Learning Hub');
 
   const handleModeChange = (mode: ViewMode) => {
     if (mode === 'learner') {
@@ -210,7 +104,7 @@ export function BaseSidebar({
     <aside
       className="flex-shrink-0 transition-all duration-300"
       style={{
-        width: isExpanded ? '280px' : '84px',
+        width: isExpanded ? '300px' : '84px',
         padding: isExpanded ? '16px' : '8px',
         backgroundColor: isDarkMode ? '#1e1e1e' : designTokens.bg.app_default,
       }}
@@ -232,22 +126,32 @@ export function BaseSidebar({
             !isExpanded && 'justify-center'
           )}
         >
-          <div
-            className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
-            style={{
-              background: 'linear-gradient(135deg, #667EEA 0%, #764BA2 100%)',
-            }}
-          >
-            <GraduationCap size={22} color="#FFFFFF" />
-          </div>
+          {/* 로고: 테넌트 로고가 있으면 사용, 없으면 기본 아이콘 */}
+          {logoUrl ? (
+            <img
+              src={logoUrl}
+              alt={platformName}
+              className="w-10 h-10 rounded-xl object-contain flex-shrink-0"
+            />
+          ) : (
+            <div
+              className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
+              style={{
+                background: 'linear-gradient(135deg, #667EEA 0%, #764BA2 100%)',
+              }}
+            >
+              <GraduationCap size={22} color="#FFFFFF" />
+            </div>
+          )}
           {isExpanded && (
             <div className="overflow-hidden">
               <h1
                 className="text-lg font-semibold whitespace-nowrap"
                 style={{ color: colors.textPrimary }}
               >
-                Learning Hub
+                {platformName}
               </h1>
+              {/* TU는 모드 스위처로 대체, 나머지 역할은 라벨 표시 */}
               {!showModeSwitcher && (
                 <p
                   className="text-xs whitespace-nowrap"
@@ -262,18 +166,19 @@ export function BaseSidebar({
 
         {/* Mode Switcher (TU only) */}
         {showModeSwitcher && (
-          <div className={cn('mb-4', !isExpanded && 'flex justify-center')}>
+          <div className={cn('mb-3', !isExpanded && 'flex justify-center')}>
             <ModeSwitcher
               currentMode={currentMode}
               isExpanded={isExpanded}
               language={language}
               colors={colors}
               onModeChange={handleModeChange}
+              isDarkMode={isDarkMode}
             />
           </div>
         )}
 
-        {/* Divider after header */}
+        {/* Divider before menu */}
         <div
           className="mb-4"
           style={{

--- a/src/components/layout/common/ModeSwitcher/ModeSwitcher.tsx
+++ b/src/components/layout/common/ModeSwitcher/ModeSwitcher.tsx
@@ -1,0 +1,113 @@
+import { BookOpen, GraduationCap } from 'lucide-react';
+import type { SidebarColors } from '@/types';
+import { cn } from '@/utils/cn';
+
+export type ViewMode = 'instructor' | 'learner';
+
+interface ModeSwitcherProps {
+  currentMode: ViewMode;
+  isExpanded: boolean;
+  language: 'ko' | 'en';
+  colors: SidebarColors;
+  onModeChange: (mode: ViewMode) => void;
+  isDarkMode?: boolean;
+}
+
+export function ModeSwitcher({
+  currentMode,
+  isExpanded,
+  language,
+  colors,
+  onModeChange,
+  isDarkMode = true,
+}: ModeSwitcherProps) {
+  const modes: { id: ViewMode; label: { ko: string; en: string }; icon: typeof BookOpen }[] = [
+    {
+      id: 'instructor',
+      label: { ko: '강사', en: 'Instructor' },
+      icon: BookOpen,
+    },
+    {
+      id: 'learner',
+      label: { ko: '학습자', en: 'Learner' },
+      icon: GraduationCap,
+    },
+  ];
+
+  // 접힌 상태 - 아이콘만 표시 (세로 배치)
+  if (!isExpanded) {
+    return (
+      <div
+        className="flex flex-col gap-1 p-1 rounded-lg"
+        style={{
+          backgroundColor: isDarkMode ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.03)',
+        }}
+      >
+        {modes.map((mode) => {
+          const Icon = mode.icon;
+          const isActive = currentMode === mode.id;
+
+          return (
+            <button
+              key={mode.id}
+              onClick={() => onModeChange(mode.id)}
+              className={cn(
+                'w-10 h-10 rounded-md flex items-center justify-center transition-all duration-200'
+              )}
+              style={{
+                backgroundColor: isActive
+                  ? (isDarkMode ? '#7C5CBF' : '#4C2D9A')
+                  : 'transparent',
+                color: isActive
+                  ? '#FFFFFF'
+                  : colors.textSecondary,
+              }}
+              title={mode.label[language]}
+            >
+              <Icon className="w-5 h-5" />
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  // 펼친 상태 - iOS 스타일 토글 스위치
+  return (
+    <div
+      className="relative rounded-lg p-1 transition-all duration-200"
+      style={{
+        backgroundColor: isDarkMode ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.03)',
+      }}
+    >
+      <div className="flex gap-1 relative">
+        {modes.map((mode) => {
+          const Icon = mode.icon;
+          const isActive = currentMode === mode.id;
+
+          return (
+            <button
+              key={mode.id}
+              onClick={() => onModeChange(mode.id)}
+              className={cn(
+                'flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-md',
+                'transition-all duration-200 text-sm font-medium whitespace-nowrap relative z-10'
+              )}
+              style={{
+                backgroundColor: isActive
+                  ? (isDarkMode ? '#7C5CBF' : '#D4CDEF')
+                  : 'transparent',
+                color: isActive
+                  ? (isDarkMode ? '#FFFFFF' : '#4C2D9A')
+                  : colors.textSecondary,
+              }}
+            >
+              <Icon className="w-4 h-4" />
+              <span>{mode.label[language]}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/common/ModeSwitcher/index.ts
+++ b/src/components/layout/common/ModeSwitcher/index.ts
@@ -1,0 +1,1 @@
+export { ModeSwitcher, type ViewMode } from './ModeSwitcher';

--- a/src/components/layout/mypage/MyPageLayout.tsx
+++ b/src/components/layout/mypage/MyPageLayout.tsx
@@ -3,8 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { MyPageSidebar } from './MyPageSidebar';
 import { LandingHeader, LandingFooter } from '@/components/landing';
 import { myPageMenuData } from '@/config/sidebar-menus';
-import { useUIStore } from '@/store/common/uiStore';
-import { useThemeStore } from '@/store/common/themeStore';
+import { useUIStore, useIsDarkMode } from '@/store/common/uiStore';
 
 interface MyPageLayoutProps {
   children: ReactNode;
@@ -12,9 +11,8 @@ interface MyPageLayoutProps {
 
 export function MyPageLayout({ children }: MyPageLayoutProps) {
   const navigate = useNavigate();
-  const { isSidebarExpanded, isDarkMode, language, toggleSidebar } = useUIStore();
-  const { theme } = useThemeStore();
-  const isDark = theme === 'dark';
+  const { isSidebarExpanded, language, toggleSidebar } = useUIStore();
+  const isDarkMode = useIsDarkMode();
 
   const handleMenuItemClick = (itemId: string) => {
     // Check top-level menu items
@@ -35,7 +33,7 @@ export function MyPageLayout({ children }: MyPageLayoutProps) {
   };
 
   return (
-    <div className={`flex flex-col min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
+    <div className={`flex flex-col min-h-screen ${isDarkMode ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
       {/* 상단 헤더 */}
       <LandingHeader />
 

--- a/src/components/layout/mypage/MyPageSidebar.tsx
+++ b/src/components/layout/mypage/MyPageSidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
-import { ChevronDown, ChevronRight, Sun, Moon, Globe, Loader2 } from 'lucide-react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { ChevronDown, ChevronRight, Sun, Moon, Globe, Loader2, BookOpen, GraduationCap } from 'lucide-react';
 import { toast } from 'sonner';
 import { myPageMenuData } from '@/config/sidebar-menus';
 import { useThemeStore } from '@/store/common/themeStore';
@@ -8,6 +8,7 @@ import { useLanguageStore, useTranslation } from '@/store/common/languageStore';
 import { useAuthStore } from '@/store/common/authStore';
 import { userService } from '@/services/common/userService';
 import { authService } from '@/services/common/authService';
+import { cn } from '@/utils/cn';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -28,14 +29,18 @@ interface MyPageSidebarProps {
   language?: 'ko' | 'en';
 }
 
+type ViewMode = 'instructor' | 'learner';
+
 export function MyPageSidebar({ onMenuItemClick }: MyPageSidebarProps) {
   const location = useLocation();
+  const navigate = useNavigate();
   const { theme, toggleTheme } = useThemeStore();
   const { language, toggleLanguage } = useLanguageStore();
   const { t } = useTranslation();
   const { user, updateUser } = useAuthStore();
   const isDark = theme === 'dark';
   const [expandedMenus, setExpandedMenus] = useState<string[]>(['my-enrollments', 'my-teaching', 'mypage-settings']);
+  const [currentMode, setCurrentMode] = useState<ViewMode>('learner');
   const [showCreateCourseDialog, setShowCreateCourseDialog] = useState(false);
   const [isGrantingRole, setIsGrantingRole] = useState(false);
   // USER: 권한 없음, DESIGNER: 강의 개설 권한, OWNER: 강의 소유자
@@ -251,6 +256,67 @@ export function MyPageSidebar({ onMenuItemClick }: MyPageSidebarProps) {
             : 'bg-white border border-gray-200 shadow-sm'
         }`}
       >
+        {/* 모드 스위처 (디자이너 권한이 있는 경우에만 표시) */}
+        {isDesigner && (
+          <>
+            <div
+              className="relative rounded-lg p-1 mb-3"
+              style={{
+                backgroundColor: isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.03)',
+              }}
+            >
+              <div className="flex gap-1">
+                <button
+                  onClick={() => {
+                    setCurrentMode('instructor');
+                    navigate('/tu/dashboard');
+                  }}
+                  className={cn(
+                    'flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-md',
+                    'transition-all duration-200 text-sm font-medium whitespace-nowrap'
+                  )}
+                  style={{
+                    backgroundColor: currentMode === 'instructor'
+                      ? (isDark ? '#7C5CBF' : '#D4CDEF')
+                      : 'transparent',
+                    color: currentMode === 'instructor'
+                      ? (isDark ? '#FFFFFF' : '#4C2D9A')
+                      : (isDark ? '#9E9E9E' : '#666666'),
+                  }}
+                >
+                  <BookOpen className="w-4 h-4" />
+                  <span>{language === 'ko' ? '강사' : 'Instructor'}</span>
+                </button>
+                <button
+                  onClick={() => setCurrentMode('learner')}
+                  className={cn(
+                    'flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-md',
+                    'transition-all duration-200 text-sm font-medium whitespace-nowrap'
+                  )}
+                  style={{
+                    backgroundColor: currentMode === 'learner'
+                      ? (isDark ? '#7C5CBF' : '#D4CDEF')
+                      : 'transparent',
+                    color: currentMode === 'learner'
+                      ? (isDark ? '#FFFFFF' : '#4C2D9A')
+                      : (isDark ? '#9E9E9E' : '#666666'),
+                  }}
+                >
+                  <GraduationCap className="w-4 h-4" />
+                  <span>{language === 'ko' ? '학습자' : 'Learner'}</span>
+                </button>
+              </div>
+            </div>
+            {/* 구분선 */}
+            <div
+              className="mb-3"
+              style={{
+                borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.1)' : '#e5e7eb'}`,
+              }}
+            />
+          </>
+        )}
+
         {/* 메뉴 리스트 */}
         <nav className="space-y-1 flex-1">
           {myPageMenuData.map(renderMenuItem)}

--- a/src/components/layout/sa/SuperAdminLayout.tsx
+++ b/src/components/layout/sa/SuperAdminLayout.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { SuperAdminSidebar } from './SuperAdminSidebar';
 import { designTokens } from '@/styles/admin-design-tokens';
 import { superAdminMenuData } from '@/config/sidebar-menus';
-import { useUIStore } from '@/store/common/uiStore';
+import { useUIStore, useIsDarkMode } from '@/store/common/uiStore';
 
 interface SuperAdminLayoutProps {
   children: ReactNode;
@@ -11,7 +11,8 @@ interface SuperAdminLayoutProps {
 
 export function SuperAdminLayout({ children }: SuperAdminLayoutProps) {
   const navigate = useNavigate();
-  const { isSidebarExpanded, isDarkMode, language, toggleSidebar } = useUIStore();
+  const { isSidebarExpanded, language, toggleSidebar } = useUIStore();
+  const isDarkMode = useIsDarkMode();
 
   const handleMenuItemClick = (itemId: string) => {
     // Check top-level menu items

--- a/src/components/layout/sa/SuperAdminSidebar/SuperAdminSidebar.tsx
+++ b/src/components/layout/sa/SuperAdminSidebar/SuperAdminSidebar.tsx
@@ -15,6 +15,7 @@ export function SuperAdminSidebar(props: SuperAdminSidebarProps) {
       {...props}
       menuData={superAdminMenuData}
       roleLabel={roleLabels.superAdmin}
+      roleType="sa"
     />
   );
 }

--- a/src/components/layout/ta/TenantAdminLayout.tsx
+++ b/src/components/layout/ta/TenantAdminLayout.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { TenantAdminSidebar } from './TenantAdminSidebar';
 import { designTokens } from '@/styles/admin-design-tokens';
 import { tenantAdminMenuData } from '@/config/sidebar-menus';
-import { useUIStore } from '@/store/common/uiStore';
+import { useUIStore, useIsDarkMode } from '@/store/common/uiStore';
 
 interface TenantAdminLayoutProps {
   children: ReactNode;
@@ -11,7 +11,8 @@ interface TenantAdminLayoutProps {
 
 export function TenantAdminLayout({ children }: TenantAdminLayoutProps) {
   const navigate = useNavigate();
-  const { isSidebarExpanded, isDarkMode, language, toggleSidebar } = useUIStore();
+  const { isSidebarExpanded, language, toggleSidebar } = useUIStore();
+  const isDarkMode = useIsDarkMode();
 
   const handleMenuItemClick = (itemId: string) => {
     // Check top-level menu items

--- a/src/components/layout/ta/TenantAdminSidebar/TenantAdminSidebar.tsx
+++ b/src/components/layout/ta/TenantAdminSidebar/TenantAdminSidebar.tsx
@@ -15,6 +15,7 @@ export function TenantAdminSidebar(props: TenantAdminSidebarProps) {
       {...props}
       menuData={tenantAdminMenuData}
       roleLabel={roleLabels.tenantAdmin}
+      roleType="ta"
     />
   );
 }

--- a/src/components/layout/to/TenantOperatorLayout.tsx
+++ b/src/components/layout/to/TenantOperatorLayout.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { TenantOperatorSidebar } from './TenantOperatorSidebar';
 import { designTokens } from '@/styles/admin-design-tokens';
 import { tenantOperatorMenuData } from '@/config/sidebar-menus';
-import { useUIStore } from '@/store/common/uiStore';
+import { useUIStore, useIsDarkMode } from '@/store/common/uiStore';
 
 interface TenantOperatorLayoutProps {
   children: ReactNode;
@@ -13,7 +13,8 @@ export function TenantOperatorLayout({
   children,
 }: TenantOperatorLayoutProps) {
   const navigate = useNavigate();
-  const { isSidebarExpanded, isDarkMode, language, toggleSidebar } = useUIStore();
+  const { isSidebarExpanded, language, toggleSidebar } = useUIStore();
+  const isDarkMode = useIsDarkMode();
 
   const handleMenuItemClick = (itemId: string) => {
     // Check top-level menu items

--- a/src/components/layout/to/TenantOperatorSidebar/TenantOperatorSidebar.tsx
+++ b/src/components/layout/to/TenantOperatorSidebar/TenantOperatorSidebar.tsx
@@ -15,6 +15,7 @@ export function TenantOperatorSidebar(props: TenantOperatorSidebarProps) {
       {...props}
       menuData={tenantOperatorMenuData}
       roleLabel={roleLabels.tenantOperator}
+      roleType="to"
     />
   );
 }

--- a/src/components/layout/tu/TenantUserLayout.tsx
+++ b/src/components/layout/tu/TenantUserLayout.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { TenantUserSidebar } from './TenantUserSidebar';
 import { designTokens } from '@/styles/admin-design-tokens';
 import { tenantUserMenuData } from '@/config/sidebar-menus';
-import { useUIStore } from '@/store/common/uiStore';
+import { useUIStore, useIsDarkMode } from '@/store/common/uiStore';
 
 interface TenantUserLayoutProps {
   children: ReactNode;
@@ -11,7 +11,8 @@ interface TenantUserLayoutProps {
 
 export function TenantUserLayout({ children }: TenantUserLayoutProps) {
   const navigate = useNavigate();
-  const { isSidebarExpanded, isDarkMode, language, toggleSidebar } = useUIStore();
+  const { isSidebarExpanded, language, toggleSidebar } = useUIStore();
+  const isDarkMode = useIsDarkMode();
 
   const handleMenuItemClick = (itemId: string) => {
     // Check top-level menu items

--- a/src/components/layout/tu/TenantUserSidebar/TenantUserSidebar.tsx
+++ b/src/components/layout/tu/TenantUserSidebar/TenantUserSidebar.tsx
@@ -15,6 +15,9 @@ export function TenantUserSidebar(props: TenantUserSidebarProps) {
       {...props}
       menuData={tenantUserMenuData}
       roleLabel={roleLabels.tenantUser}
+      showModeSwitcher={true}
+      currentMode="instructor"
+      roleType="tu"
     />
   );
 }

--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -301,8 +301,8 @@ export const myPageMenuData: MenuItem[] = [
     icon: Settings,
     subItems: [
       { id: 'profile-security', label: { ko: '프로필 및 보안', en: 'Profile & Security' }, icon: Shield, path: '/tu/b2c/mypage/settings/security' },
-      { id: 'notifications', label: { ko: '알림', en: 'Notifications' }, icon: Megaphone, path: '/tu/b2c/mypage/settings/notifications' },
       { id: 'language-region', label: { ko: '언어 및 지역', en: 'Language & Region' }, icon: Globe, path: '/tu/b2c/mypage/settings/language' },
+      { id: 'notifications', label: { ko: '알림', en: 'Notifications' }, icon: Megaphone, path: '/tu/b2c/mypage/settings/notifications' },
     ],
   },
 ];

--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -253,12 +253,7 @@ export const tenantUserMenuData: MenuItem[] = [
       { id: 'my-roadmaps', label: { ko: '로드맵', en: 'Roadmaps' }, icon: Map, path: '/tu/teaching/roadmaps', roles: ['DESIGNER', 'OPERATOR', 'TENANT_ADMIN'] },
     ],
   },
-  {
-    id: 'catalog',
-    label: { ko: '과정 둘러보기', en: 'Course Catalog' },
-    icon: Library,
-    path: '/tu/b2c/courses',
-  },
+  // '과정 둘러보기' 메뉴 제거 - 모드 스위처의 '학습자 모드'로 대체
 ];
 
 /**
@@ -314,11 +309,15 @@ export const myPageMenuData: MenuItem[] = [
 
 /**
  * 역할별 라벨
+ * - SA: 시스템 관리 (전체 플랫폼)
+ * - TA: 테넌트 관리 (기업 설정)
+ * - TO: 교육 운영 (과정/차수 관리)
+ * - TU: 모드 스위처로 대체 (강사/학습자)
  */
 export const roleLabels = {
-  superAdmin: { ko: '시스템 어드민', en: 'System Admin' },
-  tenantAdmin: { ko: '테넌트 어드민', en: 'Tenant Admin' },
-  tenantOperator: { ko: '교육 운영자', en: 'Operator' },
-  tenantUser: { ko: 'Enterprise LMS', en: 'Enterprise LMS' },
+  superAdmin: { ko: '시스템 관리', en: 'System Admin' },
+  tenantAdmin: { ko: '테넌트 관리', en: 'Tenant Admin' },
+  tenantOperator: { ko: '교육 운영', en: 'Operations' },
+  tenantUser: { ko: '강사 센터', en: 'Instructor Hub' },
   myPage: { ko: '마이페이지', en: 'My Page' },
 };

--- a/src/pages/common/settings/SettingsAppearancePage.tsx
+++ b/src/pages/common/settings/SettingsAppearancePage.tsx
@@ -18,13 +18,14 @@ import {
   Label,
   RadioOptionCard,
 } from '@/components/common';
-import { useUIStore } from '@/store/common/uiStore';
+import { useUIStore, useIsDarkMode } from '@/store/common/uiStore';
 
 export function SettingsAppearancePage() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const { isDarkMode, setDarkMode, isSidebarExpanded, setSidebarExpanded } = useUIStore();
+  const { setDarkMode, isSidebarExpanded, setSidebarExpanded } = useUIStore();
+  const isDarkMode = useIsDarkMode();
   const themeMode = isDarkMode ? 'dark' : 'light';
   const sidebarDefault = isSidebarExpanded ? 'expanded' : 'collapsed';
 

--- a/src/pages/common/settings/SettingsAppearancePage.tsx
+++ b/src/pages/common/settings/SettingsAppearancePage.tsx
@@ -1,6 +1,4 @@
-import { useNavigate, useLocation } from 'react-router-dom';
 import {
-  ArrowLeft,
   Palette,
   Monitor,
   Sun,
@@ -21,19 +19,10 @@ import {
 import { useUIStore, useIsDarkMode } from '@/store/common/uiStore';
 
 export function SettingsAppearancePage() {
-  const navigate = useNavigate();
-  const location = useLocation();
-
   const { setDarkMode, isSidebarExpanded, setSidebarExpanded } = useUIStore();
   const isDarkMode = useIsDarkMode();
   const themeMode = isDarkMode ? 'dark' : 'light';
   const sidebarDefault = isSidebarExpanded ? 'expanded' : 'collapsed';
-
-  const basePath = location.pathname.split('/settings')[0];
-
-  const handleBack = () => {
-    navigate(`${basePath}/settings`);
-  };
 
   const handleSave = () => {
     alert('외관 설정이 저장되었습니다.');
@@ -68,16 +57,6 @@ export function SettingsAppearancePage() {
       }}
     >
       <div style={{ maxWidth: '800px', margin: '0 auto' }}>
-        {/* Header with Back Button */}
-        <Button
-          variant="ghost"
-          onClick={handleBack}
-          className="mb-6 gap-2 text-muted-foreground hover:text-foreground"
-        >
-          <ArrowLeft className="w-5 h-5" />
-          <span>설정으로 돌아가기</span>
-        </Button>
-
         <h1
           style={{
             color: designTokens.text.primary,

--- a/src/pages/common/settings/SettingsSecurityPage.tsx
+++ b/src/pages/common/settings/SettingsSecurityPage.tsx
@@ -1,7 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
-  ArrowLeft,
   User,
   Mail,
   Calendar,
@@ -96,10 +95,6 @@ export function SettingsSecurityPage() {
   // Get base path from current location
   const basePath = location.pathname.split('/settings')[0];
   const isUserRole = basePath === '/tu';
-
-  const handleBack = () => {
-    navigate(`${basePath}/settings`);
-  };
 
   const handleProfileSave = async () => {
     if (!profileData.name.trim()) {
@@ -254,16 +249,6 @@ export function SettingsSecurityPage() {
   return (
     <div className={`min-h-full p-6 sm:p-10 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
       <div className="max-w-3xl mx-auto">
-        {/* Header with Back Button */}
-        <Button
-          variant="ghost"
-          onClick={handleBack}
-          className={`mb-6 gap-2 ${isDark ? 'text-gray-400 hover:text-white' : 'text-gray-600 hover:text-gray-900'}`}
-        >
-          <ArrowLeft className="w-5 h-5" />
-          <span>{language === 'ko' ? '설정으로 돌아가기' : 'Back to Settings'}</span>
-        </Button>
-
         <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
           {t.profileSecurity.title}
         </h1>

--- a/src/store/common/index.ts
+++ b/src/store/common/index.ts
@@ -1,4 +1,4 @@
-export { useUIStore } from './uiStore';
+export { useUIStore, useIsDarkMode } from './uiStore';
 export { useAuthStore } from './authStore';
 export { useThemeStore } from './themeStore';
 export { useLanguageStore, useTranslation, getTranslation } from './languageStore';

--- a/src/store/common/uiStore.ts
+++ b/src/store/common/uiStore.ts
@@ -1,31 +1,44 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { useThemeStore } from './themeStore';
 
 interface UIState {
   isSidebarExpanded: boolean;
-  isDarkMode: boolean;
   language: 'ko' | 'en';
   toggleSidebar: () => void;
   setSidebarExpanded: (expanded: boolean) => void;
+  setLanguage: (lang: 'ko' | 'en') => void;
+  // themeStore 동기화 함수들
   toggleDarkMode: () => void;
   setDarkMode: (isDark: boolean) => void;
-  setLanguage: (lang: 'ko' | 'en') => void;
 }
 
+// isDarkMode는 themeStore에서 직접 구독
 export const useUIStore = create<UIState>()(
   persist(
     (set) => ({
       isSidebarExpanded: true,
-      isDarkMode: false,
       language: 'ko',
       toggleSidebar: () => set((state) => ({ isSidebarExpanded: !state.isSidebarExpanded })),
       setSidebarExpanded: (isSidebarExpanded) => set({ isSidebarExpanded }),
-      toggleDarkMode: () => set((state) => ({ isDarkMode: !state.isDarkMode })),
-      setDarkMode: (isDarkMode) => set({ isDarkMode }),
       setLanguage: (language) => set({ language }),
+      // themeStore와 동기화
+      toggleDarkMode: () => {
+        useThemeStore.getState().toggleTheme();
+      },
+      setDarkMode: (isDark: boolean) => {
+        useThemeStore.getState().setTheme(isDark ? 'dark' : 'light');
+      },
     }),
     {
       name: 'ui-settings',
+      partialize: (state) => ({
+        isSidebarExpanded: state.isSidebarExpanded,
+        language: state.language,
+      }),
     }
   )
 );
+
+// isDarkMode를 themeStore에서 가져오는 selector hook
+export const useIsDarkMode = () => useThemeStore((state) => state.theme === 'dark');


### PR DESCRIPTION
## Summary

TU 사이드바에 강사/학습자 모드 전환 스위처를 추가하고, 테마 스토어를 통합하여 다크모드 설정이 전역에서 동기화되도록 개선합니다.
<img width="1451" height="735" alt="스크린샷 2026-01-06 오후 4 33 29" src="https://github.com/user-attachments/assets/c83f06f1-11cc-4fcd-8253-1e1bb9ae72e1" />
<img width="1502" height="844" alt="스크린샷 2026-01-06 오후 4 33 38" src="https://github.com/user-attachments/assets/51832830-3325-4222-a6d3-fad56a2375d3" />



## Related Issue

- Closes #292

## Changes

- ModeSwitcher 컴포넌트 추가 (iOS 스타일 세그먼트 토글)
- useUIStore와 useThemeStore 동기화 (useIsDarkMode hook)
- 사이드바 너비 280px → 300px 확대
- 설정 상세 페이지에서 '설정으로 돌아가기' 버튼 제거
- MyPage 설정 메뉴 순서 변경 (언어 및 지역 ↔ 알림)
- MyPage 사이드바에 모드 스위처 추가 (디자이너 권한 사용자만)

## Type of Change

- [x] Feat: 새로운 기능
- [x] Refactor: 리팩토링

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 로컬에서 테스트가 통과합니다