### PR TITLE
feat(ta): 레이아웃 설정 페이지 상세 커스터마이징 및 미리보기 기능 추가

### DIFF
--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -51,7 +51,7 @@ export function LandingHeader() {
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     if (searchQuery.trim()) {
-      navigate(`/tu/b2c/courses?search=${encodeURIComponent(searchQuery.trim())}`);
+      navigate(`/tu/b2c/search?search=${encodeURIComponent(searchQuery.trim())}`);
     }
   };
 

--- a/src/pages/ta/branding/LayoutSettingsPage.tsx
+++ b/src/pages/ta/branding/LayoutSettingsPage.tsx
@@ -7,12 +7,44 @@ import {
   PanelTop,
   PanelBottom,
   Loader2,
+  Type,
+  Palette,
+  Layers,
+  Accessibility,
+  Smartphone,
+  ChevronDown,
+  ChevronUp,
+  Check,
+  Tablet,
+  Bell,
+  Search,
+  User,
+  Home,
+  Settings,
+  FileText,
+  BarChart3,
+  Users,
+  Mail,
+  Phone,
+  MapPin,
+  Building,
+  Facebook,
+  Twitter,
+  Instagram,
+  Youtube,
+  Linkedin,
+  Menu,
+  X,
+  Star,
+  Map,
+  MessageSquare,
 } from 'lucide-react';
 import { AdminPageHeader } from '@/components/domain/admin';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
 import { Button } from '@/components/common/Button';
 import { Label } from '@/components/common/Label';
 import { Switch } from '@/components/common/Switch';
+import { Input } from '@/components/common/Input';
 import {
   Select,
   SelectContent,
@@ -21,14 +53,29 @@ import {
   SelectValue,
 } from '@/components/common/Select';
 import { useTenantSettings, useUpdateLayoutSettings } from '@/hooks/ta';
-import type { HeaderSettings, SidebarSettings, FooterSettings, ContentSettings } from '@/types/admin';
+import type {
+  HeaderSettings,
+  SidebarSettings,
+  FooterSettings,
+  ContentSettings,
+  TypographySettings,
+  ColorModeSettings,
+  ComponentStyleSettings,
+  AccessibilitySettings,
+  ResponsiveSettings,
+} from '@/types/admin';
 
-// 레이아웃 설정 타입
+// 전체 레이아웃 설정 타입
 interface LayoutSettings {
   header: HeaderSettings;
   sidebar: SidebarSettings;
   footer: FooterSettings;
   content: ContentSettings;
+  typography: TypographySettings;
+  colorMode: ColorModeSettings;
+  componentStyle: ComponentStyleSettings;
+  accessibility: AccessibilitySettings;
+  responsive: ResponsiveSettings;
 }
 
 // 기본 설정값
@@ -38,26 +85,232 @@ const defaultLayoutSettings: LayoutSettings = {
     showLogo: true,
     showSearch: true,
     showNotifications: true,
+    height: 'default',
+    backgroundOpacity: 'solid',
+    navPosition: 'left',
+    userMenuStyle: 'dropdown',
+    shadow: 'sm',
+    mobileMenuStyle: 'drawer',
   },
   sidebar: {
     style: 'collapsible',
     defaultCollapsed: false,
     showIcons: true,
+    width: 'default',
+    menuGroupStyle: 'accordion',
+    activeIndicator: 'background',
+    itemSpacing: 'default',
+    scrollbarStyle: 'hover',
+    bottomSection: 'userInfo',
   },
   footer: {
     enabled: true,
     showLinks: true,
     showCopyright: true,
+    layout: 'single',
+    showSocialLinks: false,
+    socialPlatforms: [],
+    showCompanyInfo: false,
+    companyInfoFields: [],
+    showNewsletter: false,
   },
   content: {
     maxWidth: 'full',
     padding: 'normal',
+    pageTransition: 'fade',
+    cardStyle: 'shadow',
+    cardRadius: 'md',
+    tableStyle: 'striped',
+    buttonStyle: 'rounded',
+    loadingIndicator: 'spinner',
+  },
+  typography: {
+    fontScale: 'default',
+    lineHeight: 'normal',
+    headingStyle: 'semibold',
+    headingCase: 'normal',
+  },
+  colorMode: {
+    defaultMode: 'system',
+    allowUserToggle: true,
+    togglePosition: 'header',
+    transitionDuration: 'normal',
+  },
+  componentStyle: {
+    density: 'default',
+    inputStyle: 'outline',
+    badgeStyle: 'solid',
+    avatarStyle: 'circle',
+    iconSize: 'default',
+  },
+  accessibility: {
+    highContrastMode: false,
+    fontSizeAdjustable: true,
+    reduceMotion: false,
+    focusIndicator: 'default',
+    screenReaderOptimized: false,
+  },
+  responsive: {
+    mobileBreakpoint: 768,
+    tabletBreakpoint: 1024,
+    tabletLayout: 'adaptive',
+    mobileNavStyle: 'bottom',
   },
 };
+
+// 옵션 선택 컴포넌트
+function OptionSelect({
+  label,
+  description,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  description?: string;
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <div>
+        <Label>{label}</Label>
+        {description && <p className="text-xs text-text-secondary mt-0.5">{description}</p>}
+      </div>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+// 토글 스위치 컴포넌트
+function ToggleOption({
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  label: string;
+  description?: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between py-2">
+      <div>
+        <p className="text-sm font-medium">{label}</p>
+        {description && <p className="text-xs text-text-secondary">{description}</p>}
+      </div>
+      <Switch checked={checked} onCheckedChange={onChange} />
+    </div>
+  );
+}
+
+// 체크박스 그룹 컴포넌트
+function CheckboxGroup({
+  label,
+  options,
+  selected,
+  onChange,
+}: {
+  label: string;
+  options: { value: string; label: string }[];
+  selected: string[];
+  onChange: (selected: string[]) => void;
+}) {
+  const toggle = (value: string) => {
+    if (selected.includes(value)) {
+      onChange(selected.filter((v) => v !== value));
+    } else {
+      onChange([...selected, value]);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <Label>{label}</Label>
+      <div className="flex flex-wrap gap-2">
+        {options.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => toggle(opt.value)}
+            className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
+              selected.includes(opt.value)
+                ? 'bg-brand-primary text-white border-brand-primary'
+                : 'bg-bg-secondary text-text-secondary border-border-default hover:border-brand-primary'
+            }`}
+          >
+            {selected.includes(opt.value) && <Check className="w-3 h-3 inline mr-1" />}
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// 섹션 접기/펼치기 컴포넌트
+function CollapsibleSection({
+  icon: Icon,
+  title,
+  description,
+  children,
+  defaultOpen = true,
+}: {
+  icon: React.ElementType;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <Card>
+      <CardHeader
+        className="cursor-pointer select-none"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Icon className="h-5 w-5 text-brand-primary" />
+            <div>
+              <CardTitle>{title}</CardTitle>
+              <CardDescription>{description}</CardDescription>
+            </div>
+          </div>
+          {isOpen ? (
+            <ChevronUp className="h-5 w-5 text-text-secondary" />
+          ) : (
+            <ChevronDown className="h-5 w-5 text-text-secondary" />
+          )}
+        </div>
+      </CardHeader>
+      {isOpen && <CardContent className="pt-0">{children}</CardContent>}
+    </Card>
+  );
+}
+
+// 미리보기 페이지 타입
+type PreviewPageType = 'admin' | 'operator' | 'user';
 
 export function LayoutSettingsPage() {
   const [settings, setSettings] = useState<LayoutSettings>(defaultLayoutSettings);
   const [hasChanges, setHasChanges] = useState(false);
+  const [previewMode, setPreviewMode] = useState<'desktop' | 'tablet' | 'mobile'>('desktop');
+  const [previewPageType, setPreviewPageType] = useState<PreviewPageType>('admin');
 
   const { data: tenantSettings, isLoading } = useTenantSettings();
   const updateLayout = useUpdateLayoutSettings();
@@ -66,38 +319,68 @@ export function LayoutSettingsPage() {
   useEffect(() => {
     if (tenantSettings) {
       setSettings({
-        header: tenantSettings.headerSettings || defaultLayoutSettings.header,
-        sidebar: tenantSettings.sidebarSettings || defaultLayoutSettings.sidebar,
-        footer: tenantSettings.footerSettings || defaultLayoutSettings.footer,
-        content: tenantSettings.contentSettings || defaultLayoutSettings.content,
+        header: { ...defaultLayoutSettings.header, ...tenantSettings.headerSettings },
+        sidebar: { ...defaultLayoutSettings.sidebar, ...tenantSettings.sidebarSettings },
+        footer: { ...defaultLayoutSettings.footer, ...tenantSettings.footerSettings },
+        content: { ...defaultLayoutSettings.content, ...tenantSettings.contentSettings },
+        typography: { ...defaultLayoutSettings.typography, ...tenantSettings.typographySettings },
+        colorMode: { ...defaultLayoutSettings.colorMode, ...tenantSettings.colorModeSettings },
+        componentStyle: { ...defaultLayoutSettings.componentStyle, ...tenantSettings.componentStyleSettings },
+        accessibility: { ...defaultLayoutSettings.accessibility, ...tenantSettings.accessibilitySettings },
+        responsive: { ...defaultLayoutSettings.responsive, ...tenantSettings.responsiveSettings },
       });
       setHasChanges(false);
     }
   }, [tenantSettings]);
 
+  const updateSettings = <K extends keyof LayoutSettings>(
+    section: K,
+    key: keyof LayoutSettings[K],
+    value: LayoutSettings[K][keyof LayoutSettings[K]]
+  ) => {
+    setSettings((prev) => ({
+      ...prev,
+      [section]: { ...prev[section], [key]: value },
+    }));
+    setHasChanges(true);
+  };
+
   const handleReset = () => {
     if (tenantSettings) {
       setSettings({
-        header: tenantSettings.headerSettings || defaultLayoutSettings.header,
-        sidebar: tenantSettings.sidebarSettings || defaultLayoutSettings.sidebar,
-        footer: tenantSettings.footerSettings || defaultLayoutSettings.footer,
-        content: tenantSettings.contentSettings || defaultLayoutSettings.content,
+        header: { ...defaultLayoutSettings.header, ...tenantSettings.headerSettings },
+        sidebar: { ...defaultLayoutSettings.sidebar, ...tenantSettings.sidebarSettings },
+        footer: { ...defaultLayoutSettings.footer, ...tenantSettings.footerSettings },
+        content: { ...defaultLayoutSettings.content, ...tenantSettings.contentSettings },
+        typography: { ...defaultLayoutSettings.typography, ...tenantSettings.typographySettings },
+        colorMode: { ...defaultLayoutSettings.colorMode, ...tenantSettings.colorModeSettings },
+        componentStyle: { ...defaultLayoutSettings.componentStyle, ...tenantSettings.componentStyleSettings },
+        accessibility: { ...defaultLayoutSettings.accessibility, ...tenantSettings.accessibilitySettings },
+        responsive: { ...defaultLayoutSettings.responsive, ...tenantSettings.responsiveSettings },
       });
       setHasChanges(false);
     }
   };
 
   const handleSave = () => {
-    updateLayout.mutate({
-      headerSettings: settings.header as HeaderSettings,
-      sidebarSettings: settings.sidebar as SidebarSettings,
-      footerSettings: settings.footer as FooterSettings,
-      contentSettings: settings.content as ContentSettings,
-    }, {
-      onSuccess: () => {
-        setHasChanges(false);
+    updateLayout.mutate(
+      {
+        headerSettings: settings.header,
+        sidebarSettings: settings.sidebar,
+        footerSettings: settings.footer,
+        contentSettings: settings.content,
+        typographySettings: settings.typography,
+        colorModeSettings: settings.colorMode,
+        componentStyleSettings: settings.componentStyle,
+        accessibilitySettings: settings.accessibility,
+        responsiveSettings: settings.responsive,
       },
-    });
+      {
+        onSuccess: () => {
+          setHasChanges(false);
+        },
+      }
+    );
   };
 
   if (isLoading) {
@@ -112,7 +395,7 @@ export function LayoutSettingsPage() {
     <div className="p-6">
       <AdminPageHeader
         title="레이아웃/UI 설정"
-        description="플랫폼의 레이아웃과 UI 구성을 설정합니다"
+        description="플랫폼의 레이아웃과 UI 구성을 상세하게 설정합니다"
         actions={
           <div className="flex gap-2">
             <Button variant="outline" onClick={handleReset} disabled={!hasChanges}>
@@ -131,307 +414,2151 @@ export function LayoutSettingsPage() {
         }
       />
 
-      <div className="grid grid-cols-2 gap-6">
-        {/* Header Settings */}
-        <Card>
-          <CardHeader>
-            <div className="flex items-center gap-2">
-              <PanelTop className="h-5 w-5 text-brand-primary" />
-              <CardTitle>헤더 설정</CardTitle>
-            </div>
-            <CardDescription>상단 헤더 영역 설정입니다</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <Label>헤더 스타일</Label>
-              <Select
+      <div className="space-y-6">
+        {/* ========== 헤더 설정 ========== */}
+        <CollapsibleSection
+          icon={PanelTop}
+          title="헤더 설정"
+          description="상단 헤더 영역의 스타일과 기능을 설정합니다"
+        >
+          <div className="grid grid-cols-2 gap-6">
+            <div className="space-y-4">
+              <OptionSelect
+                label="헤더 스타일"
+                description="스크롤 시 헤더 동작 방식"
                 value={settings.header.style}
-                onValueChange={(v) => {
-                  setSettings({
-                    ...settings,
-                    header: { ...settings.header, style: v as HeaderSettings['style'] },
-                  });
-                  setHasChanges(true);
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="fixed">고정</SelectItem>
-                  <SelectItem value="sticky">스티키</SelectItem>
-                  <SelectItem value="static">일반</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-3 pt-4 border-t">
-              <div className="flex items-center justify-between">
-                <span className="text-sm">로고 표시</span>
-                <Switch
-                  checked={settings.header.showLogo}
-                  onCheckedChange={(v) => {
-                    setSettings({
-                      ...settings,
-                      header: { ...settings.header, showLogo: v },
-                    });
-                    setHasChanges(true);
-                  }}
-                />
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm">검색창 표시</span>
-                <Switch
-                  checked={settings.header.showSearch}
-                  onCheckedChange={(v) => {
-                    setSettings({
-                      ...settings,
-                      header: { ...settings.header, showSearch: v },
-                    });
-                    setHasChanges(true);
-                  }}
-                />
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm">알림 표시</span>
-                <Switch
-                  checked={settings.header.showNotifications}
-                  onCheckedChange={(v) => {
-                    setSettings({
-                      ...settings,
-                      header: { ...settings.header, showNotifications: v },
-                    });
-                    setHasChanges(true);
-                  }}
-                />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Sidebar Settings */}
-        <Card>
-          <CardHeader>
-            <div className="flex items-center gap-2">
-              <Sidebar className="h-5 w-5 text-brand-primary" />
-              <CardTitle>사이드바 설정</CardTitle>
-            </div>
-            <CardDescription>좌측 네비게이션 영역 설정입니다</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <Label>사이드바 스타일</Label>
-              <Select
-                value={settings.sidebar.style}
-                onValueChange={(v) => {
-                  setSettings({
-                    ...settings,
-                    sidebar: { ...settings.sidebar, style: v as SidebarSettings['style'] },
-                  });
-                  setHasChanges(true);
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="collapsible">접이식</SelectItem>
-                  <SelectItem value="fixed">고정</SelectItem>
-                  <SelectItem value="overlay">오버레이</SelectItem>
-                  <SelectItem value="hidden">숨김</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-3 pt-4 border-t">
-              <div className="flex items-center justify-between">
-                <span className="text-sm">기본 접힌 상태</span>
-                <Switch
-                  checked={settings.sidebar.defaultCollapsed}
-                  onCheckedChange={(v) => {
-                    setSettings({
-                      ...settings,
-                      sidebar: { ...settings.sidebar, defaultCollapsed: v },
-                    });
-                    setHasChanges(true);
-                  }}
-                />
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm">아이콘 표시</span>
-                <Switch
-                  checked={settings.sidebar.showIcons}
-                  onCheckedChange={(v) => {
-                    setSettings({
-                      ...settings,
-                      sidebar: { ...settings.sidebar, showIcons: v },
-                    });
-                    setHasChanges(true);
-                  }}
-                />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Footer Settings */}
-        <Card>
-          <CardHeader>
-            <div className="flex items-center gap-2">
-              <PanelBottom className="h-5 w-5 text-brand-primary" />
-              <CardTitle>푸터 설정</CardTitle>
-            </div>
-            <CardDescription>하단 푸터 영역 설정입니다</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-medium">푸터 사용</p>
-                <p className="text-sm text-text-secondary">푸터 영역을 표시합니다</p>
-              </div>
-              <Switch
-                checked={settings.footer.enabled}
-                onCheckedChange={(v) => {
-                  setSettings({
-                    ...settings,
-                    footer: { ...settings.footer, enabled: v },
-                  });
-                  setHasChanges(true);
-                }}
+                options={[
+                  { value: 'fixed', label: '고정 (항상 상단에 표시)' },
+                  { value: 'sticky', label: '스티키 (스크롤 시 나타남)' },
+                  { value: 'static', label: '일반 (스크롤과 함께 이동)' },
+                ]}
+                onChange={(v) => updateSettings('header', 'style', v as HeaderSettings['style'])}
+              />
+              <OptionSelect
+                label="헤더 높이"
+                value={settings.header.height}
+                options={[
+                  { value: 'compact', label: '컴팩트 (48px)' },
+                  { value: 'default', label: '기본 (64px)' },
+                  { value: 'large', label: '크게 (80px)' },
+                ]}
+                onChange={(v) => updateSettings('header', 'height', v as HeaderSettings['height'])}
+              />
+              <OptionSelect
+                label="배경 투명도"
+                description="스크롤 시 배경 효과"
+                value={settings.header.backgroundOpacity}
+                options={[
+                  { value: 'solid', label: '불투명' },
+                  { value: 'translucent', label: '반투명 (블러 효과)' },
+                  { value: 'transparent', label: '투명' },
+                ]}
+                onChange={(v) => updateSettings('header', 'backgroundOpacity', v as HeaderSettings['backgroundOpacity'])}
+              />
+              <OptionSelect
+                label="그림자"
+                value={settings.header.shadow}
+                options={[
+                  { value: 'none', label: '없음' },
+                  { value: 'sm', label: '얇은 그림자' },
+                  { value: 'md', label: '두꺼운 그림자' },
+                ]}
+                onChange={(v) => updateSettings('header', 'shadow', v as HeaderSettings['shadow'])}
               />
             </div>
-            {settings.footer.enabled && (
-              <>
-                <div className="flex items-center justify-between">
-                  <span className="text-sm">링크 표시</span>
-                  <Switch
-                    checked={settings.footer.showLinks}
-                    onCheckedChange={(v) => {
-                      setSettings({
-                        ...settings,
-                        footer: { ...settings.footer, showLinks: v },
-                      });
-                      setHasChanges(true);
-                    }}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-sm">저작권 표시</span>
-                  <Switch
-                    checked={settings.footer.showCopyright}
-                    onCheckedChange={(v) => {
-                      setSettings({
-                        ...settings,
-                        footer: { ...settings.footer, showCopyright: v },
-                      });
-                      setHasChanges(true);
-                    }}
-                  />
-                </div>
-              </>
-            )}
-          </CardContent>
-        </Card>
+            <div className="space-y-4">
+              <OptionSelect
+                label="네비게이션 위치"
+                value={settings.header.navPosition}
+                options={[
+                  { value: 'left', label: '좌측' },
+                  { value: 'center', label: '중앙' },
+                  { value: 'right', label: '우측' },
+                ]}
+                onChange={(v) => updateSettings('header', 'navPosition', v as HeaderSettings['navPosition'])}
+              />
+              <OptionSelect
+                label="사용자 메뉴 스타일"
+                value={settings.header.userMenuStyle}
+                options={[
+                  { value: 'avatar', label: '아바타만' },
+                  { value: 'name', label: '이름 표시' },
+                  { value: 'dropdown', label: '드롭다운' },
+                ]}
+                onChange={(v) => updateSettings('header', 'userMenuStyle', v as HeaderSettings['userMenuStyle'])}
+              />
+              <OptionSelect
+                label="모바일 메뉴 스타일"
+                value={settings.header.mobileMenuStyle}
+                options={[
+                  { value: 'hamburger', label: '햄버거 메뉴' },
+                  { value: 'drawer', label: '드로어' },
+                  { value: 'bottomSheet', label: '바텀 시트' },
+                ]}
+                onChange={(v) => updateSettings('header', 'mobileMenuStyle', v as HeaderSettings['mobileMenuStyle'])}
+              />
+              <div className="pt-4 border-t space-y-2">
+                <ToggleOption
+                  label="로고 표시"
+                  checked={settings.header.showLogo}
+                  onChange={(v) => updateSettings('header', 'showLogo', v)}
+                />
+                <ToggleOption
+                  label="검색창 표시"
+                  checked={settings.header.showSearch}
+                  onChange={(v) => updateSettings('header', 'showSearch', v)}
+                />
+                <ToggleOption
+                  label="알림 아이콘 표시"
+                  checked={settings.header.showNotifications}
+                  onChange={(v) => updateSettings('header', 'showNotifications', v)}
+                />
+              </div>
+            </div>
+          </div>
+        </CollapsibleSection>
 
-        {/* Content Settings */}
+        {/* ========== 사이드바 설정 ========== */}
+        <CollapsibleSection
+          icon={Sidebar}
+          title="사이드바 설정"
+          description="좌측 네비게이션 영역의 스타일과 동작을 설정합니다"
+        >
+          <div className="grid grid-cols-2 gap-6">
+            <div className="space-y-4">
+              <OptionSelect
+                label="사이드바 스타일"
+                value={settings.sidebar.style}
+                options={[
+                  { value: 'collapsible', label: '접이식' },
+                  { value: 'fixed', label: '고정' },
+                  { value: 'overlay', label: '오버레이' },
+                  { value: 'hidden', label: '숨김' },
+                ]}
+                onChange={(v) => updateSettings('sidebar', 'style', v as SidebarSettings['style'])}
+              />
+              <OptionSelect
+                label="사이드바 너비"
+                value={settings.sidebar.width}
+                options={[
+                  { value: 'narrow', label: '좁게 (200px)' },
+                  { value: 'default', label: '보통 (240px)' },
+                  { value: 'wide', label: '넓게 (280px)' },
+                ]}
+                onChange={(v) => updateSettings('sidebar', 'width', v as SidebarSettings['width'])}
+              />
+              <OptionSelect
+                label="메뉴 그룹 스타일"
+                value={settings.sidebar.menuGroupStyle}
+                options={[
+                  { value: 'accordion', label: '아코디언 (접이식)' },
+                  { value: 'expanded', label: '항상 펼침' },
+                  { value: 'divider', label: '구분선만' },
+                ]}
+                onChange={(v) => updateSettings('sidebar', 'menuGroupStyle', v as SidebarSettings['menuGroupStyle'])}
+              />
+              <OptionSelect
+                label="활성 메뉴 표시"
+                value={settings.sidebar.activeIndicator}
+                options={[
+                  { value: 'background', label: '배경색 강조' },
+                  { value: 'leftBar', label: '좌측 바' },
+                  { value: 'underline', label: '밑줄' },
+                  { value: 'iconColor', label: '아이콘 색상' },
+                ]}
+                onChange={(v) => updateSettings('sidebar', 'activeIndicator', v as SidebarSettings['activeIndicator'])}
+              />
+            </div>
+            <div className="space-y-4">
+              <OptionSelect
+                label="메뉴 아이템 간격"
+                value={settings.sidebar.itemSpacing}
+                options={[
+                  { value: 'compact', label: '좁게' },
+                  { value: 'default', label: '보통' },
+                  { value: 'relaxed', label: '넓게' },
+                ]}
+                onChange={(v) => updateSettings('sidebar', 'itemSpacing', v as SidebarSettings['itemSpacing'])}
+              />
+              <OptionSelect
+                label="스크롤바 표시"
+                value={settings.sidebar.scrollbarStyle}
+                options={[
+                  { value: 'always', label: '항상 표시' },
+                  { value: 'hover', label: '호버 시만' },
+                  { value: 'hidden', label: '숨김' },
+                ]}
+                onChange={(v) => updateSettings('sidebar', 'scrollbarStyle', v as SidebarSettings['scrollbarStyle'])}
+              />
+              <OptionSelect
+                label="하단 영역"
+                value={settings.sidebar.bottomSection}
+                options={[
+                  { value: 'userInfo', label: '사용자 정보' },
+                  { value: 'logout', label: '로그아웃 버튼' },
+                  { value: 'settings', label: '설정 링크' },
+                  { value: 'none', label: '없음' },
+                ]}
+                onChange={(v) => updateSettings('sidebar', 'bottomSection', v as SidebarSettings['bottomSection'])}
+              />
+              <div className="pt-4 border-t space-y-2">
+                <ToggleOption
+                  label="기본 접힌 상태"
+                  description="페이지 로드 시 사이드바를 접은 상태로 표시"
+                  checked={settings.sidebar.defaultCollapsed}
+                  onChange={(v) => updateSettings('sidebar', 'defaultCollapsed', v)}
+                />
+                <ToggleOption
+                  label="아이콘 표시"
+                  checked={settings.sidebar.showIcons}
+                  onChange={(v) => updateSettings('sidebar', 'showIcons', v)}
+                />
+              </div>
+            </div>
+          </div>
+        </CollapsibleSection>
+
+        {/* ========== 푸터 설정 ========== */}
+        <CollapsibleSection
+          icon={PanelBottom}
+          title="푸터 설정"
+          description="하단 푸터 영역의 구성을 설정합니다"
+        >
+          <div className="space-y-6">
+            <ToggleOption
+              label="푸터 사용"
+              description="푸터 영역을 표시합니다"
+              checked={settings.footer.enabled}
+              onChange={(v) => updateSettings('footer', 'enabled', v)}
+            />
+            {settings.footer.enabled && (
+              <div className="grid grid-cols-2 gap-6 pt-4 border-t">
+                <div className="space-y-4">
+                  <OptionSelect
+                    label="푸터 레이아웃"
+                    value={settings.footer.layout}
+                    options={[
+                      { value: 'single', label: '단일 행' },
+                      { value: 'multi-column', label: '다중 열' },
+                      { value: 'minimal', label: '미니멀' },
+                    ]}
+                    onChange={(v) => updateSettings('footer', 'layout', v as FooterSettings['layout'])}
+                  />
+                  <ToggleOption
+                    label="링크 표시"
+                    checked={settings.footer.showLinks}
+                    onChange={(v) => updateSettings('footer', 'showLinks', v)}
+                  />
+                  <ToggleOption
+                    label="저작권 표시"
+                    checked={settings.footer.showCopyright}
+                    onChange={(v) => updateSettings('footer', 'showCopyright', v)}
+                  />
+                  <ToggleOption
+                    label="뉴스레터 구독 폼"
+                    checked={settings.footer.showNewsletter}
+                    onChange={(v) => updateSettings('footer', 'showNewsletter', v)}
+                  />
+                </div>
+                <div className="space-y-4">
+                  <ToggleOption
+                    label="소셜 링크 표시"
+                    checked={settings.footer.showSocialLinks}
+                    onChange={(v) => updateSettings('footer', 'showSocialLinks', v)}
+                  />
+                  {settings.footer.showSocialLinks && (
+                    <CheckboxGroup
+                      label="표시할 플랫폼"
+                      options={[
+                        { value: 'facebook', label: 'Facebook' },
+                        { value: 'twitter', label: 'Twitter' },
+                        { value: 'instagram', label: 'Instagram' },
+                        { value: 'youtube', label: 'YouTube' },
+                        { value: 'linkedin', label: 'LinkedIn' },
+                      ]}
+                      selected={settings.footer.socialPlatforms}
+                      onChange={(v) => updateSettings('footer', 'socialPlatforms', v as FooterSettings['socialPlatforms'])}
+                    />
+                  )}
+                  <ToggleOption
+                    label="회사 정보 표시"
+                    checked={settings.footer.showCompanyInfo}
+                    onChange={(v) => updateSettings('footer', 'showCompanyInfo', v)}
+                  />
+                  {settings.footer.showCompanyInfo && (
+                    <CheckboxGroup
+                      label="표시할 정보"
+                      options={[
+                        { value: 'address', label: '주소' },
+                        { value: 'phone', label: '연락처' },
+                        { value: 'email', label: '이메일' },
+                        { value: 'businessNumber', label: '사업자번호' },
+                      ]}
+                      selected={settings.footer.companyInfoFields}
+                      onChange={(v) => updateSettings('footer', 'companyInfoFields', v as FooterSettings['companyInfoFields'])}
+                    />
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </CollapsibleSection>
+
+        {/* ========== 콘텐츠 영역 설정 ========== */}
+        <CollapsibleSection
+          icon={Monitor}
+          title="콘텐츠 영역 설정"
+          description="메인 콘텐츠 영역의 레이아웃과 스타일을 설정합니다"
+        >
+          <div className="grid grid-cols-2 gap-6">
+            <div className="space-y-4">
+              <OptionSelect
+                label="최대 너비"
+                value={settings.content.maxWidth}
+                options={[
+                  { value: 'full', label: '전체 너비' },
+                  { value: 'xl', label: 'Extra Large (1280px)' },
+                  { value: 'lg', label: 'Large (1024px)' },
+                  { value: 'md', label: 'Medium (768px)' },
+                ]}
+                onChange={(v) => updateSettings('content', 'maxWidth', v as ContentSettings['maxWidth'])}
+              />
+              <OptionSelect
+                label="여백"
+                value={settings.content.padding}
+                options={[
+                  { value: 'none', label: '없음' },
+                  { value: 'compact', label: '좁게' },
+                  { value: 'normal', label: '보통' },
+                  { value: 'relaxed', label: '넓게' },
+                ]}
+                onChange={(v) => updateSettings('content', 'padding', v as ContentSettings['padding'])}
+              />
+              <OptionSelect
+                label="페이지 전환 애니메이션"
+                value={settings.content.pageTransition}
+                options={[
+                  { value: 'none', label: '없음' },
+                  { value: 'fade', label: '페이드' },
+                  { value: 'slide', label: '슬라이드' },
+                ]}
+                onChange={(v) => updateSettings('content', 'pageTransition', v as ContentSettings['pageTransition'])}
+              />
+              <OptionSelect
+                label="로딩 인디케이터"
+                value={settings.content.loadingIndicator}
+                options={[
+                  { value: 'spinner', label: '스피너' },
+                  { value: 'skeleton', label: '스켈레톤' },
+                  { value: 'progressBar', label: '프로그레스 바' },
+                ]}
+                onChange={(v) => updateSettings('content', 'loadingIndicator', v as ContentSettings['loadingIndicator'])}
+              />
+            </div>
+            <div className="space-y-4">
+              <OptionSelect
+                label="카드 스타일"
+                value={settings.content.cardStyle}
+                options={[
+                  { value: 'flat', label: '플랫' },
+                  { value: 'shadow', label: '그림자' },
+                  { value: 'border', label: '테두리' },
+                  { value: 'glass', label: '글래스모피즘' },
+                ]}
+                onChange={(v) => updateSettings('content', 'cardStyle', v as ContentSettings['cardStyle'])}
+              />
+              <OptionSelect
+                label="카드 모서리"
+                value={settings.content.cardRadius}
+                options={[
+                  { value: 'none', label: '각진' },
+                  { value: 'sm', label: '약간 둥글게' },
+                  { value: 'md', label: '둥글게' },
+                  { value: 'lg', label: '많이 둥글게' },
+                ]}
+                onChange={(v) => updateSettings('content', 'cardRadius', v as ContentSettings['cardRadius'])}
+              />
+              <OptionSelect
+                label="테이블 스타일"
+                value={settings.content.tableStyle}
+                options={[
+                  { value: 'striped', label: '줄무늬' },
+                  { value: 'plain', label: '단색' },
+                  { value: 'bordered', label: '테두리' },
+                ]}
+                onChange={(v) => updateSettings('content', 'tableStyle', v as ContentSettings['tableStyle'])}
+              />
+              <OptionSelect
+                label="버튼 스타일"
+                value={settings.content.buttonStyle}
+                options={[
+                  { value: 'square', label: '각진' },
+                  { value: 'rounded', label: '둥근' },
+                  { value: 'pill', label: '알약형' },
+                ]}
+                onChange={(v) => updateSettings('content', 'buttonStyle', v as ContentSettings['buttonStyle'])}
+              />
+            </div>
+          </div>
+        </CollapsibleSection>
+
+        {/* ========== 타이포그래피 설정 ========== */}
+        <CollapsibleSection
+          icon={Type}
+          title="타이포그래피"
+          description="폰트 크기, 줄 간격, 제목 스타일을 설정합니다"
+          defaultOpen={false}
+        >
+          <div className="grid grid-cols-2 gap-6">
+            <div className="space-y-4">
+              <OptionSelect
+                label="폰트 크기 스케일"
+                description="전체 텍스트 크기 비율"
+                value={settings.typography.fontScale}
+                options={[
+                  { value: 'small', label: '작게 (90%)' },
+                  { value: 'default', label: '기본 (100%)' },
+                  { value: 'large', label: '크게 (110%)' },
+                ]}
+                onChange={(v) => updateSettings('typography', 'fontScale', v as TypographySettings['fontScale'])}
+              />
+              <OptionSelect
+                label="줄 간격"
+                value={settings.typography.lineHeight}
+                options={[
+                  { value: 'tight', label: '좁게' },
+                  { value: 'normal', label: '보통' },
+                  { value: 'relaxed', label: '넓게' },
+                ]}
+                onChange={(v) => updateSettings('typography', 'lineHeight', v as TypographySettings['lineHeight'])}
+              />
+            </div>
+            <div className="space-y-4">
+              <OptionSelect
+                label="제목 굵기"
+                value={settings.typography.headingStyle}
+                options={[
+                  { value: 'normal', label: '일반' },
+                  { value: 'semibold', label: '세미볼드' },
+                  { value: 'bold', label: '볼드' },
+                ]}
+                onChange={(v) => updateSettings('typography', 'headingStyle', v as TypographySettings['headingStyle'])}
+              />
+              <OptionSelect
+                label="제목 대소문자"
+                value={settings.typography.headingCase}
+                options={[
+                  { value: 'normal', label: '일반' },
+                  { value: 'uppercase', label: '대문자' },
+                  { value: 'capitalize', label: '첫 글자 대문자' },
+                ]}
+                onChange={(v) => updateSettings('typography', 'headingCase', v as TypographySettings['headingCase'])}
+              />
+            </div>
+          </div>
+        </CollapsibleSection>
+
+        {/* ========== 컬러 모드 설정 ========== */}
+        <CollapsibleSection
+          icon={Palette}
+          title="컬러 모드"
+          description="다크/라이트 모드 설정을 관리합니다"
+          defaultOpen={false}
+        >
+          <div className="grid grid-cols-2 gap-6">
+            <div className="space-y-4">
+              <OptionSelect
+                label="기본 모드"
+                value={settings.colorMode.defaultMode}
+                options={[
+                  { value: 'light', label: '라이트 모드' },
+                  { value: 'dark', label: '다크 모드' },
+                  { value: 'system', label: '시스템 설정 따라가기' },
+                ]}
+                onChange={(v) => updateSettings('colorMode', 'defaultMode', v as ColorModeSettings['defaultMode'])}
+              />
+              <OptionSelect
+                label="전환 속도"
+                value={settings.colorMode.transitionDuration}
+                options={[
+                  { value: 'instant', label: '즉시' },
+                  { value: 'fast', label: '빠르게' },
+                  { value: 'normal', label: '보통' },
+                ]}
+                onChange={(v) => updateSettings('colorMode', 'transitionDuration', v as ColorModeSettings['transitionDuration'])}
+              />
+            </div>
+            <div className="space-y-4">
+              <ToggleOption
+                label="사용자 전환 허용"
+                description="사용자가 직접 모드를 전환할 수 있도록 허용"
+                checked={settings.colorMode.allowUserToggle}
+                onChange={(v) => updateSettings('colorMode', 'allowUserToggle', v)}
+              />
+              {settings.colorMode.allowUserToggle && (
+                <OptionSelect
+                  label="전환 버튼 위치"
+                  value={settings.colorMode.togglePosition}
+                  options={[
+                    { value: 'header', label: '헤더' },
+                    { value: 'sidebar', label: '사이드바' },
+                    { value: 'footer', label: '푸터' },
+                    { value: 'hidden', label: '숨김 (단축키만)' },
+                  ]}
+                  onChange={(v) => updateSettings('colorMode', 'togglePosition', v as ColorModeSettings['togglePosition'])}
+                />
+              )}
+            </div>
+          </div>
+        </CollapsibleSection>
+
+        {/* ========== 컴포넌트 스타일 설정 ========== */}
+        <CollapsibleSection
+          icon={Layers}
+          title="컴포넌트 스타일"
+          description="UI 컴포넌트의 전반적인 스타일을 설정합니다"
+          defaultOpen={false}
+        >
+          <div className="grid grid-cols-2 gap-6">
+            <div className="space-y-4">
+              <OptionSelect
+                label="UI 밀도"
+                description="전체 UI 요소의 간격 및 크기"
+                value={settings.componentStyle.density}
+                options={[
+                  { value: 'compact', label: '컴팩트' },
+                  { value: 'default', label: '기본' },
+                  { value: 'comfortable', label: '편안함' },
+                ]}
+                onChange={(v) => updateSettings('componentStyle', 'density', v as ComponentStyleSettings['density'])}
+              />
+              <OptionSelect
+                label="입력 필드 스타일"
+                value={settings.componentStyle.inputStyle}
+                options={[
+                  { value: 'outline', label: '외곽선' },
+                  { value: 'filled', label: '채워진' },
+                  { value: 'underline', label: '밑줄' },
+                ]}
+                onChange={(v) => updateSettings('componentStyle', 'inputStyle', v as ComponentStyleSettings['inputStyle'])}
+              />
+              <OptionSelect
+                label="아이콘 크기"
+                value={settings.componentStyle.iconSize}
+                options={[
+                  { value: 'small', label: '작게' },
+                  { value: 'default', label: '기본' },
+                  { value: 'large', label: '크게' },
+                ]}
+                onChange={(v) => updateSettings('componentStyle', 'iconSize', v as ComponentStyleSettings['iconSize'])}
+              />
+            </div>
+            <div className="space-y-4">
+              <OptionSelect
+                label="배지 스타일"
+                value={settings.componentStyle.badgeStyle}
+                options={[
+                  { value: 'solid', label: '채움' },
+                  { value: 'outline', label: '외곽선' },
+                  { value: 'soft', label: '소프트' },
+                ]}
+                onChange={(v) => updateSettings('componentStyle', 'badgeStyle', v as ComponentStyleSettings['badgeStyle'])}
+              />
+              <OptionSelect
+                label="아바타 스타일"
+                value={settings.componentStyle.avatarStyle}
+                options={[
+                  { value: 'circle', label: '원형' },
+                  { value: 'rounded', label: '둥근 사각형' },
+                  { value: 'square', label: '사각형' },
+                ]}
+                onChange={(v) => updateSettings('componentStyle', 'avatarStyle', v as ComponentStyleSettings['avatarStyle'])}
+              />
+            </div>
+          </div>
+        </CollapsibleSection>
+
+        {/* ========== 접근성 설정 ========== */}
+        <CollapsibleSection
+          icon={Accessibility}
+          title="접근성"
+          description="접근성 관련 옵션을 설정합니다"
+          defaultOpen={false}
+        >
+          <div className="grid grid-cols-2 gap-6">
+            <div className="space-y-4">
+              <ToggleOption
+                label="고대비 모드"
+                description="시각적 대비를 높여 가독성 향상"
+                checked={settings.accessibility.highContrastMode}
+                onChange={(v) => updateSettings('accessibility', 'highContrastMode', v)}
+              />
+              <ToggleOption
+                label="폰트 크기 조절 허용"
+                description="사용자가 폰트 크기를 조절할 수 있도록 허용"
+                checked={settings.accessibility.fontSizeAdjustable}
+                onChange={(v) => updateSettings('accessibility', 'fontSizeAdjustable', v)}
+              />
+              <ToggleOption
+                label="모션 감소"
+                description="애니메이션 및 전환 효과 최소화"
+                checked={settings.accessibility.reduceMotion}
+                onChange={(v) => updateSettings('accessibility', 'reduceMotion', v)}
+              />
+            </div>
+            <div className="space-y-4">
+              <OptionSelect
+                label="포커스 표시"
+                value={settings.accessibility.focusIndicator}
+                options={[
+                  { value: 'default', label: '기본' },
+                  { value: 'enhanced', label: '강화' },
+                  { value: 'custom', label: '커스텀' },
+                ]}
+                onChange={(v) => updateSettings('accessibility', 'focusIndicator', v as AccessibilitySettings['focusIndicator'])}
+              />
+              <ToggleOption
+                label="스크린 리더 최적화"
+                description="스크린 리더 사용자를 위한 추가 최적화"
+                checked={settings.accessibility.screenReaderOptimized}
+                onChange={(v) => updateSettings('accessibility', 'screenReaderOptimized', v)}
+              />
+            </div>
+          </div>
+        </CollapsibleSection>
+
+        {/* ========== 반응형 설정 ========== */}
+        <CollapsibleSection
+          icon={Smartphone}
+          title="반응형 설정"
+          description="모바일 및 태블릿 화면 설정을 관리합니다"
+          defaultOpen={false}
+        >
+          <div className="grid grid-cols-2 gap-6">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label>모바일 브레이크포인트 (px)</Label>
+                <Input
+                  type="number"
+                  value={settings.responsive.mobileBreakpoint}
+                  onChange={(e) => updateSettings('responsive', 'mobileBreakpoint', parseInt(e.target.value) || 768)}
+                  min={320}
+                  max={1024}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>태블릿 브레이크포인트 (px)</Label>
+                <Input
+                  type="number"
+                  value={settings.responsive.tabletBreakpoint}
+                  onChange={(e) => updateSettings('responsive', 'tabletBreakpoint', parseInt(e.target.value) || 1024)}
+                  min={768}
+                  max={1440}
+                />
+              </div>
+            </div>
+            <div className="space-y-4">
+              <OptionSelect
+                label="태블릿 레이아웃"
+                value={settings.responsive.tabletLayout}
+                options={[
+                  { value: 'mobile', label: '모바일 레이아웃 사용' },
+                  { value: 'desktop', label: '데스크톱 레이아웃 사용' },
+                  { value: 'adaptive', label: '적응형 (자동)' },
+                ]}
+                onChange={(v) => updateSettings('responsive', 'tabletLayout', v as ResponsiveSettings['tabletLayout'])}
+              />
+              <OptionSelect
+                label="모바일 네비게이션"
+                value={settings.responsive.mobileNavStyle}
+                options={[
+                  { value: 'bottom', label: '하단 탭 바' },
+                  { value: 'top', label: '상단 메뉴' },
+                  { value: 'drawer', label: '드로어' },
+                ]}
+                onChange={(v) => updateSettings('responsive', 'mobileNavStyle', v as ResponsiveSettings['mobileNavStyle'])}
+              />
+            </div>
+          </div>
+        </CollapsibleSection>
+
+        {/* ========== 미리보기 ========== */}
         <Card>
           <CardHeader>
-            <div className="flex items-center gap-2">
-              <Monitor className="h-5 w-5 text-brand-primary" />
-              <CardTitle>콘텐츠 영역 설정</CardTitle>
+            <div className="flex flex-col gap-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <CardTitle>미리보기</CardTitle>
+                  <CardDescription>현재 설정이 적용된 레이아웃 미리보기입니다. 페이지 타입과 뷰 모드를 선택하세요.</CardDescription>
+                </div>
+                {/* 뷰 모드 선택 */}
+                <div className="flex items-center gap-1 p-1 bg-gray-100 rounded-lg">
+                  <button
+                    onClick={() => setPreviewMode('desktop')}
+                    className={`flex items-center gap-1 px-3 py-1.5 rounded-md text-sm transition-colors ${
+                      previewMode === 'desktop'
+                        ? 'bg-white text-brand-primary shadow-sm'
+                        : 'text-gray-600 hover:text-gray-900'
+                    }`}
+                  >
+                    <Monitor className="w-4 h-4" />
+                    데스크톱
+                  </button>
+                  <button
+                    onClick={() => setPreviewMode('tablet')}
+                    className={`flex items-center gap-1 px-3 py-1.5 rounded-md text-sm transition-colors ${
+                      previewMode === 'tablet'
+                        ? 'bg-white text-brand-primary shadow-sm'
+                        : 'text-gray-600 hover:text-gray-900'
+                    }`}
+                  >
+                    <Tablet className="w-4 h-4" />
+                    태블릿
+                  </button>
+                  <button
+                    onClick={() => setPreviewMode('mobile')}
+                    className={`flex items-center gap-1 px-3 py-1.5 rounded-md text-sm transition-colors ${
+                      previewMode === 'mobile'
+                        ? 'bg-white text-brand-primary shadow-sm'
+                        : 'text-gray-600 hover:text-gray-900'
+                    }`}
+                  >
+                    <Smartphone className="w-4 h-4" />
+                    모바일
+                  </button>
+                </div>
+              </div>
+
+              {/* 페이지 타입 탭 */}
+              <div className="flex items-center gap-1 border-b border-gray-200">
+                <button
+                  onClick={() => setPreviewPageType('admin')}
+                  className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                    previewPageType === 'admin'
+                      ? 'border-brand-primary text-brand-primary'
+                      : 'border-transparent text-gray-500 hover:text-gray-700'
+                  }`}
+                >
+                  관리자 페이지 (TA/TO)
+                </button>
+                <button
+                  onClick={() => setPreviewPageType('operator')}
+                  className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                    previewPageType === 'operator'
+                      ? 'border-brand-primary text-brand-primary'
+                      : 'border-transparent text-gray-500 hover:text-gray-700'
+                  }`}
+                >
+                  운영자 페이지 (TO)
+                </button>
+                <button
+                  onClick={() => setPreviewPageType('user')}
+                  className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                    previewPageType === 'user'
+                      ? 'border-brand-primary text-brand-primary'
+                      : 'border-transparent text-gray-500 hover:text-gray-700'
+                  }`}
+                >
+                  사용자 페이지 (TU)
+                </button>
+              </div>
             </div>
-            <CardDescription>메인 콘텐츠 영역 설정입니다</CardDescription>
           </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <Label>최대 너비</Label>
-              <Select
-                value={settings.content.maxWidth}
-                onValueChange={(v) => {
-                  setSettings({
-                    ...settings,
-                    content: { ...settings.content, maxWidth: v as ContentSettings['maxWidth'] },
-                  });
-                  setHasChanges(true);
-                }}
+          <CardContent className="space-y-6">
+            {/* 미리보기 컨테이너 */}
+            <div className="flex justify-center">
+              <div
+                className={`border-2 border-gray-300 rounded-xl overflow-hidden transition-all duration-300 ${
+                  previewMode === 'desktop' ? 'w-full' : previewMode === 'tablet' ? 'w-[768px]' : 'w-[375px]'
+                } ${settings.colorMode.defaultMode === 'dark' ? 'bg-gray-900' : 'bg-gray-50'}`}
+                style={{ minHeight: previewMode === 'mobile' ? '600px' : '500px' }}
               >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="full">전체 너비</SelectItem>
-                  <SelectItem value="xl">Extra Large (1280px)</SelectItem>
-                  <SelectItem value="lg">Large (1024px)</SelectItem>
-                  <SelectItem value="md">Medium (768px)</SelectItem>
-                </SelectContent>
-              </Select>
+                {/* ========== 사용자 페이지 (TU) 미리보기 ========== */}
+                {previewPageType === 'user' && (
+                  <>
+                    {/* 랜딩 헤더 */}
+                    <div
+                      className={`flex items-center justify-between px-6 ${
+                        settings.colorMode.defaultMode === 'dark' ? 'bg-[#1e1e1e]' : 'bg-white'
+                      } ${
+                        settings.header.height === 'compact' ? 'h-14' : settings.header.height === 'large' ? 'h-20' : 'h-16'
+                      } border-b ${settings.colorMode.defaultMode === 'dark' ? 'border-white/10' : 'border-gray-200'}`}
+                    >
+                      {/* 로고 */}
+                      <div className="flex items-center gap-3">
+                        <div className={`w-8 h-8 rounded-lg flex items-center justify-center ${
+                          settings.colorMode.defaultMode === 'dark' ? 'bg-[#6778ff]' : 'bg-brand-primary'
+                        }`}>
+                          <span className="text-white font-bold text-sm">LP</span>
+                        </div>
+                        {previewMode !== 'mobile' && (
+                          <span className={`font-semibold ${
+                            settings.colorMode.defaultMode === 'dark' ? 'text-white' : 'text-gray-900'
+                          }`}>Learn Platform</span>
+                        )}
+                      </div>
+
+                      {/* 네비게이션 */}
+                      {previewMode !== 'mobile' && (
+                        <nav className="flex items-center gap-6">
+                          {['강의', '로드맵', '커뮤니티'].map((item, i) => (
+                            <span
+                              key={item}
+                              className={`text-sm cursor-pointer transition-colors ${
+                                i === 0
+                                  ? settings.colorMode.defaultMode === 'dark' ? 'text-[#6778ff]' : 'text-brand-primary'
+                                  : settings.colorMode.defaultMode === 'dark' ? 'text-gray-400 hover:text-white' : 'text-gray-600 hover:text-gray-900'
+                              }`}
+                            >
+                              {item}
+                            </span>
+                          ))}
+                        </nav>
+                      )}
+
+                      {/* 오른쪽 영역 */}
+                      <div className="flex items-center gap-3">
+                        {settings.header.showSearch && previewMode !== 'mobile' && (
+                          <div className={`flex items-center gap-2 px-3 py-1.5 rounded-lg ${
+                            settings.colorMode.defaultMode === 'dark' ? 'bg-white/10' : 'bg-gray-100'
+                          }`}>
+                            <Search className={`w-4 h-4 ${
+                              settings.colorMode.defaultMode === 'dark' ? 'text-gray-400' : 'text-gray-500'
+                            }`} />
+                            <span className={`text-sm ${
+                              settings.colorMode.defaultMode === 'dark' ? 'text-gray-500' : 'text-gray-400'
+                            }`}>검색...</span>
+                          </div>
+                        )}
+                        {previewMode === 'mobile' && <Search className={`w-5 h-5 ${
+                          settings.colorMode.defaultMode === 'dark' ? 'text-gray-400' : 'text-gray-600'
+                        }`} />}
+                        <div className={`w-8 h-8 flex items-center justify-center ${
+                          settings.componentStyle.avatarStyle === 'circle' ? 'rounded-full' : 'rounded-lg'
+                        } ${settings.colorMode.defaultMode === 'dark' ? 'bg-[#6778ff]/20' : 'bg-brand-primary/10'}`}>
+                          <User className={`w-4 h-4 ${
+                            settings.colorMode.defaultMode === 'dark' ? 'text-[#6778ff]' : 'text-brand-primary'
+                          }`} />
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* 메인 콘텐츠 */}
+                    <div className={`${
+                      settings.content.padding === 'none' ? 'p-0' : settings.content.padding === 'compact' ? 'p-4' : settings.content.padding === 'relaxed' ? 'p-8' : 'p-6'
+                    }`}>
+                      {/* 히어로 섹션 */}
+                      <div className={`text-center py-8 px-4 mb-6 rounded-xl ${
+                        settings.colorMode.defaultMode === 'dark'
+                          ? 'bg-gradient-to-r from-[#6778ff]/20 to-purple-500/20'
+                          : 'bg-gradient-to-r from-brand-primary/10 to-purple-100'
+                      }`}>
+                        <h1 className={`${
+                          settings.typography.fontScale === 'small' ? 'text-xl' : settings.typography.fontScale === 'large' ? 'text-3xl' : 'text-2xl'
+                        } ${
+                          settings.typography.headingStyle === 'bold' ? 'font-bold' : 'font-semibold'
+                        } ${settings.colorMode.defaultMode === 'dark' ? 'text-white' : 'text-gray-900'} mb-2`}>
+                          나만의 학습 여정을 시작하세요
+                        </h1>
+                        <p className={`${
+                          settings.typography.fontScale === 'small' ? 'text-xs' : 'text-sm'
+                        } ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
+                          다양한 강의와 로드맵으로 성장하세요
+                        </p>
+                      </div>
+
+                      {/* 강의 카드 그리드 */}
+                      <h2 className={`${
+                        settings.typography.fontScale === 'small' ? 'text-base' : settings.typography.fontScale === 'large' ? 'text-xl' : 'text-lg'
+                      } ${settings.typography.headingStyle === 'bold' ? 'font-bold' : 'font-semibold'} ${
+                        settings.colorMode.defaultMode === 'dark' ? 'text-white' : 'text-gray-900'
+                      } mb-4`}>인기 강의</h2>
+                      <div className={`grid ${previewMode === 'mobile' ? 'grid-cols-1' : previewMode === 'tablet' ? 'grid-cols-2' : 'grid-cols-3'} gap-4`}>
+                        {[
+                          { title: 'React 완전 정복', instructor: '김리액트', price: '₩99,000', rating: 4.8, students: 1234 },
+                          { title: 'TypeScript 마스터', instructor: '박타입', price: '₩79,000', rating: 4.7, students: 856 },
+                          { title: 'Python AI 기초', instructor: '이파이썬', price: '무료', rating: 4.9, students: 2341 },
+                        ].slice(0, previewMode === 'mobile' ? 2 : 3).map((course, i) => (
+                          <div
+                            key={i}
+                            className={`overflow-hidden ${
+                              settings.colorMode.defaultMode === 'dark' ? 'bg-[#2a2a2a]' : 'bg-white'
+                            } ${
+                              settings.content.cardStyle === 'shadow' ? 'shadow-lg' : settings.content.cardStyle === 'border' ? `border ${settings.colorMode.defaultMode === 'dark' ? 'border-white/10' : 'border-gray-200'}` : ''
+                            } ${
+                              settings.content.cardRadius === 'none' ? 'rounded-none' : settings.content.cardRadius === 'sm' ? 'rounded' : settings.content.cardRadius === 'lg' ? 'rounded-2xl' : 'rounded-xl'
+                            }`}
+                          >
+                            {/* 썸네일 */}
+                            <div className={`h-24 ${
+                              i === 0 ? 'bg-gradient-to-br from-blue-500 to-purple-600' :
+                              i === 1 ? 'bg-gradient-to-br from-indigo-500 to-blue-600' :
+                              'bg-gradient-to-br from-green-500 to-teal-600'
+                            }`} />
+                            <div className="p-3">
+                              <div className="flex items-center gap-1 mb-1">
+                                <span className={`px-1.5 py-0.5 text-[10px] ${
+                                  settings.componentStyle.badgeStyle === 'solid'
+                                    ? 'bg-[#6778ff] text-white'
+                                    : settings.componentStyle.badgeStyle === 'outline'
+                                    ? 'border border-[#6778ff] text-[#6778ff]'
+                                    : 'bg-[#6778ff]/10 text-[#6778ff]'
+                                } rounded`}>상시모집</span>
+                                {course.price === '무료' && (
+                                  <span className={`px-1.5 py-0.5 text-[10px] ${
+                                    settings.componentStyle.badgeStyle === 'solid'
+                                      ? 'bg-green-500 text-white'
+                                      : settings.componentStyle.badgeStyle === 'outline'
+                                      ? 'border border-green-500 text-green-500'
+                                      : 'bg-green-100 text-green-700'
+                                  } rounded`}>무료</span>
+                                )}
+                              </div>
+                              <h3 className={`text-sm font-medium mb-1 truncate ${
+                                settings.colorMode.defaultMode === 'dark' ? 'text-white' : 'text-gray-900'
+                              }`}>{course.title}</h3>
+                              <p className={`text-xs mb-2 ${
+                                settings.colorMode.defaultMode === 'dark' ? 'text-gray-400' : 'text-gray-500'
+                              }`}>{course.instructor}</p>
+                              <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-1">
+                                  <Star className="w-3 h-3 text-yellow-500 fill-yellow-500" />
+                                  <span className={`text-xs ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}>{course.rating}</span>
+                                  <span className={`text-xs ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-500' : 'text-gray-400'}`}>({course.students})</span>
+                                </div>
+                                <span className={`text-sm font-semibold ${
+                                  course.price === '무료'
+                                    ? 'text-green-500'
+                                    : settings.colorMode.defaultMode === 'dark' ? 'text-white' : 'text-gray-900'
+                                }`}>{course.price}</span>
+                              </div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+
+                      {/* 로드맵 섹션 */}
+                      <h2 className={`${
+                        settings.typography.fontScale === 'small' ? 'text-base' : settings.typography.fontScale === 'large' ? 'text-xl' : 'text-lg'
+                      } ${settings.typography.headingStyle === 'bold' ? 'font-bold' : 'font-semibold'} ${
+                        settings.colorMode.defaultMode === 'dark' ? 'text-white' : 'text-gray-900'
+                      } mt-6 mb-4`}>추천 로드맵</h2>
+                      <div className={`grid ${previewMode === 'mobile' ? 'grid-cols-1' : 'grid-cols-2'} gap-3`}>
+                        {[
+                          { title: '프론트엔드 개발자 되기', courses: 12, duration: '3개월' },
+                          { title: '풀스택 마스터 과정', courses: 20, duration: '6개월' },
+                        ].map((roadmap, i) => (
+                          <div
+                            key={i}
+                            className={`p-4 ${
+                              settings.colorMode.defaultMode === 'dark' ? 'bg-[#2a2a2a]' : 'bg-white'
+                            } ${
+                              settings.content.cardStyle === 'shadow' ? 'shadow-md' : settings.content.cardStyle === 'border' ? `border ${settings.colorMode.defaultMode === 'dark' ? 'border-white/10' : 'border-gray-200'}` : ''
+                            } ${
+                              settings.content.cardRadius === 'none' ? 'rounded-none' : settings.content.cardRadius === 'sm' ? 'rounded' : 'rounded-xl'
+                            }`}
+                          >
+                            <div className="flex items-start gap-3">
+                              <div className={`w-10 h-10 flex items-center justify-center rounded-lg ${
+                                i === 0 ? 'bg-purple-500/20 text-purple-500' : 'bg-blue-500/20 text-blue-500'
+                              }`}>
+                                <Map className="w-5 h-5" />
+                              </div>
+                              <div className="flex-1">
+                                <h3 className={`text-sm font-medium ${
+                                  settings.colorMode.defaultMode === 'dark' ? 'text-white' : 'text-gray-900'
+                                }`}>{roadmap.title}</h3>
+                                <p className={`text-xs ${
+                                  settings.colorMode.defaultMode === 'dark' ? 'text-gray-400' : 'text-gray-500'
+                                }`}>{roadmap.courses}개 강의 • {roadmap.duration}</p>
+                              </div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+
+                    {/* 모바일 하단 네비게이션 */}
+                    {previewMode === 'mobile' && settings.responsive.mobileNavStyle === 'bottom' && (
+                      <div className={`absolute bottom-0 left-0 right-0 flex items-center justify-around py-2 border-t ${
+                        settings.colorMode.defaultMode === 'dark' ? 'bg-[#1e1e1e] border-white/10' : 'bg-white border-gray-200'
+                      }`}>
+                        {[
+                          { icon: Home, label: '홈', active: true },
+                          { icon: FileText, label: '강의' },
+                          { icon: Map, label: '로드맵' },
+                          { icon: User, label: '마이' },
+                        ].map((item, idx) => (
+                          <div
+                            key={idx}
+                            className={`flex flex-col items-center gap-0.5 ${
+                              item.active
+                                ? settings.colorMode.defaultMode === 'dark' ? 'text-[#6778ff]' : 'text-brand-primary'
+                                : settings.colorMode.defaultMode === 'dark' ? 'text-gray-500' : 'text-gray-400'
+                            }`}
+                          >
+                            <item.icon className="w-5 h-5" />
+                            <span className="text-[10px]">{item.label}</span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </>
+                )}
+
+                {/* ========== 운영자 페이지 (TO) 미리보기 ========== */}
+                {previewPageType === 'operator' && (
+                  <>
+                    {/* 헤더 */}
+                    <div
+                      className={`flex items-center px-4 ${
+                        settings.colorMode.defaultMode === 'dark' ? 'bg-gray-800' : 'bg-brand-primary'
+                      } ${
+                        settings.header.height === 'compact' ? 'h-12' : settings.header.height === 'large' ? 'h-20' : 'h-16'
+                      } ${settings.header.shadow === 'md' ? 'shadow-md' : settings.header.shadow === 'sm' ? 'shadow-sm' : ''}`}
+                    >
+                      {previewMode === 'mobile' && (
+                        <button className="mr-2 text-white/80 hover:text-white">
+                          <Menu className="w-5 h-5" />
+                        </button>
+                      )}
+                      <div className="flex items-center gap-2">
+                        <div className="w-8 h-8 bg-white/30 rounded-lg flex items-center justify-center">
+                          <span className="text-white font-bold text-sm">LP</span>
+                        </div>
+                        {previewMode !== 'mobile' && (
+                          <span className="text-white font-semibold text-sm">운영자 콘솔</span>
+                        )}
+                      </div>
+                      <div className="flex-1" />
+                      <div className="flex items-center gap-3">
+                        {settings.header.showNotifications && (
+                          <div className="relative">
+                            <Bell className="w-5 h-5 text-white/80" />
+                            <span className="absolute -top-1 -right-1 w-4 h-4 bg-red-500 rounded-full text-[10px] text-white flex items-center justify-center">5</span>
+                          </div>
+                        )}
+                        <div className={`w-8 h-8 bg-white/30 flex items-center justify-center ${
+                          settings.componentStyle.avatarStyle === 'circle' ? 'rounded-full' : 'rounded-lg'
+                        }`}>
+                          <User className="w-4 h-4 text-white" />
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* 본문 */}
+                    <div className={`flex ${previewMode === 'mobile' ? 'flex-col' : ''}`} style={{ height: 'calc(100% - 64px)' }}>
+                      {/* 사이드바 */}
+                      {settings.sidebar.style !== 'hidden' && previewMode !== 'mobile' && (
+                        <div className={`${
+                          settings.colorMode.defaultMode === 'dark' ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+                        } border-r ${
+                          settings.sidebar.defaultCollapsed ? 'w-16' : settings.sidebar.width === 'narrow' ? 'w-48' : settings.sidebar.width === 'wide' ? 'w-72' : 'w-60'
+                        } p-3`}>
+                          <div className={`space-y-${settings.sidebar.itemSpacing === 'compact' ? '0.5' : settings.sidebar.itemSpacing === 'relaxed' ? '2' : '1'}`}>
+                            {[
+                              { icon: BarChart3, label: '대시보드', active: true },
+                              { icon: FileText, label: '강의 관리' },
+                              { icon: Users, label: '수강생 관리' },
+                              { icon: MessageSquare, label: 'Q&A 관리' },
+                            ].map((item, i) => (
+                              <div
+                                key={i}
+                                className={`flex items-center gap-3 px-3 py-2 cursor-pointer transition-all rounded-lg ${
+                                  item.active
+                                    ? settings.sidebar.activeIndicator === 'background'
+                                      ? 'bg-brand-primary/10 text-brand-primary'
+                                      : settings.sidebar.activeIndicator === 'leftBar'
+                                      ? 'border-l-3 border-brand-primary text-brand-primary'
+                                      : 'text-brand-primary'
+                                    : settings.colorMode.defaultMode === 'dark'
+                                    ? 'text-gray-400 hover:bg-gray-700/50'
+                                    : 'text-gray-600 hover:bg-gray-100'
+                                }`}
+                              >
+                                {settings.sidebar.showIcons && <item.icon className="w-5 h-5" />}
+                                {!settings.sidebar.defaultCollapsed && <span className="text-sm font-medium">{item.label}</span>}
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {/* 콘텐츠 */}
+                      <div className={`flex-1 ${
+                        settings.content.padding === 'none' ? 'p-0' : settings.content.padding === 'compact' ? 'p-3' : settings.content.padding === 'relaxed' ? 'p-8' : 'p-5'
+                      }`}>
+                        <h1 className={`${
+                          settings.typography.fontScale === 'small' ? 'text-lg' : settings.typography.fontScale === 'large' ? 'text-2xl' : 'text-xl'
+                        } ${settings.typography.headingStyle === 'bold' ? 'font-bold' : 'font-semibold'} ${
+                          settings.colorMode.defaultMode === 'dark' ? 'text-white' : 'text-gray-900'
+                        } mb-4`}>강의 관리</h1>
+
+                        {/* 통계 카드 */}
+                        <div className={`grid ${previewMode === 'mobile' ? 'grid-cols-2' : 'grid-cols-4'} gap-3 mb-4`}>
+                          {[
+                            { label: '총 강의', value: '24', color: 'blue' },
+                            { label: '수강생', value: '1,234', color: 'green' },
+                            { label: '완료율', value: '78%', color: 'purple' },
+                            { label: 'Q&A', value: '12', color: 'orange' },
+                          ].map((stat, i) => (
+                            <div
+                              key={i}
+                              className={`p-3 ${
+                                settings.colorMode.defaultMode === 'dark' ? 'bg-gray-800' : 'bg-white'
+                              } ${
+                                settings.content.cardStyle === 'shadow' ? 'shadow-md' : settings.content.cardStyle === 'border' ? `border ${settings.colorMode.defaultMode === 'dark' ? 'border-gray-700' : 'border-gray-200'}` : ''
+                              } ${
+                                settings.content.cardRadius === 'none' ? 'rounded-none' : settings.content.cardRadius === 'sm' ? 'rounded' : 'rounded-lg'
+                              }`}
+                            >
+                              <div className={`text-xs ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}>{stat.label}</div>
+                              <div className={`text-lg font-bold ${settings.colorMode.defaultMode === 'dark' ? 'text-white' : 'text-gray-900'}`}>{stat.value}</div>
+                            </div>
+                          ))}
+                        </div>
+
+                        {/* 강의 목록 테이블 */}
+                        <div className={`overflow-hidden ${
+                          settings.colorMode.defaultMode === 'dark' ? 'bg-gray-800' : 'bg-white'
+                        } ${
+                          settings.content.cardStyle === 'shadow' ? 'shadow-md' : settings.content.cardStyle === 'border' ? `border ${settings.colorMode.defaultMode === 'dark' ? 'border-gray-700' : 'border-gray-200'}` : ''
+                        } ${
+                          settings.content.cardRadius === 'none' ? 'rounded-none' : settings.content.cardRadius === 'sm' ? 'rounded' : 'rounded-lg'
+                        }`}>
+                          <div className={`px-4 py-3 border-b ${settings.colorMode.defaultMode === 'dark' ? 'border-gray-700' : 'border-gray-200'}`}>
+                            <h3 className={`text-sm font-semibold ${settings.colorMode.defaultMode === 'dark' ? 'text-white' : 'text-gray-900'}`}>내 강의 목록</h3>
+                          </div>
+                          <table className="w-full text-sm">
+                            <thead>
+                              <tr className={settings.colorMode.defaultMode === 'dark' ? 'bg-gray-700/50' : 'bg-gray-50'}>
+                                <th className={`px-4 py-2 text-left ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>강의명</th>
+                                <th className={`px-4 py-2 text-left ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>수강생</th>
+                                <th className={`px-4 py-2 text-left ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>상태</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {[
+                                { name: 'React 기초', students: 234, status: '진행중' },
+                                { name: 'TypeScript 입문', students: 156, status: '진행중' },
+                                { name: 'Node.js 백엔드', students: 89, status: '준비중' },
+                              ].map((row, i) => (
+                                <tr key={i} className={settings.content.tableStyle === 'striped' && i % 2 === 1 ? (settings.colorMode.defaultMode === 'dark' ? 'bg-gray-700/30' : 'bg-gray-50') : ''}>
+                                  <td className={`px-4 py-2 ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-200' : 'text-gray-900'}`}>{row.name}</td>
+                                  <td className={`px-4 py-2 ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>{row.students}명</td>
+                                  <td className="px-4 py-2">
+                                    <span className={`px-2 py-0.5 text-xs rounded ${
+                                      row.status === '진행중'
+                                        ? settings.componentStyle.badgeStyle === 'solid' ? 'bg-green-500 text-white' : 'bg-green-100 text-green-700'
+                                        : settings.componentStyle.badgeStyle === 'solid' ? 'bg-yellow-500 text-white' : 'bg-yellow-100 text-yellow-700'
+                                    }`}>{row.status}</span>
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                  </>
+                )}
+
+                {/* ========== 관리자 페이지 (TA) 미리보기 ========== */}
+                {previewPageType === 'admin' && (
+                  <>
+                {/* ===== 헤더 미리보기 ===== */}
+                <div
+                  className={`flex items-center px-4 ${
+                    settings.colorMode.defaultMode === 'dark' ? 'bg-gray-800' : 'bg-brand-primary'
+                  } ${
+                    settings.header.height === 'compact' ? 'h-12' : settings.header.height === 'large' ? 'h-20' : 'h-16'
+                  } ${
+                    settings.header.shadow === 'md' ? 'shadow-md' : settings.header.shadow === 'sm' ? 'shadow-sm' : ''
+                  } ${
+                    settings.header.backgroundOpacity === 'translucent'
+                      ? 'bg-opacity-90'
+                      : settings.header.backgroundOpacity === 'transparent'
+                      ? 'bg-opacity-70'
+                      : ''
+                  }`}
+                >
+                  {/* 모바일 메뉴 버튼 */}
+                  {previewMode === 'mobile' && (
+                    <button className="mr-2 text-white/80 hover:text-white">
+                      <Menu className="w-5 h-5" />
+                    </button>
+                  )}
+
+                  {/* 로고 */}
+                  {settings.header.showLogo && (
+                    <div className="flex items-center gap-2">
+                      <div className="w-8 h-8 bg-white/30 rounded-lg flex items-center justify-center">
+                        <span className="text-white font-bold text-sm">LP</span>
+                      </div>
+                      {previewMode !== 'mobile' && (
+                        <span className="text-white font-semibold text-sm">Learn Platform</span>
+                      )}
+                    </div>
+                  )}
+
+                  {/* 네비게이션 */}
+                  {previewMode !== 'mobile' && (
+                    <div
+                      className={`flex-1 flex ${
+                        settings.header.navPosition === 'center'
+                          ? 'justify-center'
+                          : settings.header.navPosition === 'right'
+                          ? 'justify-end'
+                          : 'justify-start ml-6'
+                      }`}
+                    >
+                      <nav className="flex gap-4">
+                        {['홈', '강의', '로드맵', '커뮤니티'].map((item, i) => (
+                          <span
+                            key={item}
+                            className={`text-sm ${
+                              i === 0 ? 'text-white font-medium' : 'text-white/70 hover:text-white'
+                            } cursor-pointer transition-colors`}
+                          >
+                            {item}
+                          </span>
+                        ))}
+                      </nav>
+                    </div>
+                  )}
+
+                  <div className="flex items-center gap-3 ml-auto">
+                    {/* 검색 */}
+                    {settings.header.showSearch && previewMode !== 'mobile' && (
+                      <div className="flex items-center gap-2 px-3 py-1.5 bg-white/20 rounded-lg">
+                        <Search className="w-4 h-4 text-white/70" />
+                        <span className="text-sm text-white/70">검색...</span>
+                      </div>
+                    )}
+                    {settings.header.showSearch && previewMode === 'mobile' && (
+                      <Search className="w-5 h-5 text-white/80" />
+                    )}
+
+                    {/* 알림 */}
+                    {settings.header.showNotifications && (
+                      <div className="relative">
+                        <Bell className="w-5 h-5 text-white/80" />
+                        <span className="absolute -top-1 -right-1 w-4 h-4 bg-red-500 rounded-full text-[10px] text-white flex items-center justify-center">
+                          3
+                        </span>
+                      </div>
+                    )}
+
+                    {/* 사용자 메뉴 */}
+                    <div
+                      className={`flex items-center gap-2 ${
+                        settings.header.userMenuStyle === 'dropdown'
+                          ? 'px-2 py-1 bg-white/10 rounded-lg cursor-pointer hover:bg-white/20'
+                          : ''
+                      }`}
+                    >
+                      <div
+                        className={`w-8 h-8 bg-white/30 flex items-center justify-center ${
+                          settings.componentStyle.avatarStyle === 'circle'
+                            ? 'rounded-full'
+                            : settings.componentStyle.avatarStyle === 'rounded'
+                            ? 'rounded-lg'
+                            : 'rounded-sm'
+                        }`}
+                      >
+                        <User className="w-4 h-4 text-white" />
+                      </div>
+                      {settings.header.userMenuStyle === 'name' && previewMode !== 'mobile' && (
+                        <span className="text-sm text-white">홍길동</span>
+                      )}
+                      {settings.header.userMenuStyle === 'dropdown' && previewMode !== 'mobile' && (
+                        <>
+                          <span className="text-sm text-white">홍길동</span>
+                          <ChevronDown className="w-4 h-4 text-white/70" />
+                        </>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                {/* ===== 본문 영역 ===== */}
+                <div
+                  className={`flex ${
+                    previewMode === 'mobile' ? 'flex-col' : ''
+                  }`}
+                  style={{
+                    height: `calc(100% - ${
+                      settings.header.height === 'compact' ? '48px' : settings.header.height === 'large' ? '80px' : '64px'
+                    } - ${settings.footer.enabled ? (settings.footer.layout === 'minimal' ? '40px' : settings.footer.layout === 'multi-column' ? '120px' : '60px') : '0px'})`,
+                  }}
+                >
+                  {/* ===== 사이드바 미리보기 ===== */}
+                  {settings.sidebar.style !== 'hidden' && previewMode !== 'mobile' && (
+                    <div
+                      className={`${
+                        settings.colorMode.defaultMode === 'dark' ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+                      } border-r flex flex-col ${
+                        settings.sidebar.defaultCollapsed
+                          ? 'w-16'
+                          : settings.sidebar.width === 'narrow'
+                          ? 'w-48'
+                          : settings.sidebar.width === 'wide'
+                          ? 'w-72'
+                          : 'w-60'
+                      } ${previewMode === 'tablet' && settings.sidebar.width !== 'narrow' ? 'w-48' : ''}`}
+                    >
+                      <div
+                        className={`flex-1 p-3 overflow-y-auto ${
+                          settings.sidebar.scrollbarStyle === 'hidden' ? 'scrollbar-hide' : ''
+                        }`}
+                      >
+                        {/* 메뉴 그룹 */}
+                        {settings.sidebar.menuGroupStyle === 'divider' && (
+                          <div
+                            className={`text-xs uppercase tracking-wider mb-2 px-2 ${
+                              settings.colorMode.defaultMode === 'dark' ? 'text-gray-500' : 'text-gray-400'
+                            }`}
+                          >
+                            {!settings.sidebar.defaultCollapsed && '메인 메뉴'}
+                          </div>
+                        )}
+
+                        <div
+                          className={`space-y-${
+                            settings.sidebar.itemSpacing === 'compact' ? '0.5' : settings.sidebar.itemSpacing === 'relaxed' ? '2' : '1'
+                          }`}
+                        >
+                          {[
+                            { icon: Home, label: '대시보드', active: true },
+                            { icon: FileText, label: '내 강의' },
+                            { icon: BarChart3, label: '학습 통계' },
+                            { icon: Users, label: '커뮤니티' },
+                          ].map((item, i) => (
+                            <div
+                              key={i}
+                              className={`flex items-center gap-3 px-3 py-2 cursor-pointer transition-all ${
+                                settings.content.cardRadius === 'none'
+                                  ? 'rounded-none'
+                                  : settings.content.cardRadius === 'sm'
+                                  ? 'rounded'
+                                  : settings.content.cardRadius === 'lg'
+                                  ? 'rounded-xl'
+                                  : 'rounded-lg'
+                              } ${
+                                item.active
+                                  ? settings.sidebar.activeIndicator === 'background'
+                                    ? 'bg-brand-primary/10 text-brand-primary'
+                                    : settings.sidebar.activeIndicator === 'leftBar'
+                                    ? 'border-l-3 border-brand-primary bg-brand-primary/5 text-brand-primary -ml-[1px]'
+                                    : settings.sidebar.activeIndicator === 'underline'
+                                    ? 'border-b-2 border-brand-primary text-brand-primary'
+                                    : 'text-brand-primary'
+                                  : settings.colorMode.defaultMode === 'dark'
+                                  ? 'text-gray-400 hover:text-gray-200 hover:bg-gray-700/50'
+                                  : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                              }`}
+                            >
+                              {settings.sidebar.showIcons && (
+                                <item.icon
+                                  className={`${
+                                    settings.componentStyle.iconSize === 'small'
+                                      ? 'w-4 h-4'
+                                      : settings.componentStyle.iconSize === 'large'
+                                      ? 'w-6 h-6'
+                                      : 'w-5 h-5'
+                                  } ${
+                                    item.active && settings.sidebar.activeIndicator === 'iconColor'
+                                      ? 'text-brand-primary'
+                                      : ''
+                                  }`}
+                                />
+                              )}
+                              {!settings.sidebar.defaultCollapsed && (
+                                <span className="text-sm font-medium">{item.label}</span>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+
+                        {/* 설정 메뉴 그룹 */}
+                        {settings.sidebar.menuGroupStyle === 'divider' && !settings.sidebar.defaultCollapsed && (
+                          <>
+                            <div
+                              className={`text-xs uppercase tracking-wider mt-6 mb-2 px-2 ${
+                                settings.colorMode.defaultMode === 'dark' ? 'text-gray-500' : 'text-gray-400'
+                              }`}
+                            >
+                              설정
+                            </div>
+                            <div
+                              className={`flex items-center gap-3 px-3 py-2 cursor-pointer transition-all ${
+                                settings.content.cardRadius === 'none'
+                                  ? 'rounded-none'
+                                  : settings.content.cardRadius === 'sm'
+                                  ? 'rounded'
+                                  : 'rounded-lg'
+                              } ${
+                                settings.colorMode.defaultMode === 'dark'
+                                  ? 'text-gray-400 hover:text-gray-200 hover:bg-gray-700/50'
+                                  : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                              }`}
+                            >
+                              {settings.sidebar.showIcons && <Settings className="w-5 h-5" />}
+                              <span className="text-sm font-medium">설정</span>
+                            </div>
+                          </>
+                        )}
+                      </div>
+
+                      {/* 사이드바 하단 영역 */}
+                      {settings.sidebar.bottomSection !== 'none' && !settings.sidebar.defaultCollapsed && (
+                        <div
+                          className={`p-3 border-t ${
+                            settings.colorMode.defaultMode === 'dark' ? 'border-gray-700' : 'border-gray-200'
+                          }`}
+                        >
+                          {settings.sidebar.bottomSection === 'userInfo' && (
+                            <div className="flex items-center gap-3">
+                              <div
+                                className={`w-10 h-10 bg-brand-primary/20 flex items-center justify-center ${
+                                  settings.componentStyle.avatarStyle === 'circle'
+                                    ? 'rounded-full'
+                                    : settings.componentStyle.avatarStyle === 'rounded'
+                                    ? 'rounded-lg'
+                                    : 'rounded-sm'
+                                }`}
+                              >
+                                <User className="w-5 h-5 text-brand-primary" />
+                              </div>
+                              <div className="flex-1 min-w-0">
+                                <div
+                                  className={`text-sm font-medium truncate ${
+                                    settings.colorMode.defaultMode === 'dark' ? 'text-gray-200' : 'text-gray-900'
+                                  }`}
+                                >
+                                  홍길동
+                                </div>
+                                <div
+                                  className={`text-xs truncate ${
+                                    settings.colorMode.defaultMode === 'dark' ? 'text-gray-500' : 'text-gray-500'
+                                  }`}
+                                >
+                                  hong@example.com
+                                </div>
+                              </div>
+                            </div>
+                          )}
+                          {settings.sidebar.bottomSection === 'logout' && (
+                            <button
+                              className={`w-full flex items-center gap-2 px-3 py-2 text-sm ${
+                                settings.colorMode.defaultMode === 'dark'
+                                  ? 'text-gray-400 hover:text-red-400'
+                                  : 'text-gray-600 hover:text-red-600'
+                              }`}
+                            >
+                              <X className="w-4 h-4" />
+                              로그아웃
+                            </button>
+                          )}
+                          {settings.sidebar.bottomSection === 'settings' && (
+                            <button
+                              className={`w-full flex items-center gap-2 px-3 py-2 text-sm ${
+                                settings.colorMode.defaultMode === 'dark'
+                                  ? 'text-gray-400 hover:text-gray-200'
+                                  : 'text-gray-600 hover:text-gray-900'
+                              }`}
+                            >
+                              <Settings className="w-4 h-4" />
+                              설정
+                            </button>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  {/* ===== 콘텐츠 영역 ===== */}
+                  <div className="flex-1 flex flex-col overflow-y-auto">
+                    <div
+                      className={`flex-1 ${
+                        settings.content.padding === 'none'
+                          ? 'p-0'
+                          : settings.content.padding === 'compact'
+                          ? 'p-3'
+                          : settings.content.padding === 'relaxed'
+                          ? 'p-8'
+                          : 'p-5'
+                      }`}
+                    >
+                      <div
+                        className={`${
+                          settings.content.maxWidth === 'md'
+                            ? 'max-w-2xl'
+                            : settings.content.maxWidth === 'lg'
+                            ? 'max-w-4xl'
+                            : settings.content.maxWidth === 'xl'
+                            ? 'max-w-6xl'
+                            : ''
+                        } mx-auto space-y-4`}
+                      >
+                        {/* 페이지 제목 */}
+                        <div className="mb-4">
+                          <h1
+                            className={`${
+                              settings.typography.fontScale === 'small'
+                                ? 'text-lg'
+                                : settings.typography.fontScale === 'large'
+                                ? 'text-2xl'
+                                : 'text-xl'
+                            } ${
+                              settings.typography.headingStyle === 'bold'
+                                ? 'font-bold'
+                                : settings.typography.headingStyle === 'semibold'
+                                ? 'font-semibold'
+                                : 'font-normal'
+                            } ${
+                              settings.typography.headingCase === 'uppercase'
+                                ? 'uppercase'
+                                : settings.typography.headingCase === 'capitalize'
+                                ? 'capitalize'
+                                : ''
+                            } ${settings.colorMode.defaultMode === 'dark' ? 'text-white' : 'text-gray-900'}`}
+                          >
+                            대시보드
+                          </h1>
+                          <p
+                            className={`mt-1 ${
+                              settings.typography.fontScale === 'small' ? 'text-xs' : settings.typography.fontScale === 'large' ? 'text-base' : 'text-sm'
+                            } ${
+                              settings.typography.lineHeight === 'tight'
+                                ? 'leading-tight'
+                                : settings.typography.lineHeight === 'relaxed'
+                                ? 'leading-relaxed'
+                                : 'leading-normal'
+                            } ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}
+                          >
+                            학습 현황을 한눈에 확인하세요
+                          </p>
+                        </div>
+
+                        {/* 통계 카드 그리드 */}
+                        <div className={`grid ${previewMode === 'mobile' ? 'grid-cols-2' : 'grid-cols-4'} gap-3`}>
+                          {[
+                            { label: '수강중', value: '12', color: 'blue' },
+                            { label: '완료', value: '8', color: 'green' },
+                            { label: '진행률', value: '67%', color: 'purple' },
+                            { label: '학습시간', value: '24h', color: 'orange' },
+                          ].map((stat, i) => (
+                            <div
+                              key={i}
+                              className={`p-3 ${
+                                settings.colorMode.defaultMode === 'dark' ? 'bg-gray-800' : 'bg-white'
+                              } ${
+                                settings.content.cardStyle === 'shadow'
+                                  ? 'shadow-md'
+                                  : settings.content.cardStyle === 'border'
+                                  ? settings.colorMode.defaultMode === 'dark'
+                                    ? 'border border-gray-700'
+                                    : 'border border-gray-200'
+                                  : settings.content.cardStyle === 'glass'
+                                  ? 'bg-white/50 backdrop-blur-sm border border-white/20'
+                                  : ''
+                              } ${
+                                settings.content.cardRadius === 'none'
+                                  ? 'rounded-none'
+                                  : settings.content.cardRadius === 'sm'
+                                  ? 'rounded'
+                                  : settings.content.cardRadius === 'lg'
+                                  ? 'rounded-xl'
+                                  : 'rounded-lg'
+                              }`}
+                            >
+                              <div
+                                className={`text-xs ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}
+                              >
+                                {stat.label}
+                              </div>
+                              <div
+                                className={`mt-1 ${
+                                  settings.typography.fontScale === 'small' ? 'text-lg' : settings.typography.fontScale === 'large' ? 'text-2xl' : 'text-xl'
+                                } font-bold ${settings.colorMode.defaultMode === 'dark' ? 'text-white' : 'text-gray-900'}`}
+                              >
+                                {stat.value}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+
+                        {/* 입력 필드 & 버튼 미리보기 */}
+                        <div
+                          className={`p-4 ${
+                            settings.colorMode.defaultMode === 'dark' ? 'bg-gray-800' : 'bg-white'
+                          } ${
+                            settings.content.cardStyle === 'shadow'
+                              ? 'shadow-md'
+                              : settings.content.cardStyle === 'border'
+                              ? settings.colorMode.defaultMode === 'dark'
+                                ? 'border border-gray-700'
+                                : 'border border-gray-200'
+                              : ''
+                          } ${
+                            settings.content.cardRadius === 'none'
+                              ? 'rounded-none'
+                              : settings.content.cardRadius === 'sm'
+                              ? 'rounded'
+                              : settings.content.cardRadius === 'lg'
+                              ? 'rounded-xl'
+                              : 'rounded-lg'
+                          }`}
+                        >
+                          <h3
+                            className={`mb-3 ${
+                              settings.typography.fontScale === 'small' ? 'text-sm' : settings.typography.fontScale === 'large' ? 'text-lg' : 'text-base'
+                            } ${
+                              settings.typography.headingStyle === 'bold'
+                                ? 'font-bold'
+                                : settings.typography.headingStyle === 'semibold'
+                                ? 'font-semibold'
+                                : 'font-normal'
+                            } ${settings.colorMode.defaultMode === 'dark' ? 'text-white' : 'text-gray-900'}`}
+                          >
+                            컴포넌트 스타일
+                          </h3>
+
+                          {/* 입력 필드 */}
+                          <div className="grid grid-cols-2 gap-3 mb-4">
+                            <div
+                              className={`px-3 py-2 text-sm ${
+                                settings.colorMode.defaultMode === 'dark'
+                                  ? 'bg-gray-700 text-gray-300 placeholder-gray-500'
+                                  : 'bg-gray-50 text-gray-900 placeholder-gray-400'
+                              } ${
+                                settings.componentStyle.inputStyle === 'outline'
+                                  ? settings.colorMode.defaultMode === 'dark'
+                                    ? 'border border-gray-600 bg-transparent'
+                                    : 'border border-gray-300 bg-white'
+                                  : settings.componentStyle.inputStyle === 'underline'
+                                  ? 'border-b-2 border-gray-300 bg-transparent rounded-none px-0'
+                                  : ''
+                              } ${
+                                settings.componentStyle.inputStyle !== 'underline'
+                                  ? settings.content.cardRadius === 'none'
+                                    ? 'rounded-none'
+                                    : settings.content.cardRadius === 'sm'
+                                    ? 'rounded'
+                                    : settings.content.cardRadius === 'lg'
+                                    ? 'rounded-xl'
+                                    : 'rounded-lg'
+                                  : ''
+                              }`}
+                            >
+                              이메일 입력...
+                            </div>
+                            <div
+                              className={`px-3 py-2 text-sm ${
+                                settings.colorMode.defaultMode === 'dark'
+                                  ? 'bg-gray-700 text-gray-300'
+                                  : 'bg-gray-50 text-gray-900'
+                              } ${
+                                settings.componentStyle.inputStyle === 'outline'
+                                  ? settings.colorMode.defaultMode === 'dark'
+                                    ? 'border border-gray-600 bg-transparent'
+                                    : 'border border-gray-300 bg-white'
+                                  : settings.componentStyle.inputStyle === 'underline'
+                                  ? 'border-b-2 border-gray-300 bg-transparent rounded-none px-0'
+                                  : ''
+                              } ${
+                                settings.componentStyle.inputStyle !== 'underline'
+                                  ? settings.content.cardRadius === 'none'
+                                    ? 'rounded-none'
+                                    : settings.content.cardRadius === 'sm'
+                                    ? 'rounded'
+                                    : settings.content.cardRadius === 'lg'
+                                    ? 'rounded-xl'
+                                    : 'rounded-lg'
+                                  : ''
+                              }`}
+                            >
+                              비밀번호 입력...
+                            </div>
+                          </div>
+
+                          {/* 버튼들 */}
+                          <div className="flex flex-wrap gap-2 mb-4">
+                            <button
+                              className={`px-4 py-2 text-sm bg-brand-primary text-white ${
+                                settings.content.buttonStyle === 'square'
+                                  ? 'rounded-none'
+                                  : settings.content.buttonStyle === 'pill'
+                                  ? 'rounded-full'
+                                  : 'rounded-lg'
+                              }`}
+                            >
+                              Primary
+                            </button>
+                            <button
+                              className={`px-4 py-2 text-sm ${
+                                settings.colorMode.defaultMode === 'dark'
+                                  ? 'bg-gray-700 text-gray-200'
+                                  : 'bg-gray-200 text-gray-700'
+                              } ${
+                                settings.content.buttonStyle === 'square'
+                                  ? 'rounded-none'
+                                  : settings.content.buttonStyle === 'pill'
+                                  ? 'rounded-full'
+                                  : 'rounded-lg'
+                              }`}
+                            >
+                              Secondary
+                            </button>
+                            <button
+                              className={`px-4 py-2 text-sm border ${
+                                settings.colorMode.defaultMode === 'dark'
+                                  ? 'border-gray-600 text-gray-300 hover:bg-gray-700'
+                                  : 'border-gray-300 text-gray-700 hover:bg-gray-50'
+                              } ${
+                                settings.content.buttonStyle === 'square'
+                                  ? 'rounded-none'
+                                  : settings.content.buttonStyle === 'pill'
+                                  ? 'rounded-full'
+                                  : 'rounded-lg'
+                              }`}
+                            >
+                              Outline
+                            </button>
+                          </div>
+
+                          {/* 배지들 */}
+                          <div className="flex flex-wrap gap-2 mb-4">
+                            <span
+                              className={`px-2 py-1 text-xs ${
+                                settings.componentStyle.badgeStyle === 'solid'
+                                  ? 'bg-blue-500 text-white'
+                                  : settings.componentStyle.badgeStyle === 'outline'
+                                  ? 'border border-blue-500 text-blue-500'
+                                  : 'bg-blue-100 text-blue-700'
+                              } ${
+                                settings.content.buttonStyle === 'pill' ? 'rounded-full' : 'rounded'
+                              }`}
+                            >
+                              진행중
+                            </span>
+                            <span
+                              className={`px-2 py-1 text-xs ${
+                                settings.componentStyle.badgeStyle === 'solid'
+                                  ? 'bg-green-500 text-white'
+                                  : settings.componentStyle.badgeStyle === 'outline'
+                                  ? 'border border-green-500 text-green-500'
+                                  : 'bg-green-100 text-green-700'
+                              } ${
+                                settings.content.buttonStyle === 'pill' ? 'rounded-full' : 'rounded'
+                              }`}
+                            >
+                              완료
+                            </span>
+                            <span
+                              className={`px-2 py-1 text-xs ${
+                                settings.componentStyle.badgeStyle === 'solid'
+                                  ? 'bg-orange-500 text-white'
+                                  : settings.componentStyle.badgeStyle === 'outline'
+                                  ? 'border border-orange-500 text-orange-500'
+                                  : 'bg-orange-100 text-orange-700'
+                              } ${
+                                settings.content.buttonStyle === 'pill' ? 'rounded-full' : 'rounded'
+                              }`}
+                            >
+                              대기중
+                            </span>
+                            <span
+                              className={`px-2 py-1 text-xs ${
+                                settings.componentStyle.badgeStyle === 'solid'
+                                  ? 'bg-red-500 text-white'
+                                  : settings.componentStyle.badgeStyle === 'outline'
+                                  ? 'border border-red-500 text-red-500'
+                                  : 'bg-red-100 text-red-700'
+                              } ${
+                                settings.content.buttonStyle === 'pill' ? 'rounded-full' : 'rounded'
+                              }`}
+                            >
+                              취소됨
+                            </span>
+                          </div>
+
+                          {/* 아바타들 */}
+                          <div className="flex items-center gap-2">
+                            <span className={`text-xs ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}>
+                              아바타:
+                            </span>
+                            <div className="flex -space-x-2">
+                              {['bg-blue-500', 'bg-green-500', 'bg-purple-500', 'bg-orange-500'].map((color, i) => (
+                                <div
+                                  key={i}
+                                  className={`w-8 h-8 ${color} flex items-center justify-center text-white text-xs font-medium border-2 ${
+                                    settings.colorMode.defaultMode === 'dark' ? 'border-gray-800' : 'border-white'
+                                  } ${
+                                    settings.componentStyle.avatarStyle === 'circle'
+                                      ? 'rounded-full'
+                                      : settings.componentStyle.avatarStyle === 'rounded'
+                                      ? 'rounded-lg'
+                                      : 'rounded-sm'
+                                  }`}
+                                >
+                                  {String.fromCharCode(65 + i)}
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        </div>
+
+                        {/* 테이블 미리보기 */}
+                        <div
+                          className={`overflow-hidden ${
+                            settings.colorMode.defaultMode === 'dark' ? 'bg-gray-800' : 'bg-white'
+                          } ${
+                            settings.content.cardStyle === 'shadow'
+                              ? 'shadow-md'
+                              : settings.content.cardStyle === 'border'
+                              ? settings.colorMode.defaultMode === 'dark'
+                                ? 'border border-gray-700'
+                                : 'border border-gray-200'
+                              : ''
+                          } ${
+                            settings.content.cardRadius === 'none'
+                              ? 'rounded-none'
+                              : settings.content.cardRadius === 'sm'
+                              ? 'rounded'
+                              : settings.content.cardRadius === 'lg'
+                              ? 'rounded-xl'
+                              : 'rounded-lg'
+                          }`}
+                        >
+                          <div className="p-3 border-b border-gray-200 dark:border-gray-700">
+                            <h3
+                              className={`${
+                                settings.typography.fontScale === 'small' ? 'text-sm' : settings.typography.fontScale === 'large' ? 'text-lg' : 'text-base'
+                              } ${
+                                settings.typography.headingStyle === 'bold'
+                                  ? 'font-bold'
+                                  : settings.typography.headingStyle === 'semibold'
+                                  ? 'font-semibold'
+                                  : 'font-normal'
+                              } ${settings.colorMode.defaultMode === 'dark' ? 'text-white' : 'text-gray-900'}`}
+                            >
+                              테이블 스타일
+                            </h3>
+                          </div>
+                          <table className="w-full text-sm">
+                            <thead>
+                              <tr
+                                className={
+                                  settings.colorMode.defaultMode === 'dark' ? 'bg-gray-700/50' : 'bg-gray-50'
+                                }
+                              >
+                                <th className={`px-3 py-2 text-left ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
+                                  강의명
+                                </th>
+                                <th className={`px-3 py-2 text-left ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
+                                  진행률
+                                </th>
+                                <th className={`px-3 py-2 text-left ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
+                                  상태
+                                </th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {[
+                                { name: 'React 기초', progress: '80%', status: '진행중' },
+                                { name: 'TypeScript', progress: '100%', status: '완료' },
+                                { name: 'Node.js', progress: '45%', status: '진행중' },
+                              ].map((row, i) => (
+                                <tr
+                                  key={i}
+                                  className={`${
+                                    settings.content.tableStyle === 'striped' && i % 2 === 1
+                                      ? settings.colorMode.defaultMode === 'dark'
+                                        ? 'bg-gray-700/30'
+                                        : 'bg-gray-50'
+                                      : ''
+                                  } ${
+                                    settings.content.tableStyle === 'bordered'
+                                      ? settings.colorMode.defaultMode === 'dark'
+                                        ? 'border-b border-gray-700'
+                                        : 'border-b border-gray-200'
+                                      : ''
+                                  }`}
+                                >
+                                  <td className={`px-3 py-2 ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-200' : 'text-gray-900'}`}>
+                                    {row.name}
+                                  </td>
+                                  <td className={`px-3 py-2 ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
+                                    {row.progress}
+                                  </td>
+                                  <td className="px-3 py-2">
+                                    <span
+                                      className={`px-2 py-0.5 text-xs ${
+                                        row.status === '완료'
+                                          ? settings.componentStyle.badgeStyle === 'solid'
+                                            ? 'bg-green-500 text-white'
+                                            : settings.componentStyle.badgeStyle === 'outline'
+                                            ? 'border border-green-500 text-green-500'
+                                            : 'bg-green-100 text-green-700'
+                                          : settings.componentStyle.badgeStyle === 'solid'
+                                          ? 'bg-blue-500 text-white'
+                                          : settings.componentStyle.badgeStyle === 'outline'
+                                          ? 'border border-blue-500 text-blue-500'
+                                          : 'bg-blue-100 text-blue-700'
+                                      } rounded`}
+                                    >
+                                      {row.status}
+                                    </span>
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* ===== 푸터 미리보기 ===== */}
+                    {settings.footer.enabled && (
+                      <div
+                        className={`mt-auto ${
+                          settings.footer.layout === 'minimal'
+                            ? 'py-3'
+                            : settings.footer.layout === 'multi-column'
+                            ? 'py-6'
+                            : 'py-4'
+                        } px-4 ${
+                          settings.colorMode.defaultMode === 'dark' ? 'bg-gray-800 border-gray-700' : 'bg-gray-100 border-gray-200'
+                        } border-t`}
+                      >
+                        {settings.footer.layout === 'multi-column' && (
+                          <div className={`grid ${previewMode === 'mobile' ? 'grid-cols-1 gap-4' : 'grid-cols-4 gap-6'} mb-4`}>
+                            {/* 회사 정보 */}
+                            {settings.footer.showCompanyInfo && (
+                              <div>
+                                <h4
+                                  className={`text-sm font-semibold mb-2 ${
+                                    settings.colorMode.defaultMode === 'dark' ? 'text-gray-200' : 'text-gray-900'
+                                  }`}
+                                >
+                                  회사 정보
+                                </h4>
+                                <div className={`space-y-1 text-xs ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
+                                  {settings.footer.companyInfoFields.includes('address') && (
+                                    <div className="flex items-center gap-1">
+                                      <MapPin className="w-3 h-3" />
+                                      <span>서울시 강남구</span>
+                                    </div>
+                                  )}
+                                  {settings.footer.companyInfoFields.includes('phone') && (
+                                    <div className="flex items-center gap-1">
+                                      <Phone className="w-3 h-3" />
+                                      <span>02-1234-5678</span>
+                                    </div>
+                                  )}
+                                  {settings.footer.companyInfoFields.includes('email') && (
+                                    <div className="flex items-center gap-1">
+                                      <Mail className="w-3 h-3" />
+                                      <span>info@example.com</span>
+                                    </div>
+                                  )}
+                                  {settings.footer.companyInfoFields.includes('businessNumber') && (
+                                    <div className="flex items-center gap-1">
+                                      <Building className="w-3 h-3" />
+                                      <span>123-45-67890</span>
+                                    </div>
+                                  )}
+                                </div>
+                              </div>
+                            )}
+
+                            {/* 링크 */}
+                            {settings.footer.showLinks && (
+                              <div>
+                                <h4
+                                  className={`text-sm font-semibold mb-2 ${
+                                    settings.colorMode.defaultMode === 'dark' ? 'text-gray-200' : 'text-gray-900'
+                                  }`}
+                                >
+                                  바로가기
+                                </h4>
+                                <div className={`space-y-1 text-xs ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
+                                  {['이용약관', '개인정보처리방침', '고객센터'].map((link) => (
+                                    <div key={link} className="hover:underline cursor-pointer">
+                                      {link}
+                                    </div>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
+
+                            {/* 뉴스레터 */}
+                            {settings.footer.showNewsletter && (
+                              <div className="col-span-2">
+                                <h4
+                                  className={`text-sm font-semibold mb-2 ${
+                                    settings.colorMode.defaultMode === 'dark' ? 'text-gray-200' : 'text-gray-900'
+                                  }`}
+                                >
+                                  뉴스레터 구독
+                                </h4>
+                                <div className="flex gap-2">
+                                  <div
+                                    className={`flex-1 px-3 py-1.5 text-xs ${
+                                      settings.colorMode.defaultMode === 'dark' ? 'bg-gray-700 text-gray-400' : 'bg-white text-gray-400'
+                                    } rounded`}
+                                  >
+                                    이메일을 입력하세요
+                                  </div>
+                                  <button className="px-3 py-1.5 text-xs bg-brand-primary text-white rounded">
+                                    구독
+                                  </button>
+                                </div>
+                              </div>
+                            )}
+                          </div>
+                        )}
+
+                        {/* 하단 영역 */}
+                        <div
+                          className={`flex ${
+                            previewMode === 'mobile' ? 'flex-col gap-3' : 'items-center justify-between'
+                          }`}
+                        >
+                          {/* 저작권 */}
+                          {settings.footer.showCopyright && (
+                            <div className={`text-xs ${settings.colorMode.defaultMode === 'dark' ? 'text-gray-500' : 'text-gray-500'}`}>
+                              © 2024 Learn Platform. All rights reserved.
+                            </div>
+                          )}
+
+                          {/* 소셜 링크 */}
+                          {settings.footer.showSocialLinks && settings.footer.socialPlatforms.length > 0 && (
+                            <div className="flex items-center gap-3">
+                              {settings.footer.socialPlatforms.includes('facebook') && (
+                                <Facebook
+                                  className={`w-4 h-4 cursor-pointer ${
+                                    settings.colorMode.defaultMode === 'dark' ? 'text-gray-400 hover:text-blue-400' : 'text-gray-500 hover:text-blue-600'
+                                  }`}
+                                />
+                              )}
+                              {settings.footer.socialPlatforms.includes('twitter') && (
+                                <Twitter
+                                  className={`w-4 h-4 cursor-pointer ${
+                                    settings.colorMode.defaultMode === 'dark' ? 'text-gray-400 hover:text-sky-400' : 'text-gray-500 hover:text-sky-500'
+                                  }`}
+                                />
+                              )}
+                              {settings.footer.socialPlatforms.includes('instagram') && (
+                                <Instagram
+                                  className={`w-4 h-4 cursor-pointer ${
+                                    settings.colorMode.defaultMode === 'dark' ? 'text-gray-400 hover:text-pink-400' : 'text-gray-500 hover:text-pink-600'
+                                  }`}
+                                />
+                              )}
+                              {settings.footer.socialPlatforms.includes('youtube') && (
+                                <Youtube
+                                  className={`w-4 h-4 cursor-pointer ${
+                                    settings.colorMode.defaultMode === 'dark' ? 'text-gray-400 hover:text-red-400' : 'text-gray-500 hover:text-red-600'
+                                  }`}
+                                />
+                              )}
+                              {settings.footer.socialPlatforms.includes('linkedin') && (
+                                <Linkedin
+                                  className={`w-4 h-4 cursor-pointer ${
+                                    settings.colorMode.defaultMode === 'dark' ? 'text-gray-400 hover:text-blue-400' : 'text-gray-500 hover:text-blue-700'
+                                  }`}
+                                />
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* 모바일 하단 네비게이션 */}
+                {previewMode === 'mobile' && settings.responsive.mobileNavStyle === 'bottom' && (
+                  <div
+                    className={`flex items-center justify-around py-2 border-t ${
+                      settings.colorMode.defaultMode === 'dark' ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+                    }`}
+                  >
+                    {[
+                      { icon: Home, label: '홈', active: true },
+                      { icon: FileText, label: '강의' },
+                      { icon: Search, label: '검색' },
+                      { icon: User, label: '마이' },
+                    ].map((item, i) => (
+                      <div
+                        key={i}
+                        className={`flex flex-col items-center gap-0.5 ${
+                          item.active
+                            ? 'text-brand-primary'
+                            : settings.colorMode.defaultMode === 'dark'
+                            ? 'text-gray-500'
+                            : 'text-gray-400'
+                        }`}
+                      >
+                        <item.icon className="w-5 h-5" />
+                        <span className="text-[10px]">{item.label}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                  </>
+                )}
+              </div>
             </div>
-            <div className="space-y-2">
-              <Label>여백</Label>
-              <Select
-                value={settings.content.padding}
-                onValueChange={(v) => {
-                  setSettings({
-                    ...settings,
-                    content: { ...settings.content, padding: v as ContentSettings['padding'] },
-                  });
-                  setHasChanges(true);
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">없음</SelectItem>
-                  <SelectItem value="compact">좁게</SelectItem>
-                  <SelectItem value="normal">보통</SelectItem>
-                  <SelectItem value="relaxed">넓게</SelectItem>
-                </SelectContent>
-              </Select>
+
+            {/* 설정 요약 */}
+            <div
+              className={`p-4 rounded-lg ${
+                settings.colorMode.defaultMode === 'dark' ? 'bg-gray-800' : 'bg-gray-50'
+              }`}
+            >
+              <h4 className="text-sm font-semibold mb-3 text-gray-700">현재 적용된 주요 설정</h4>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-xs">
+                <div>
+                  <span className="text-gray-500">헤더 높이:</span>{' '}
+                  <span className="font-medium text-gray-700">{settings.header.height}</span>
+                </div>
+                <div>
+                  <span className="text-gray-500">사이드바 너비:</span>{' '}
+                  <span className="font-medium text-gray-700">{settings.sidebar.width}</span>
+                </div>
+                <div>
+                  <span className="text-gray-500">카드 스타일:</span>{' '}
+                  <span className="font-medium text-gray-700">{settings.content.cardStyle}</span>
+                </div>
+                <div>
+                  <span className="text-gray-500">버튼 스타일:</span>{' '}
+                  <span className="font-medium text-gray-700">{settings.content.buttonStyle}</span>
+                </div>
+                <div>
+                  <span className="text-gray-500">폰트 크기:</span>{' '}
+                  <span className="font-medium text-gray-700">{settings.typography.fontScale}</span>
+                </div>
+                <div>
+                  <span className="text-gray-500">컬러 모드:</span>{' '}
+                  <span className="font-medium text-gray-700">{settings.colorMode.defaultMode}</span>
+                </div>
+                <div>
+                  <span className="text-gray-500">입력 필드:</span>{' '}
+                  <span className="font-medium text-gray-700">{settings.componentStyle.inputStyle}</span>
+                </div>
+                <div>
+                  <span className="text-gray-500">배지 스타일:</span>{' '}
+                  <span className="font-medium text-gray-700">{settings.componentStyle.badgeStyle}</span>
+                </div>
+              </div>
             </div>
           </CardContent>
         </Card>
       </div>
-
-      {/* Preview */}
-      <Card className="mt-6">
-        <CardHeader>
-          <CardTitle>미리보기</CardTitle>
-          <CardDescription>현재 설정이 적용된 레이아웃 미리보기입니다</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="border rounded-lg overflow-hidden h-64 bg-bg-secondary">
-            <div className="h-10 bg-brand-primary flex items-center px-4">
-              {settings.header.showLogo && <div className="w-20 h-5 bg-white/30 rounded" />}
-              {settings.header.showSearch && <div className="ml-auto w-32 h-5 bg-white/20 rounded mr-2" />}
-              {settings.header.showNotifications && <div className="w-5 h-5 bg-white/20 rounded" />}
-            </div>
-            <div className="flex h-[calc(100%-40px)]">
-              {settings.sidebar.style !== 'hidden' && (
-                <div className={`bg-gray-100 ${settings.sidebar.defaultCollapsed ? 'w-12' : 'w-48'} p-2`}>
-                  <div className="space-y-2">
-                    {[1, 2, 3].map((i) => (
-                      <div key={i} className="flex items-center gap-2">
-                        {settings.sidebar.showIcons && <div className="w-4 h-4 bg-gray-300 rounded" />}
-                        {!settings.sidebar.defaultCollapsed && <div className="flex-1 h-3 bg-gray-300 rounded" />}
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-              <div className="flex-1 flex flex-col">
-                <div className="flex-1 p-4">
-                  <div className="h-4 bg-gray-200 rounded w-1/3 mb-2" />
-                  <div className="h-3 bg-gray-200 rounded w-2/3" />
-                </div>
-                {settings.footer.enabled && (
-                  <div className="h-8 bg-gray-200 flex items-center justify-center px-4">
-                    {settings.footer.showCopyright && <div className="h-2 w-32 bg-gray-300 rounded" />}
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/src/pages/tu/index.ts
+++ b/src/pages/tu/index.ts
@@ -16,7 +16,7 @@ export {
   RoadmapCreatePage,
 } from './teaching';
 export { SettingsLanguagePage } from './settings';
-export { LandingPage, CoursesExplorePage, RoadmapExplorePage, RoadmapDetailPage, CommunityPage, CommunityDetailPage, CartPage, WishlistPage, NotificationsPage, NotificationDetailPage, CourseDetailPage, InstructorProfilePage } from './main';
+export { LandingPage, CoursesExplorePage, RoadmapExplorePage, RoadmapDetailPage, CommunityPage, CommunityDetailPage, CartPage, WishlistPage, NotificationsPage, NotificationDetailPage, CourseDetailPage, InstructorProfilePage, SearchPage } from './main';
 export { CatalogPage, CatalogDetailPage } from './catalog';
 export { MyLearningPage, LearningDetailPage, LearningPlayerPage } from './learning';
 export { MyPage, MyPageHome, ProfilePage, MyTeachingPage, TeachingStatsPage, CompletedCoursesPage, CertificationsPage, MyPostsPage, MyCommentsPage } from './mypage';

--- a/src/pages/tu/main/CommunityDetailPage.tsx
+++ b/src/pages/tu/main/CommunityDetailPage.tsx
@@ -726,9 +726,9 @@ export function CommunityDetailPage() {
           <span>목록으로</span>
         </button>
 
-        <div className="flex flex-col lg:flex-row gap-8">
+        <div className="max-w-6xl mx-auto flex flex-col lg:flex-row gap-8">
           {/* 메인 콘텐츠 */}
-          <article className="flex-1 max-w-3xl">
+          <article className="flex-1 min-w-0">
             {/* 프로필 섹션 */}
             <div className="flex items-center gap-4 mb-6">
               {getImageUrl(post.author.avatar) ? (

--- a/src/pages/tu/main/CommunityPage.tsx
+++ b/src/pages/tu/main/CommunityPage.tsx
@@ -168,6 +168,9 @@ export function CommunityPage() {
   const [popularTab, setPopularTab] = useState<PopularTab>('today');
   const [isWriteModalOpen, setIsWriteModalOpen] = useState(false);
   const [carouselIndex, setCarouselIndex] = useState(0);
+  const [pendingTags, setPendingTags] = useState<string[]>([]); // 추가 대기 중인 태그
+  const [confirmedTags, setConfirmedTags] = useState<string[]>([]); // 사용자가 확인한 태그
+  const [rejectedTags, setRejectedTags] = useState<string[]>([]); // 거절된 태그
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
   const navigate = useNavigate();
@@ -188,7 +191,7 @@ export function CommunityPage() {
   const { data: commentedPostsData } = useCommentedPosts(0, 5, USE_API && isAuthenticated);
 
   // 사용자의 관심 태그 추출 (내가 쓴 글 + 참여한 글에서 태그 수집)
-  const userInterestTags = (() => {
+  const suggestedTags = (() => {
     const tagCount: Record<string, number> = {};
 
     // 내가 쓴 글의 태그
@@ -211,6 +214,38 @@ export function CommunityPage() {
       .slice(0, 5)
       .map(([tag]) => tag);
   })();
+
+  // 추가 대기 중인 태그 업데이트 (새로운 태그가 발견되면)
+  useEffect(() => {
+    const newTags = suggestedTags.filter(tag =>
+      !confirmedTags.includes(tag) &&
+      !pendingTags.includes(tag) &&
+      !rejectedTags.includes(tag)
+    );
+    if (newTags.length > 0) {
+      setPendingTags(prev => [...prev, ...newTags]);
+    }
+  }, [suggestedTags, confirmedTags, pendingTags, rejectedTags]);
+
+  // 실제 사용할 관심 태그 (확인된 태그만)
+  const userInterestTags = confirmedTags;
+
+  // 태그 추가 확인 핸들러
+  const handleConfirmTag = (tag: string) => {
+    setConfirmedTags(prev => [...prev, tag]);
+    setPendingTags(prev => prev.filter(t => t !== tag));
+  };
+
+  // 태그 추가 거절 핸들러
+  const handleRejectTag = (tag: string) => {
+    setPendingTags(prev => prev.filter(t => t !== tag));
+    setRejectedTags(prev => [...prev, tag]);
+  };
+
+  // 태그 삭제 핸들러
+  const handleRemoveTag = (tag: string) => {
+    setConfirmedTags(prev => prev.filter(t => t !== tag));
+  };
 
   // 관심 태그 기반 추천 게시글 필터링
   const recommendedPosts = (() => {
@@ -597,7 +632,7 @@ export function CommunityPage() {
             </div>
 
             {/* 관심 태그 기반 추천 */}
-            {(userInterestTags.length > 0 || recommendedPosts.length > 0) && (
+            {(pendingTags.length > 0 || userInterestTags.length > 0 || recommendedPosts.length > 0) && (
               <div className={`mt-6 rounded-2xl p-6 border ${
                 isDark ? 'glass border-white/10' : 'bg-gradient-to-r from-[#6778ff]/5 to-[#10b981]/5 border-gray-200'
               }`}>
@@ -613,7 +648,53 @@ export function CommunityPage() {
                   </div>
                 </div>
 
-                {/* 관심 태그 */}
+                {/* 추천 태그 추가 질문 */}
+                {pendingTags.length > 0 && (
+                  <div className={`mb-4 p-4 rounded-xl border ${
+                    isDark ? 'bg-[#f59e0b]/10 border-[#f59e0b]/20' : 'bg-[#f59e0b]/5 border-[#f59e0b]/20'
+                  }`}>
+                    <p className="text-sm landing-text-primary mb-3 flex items-center gap-2">
+                      <Sparkles className="w-4 h-4 text-[#f59e0b]" />
+                      이 태그를 관심 태그에 추가할까요?
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {pendingTags.map((tag) => (
+                        <div
+                          key={tag}
+                          className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-xs font-medium ${
+                            isDark ? 'bg-white/10 text-gray-300' : 'bg-gray-100 text-gray-600'
+                          }`}
+                        >
+                          <span>#{tag}</span>
+                          <button
+                            onClick={() => handleConfirmTag(tag)}
+                            className={`ml-1 p-0.5 rounded-full transition-colors ${
+                              isDark ? 'hover:bg-green-500/30 text-green-400' : 'hover:bg-green-100 text-green-600'
+                            }`}
+                            title="추가"
+                          >
+                            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                            </svg>
+                          </button>
+                          <button
+                            onClick={() => handleRejectTag(tag)}
+                            className={`p-0.5 rounded-full transition-colors ${
+                              isDark ? 'hover:bg-red-500/30 text-red-400' : 'hover:bg-red-100 text-red-600'
+                            }`}
+                            title="거절"
+                          >
+                            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* 확인된 관심 태그 */}
                 {userInterestTags.length > 0 && (
                   <div className="mb-4">
                     <p className="text-xs landing-text-muted mb-2 flex items-center gap-1">
@@ -621,17 +702,29 @@ export function CommunityPage() {
                     </p>
                     <div className="flex flex-wrap gap-2">
                       {userInterestTags.map((tag) => (
-                        <Link
+                        <div
                           key={tag}
-                          to={`/tu/b2c/community?search=${encodeURIComponent(tag)}`}
-                          className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all ${
+                          className={`group flex items-center gap-1 px-3 py-1.5 rounded-full text-xs font-medium transition-all ${
                             isDark
-                              ? 'bg-[#6778ff]/20 text-[#6778ff] hover:bg-[#6778ff]/30'
-                              : 'bg-[#6778ff]/10 text-[#6778ff] hover:bg-[#6778ff]/20'
+                              ? 'bg-[#6778ff]/20 text-[#6778ff]'
+                              : 'bg-[#6778ff]/10 text-[#6778ff]'
                           }`}
                         >
-                          #{tag}
-                        </Link>
+                          <Link to={`/tu/b2c/community?search=${encodeURIComponent(tag)}`}>
+                            #{tag}
+                          </Link>
+                          <button
+                            onClick={() => handleRemoveTag(tag)}
+                            className={`opacity-0 group-hover:opacity-100 p-0.5 rounded-full transition-all ${
+                              isDark ? 'hover:bg-white/20' : 'hover:bg-[#6778ff]/20'
+                            }`}
+                            title="삭제"
+                          >
+                            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                          </button>
+                        </div>
                       ))}
                     </div>
                   </div>

--- a/src/pages/tu/main/InstructorProfilePage.tsx
+++ b/src/pages/tu/main/InstructorProfilePage.tsx
@@ -358,14 +358,17 @@ export function InstructorProfilePage() {
                     <Heart className={`w-4 h-4 ${isFollowing ? 'fill-current text-red-500' : ''}`} />
                     {isFollowing ? '팔로잉' : '팔로우'}
                   </Button>
-                  <Button
-                    variant="outline"
+                  <button
                     onClick={handleShare}
-                    className={`gap-2 ${isDark ? 'border-white/20 text-white hover:bg-white/10' : ''}`}
+                    className={`flex items-center gap-2 px-4 py-2 rounded-md font-medium transition-colors ${
+                      isDark
+                        ? 'bg-white/10 text-white hover:bg-white/20 border border-white/20'
+                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200'
+                    }`}
                   >
                     <Share2 className="w-4 h-4" />
                     공유
-                  </Button>
+                  </button>
                 </div>
               </div>
 

--- a/src/pages/tu/main/RoadmapDetailPage.tsx
+++ b/src/pages/tu/main/RoadmapDetailPage.tsx
@@ -273,7 +273,7 @@ export function RoadmapDetailPage() {
       <div className={`min-h-screen flex items-center justify-center ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
         <div className="text-center">
           <p className={`text-xl ${isDark ? 'text-white' : 'text-gray-900'}`}>로드맵을 불러올 수 없습니다.</p>
-          <Link to="/tu/b2c/roadmap" className="text-[#6778ff] hover:underline mt-4 inline-block">
+          <Link to="/tu/b2c/roadmaps" className="text-[#6778ff] hover:underline mt-4 inline-block">
             로드맵 목록으로 돌아가기
           </Link>
         </div>
@@ -315,7 +315,7 @@ export function RoadmapDetailPage() {
             <div className="lg:w-1/2">
               {/* Breadcrumb */}
               <nav className={`flex items-center gap-2 text-sm mb-4 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
-                <Link to="/tu/b2c/roadmap" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
+                <Link to="/tu/b2c/roadmaps" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
                   로드맵
                 </Link>
                 <ChevronRight className="w-4 h-4" />

--- a/src/pages/tu/main/SearchPage.tsx
+++ b/src/pages/tu/main/SearchPage.tsx
@@ -1,0 +1,1459 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useSearchParams, Link } from 'react-router-dom';
+import {
+  Search,
+  Loader2,
+  BookOpen,
+  Map,
+  MessageSquare,
+  Clock,
+  Star,
+  ChevronRight,
+  X,
+  SlidersHorizontal,
+  ChevronDown,
+} from 'lucide-react';
+import { useThemeStore } from '@/store/common/themeStore';
+import { LandingHeader } from '@/components/landing/LandingHeader';
+import { LandingFooter } from '@/components/landing/LandingFooter';
+import { LandingCourseCard } from '@/components/landing';
+import { useCourseTimeCatalog, useRoadmapExplore, useCommunityPosts } from '@/hooks/tu';
+import type { RoadmapExploreItem } from '@/types/tu/roadmapExplore.types';
+import type { CommunityPost } from '@/types/tu/community.types';
+import { ROADMAP_LEVEL_LABELS } from '@/types/tu/roadmapExplore.types';
+
+// API 사용 여부 (false면 더미 데이터 사용)
+const USE_API = false;
+
+// 더미 강의 카드 데이터 (LandingCourseCard용)
+interface MockCourseCard {
+  id: number;
+  title: string;
+  instructor: string;
+  price: string;
+  rating: number;
+  reviewCount: number;
+  image: string;
+  tags: string[];
+  category: string;
+  keywords: string[]; // 검색용 키워드
+}
+
+const MOCK_COURSES: MockCourseCard[] = [
+  {
+    id: 1,
+    title: 'React 완전 정복: 기초부터 고급까지',
+    instructor: '김리액트',
+    price: '₩99,000',
+    rating: 4.8,
+    reviewCount: 45,
+    image: 'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=250&fit=crop',
+    tags: ['상시모집', '인기'],
+    category: '개발',
+    keywords: ['React', '리액트', '프론트엔드', 'JavaScript', 'JS', '강의'],
+  },
+  {
+    id: 2,
+    title: 'TypeScript 마스터클래스',
+    instructor: '박타입',
+    price: '₩79,000',
+    rating: 4.7,
+    reviewCount: 32,
+    image: 'https://images.unsplash.com/photo-1587620962725-abab7fe55159?w=400&h=250&fit=crop',
+    tags: ['상시모집'],
+    category: '개발',
+    keywords: ['TypeScript', '타입스크립트', 'TS', '프론트엔드', '강의'],
+  },
+  {
+    id: 3,
+    title: 'Python으로 배우는 AI 기초',
+    instructor: '이파이썬',
+    price: '₩129,000',
+    rating: 4.9,
+    reviewCount: 28,
+    image: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=400&h=250&fit=crop',
+    tags: ['모집중', '신규'],
+    category: 'AI',
+    keywords: ['Python', '파이썬', 'AI', '인공지능', '머신러닝', '강의'],
+  },
+  {
+    id: 4,
+    title: 'AWS 클라우드 실전 가이드',
+    instructor: '최클라우드',
+    price: '무료',
+    rating: 4.6,
+    reviewCount: 156,
+    image: 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=400&h=250&fit=crop',
+    tags: ['상시모집', '무료'],
+    category: '클라우드',
+    keywords: ['AWS', '클라우드', 'Cloud', 'DevOps', '강의'],
+  },
+  {
+    id: 5,
+    title: 'Next.js 14 완벽 가이드',
+    instructor: '정넥스트',
+    price: '₩89,000',
+    rating: 4.8,
+    reviewCount: 41,
+    image: 'https://images.unsplash.com/photo-1555066931-4365d14bab8c?w=400&h=250&fit=crop',
+    tags: ['상시모집', '인기'],
+    category: '개발',
+    keywords: ['Next.js', 'Next', 'React', '프론트엔드', 'SSR', '강의'],
+  },
+  {
+    id: 6,
+    title: 'Vue.js 3 실전 프로젝트',
+    instructor: '한뷰',
+    price: '₩75,000',
+    rating: 4.5,
+    reviewCount: 22,
+    image: 'https://images.unsplash.com/photo-1517694712202-14dd9538aa97?w=400&h=250&fit=crop',
+    tags: ['모집중'],
+    category: '개발',
+    keywords: ['Vue', 'Vue.js', '뷰', '프론트엔드', 'JavaScript', '강의'],
+  },
+  {
+    id: 7,
+    title: 'Docker & Kubernetes 완벽 가이드',
+    instructor: '강도커',
+    price: '₩149,000',
+    rating: 4.9,
+    reviewCount: 89,
+    image: 'https://images.unsplash.com/photo-1667372393119-3d4c48d07fc9?w=400&h=250&fit=crop',
+    tags: ['상시모집', '인기'],
+    category: '클라우드',
+    keywords: ['Docker', '도커', 'Kubernetes', '쿠버네티스', 'K8s', 'DevOps', '컨테이너', '강의'],
+  },
+  {
+    id: 8,
+    title: 'Node.js 백엔드 개발 실전',
+    instructor: '노드맨',
+    price: '₩110,000',
+    rating: 4.7,
+    reviewCount: 67,
+    image: 'https://images.unsplash.com/photo-1627398242454-45a1465c2479?w=400&h=250&fit=crop',
+    tags: ['상시모집'],
+    category: '개발',
+    keywords: ['Node.js', '노드', 'Express', '백엔드', 'JavaScript', 'API', '강의'],
+  },
+  {
+    id: 9,
+    title: 'Spring Boot 3.0 실무 프로젝트',
+    instructor: '자바킹',
+    price: '₩139,000',
+    rating: 4.8,
+    reviewCount: 112,
+    image: 'https://images.unsplash.com/photo-1515879218367-8466d910aaa4?w=400&h=250&fit=crop',
+    tags: ['상시모집', '인기'],
+    category: '개발',
+    keywords: ['Spring', 'Spring Boot', '스프링', 'Java', '자바', '백엔드', '강의'],
+  },
+  {
+    id: 10,
+    title: 'Flutter로 만드는 크로스플랫폼 앱',
+    instructor: '플러터박사',
+    price: '₩95,000',
+    rating: 4.6,
+    reviewCount: 54,
+    image: 'https://images.unsplash.com/photo-1512941937669-90a1b58e7e9c?w=400&h=250&fit=crop',
+    tags: ['모집중', '신규'],
+    category: '개발',
+    keywords: ['Flutter', '플러터', 'Dart', '다트', '앱개발', '모바일', '강의'],
+  },
+  {
+    id: 11,
+    title: 'SQL과 데이터베이스 기초',
+    instructor: '데이터맨',
+    price: '₩69,000',
+    rating: 4.5,
+    reviewCount: 203,
+    image: 'https://images.unsplash.com/photo-1544383835-bda2bc66a55d?w=400&h=250&fit=crop',
+    tags: ['상시모집', '무료'],
+    category: '데이터',
+    keywords: ['SQL', '데이터베이스', 'MySQL', 'PostgreSQL', 'DB', '강의'],
+  },
+  {
+    id: 12,
+    title: 'Git & GitHub 협업 마스터',
+    instructor: '깃전문가',
+    price: '무료',
+    rating: 4.8,
+    reviewCount: 321,
+    image: 'https://images.unsplash.com/photo-1618401471353-b98afee0b2eb?w=400&h=250&fit=crop',
+    tags: ['상시모집', '무료', '인기'],
+    category: '개발',
+    keywords: ['Git', '깃', 'GitHub', '깃허브', '버전관리', '협업', '강의'],
+  },
+  {
+    id: 13,
+    title: 'ChatGPT API 활용 실전',
+    instructor: 'AI개발자',
+    price: '₩89,000',
+    rating: 4.9,
+    reviewCount: 78,
+    image: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=400&h=250&fit=crop',
+    tags: ['신규', '인기'],
+    category: 'AI',
+    keywords: ['ChatGPT', 'GPT', 'OpenAI', 'AI', 'LLM', 'API', '강의'],
+  },
+  {
+    id: 14,
+    title: 'UI/UX 디자인 실무',
+    instructor: '디자이너K',
+    price: '₩85,000',
+    rating: 4.7,
+    reviewCount: 95,
+    image: 'https://images.unsplash.com/photo-1561070791-2526d30994b5?w=400&h=250&fit=crop',
+    tags: ['상시모집'],
+    category: '디자인',
+    keywords: ['UI', 'UX', '디자인', 'Figma', '피그마', '웹디자인', '강의'],
+  },
+  {
+    id: 15,
+    title: '데이터 분석 with Python',
+    instructor: '분석전문가',
+    price: '₩119,000',
+    rating: 4.8,
+    reviewCount: 134,
+    image: 'https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=400&h=250&fit=crop',
+    tags: ['상시모집', '인기'],
+    category: '데이터',
+    keywords: ['데이터분석', 'Python', '파이썬', 'Pandas', '판다스', 'NumPy', '강의'],
+  },
+];
+
+// 더미 로드맵 데이터
+const MOCK_ROADMAPS: RoadmapExploreItem[] = [
+  {
+    id: 1,
+    title: '프론트엔드 개발자 로드맵',
+    description: 'HTML, CSS부터 React, TypeScript까지 프론트엔드 개발의 모든 것을 배웁니다.',
+    image: 'https://images.unsplash.com/photo-1593720213428-28a5b9e94613?w=400&h=250&fit=crop',
+    author: '김프론트',
+    authorImage: '',
+    level: 'beginner',
+    courseCount: 12,
+    estimatedHours: 120,
+    enrollCount: 2500,
+    rating: 4.8,
+    reviewCount: 320,
+    category: '개발',
+    tags: ['React', 'TypeScript', 'CSS', '프론트엔드', '강의'],
+    isNew: false,
+    isPopular: true,
+  },
+  {
+    id: 2,
+    title: '백엔드 개발자 로드맵',
+    description: 'Node.js, Python, 데이터베이스를 활용한 백엔드 개발 마스터 과정',
+    image: 'https://images.unsplash.com/photo-1627398242454-45a1465c2479?w=400&h=250&fit=crop',
+    author: '박백엔드',
+    authorImage: '',
+    level: 'intermediate',
+    courseCount: 15,
+    estimatedHours: 180,
+    enrollCount: 1800,
+    rating: 4.7,
+    reviewCount: 215,
+    category: '개발',
+    tags: ['Node.js', 'Python', 'Database', '백엔드', '강의'],
+    isNew: false,
+    isPopular: true,
+  },
+  {
+    id: 3,
+    title: 'AI/ML 엔지니어 로드맵',
+    description: '인공지능과 머신러닝의 기초부터 실전 프로젝트까지',
+    image: 'https://images.unsplash.com/photo-1555255707-c07966088b7b?w=400&h=250&fit=crop',
+    author: '이에이아이',
+    authorImage: '',
+    level: 'advanced',
+    courseCount: 20,
+    estimatedHours: 240,
+    enrollCount: 1200,
+    rating: 4.9,
+    reviewCount: 180,
+    category: 'AI',
+    tags: ['Python', 'AI', 'TensorFlow', '머신러닝', '딥러닝', '강의'],
+    isNew: true,
+    isPopular: true,
+  },
+  {
+    id: 4,
+    title: '클라우드 아키텍트 로드맵',
+    description: 'AWS, GCP, Azure를 활용한 클라우드 인프라 설계 및 구축',
+    image: 'https://images.unsplash.com/photo-1544197150-b99a580bb7a8?w=400&h=250&fit=crop',
+    author: '최클라우드',
+    authorImage: '',
+    level: 'intermediate',
+    courseCount: 10,
+    estimatedHours: 100,
+    enrollCount: 900,
+    rating: 4.6,
+    reviewCount: 95,
+    category: '클라우드',
+    tags: ['AWS', '클라우드', 'DevOps', 'GCP', 'Azure', '강의'],
+    isNew: false,
+    isPopular: false,
+  },
+  {
+    id: 5,
+    title: '풀스택 개발자 로드맵',
+    description: '프론트엔드와 백엔드를 모두 아우르는 풀스택 개발자가 되기 위한 종합 과정',
+    image: 'https://images.unsplash.com/photo-1504639725590-34d0984388bd?w=400&h=250&fit=crop',
+    author: '풀스택킹',
+    authorImage: '',
+    level: 'intermediate',
+    courseCount: 25,
+    estimatedHours: 300,
+    enrollCount: 3200,
+    rating: 4.8,
+    reviewCount: 420,
+    category: '개발',
+    tags: ['React', 'Node.js', 'Database', '풀스택', '강의'],
+    isNew: false,
+    isPopular: true,
+  },
+  {
+    id: 6,
+    title: '데이터 사이언티스트 로드맵',
+    description: '데이터 분석부터 머신러닝까지, 데이터 사이언스 전문가 양성 과정',
+    image: 'https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=400&h=250&fit=crop',
+    author: '데이터박사',
+    authorImage: '',
+    level: 'intermediate',
+    courseCount: 18,
+    estimatedHours: 200,
+    enrollCount: 1500,
+    rating: 4.7,
+    reviewCount: 185,
+    category: '데이터',
+    tags: ['Python', 'SQL', '데이터분석', '머신러닝', '강의'],
+    isNew: true,
+    isPopular: false,
+  },
+  {
+    id: 7,
+    title: 'DevOps 엔지니어 로드맵',
+    description: 'CI/CD, 컨테이너, 인프라 자동화를 위한 DevOps 완벽 가이드',
+    image: 'https://images.unsplash.com/photo-1667372393119-3d4c48d07fc9?w=400&h=250&fit=crop',
+    author: '데브옵스마스터',
+    authorImage: '',
+    level: 'advanced',
+    courseCount: 14,
+    estimatedHours: 150,
+    enrollCount: 800,
+    rating: 4.8,
+    reviewCount: 110,
+    category: '클라우드',
+    tags: ['Docker', 'Kubernetes', 'CI/CD', 'DevOps', '강의'],
+    isNew: false,
+    isPopular: true,
+  },
+  {
+    id: 8,
+    title: '모바일 앱 개발자 로드맵',
+    description: 'React Native와 Flutter로 iOS, Android 앱을 동시에 개발하는 방법',
+    image: 'https://images.unsplash.com/photo-1512941937669-90a1b58e7e9c?w=400&h=250&fit=crop',
+    author: '앱개발자',
+    authorImage: '',
+    level: 'beginner',
+    courseCount: 16,
+    estimatedHours: 180,
+    enrollCount: 2100,
+    rating: 4.6,
+    reviewCount: 275,
+    category: '개발',
+    tags: ['React Native', 'Flutter', '모바일', '앱개발', '강의'],
+    isNew: false,
+    isPopular: true,
+  },
+];
+
+// 더미 커뮤니티 데이터
+const MOCK_COMMUNITY: CommunityPost[] = [
+  {
+    id: 1,
+    type: 'tip',
+    title: 'React 18에서 새로 추가된 기능들 정리',
+    content: 'React 18에서 추가된 Concurrent Features, Suspense 개선사항, 자동 배칭 등을 정리해봤습니다.',
+    category: '개발 질문',
+    author: { id: 1, name: '김개발', avatar: '' },
+    viewCount: 342,
+    likeCount: 28,
+    commentCount: 15,
+    tags: ['React', 'JavaScript', '프론트엔드', '강의'],
+    createdAt: '2025-01-05T10:30:00',
+    updatedAt: '2025-01-05T10:30:00',
+    isLiked: false,
+  },
+  {
+    id: 2,
+    type: 'tip',
+    title: 'TypeScript 5.0 새로운 기능 소개',
+    content: 'TypeScript 5.0에서 추가된 데코레이터, const type parameters 등 새로운 기능들을 살펴봅니다.',
+    category: '개발 질문',
+    author: { id: 2, name: '박타입', avatar: '' },
+    viewCount: 256,
+    likeCount: 19,
+    commentCount: 8,
+    tags: ['TypeScript', '프론트엔드', '강의'],
+    createdAt: '2025-01-04T14:20:00',
+    updatedAt: '2025-01-04T14:20:00',
+    isLiked: false,
+  },
+  {
+    id: 3,
+    type: 'discussion',
+    title: 'Python으로 AI 프로젝트 시작하기',
+    content: 'AI 프로젝트를 처음 시작하시는 분들을 위한 가이드입니다. 환경 설정부터 첫 모델 학습까지!',
+    category: '스터디 모집',
+    author: { id: 3, name: '이파이썬', avatar: '' },
+    viewCount: 489,
+    likeCount: 45,
+    commentCount: 23,
+    tags: ['Python', 'AI', '머신러닝', '강의'],
+    createdAt: '2025-01-03T09:15:00',
+    updatedAt: '2025-01-03T09:15:00',
+    isLiked: false,
+  },
+  {
+    id: 4,
+    type: 'discussion',
+    title: 'AWS 자격증 준비 스터디원 모집합니다',
+    content: 'AWS Solutions Architect Associate 자격증 준비 스터디원을 모집합니다. 주 2회 온라인 모임!',
+    category: '스터디 모집',
+    author: { id: 4, name: '최클라우드', avatar: '' },
+    viewCount: 178,
+    likeCount: 12,
+    commentCount: 31,
+    tags: ['AWS', '클라우드', '자격증', '강의'],
+    createdAt: '2025-01-02T16:45:00',
+    updatedAt: '2025-01-02T16:45:00',
+    isLiked: false,
+  },
+  {
+    id: 5,
+    type: 'review',
+    title: 'Next.js 14 App Router 마이그레이션 경험담',
+    content: 'Pages Router에서 App Router로 마이그레이션하면서 겪은 이슈들과 해결 방법을 공유합니다.',
+    category: '경험 공유',
+    author: { id: 5, name: '정넥스트', avatar: '' },
+    viewCount: 623,
+    likeCount: 52,
+    commentCount: 18,
+    tags: ['Next.js', 'React', '마이그레이션', '강의'],
+    createdAt: '2025-01-01T11:00:00',
+    updatedAt: '2025-01-01T11:00:00',
+    isLiked: false,
+  },
+  {
+    id: 6,
+    type: 'tip',
+    title: 'Vue 3 Composition API 실전 팁',
+    content: 'Vue 3 Composition API를 실무에서 효과적으로 사용하는 방법과 팁들을 정리했습니다.',
+    category: '개발 질문',
+    author: { id: 6, name: '한뷰', avatar: '' },
+    viewCount: 198,
+    likeCount: 15,
+    commentCount: 7,
+    tags: ['Vue', 'JavaScript', '프론트엔드', '강의'],
+    createdAt: '2024-12-30T13:30:00',
+    updatedAt: '2024-12-30T13:30:00',
+    isLiked: false,
+  },
+  {
+    id: 7,
+    type: 'question',
+    title: 'Docker 컨테이너 네트워킹 질문드립니다',
+    content: 'Docker Compose로 여러 컨테이너를 연결할 때 네트워크 설정이 헷갈립니다. 도움 부탁드려요!',
+    category: '개발 질문',
+    author: { id: 7, name: '도커초보', avatar: '' },
+    viewCount: 89,
+    likeCount: 5,
+    commentCount: 12,
+    tags: ['Docker', 'DevOps', '네트워크', '강의'],
+    createdAt: '2025-01-05T15:20:00',
+    updatedAt: '2025-01-05T15:20:00',
+    isLiked: false,
+  },
+  {
+    id: 8,
+    type: 'tip',
+    title: 'Spring Boot 3.0 마이그레이션 가이드',
+    content: 'Spring Boot 2.x에서 3.0으로 업그레이드하면서 주의해야 할 점들을 정리했습니다.',
+    category: '경험 공유',
+    author: { id: 8, name: '스프링매니아', avatar: '' },
+    viewCount: 445,
+    likeCount: 38,
+    commentCount: 21,
+    tags: ['Spring', 'Java', '백엔드', '마이그레이션', '강의'],
+    createdAt: '2025-01-04T09:00:00',
+    updatedAt: '2025-01-04T09:00:00',
+    isLiked: false,
+  },
+  {
+    id: 9,
+    type: 'discussion',
+    title: 'Flutter vs React Native 어떤걸 배워야 할까요?',
+    content: '모바일 앱 개발을 시작하려고 합니다. 두 프레임워크 중 어떤 것이 더 좋을까요?',
+    category: '자유 토론',
+    author: { id: 9, name: '모바일러', avatar: '' },
+    viewCount: 567,
+    likeCount: 42,
+    commentCount: 89,
+    tags: ['Flutter', 'React Native', '모바일', '앱개발', '강의'],
+    createdAt: '2025-01-03T18:30:00',
+    updatedAt: '2025-01-03T18:30:00',
+    isLiked: false,
+  },
+  {
+    id: 10,
+    type: 'tip',
+    title: 'Git 브랜치 전략 - GitFlow vs Trunk-based',
+    content: '팀에서 사용할 Git 브랜치 전략을 고민 중이라면 이 글을 참고하세요.',
+    category: '개발 질문',
+    author: { id: 10, name: '깃마스터', avatar: '' },
+    viewCount: 312,
+    likeCount: 29,
+    commentCount: 16,
+    tags: ['Git', 'GitHub', '협업', '버전관리', '강의'],
+    createdAt: '2025-01-02T11:15:00',
+    updatedAt: '2025-01-02T11:15:00',
+    isLiked: false,
+  },
+  {
+    id: 11,
+    type: 'review',
+    title: 'ChatGPT API를 활용한 챗봇 만들기 후기',
+    content: 'OpenAI API를 사용해서 간단한 고객 상담 챗봇을 만들어봤습니다. 생각보다 쉬웠어요!',
+    category: '경험 공유',
+    author: { id: 11, name: 'AI개발자', avatar: '' },
+    viewCount: 892,
+    likeCount: 76,
+    commentCount: 34,
+    tags: ['ChatGPT', 'AI', 'OpenAI', 'API', '강의'],
+    createdAt: '2025-01-01T14:00:00',
+    updatedAt: '2025-01-01T14:00:00',
+    isLiked: false,
+  },
+  {
+    id: 12,
+    type: 'discussion',
+    title: 'Kubernetes 스터디 그룹 모집 (온라인)',
+    content: '쿠버네티스를 함께 공부할 스터디원을 모집합니다. 매주 토요일 오전 진행 예정입니다.',
+    category: '스터디 모집',
+    author: { id: 12, name: 'K8s러버', avatar: '' },
+    viewCount: 234,
+    likeCount: 18,
+    commentCount: 45,
+    tags: ['Kubernetes', 'Docker', 'DevOps', '클라우드', '강의'],
+    createdAt: '2024-12-31T10:00:00',
+    updatedAt: '2024-12-31T10:00:00',
+    isLiked: false,
+  },
+];
+
+// 탭 타입
+type SearchTab = 'all' | 'courses' | 'roadmaps' | 'community';
+
+// 필터 옵션 상수
+const SORT_OPTIONS = [
+  { value: 'relevance', label: '관련도순' },
+  { value: 'latest', label: '최신순' },
+  { value: 'popular', label: '인기순' },
+  { value: 'rating', label: '평점순' },
+];
+
+const CATEGORY_OPTIONS = [
+  { value: 'all', label: '전체' },
+  { value: '개발', label: '개발' },
+  { value: 'AI', label: 'AI' },
+  { value: '클라우드', label: '클라우드' },
+  { value: '데이터', label: '데이터' },
+  { value: '디자인', label: '디자인' },
+];
+
+const LEVEL_OPTIONS = [
+  { value: 'all', label: '전체' },
+  { value: 'beginner', label: '입문' },
+  { value: 'intermediate', label: '중급' },
+  { value: 'advanced', label: '고급' },
+];
+
+const PRICE_OPTIONS = [
+  { value: 'all', label: '전체' },
+  { value: 'free', label: '무료' },
+  { value: 'paid', label: '유료' },
+];
+
+const STATUS_OPTIONS = [
+  { value: 'all', label: '전체' },
+  { value: 'recruiting', label: '모집중' },
+  { value: 'ongoing', label: '상시모집' },
+];
+
+const POST_TYPE_OPTIONS = [
+  { value: 'all', label: '전체' },
+  { value: 'tip', label: '팁/노하우' },
+  { value: 'question', label: '질문' },
+  { value: 'discussion', label: '토론' },
+  { value: 'review', label: '후기' },
+];
+
+const COMMUNITY_CATEGORY_OPTIONS = [
+  { value: 'all', label: '전체' },
+  { value: '개발 질문', label: '개발 질문' },
+  { value: '스터디 모집', label: '스터디 모집' },
+  { value: '경험 공유', label: '경험 공유' },
+  { value: '자유 토론', label: '자유 토론' },
+];
+
+// 필터 타입
+interface Filters {
+  sort: string;
+  category: string;
+  level: string;
+  price: string;
+  status: string;
+  postType: string;
+  communityCategory: string;
+}
+
+// 상대 시간 포맷
+const formatRelativeTime = (dateString: string): string => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+
+  if (diffInSeconds < 60) return '방금 전';
+  if (diffInSeconds < 3600) return `${Math.floor(diffInSeconds / 60)}분 전`;
+  if (diffInSeconds < 86400) return `${Math.floor(diffInSeconds / 3600)}시간 전`;
+  if (diffInSeconds < 604800) return `${Math.floor(diffInSeconds / 86400)}일 전`;
+  return date.toLocaleDateString('ko-KR');
+};
+
+// 검색 필터 함수
+function searchCourses(courses: MockCourseCard[], keyword: string): MockCourseCard[] {
+  const lowerKeyword = keyword.toLowerCase();
+  return courses.filter(course =>
+    course.title.toLowerCase().includes(lowerKeyword) ||
+    course.instructor.toLowerCase().includes(lowerKeyword) ||
+    course.category.toLowerCase().includes(lowerKeyword) ||
+    course.keywords.some(k => k.toLowerCase().includes(lowerKeyword)) ||
+    course.tags.some(t => t.toLowerCase().includes(lowerKeyword))
+  );
+}
+
+function searchRoadmaps(roadmaps: RoadmapExploreItem[], keyword: string): RoadmapExploreItem[] {
+  const lowerKeyword = keyword.toLowerCase();
+  return roadmaps.filter(roadmap =>
+    roadmap.title.toLowerCase().includes(lowerKeyword) ||
+    roadmap.description.toLowerCase().includes(lowerKeyword) ||
+    roadmap.category.toLowerCase().includes(lowerKeyword) ||
+    (roadmap.tags || []).some(t => t.toLowerCase().includes(lowerKeyword))
+  );
+}
+
+function searchCommunity(posts: CommunityPost[], keyword: string): CommunityPost[] {
+  const lowerKeyword = keyword.toLowerCase();
+  return posts.filter(post =>
+    post.title.toLowerCase().includes(lowerKeyword) ||
+    post.content.toLowerCase().includes(lowerKeyword) ||
+    post.category.toLowerCase().includes(lowerKeyword) ||
+    (post.tags || []).some(t => t.toLowerCase().includes(lowerKeyword))
+  );
+}
+
+/**
+ * 로드맵 카드 컴포넌트
+ */
+function RoadmapCard({ roadmap, isDark }: { roadmap: RoadmapExploreItem; isDark: boolean }) {
+  return (
+    <Link to={`/tu/b2c/roadmaps/${roadmap.id}`} className="group block">
+      <div
+        className={`rounded-2xl overflow-hidden border transition-all duration-300 ${
+          isDark
+            ? 'bg-white/5 border-white/10 hover:border-[#6778ff]/50'
+            : 'bg-white border-gray-200 hover:border-[#6778ff] hover:shadow-lg'
+        }`}
+      >
+        <div className="relative aspect-[16/9] overflow-hidden">
+          <img
+            src={roadmap.image}
+            alt={roadmap.title}
+            className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
+          <div className="absolute bottom-3 left-3 right-3">
+            <span
+              className={`inline-block text-xs px-2 py-1 rounded-full ${
+                roadmap.level === 'beginner'
+                  ? 'bg-green-500/80 text-white'
+                  : roadmap.level === 'intermediate'
+                    ? 'bg-yellow-500/80 text-white'
+                    : 'bg-red-500/80 text-white'
+              }`}
+            >
+              {ROADMAP_LEVEL_LABELS[roadmap.level]}
+            </span>
+          </div>
+        </div>
+        <div className="p-4">
+          <h3
+            className={`font-bold line-clamp-2 mb-2 group-hover:text-[#6778ff] transition-colors ${
+              isDark ? 'text-white' : 'text-gray-900'
+            }`}
+          >
+            {roadmap.title}
+          </h3>
+          <p className={`text-sm line-clamp-2 mb-3 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+            {roadmap.description}
+          </p>
+          <div className="flex items-center justify-between text-xs">
+            <div className="flex items-center gap-3">
+              <span className={`flex items-center gap-1 ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+                <BookOpen className="w-3 h-3" />
+                {roadmap.courseCount}개 강의
+              </span>
+              <span className={`flex items-center gap-1 ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+                <Clock className="w-3 h-3" />
+                {roadmap.estimatedHours}시간
+              </span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Star className="w-3 h-3 text-yellow-500 fill-yellow-500" />
+              <span className={isDark ? 'text-gray-400' : 'text-gray-600'}>{roadmap.rating}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+/**
+ * 필터 드롭다운 컴포넌트
+ */
+function FilterDropdown({
+  label,
+  value,
+  options,
+  onChange,
+  isDark,
+}: {
+  label: string;
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (value: string) => void;
+  isDark: boolean;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const selectedOption = options.find((opt) => opt.value === value);
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-all ${
+          isDark
+            ? 'bg-white/5 border border-white/10 text-gray-300 hover:bg-white/10'
+            : 'bg-white border border-gray-200 text-gray-700 hover:bg-gray-50'
+        } ${value !== 'all' && value !== 'relevance' ? (isDark ? 'border-[#6778ff]/50 text-[#6778ff]' : 'border-[#6778ff] text-[#6778ff]') : ''}`}
+      >
+        <span className={isDark ? 'text-gray-500' : 'text-gray-400'}>{label}:</span>
+        <span>{selectedOption?.label}</span>
+        <ChevronDown className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+      </button>
+      {isOpen && (
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setIsOpen(false)} />
+          <div
+            className={`absolute top-full left-0 mt-1 py-1 rounded-lg shadow-lg z-20 min-w-[140px] ${
+              isDark ? 'bg-[#2a2a2a] border border-white/10' : 'bg-white border border-gray-200'
+            }`}
+          >
+            {options.map((option) => (
+              <button
+                key={option.value}
+                onClick={() => {
+                  onChange(option.value);
+                  setIsOpen(false);
+                }}
+                className={`w-full text-left px-4 py-2 text-sm transition-colors ${
+                  value === option.value
+                    ? 'bg-[#6778ff] text-white'
+                    : isDark
+                      ? 'text-gray-300 hover:bg-white/5'
+                      : 'text-gray-700 hover:bg-gray-50'
+                }`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * 커뮤니티 게시글 카드 컴포넌트
+ */
+function CommunityCard({ post, isDark }: { post: CommunityPost; isDark: boolean }) {
+  return (
+    <Link
+      to={`/tu/b2c/community/${post.id}`}
+      className={`block p-4 rounded-xl border transition-all duration-300 ${
+        isDark
+          ? 'bg-white/5 border-white/10 hover:border-[#6778ff]/50'
+          : 'bg-white border-gray-200 hover:border-[#6778ff] hover:shadow-md'
+      }`}
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex-1 min-w-0">
+          <h3
+            className={`font-semibold line-clamp-1 mb-1 ${isDark ? 'text-white' : 'text-gray-900'}`}
+          >
+            {post.title}
+          </h3>
+          <p className={`text-sm line-clamp-2 mb-2 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+            {post.content}
+          </p>
+          <div className="flex items-center gap-3 text-xs">
+            <span className={isDark ? 'text-gray-500' : 'text-gray-500'}>{post.author.name}</span>
+            <span className={isDark ? 'text-gray-600' : 'text-gray-400'}>
+              {formatRelativeTime(post.createdAt)}
+            </span>
+            <span className={`flex items-center gap-1 ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+              <MessageSquare className="w-3 h-3" />
+              {post.commentCount}
+            </span>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+const DEFAULT_FILTERS: Filters = {
+  sort: 'relevance',
+  category: 'all',
+  level: 'all',
+  price: 'all',
+  status: 'all',
+  postType: 'all',
+  communityCategory: 'all',
+};
+
+export function SearchPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [activeTab, setActiveTab] = useState<SearchTab>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [inputValue, setInputValue] = useState('');
+  const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
+  const [showFilters, setShowFilters] = useState(false);
+  const { theme } = useThemeStore();
+  const isDark = theme === 'dark';
+
+  // 필터 초기화
+  const resetFilters = () => {
+    setFilters(DEFAULT_FILTERS);
+    // URL도 초기화
+    const params = new URLSearchParams();
+    if (searchQuery) params.set('search', searchQuery);
+    if (activeTab !== 'all') params.set('tab', activeTab);
+    setSearchParams(params);
+  };
+
+  // 활성화된 필터 개수
+  const activeFilterCount = useMemo(() => {
+    let count = 0;
+    if (filters.sort !== 'relevance') count++;
+    if (filters.category !== 'all') count++;
+    if (filters.level !== 'all') count++;
+    if (filters.price !== 'all') count++;
+    if (filters.status !== 'all') count++;
+    if (filters.postType !== 'all') count++;
+    if (filters.communityCategory !== 'all') count++;
+    return count;
+  }, [filters]);
+
+  // URL에서 검색어 및 필터 가져오기
+  useEffect(() => {
+    const search = searchParams.get('search') || searchParams.get('q') || '';
+    const tab = searchParams.get('tab') as SearchTab;
+    const sort = searchParams.get('sort');
+    const category = searchParams.get('category');
+    const level = searchParams.get('level');
+    const price = searchParams.get('price');
+    const status = searchParams.get('status');
+    const postType = searchParams.get('postType');
+    const communityCategory = searchParams.get('communityCategory');
+
+    if (search) {
+      setSearchQuery(search);
+      setInputValue(search);
+    }
+    if (tab && ['all', 'courses', 'roadmaps', 'community'].includes(tab)) {
+      setActiveTab(tab);
+    }
+
+    // URL에서 필터 복원
+    setFilters({
+      sort: sort || 'relevance',
+      category: category || 'all',
+      level: level || 'all',
+      price: price || 'all',
+      status: status || 'all',
+      postType: postType || 'all',
+      communityCategory: communityCategory || 'all',
+    });
+  }, [searchParams]);
+
+  // 필터 변경 시 URL 업데이트
+  const updateFilterWithUrl = (key: keyof Filters, value: string) => {
+    const newFilters = { ...filters, [key]: value };
+    setFilters(newFilters);
+
+    // URL 파라미터 업데이트
+    const params = new URLSearchParams();
+    if (searchQuery) params.set('search', searchQuery);
+    if (activeTab !== 'all') params.set('tab', activeTab);
+    if (newFilters.sort !== 'relevance') params.set('sort', newFilters.sort);
+    if (newFilters.category !== 'all') params.set('category', newFilters.category);
+    if (newFilters.level !== 'all') params.set('level', newFilters.level);
+    if (newFilters.price !== 'all') params.set('price', newFilters.price);
+    if (newFilters.status !== 'all') params.set('status', newFilters.status);
+    if (newFilters.postType !== 'all') params.set('postType', newFilters.postType);
+    if (newFilters.communityCategory !== 'all') params.set('communityCategory', newFilters.communityCategory);
+
+    setSearchParams(params);
+  };
+
+  // API 데이터 (USE_API가 true일 때만 사용)
+  const {
+    data: coursesData,
+    isLoading: isCoursesLoading,
+  } = useCourseTimeCatalog(
+    {
+      keyword: searchQuery || undefined,
+      status: ['RECRUITING', 'ONGOING'],
+      size: activeTab === 'courses' ? 20 : 6,
+    },
+    USE_API && !!searchQuery
+  );
+
+  const {
+    data: roadmapsData,
+    isLoading: isRoadmapsLoading,
+  } = useRoadmapExplore(
+    {
+      search: searchQuery || undefined,
+      pageSize: activeTab === 'roadmaps' ? 20 : 6,
+    },
+    USE_API && !!searchQuery
+  );
+
+  const {
+    data: communityData,
+    isLoading: isCommunityLoading,
+  } = useCommunityPosts(
+    {
+      search: searchQuery || undefined,
+      pageSize: activeTab === 'community' ? 20 : 6,
+    },
+    USE_API && !!searchQuery
+  );
+
+  // 더미 데이터 검색 결과
+  const mockSearchResults = useMemo(() => {
+    if (!searchQuery) return { courses: [], roadmaps: [], community: [] };
+    return {
+      courses: searchCourses(MOCK_COURSES, searchQuery),
+      roadmaps: searchRoadmaps(MOCK_ROADMAPS, searchQuery),
+      community: searchCommunity(MOCK_COMMUNITY, searchQuery),
+    };
+  }, [searchQuery]);
+
+  // 필터링된 결과 (더미 데이터용)
+  const filteredResults = useMemo(() => {
+    let filteredCourses = [...mockSearchResults.courses];
+    let filteredRoadmaps = [...mockSearchResults.roadmaps];
+    let filteredCommunity = [...mockSearchResults.community];
+
+    // 강의 필터링
+    if (filters.category !== 'all') {
+      filteredCourses = filteredCourses.filter((c) => c.category === filters.category);
+    }
+    if (filters.price !== 'all') {
+      filteredCourses = filteredCourses.filter((c) =>
+        filters.price === 'free' ? c.price === '무료' : c.price !== '무료'
+      );
+    }
+    if (filters.status !== 'all') {
+      filteredCourses = filteredCourses.filter((c) =>
+        filters.status === 'recruiting'
+          ? c.tags.some((t) => t.includes('모집'))
+          : c.tags.some((t) => t.includes('상시'))
+      );
+    }
+
+    // 로드맵 필터링
+    if (filters.category !== 'all') {
+      filteredRoadmaps = filteredRoadmaps.filter((r) => r.category === filters.category);
+    }
+    if (filters.level !== 'all') {
+      filteredRoadmaps = filteredRoadmaps.filter((r) => r.level === filters.level);
+    }
+
+    // 커뮤니티 필터링
+    if (filters.postType !== 'all') {
+      filteredCommunity = filteredCommunity.filter((p) => p.type === filters.postType);
+    }
+    if (filters.communityCategory !== 'all') {
+      filteredCommunity = filteredCommunity.filter((p) => p.category === filters.communityCategory);
+    }
+
+    // 정렬
+    const sortFn = (a: { rating?: number; createdAt?: string; viewCount?: number }, b: { rating?: number; createdAt?: string; viewCount?: number }) => {
+      switch (filters.sort) {
+        case 'latest':
+          return new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime();
+        case 'popular':
+          return (b.viewCount || 0) - (a.viewCount || 0);
+        case 'rating':
+          return (b.rating || 0) - (a.rating || 0);
+        default:
+          return 0; // relevance - 기본 순서 유지
+      }
+    };
+
+    if (filters.sort !== 'relevance') {
+      filteredCourses.sort((a, b) => sortFn({ rating: a.rating }, { rating: b.rating }));
+      filteredRoadmaps.sort((a, b) => sortFn({ rating: a.rating, viewCount: a.enrollCount }, { rating: b.rating, viewCount: b.enrollCount }));
+      filteredCommunity.sort(sortFn);
+    }
+
+    return {
+      courses: filteredCourses,
+      roadmaps: filteredRoadmaps,
+      community: filteredCommunity,
+    };
+  }, [mockSearchResults, filters]);
+
+  // 실제 사용할 데이터 결정
+  const courses = USE_API ? (coursesData?.content || []) : filteredResults.courses;
+  const roadmaps = USE_API ? (roadmapsData?.roadmaps || []) : filteredResults.roadmaps;
+  const communityPosts = USE_API ? (communityData?.posts || []) : filteredResults.community;
+
+  const totalCourses = USE_API ? (coursesData?.totalElements || 0) : filteredResults.courses.length;
+  const totalRoadmaps = USE_API ? (roadmapsData?.totalCount || 0) : filteredResults.roadmaps.length;
+  const totalCommunity = USE_API ? (communityData?.totalCount || 0) : filteredResults.community.length;
+  const totalResults = totalCourses + totalRoadmaps + totalCommunity;
+
+  const isLoading = USE_API && (isCoursesLoading || isRoadmapsLoading || isCommunityLoading);
+
+  // 검색 실행
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (inputValue.trim()) {
+      setSearchQuery(inputValue.trim());
+      setSearchParams({ search: inputValue.trim(), tab: activeTab });
+    }
+  };
+
+  // 탭 변경
+  const handleTabChange = (tab: SearchTab) => {
+    setActiveTab(tab);
+    if (searchQuery) {
+      setSearchParams({ search: searchQuery, tab });
+    }
+  };
+
+  // 검색어 초기화
+  const handleClearSearch = () => {
+    setSearchQuery('');
+    setInputValue('');
+    setSearchParams({});
+  };
+
+  // 탭 데이터
+  const tabs = [
+    { id: 'all' as const, label: '전체', count: totalResults },
+    { id: 'courses' as const, label: '강의', count: totalCourses, icon: BookOpen },
+    { id: 'roadmaps' as const, label: '로드맵', count: totalRoadmaps, icon: Map },
+    { id: 'community' as const, label: '커뮤니티', count: totalCommunity, icon: MessageSquare },
+  ];
+
+  return (
+    <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
+      <LandingHeader />
+
+      <main className="w-full px-4 md:px-8 lg:px-16 py-12">
+        {/* 검색 헤더 */}
+        <div className="mb-8">
+          <h1 className={`text-3xl md:text-4xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            통합 검색
+          </h1>
+          <p className={`mb-6 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+            강의, 로드맵, 커뮤니티를 한 번에 검색하세요
+          </p>
+
+          {/* 검색바 */}
+          <form onSubmit={handleSearch} className="relative w-full">
+            <Search
+              className={`absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 ${
+                isDark ? 'text-gray-500' : 'text-gray-400'
+              }`}
+            />
+            <input
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              placeholder="강의, 로드맵, 커뮤니티 글을 검색하세요"
+              className={`w-full rounded-xl pl-12 pr-12 py-3 focus:outline-none focus:ring-2 focus:ring-[#6778ff] focus:border-transparent transition-all ${
+                isDark
+                  ? 'bg-white/5 border border-white/10 text-white placeholder-gray-500'
+                  : 'bg-white border border-gray-200 text-gray-900 placeholder-gray-400'
+              }`}
+            />
+            {inputValue && (
+              <button
+                type="button"
+                onClick={handleClearSearch}
+                className={`absolute right-4 top-1/2 -translate-y-1/2 p-1 rounded-full ${
+                  isDark ? 'text-gray-500 hover:text-white' : 'text-gray-400 hover:text-gray-600'
+                }`}
+              >
+                <X className="w-5 h-5" />
+              </button>
+            )}
+          </form>
+        </div>
+
+        {/* 검색 결과 */}
+        {searchQuery && (
+          <>
+            {/* 탭 */}
+            <div className={`flex gap-1 mb-8 border-b ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => handleTabChange(tab.id)}
+                  className={`flex-1 md:flex-none flex items-center justify-center gap-2 px-6 md:px-8 py-4 text-sm md:text-base font-medium transition-colors relative ${
+                    activeTab === tab.id
+                      ? isDark
+                        ? 'text-white'
+                        : 'text-[#6778ff]'
+                      : isDark
+                        ? 'text-gray-500 hover:text-gray-300'
+                        : 'text-gray-500 hover:text-gray-700'
+                  }`}
+                >
+                  {tab.icon && <tab.icon className="w-4 h-4 md:w-5 md:h-5" />}
+                  {tab.label}
+                  {searchQuery && (
+                    <span
+                      className={`px-2 py-0.5 rounded-full text-xs ${
+                        activeTab === tab.id
+                          ? 'bg-[#6778ff] text-white'
+                          : isDark
+                            ? 'bg-white/10 text-gray-400'
+                            : 'bg-gray-100 text-gray-500'
+                      }`}
+                    >
+                      {tab.count}
+                    </span>
+                  )}
+                  {activeTab === tab.id && (
+                    <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-[#6778ff]" />
+                  )}
+                </button>
+              ))}
+            </div>
+
+            {/* 필터 영역 */}
+            <div className="mb-6">
+              {/* 필터 토글 버튼 (모바일) */}
+              <button
+                onClick={() => setShowFilters(!showFilters)}
+                className={`md:hidden flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium mb-4 ${
+                  isDark
+                    ? 'bg-white/5 border border-white/10 text-gray-300'
+                    : 'bg-white border border-gray-200 text-gray-700'
+                }`}
+              >
+                <SlidersHorizontal className="w-4 h-4" />
+                필터
+                {activeFilterCount > 0 && (
+                  <span className="px-1.5 py-0.5 rounded-full bg-[#6778ff] text-white text-xs">
+                    {activeFilterCount}
+                  </span>
+                )}
+              </button>
+
+              {/* 필터 드롭다운들 */}
+              <div className={`flex flex-wrap gap-2 ${!showFilters ? 'max-md:hidden' : ''}`}>
+                {/* 공통: 정렬 */}
+                <FilterDropdown
+                  label="정렬"
+                  value={filters.sort}
+                  options={SORT_OPTIONS}
+                  onChange={(value) => updateFilterWithUrl('sort', value)}
+                  isDark={isDark}
+                />
+
+                {/* 강의/로드맵: 카테고리 */}
+                {(activeTab === 'all' || activeTab === 'courses' || activeTab === 'roadmaps') && (
+                  <FilterDropdown
+                    label="카테고리"
+                    value={filters.category}
+                    options={CATEGORY_OPTIONS}
+                    onChange={(value) => updateFilterWithUrl('category', value)}
+                    isDark={isDark}
+                  />
+                )}
+
+                {/* 강의/로드맵: 난이도 */}
+                {(activeTab === 'courses' || activeTab === 'roadmaps') && (
+                  <FilterDropdown
+                    label="난이도"
+                    value={filters.level}
+                    options={LEVEL_OPTIONS}
+                    onChange={(value) => updateFilterWithUrl('level', value)}
+                    isDark={isDark}
+                  />
+                )}
+
+                {/* 강의: 가격 */}
+                {activeTab === 'courses' && (
+                  <FilterDropdown
+                    label="가격"
+                    value={filters.price}
+                    options={PRICE_OPTIONS}
+                    onChange={(value) => updateFilterWithUrl('price', value)}
+                    isDark={isDark}
+                  />
+                )}
+
+                {/* 강의: 모집상태 */}
+                {activeTab === 'courses' && (
+                  <FilterDropdown
+                    label="모집상태"
+                    value={filters.status}
+                    options={STATUS_OPTIONS}
+                    onChange={(value) => updateFilterWithUrl('status', value)}
+                    isDark={isDark}
+                  />
+                )}
+
+                {/* 커뮤니티: 게시글 유형 */}
+                {activeTab === 'community' && (
+                  <FilterDropdown
+                    label="유형"
+                    value={filters.postType}
+                    options={POST_TYPE_OPTIONS}
+                    onChange={(value) => updateFilterWithUrl('postType', value)}
+                    isDark={isDark}
+                  />
+                )}
+
+                {/* 커뮤니티: 카테고리 */}
+                {activeTab === 'community' && (
+                  <FilterDropdown
+                    label="카테고리"
+                    value={filters.communityCategory}
+                    options={COMMUNITY_CATEGORY_OPTIONS}
+                    onChange={(value) => updateFilterWithUrl('communityCategory', value)}
+                    isDark={isDark}
+                  />
+                )}
+
+                {/* 필터 초기화 */}
+                {activeFilterCount > 0 && (
+                  <button
+                    onClick={resetFilters}
+                    className={`flex items-center gap-1 px-3 py-2 rounded-lg text-sm font-medium transition-all ${
+                      isDark
+                        ? 'text-gray-400 hover:text-white hover:bg-white/5'
+                        : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+                    }`}
+                  >
+                    <X className="w-4 h-4" />
+                    초기화
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* 검색 결과 요약 */}
+            <p className={`mb-6 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+              "<span className={`font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>{searchQuery}</span>"
+              검색 결과{' '}
+              <span className={`font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                {totalResults}
+              </span>
+              건
+            </p>
+
+            {isLoading ? (
+              <div className="flex items-center justify-center py-20">
+                <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
+                <span className={`ml-3 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  검색 중...
+                </span>
+              </div>
+            ) : totalResults === 0 ? (
+              <div className="text-center py-20">
+                <Search className={`w-16 h-16 mx-auto mb-4 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
+                <p className={`text-lg ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  검색 결과가 없습니다
+                </p>
+                <p className={`text-sm mt-2 ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+                  다른 키워드로 검색해 보세요
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-12">
+                {/* 강의 섹션 */}
+                {(activeTab === 'all' || activeTab === 'courses') && courses.length > 0 && (
+                  <section>
+                    {activeTab === 'all' && (
+                      <div className="flex items-center justify-between mb-6">
+                        <h2 className={`text-xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                          강의
+                          <span className="ml-2 text-sm font-normal text-[#6778ff]">{totalCourses}</span>
+                        </h2>
+                        {totalCourses > 6 && (
+                          <button
+                            onClick={() => handleTabChange('courses')}
+                            className="text-sm text-[#6778ff] hover:underline flex items-center gap-1"
+                          >
+                            더보기 <ChevronRight className="w-4 h-4" />
+                          </button>
+                        )}
+                      </div>
+                    )}
+                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6">
+                      {(courses as MockCourseCard[]).map((course) => (
+                        <LandingCourseCard
+                          key={course.id}
+                          id={course.id}
+                          title={course.title}
+                          instructor={course.instructor}
+                          price={course.price}
+                          rating={course.rating}
+                          reviewCount={course.reviewCount}
+                          image={course.image}
+                          tags={course.tags}
+                          category={course.category}
+                        />
+                      ))}
+                    </div>
+                  </section>
+                )}
+
+                {/* 로드맵 섹션 */}
+                {(activeTab === 'all' || activeTab === 'roadmaps') && roadmaps.length > 0 && (
+                  <section>
+                    {activeTab === 'all' && (
+                      <div className="flex items-center justify-between mb-6">
+                        <h2 className={`text-xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                          로드맵
+                          <span className="ml-2 text-sm font-normal text-[#6778ff]">{totalRoadmaps}</span>
+                        </h2>
+                        {totalRoadmaps > 6 && (
+                          <button
+                            onClick={() => handleTabChange('roadmaps')}
+                            className="text-sm text-[#6778ff] hover:underline flex items-center gap-1"
+                          >
+                            더보기 <ChevronRight className="w-4 h-4" />
+                          </button>
+                        )}
+                      </div>
+                    )}
+                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+                      {roadmaps.map((roadmap) => (
+                        <RoadmapCard key={roadmap.id} roadmap={roadmap} isDark={isDark} />
+                      ))}
+                    </div>
+                  </section>
+                )}
+
+                {/* 커뮤니티 섹션 */}
+                {(activeTab === 'all' || activeTab === 'community') && communityPosts.length > 0 && (
+                  <section>
+                    {activeTab === 'all' && (
+                      <div className="flex items-center justify-between mb-6">
+                        <h2 className={`text-xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                          커뮤니티
+                          <span className="ml-2 text-sm font-normal text-[#6778ff]">{totalCommunity}</span>
+                        </h2>
+                        {totalCommunity > 6 && (
+                          <button
+                            onClick={() => handleTabChange('community')}
+                            className="text-sm text-[#6778ff] hover:underline flex items-center gap-1"
+                          >
+                            더보기 <ChevronRight className="w-4 h-4" />
+                          </button>
+                        )}
+                      </div>
+                    )}
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      {communityPosts.map((post) => (
+                        <CommunityCard key={post.id} post={post} isDark={isDark} />
+                      ))}
+                    </div>
+                  </section>
+                )}
+              </div>
+            )}
+          </>
+        )}
+
+        {/* 검색어 없을 때 */}
+        {!searchQuery && (
+          <div className="text-center py-16">
+            <Search className={`w-16 h-16 mx-auto mb-4 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
+            <h2 className={`text-xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              무엇을 찾으시나요?
+            </h2>
+            <p className={`mb-8 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+              위 검색창에 키워드를 입력해주세요
+            </p>
+
+            {/* 인기 검색어 */}
+            <div className="max-w-lg mx-auto">
+              <p className={`text-sm mb-4 ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+                인기 검색어
+              </p>
+              <div className="flex flex-wrap justify-center gap-3">
+                {['React', 'Python', 'AI', '클라우드', 'TypeScript', 'AWS', 'Docker', 'Spring'].map((keyword) => (
+                  <button
+                    key={keyword}
+                    onClick={() => {
+                      setInputValue(keyword);
+                      setSearchQuery(keyword);
+                      setSearchParams({ search: keyword, tab: 'all' });
+                    }}
+                    className={`px-4 py-2 rounded-full text-sm font-medium transition-all duration-300 ${
+                      isDark
+                        ? 'bg-white/5 text-gray-300 hover:bg-white/10 border border-white/10 hover:text-white'
+                        : 'bg-white text-gray-600 hover:bg-gray-100 border border-gray-200 hover:text-gray-900'
+                    }`}
+                  >
+                    {keyword}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+      </main>
+
+      <LandingFooter />
+    </div>
+  );
+}

--- a/src/pages/tu/main/SearchPage.tsx
+++ b/src/pages/tu/main/SearchPage.tsx
@@ -33,6 +33,7 @@ interface MockCourseCard {
   price: string;
   rating: number;
   reviewCount: number;
+  studentCount: number;
   image: string;
   tags: string[];
   category: string;
@@ -47,6 +48,7 @@ const MOCK_COURSES: MockCourseCard[] = [
     price: '₩99,000',
     rating: 4.8,
     reviewCount: 45,
+    studentCount: 1234,
     image: 'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=250&fit=crop',
     tags: ['상시모집', '인기'],
     category: '개발',
@@ -59,6 +61,7 @@ const MOCK_COURSES: MockCourseCard[] = [
     price: '₩79,000',
     rating: 4.7,
     reviewCount: 32,
+    studentCount: 856,
     image: 'https://images.unsplash.com/photo-1587620962725-abab7fe55159?w=400&h=250&fit=crop',
     tags: ['상시모집'],
     category: '개발',
@@ -71,6 +74,7 @@ const MOCK_COURSES: MockCourseCard[] = [
     price: '₩129,000',
     rating: 4.9,
     reviewCount: 28,
+    studentCount: 2341,
     image: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=400&h=250&fit=crop',
     tags: ['모집중', '신규'],
     category: 'AI',
@@ -83,6 +87,7 @@ const MOCK_COURSES: MockCourseCard[] = [
     price: '무료',
     rating: 4.6,
     reviewCount: 156,
+    studentCount: 3456,
     image: 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=400&h=250&fit=crop',
     tags: ['상시모집', '무료'],
     category: '클라우드',
@@ -95,6 +100,7 @@ const MOCK_COURSES: MockCourseCard[] = [
     price: '₩89,000',
     rating: 4.8,
     reviewCount: 41,
+    studentCount: 1567,
     image: 'https://images.unsplash.com/photo-1555066931-4365d14bab8c?w=400&h=250&fit=crop',
     tags: ['상시모집', '인기'],
     category: '개발',
@@ -107,6 +113,7 @@ const MOCK_COURSES: MockCourseCard[] = [
     price: '₩75,000',
     rating: 4.5,
     reviewCount: 22,
+    studentCount: 432,
     image: 'https://images.unsplash.com/photo-1517694712202-14dd9538aa97?w=400&h=250&fit=crop',
     tags: ['모집중'],
     category: '개발',
@@ -119,6 +126,7 @@ const MOCK_COURSES: MockCourseCard[] = [
     price: '₩149,000',
     rating: 4.9,
     reviewCount: 89,
+    studentCount: 2789,
     image: 'https://images.unsplash.com/photo-1667372393119-3d4c48d07fc9?w=400&h=250&fit=crop',
     tags: ['상시모집', '인기'],
     category: '클라우드',
@@ -131,6 +139,7 @@ const MOCK_COURSES: MockCourseCard[] = [
     price: '₩110,000',
     rating: 4.7,
     reviewCount: 67,
+    studentCount: 1890,
     image: 'https://images.unsplash.com/photo-1627398242454-45a1465c2479?w=400&h=250&fit=crop',
     tags: ['상시모집'],
     category: '개발',
@@ -143,6 +152,7 @@ const MOCK_COURSES: MockCourseCard[] = [
     price: '₩139,000',
     rating: 4.8,
     reviewCount: 112,
+    studentCount: 3210,
     image: 'https://images.unsplash.com/photo-1515879218367-8466d910aaa4?w=400&h=250&fit=crop',
     tags: ['상시모집', '인기'],
     category: '개발',
@@ -155,6 +165,7 @@ const MOCK_COURSES: MockCourseCard[] = [
     price: '₩95,000',
     rating: 4.6,
     reviewCount: 54,
+    studentCount: 987,
     image: 'https://images.unsplash.com/photo-1512941937669-90a1b58e7e9c?w=400&h=250&fit=crop',
     tags: ['모집중', '신규'],
     category: '개발',
@@ -167,6 +178,7 @@ const MOCK_COURSES: MockCourseCard[] = [
     price: '₩69,000',
     rating: 4.5,
     reviewCount: 203,
+    studentCount: 4567,
     image: 'https://images.unsplash.com/photo-1544383835-bda2bc66a55d?w=400&h=250&fit=crop',
     tags: ['상시모집', '무료'],
     category: '데이터',
@@ -179,6 +191,7 @@ const MOCK_COURSES: MockCourseCard[] = [
     price: '무료',
     rating: 4.8,
     reviewCount: 321,
+    studentCount: 5678,
     image: 'https://images.unsplash.com/photo-1618401471353-b98afee0b2eb?w=400&h=250&fit=crop',
     tags: ['상시모집', '무료', '인기'],
     category: '개발',
@@ -191,6 +204,7 @@ const MOCK_COURSES: MockCourseCard[] = [
     price: '₩89,000',
     rating: 4.9,
     reviewCount: 78,
+    studentCount: 1876,
     image: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=400&h=250&fit=crop',
     tags: ['신규', '인기'],
     category: 'AI',
@@ -203,6 +217,7 @@ const MOCK_COURSES: MockCourseCard[] = [
     price: '₩85,000',
     rating: 4.7,
     reviewCount: 95,
+    studentCount: 1345,
     image: 'https://images.unsplash.com/photo-1561070791-2526d30994b5?w=400&h=250&fit=crop',
     tags: ['상시모집'],
     category: '디자인',
@@ -215,6 +230,7 @@ const MOCK_COURSES: MockCourseCard[] = [
     price: '₩119,000',
     rating: 4.8,
     reviewCount: 134,
+    studentCount: 2987,
     image: 'https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=400&h=250&fit=crop',
     tags: ['상시모집', '인기'],
     category: '데이터',
@@ -1346,6 +1362,7 @@ export function SearchPage() {
                           price={course.price}
                           rating={course.rating}
                           reviewCount={course.reviewCount}
+                          studentCount={course.studentCount}
                           image={course.image}
                           tags={course.tags}
                           category={course.category}

--- a/src/pages/tu/main/index.ts
+++ b/src/pages/tu/main/index.ts
@@ -10,3 +10,4 @@ export { NotificationsPage } from './NotificationsPage';
 export { NotificationDetailPage } from './NotificationDetailPage';
 export { CourseDetailPage } from './CourseDetailPage';
 export { InstructorProfilePage } from './InstructorProfilePage';
+export { SearchPage } from './SearchPage';

--- a/src/routes/tu.b2c.routes.tsx
+++ b/src/routes/tu.b2c.routes.tsx
@@ -12,6 +12,7 @@ import {
   NotificationsPage,
   NotificationDetailPage,
   InstructorProfilePage,
+  SearchPage,
 } from '@/pages/tu';
 
 /**
@@ -24,6 +25,9 @@ export const tuB2cRoutes = (
   <>
     {/* 랜딩 페이지 */}
     <Route path="/tu/b2c" element={<LandingPage />} />
+
+    {/* 통합 검색 */}
+    <Route path="/tu/b2c/search" element={<SearchPage />} />
 
     {/* 강의 탐색 */}
     <Route path="/tu/b2c/courses" element={<CoursesExplorePage />} />

--- a/src/services/ta/brandingService.ts
+++ b/src/services/ta/brandingService.ts
@@ -3,6 +3,34 @@
  */
 import axiosInstance from '@/services/common/api/axiosInstance';
 import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type {
+  HeaderSettings,
+  SidebarSettings,
+  FooterSettings,
+  ContentSettings,
+  TypographySettings,
+  ColorModeSettings,
+  ComponentStyleSettings,
+  AccessibilitySettings,
+  ResponsiveSettings,
+  UpdateDesignSettingsRequest,
+  UpdateLayoutSettingsRequest,
+} from '@/types/admin';
+
+// Re-export types for consumers
+export type {
+  HeaderSettings,
+  SidebarSettings,
+  FooterSettings,
+  ContentSettings,
+  TypographySettings,
+  ColorModeSettings,
+  ComponentStyleSettings,
+  AccessibilitySettings,
+  ResponsiveSettings,
+  UpdateDesignSettingsRequest,
+  UpdateLayoutSettingsRequest,
+};
 
 // ============================================
 // 타입 정의
@@ -26,6 +54,12 @@ export interface TenantSettingsResponse {
   sidebarSettings: SidebarSettings;
   footerSettings: FooterSettings;
   contentSettings: ContentSettings;
+  // 확장 UI 설정
+  typographySettings: TypographySettings | null;
+  colorModeSettings: ColorModeSettings | null;
+  componentStyleSettings: ComponentStyleSettings | null;
+  accessibilitySettings: AccessibilitySettings | null;
+  responsiveSettings: ResponsiveSettings | null;
   // 일반 설정
   defaultLanguage: string;
   timezone: string;
@@ -45,48 +79,6 @@ export interface TenantSettingsResponse {
   apiAccessEnabled: boolean;
   createdAt: string;
   updatedAt: string;
-}
-
-export interface HeaderSettings {
-  style: 'fixed' | 'sticky' | 'static';
-  showLogo: boolean;
-  showSearch: boolean;
-  showNotifications: boolean;
-}
-
-export interface SidebarSettings {
-  style: 'collapsible' | 'fixed' | 'overlay' | 'hidden';
-  defaultCollapsed: boolean;
-  showIcons: boolean;
-}
-
-export interface FooterSettings {
-  enabled: boolean;
-  showLinks: boolean;
-  showCopyright: boolean;
-}
-
-export interface ContentSettings {
-  maxWidth: 'full' | 'xl' | 'lg' | 'md';
-  padding: 'none' | 'compact' | 'normal' | 'relaxed';
-}
-
-export interface UpdateDesignSettingsRequest {
-  logoUrl?: string | null;
-  darkLogoUrl?: string | null;
-  faviconUrl?: string | null;
-  primaryColor?: string;
-  secondaryColor?: string;
-  accentColor?: string;
-  headingFont?: string;
-  bodyFont?: string;
-}
-
-export interface UpdateLayoutSettingsRequest {
-  headerSettings?: HeaderSettings;
-  sidebarSettings?: SidebarSettings;
-  footerSettings?: FooterSettings;
-  contentSettings?: ContentSettings;
 }
 
 export interface NavigationItemResponse {

--- a/src/types/admin/tenantSettings.types.ts
+++ b/src/types/admin/tenantSettings.types.ts
@@ -2,29 +2,110 @@
  * Tenant Settings 타입 정의 (TA)
  */
 
-// 레이아웃 설정 타입
+// ============================================
+// 레이아웃 설정 타입 (확장)
+// ============================================
+
+// 헤더 설정
 export interface HeaderSettings {
+  // 기본 설정
   style: 'fixed' | 'sticky' | 'static';
   showLogo: boolean;
   showSearch: boolean;
   showNotifications: boolean;
+  // 확장 설정
+  height: 'compact' | 'default' | 'large'; // 48px / 64px / 80px
+  backgroundOpacity: 'solid' | 'translucent' | 'transparent'; // 스크롤 시 효과
+  navPosition: 'left' | 'center' | 'right'; // 네비게이션 위치
+  userMenuStyle: 'avatar' | 'name' | 'dropdown'; // 사용자 메뉴 스타일
+  shadow: 'none' | 'sm' | 'md'; // 그림자
+  mobileMenuStyle: 'hamburger' | 'drawer' | 'bottomSheet'; // 모바일 메뉴
 }
 
+// 사이드바 설정
 export interface SidebarSettings {
+  // 기본 설정
   style: 'collapsible' | 'fixed' | 'overlay' | 'hidden';
   defaultCollapsed: boolean;
   showIcons: boolean;
+  // 확장 설정
+  width: 'narrow' | 'default' | 'wide'; // 200px / 240px / 280px
+  menuGroupStyle: 'accordion' | 'expanded' | 'divider'; // 메뉴 그룹 스타일
+  activeIndicator: 'background' | 'leftBar' | 'underline' | 'iconColor'; // 활성 메뉴 표시
+  itemSpacing: 'compact' | 'default' | 'relaxed'; // 메뉴 아이템 간격
+  scrollbarStyle: 'always' | 'hover' | 'hidden'; // 스크롤바 표시
+  bottomSection: 'userInfo' | 'logout' | 'settings' | 'none'; // 하단 영역
 }
 
+// 푸터 설정
 export interface FooterSettings {
+  // 기본 설정
   enabled: boolean;
   showLinks: boolean;
   showCopyright: boolean;
+  // 확장 설정
+  layout: 'single' | 'multi-column' | 'minimal'; // 레이아웃 유형
+  showSocialLinks: boolean; // 소셜 링크 표시
+  socialPlatforms: ('facebook' | 'twitter' | 'instagram' | 'youtube' | 'linkedin')[]; // 표시할 플랫폼
+  showCompanyInfo: boolean; // 회사 정보 표시
+  companyInfoFields: ('address' | 'phone' | 'email' | 'businessNumber')[]; // 표시할 정보
+  showNewsletter: boolean; // 뉴스레터 구독 폼
 }
 
+// 콘텐츠 영역 설정
 export interface ContentSettings {
+  // 기본 설정
   maxWidth: 'full' | 'xl' | 'lg' | 'md';
   padding: 'none' | 'compact' | 'normal' | 'relaxed';
+  // 확장 설정
+  pageTransition: 'none' | 'fade' | 'slide'; // 페이지 전환 애니메이션
+  cardStyle: 'flat' | 'shadow' | 'border' | 'glass'; // 카드 스타일
+  cardRadius: 'none' | 'sm' | 'md' | 'lg'; // 카드 모서리
+  tableStyle: 'striped' | 'plain' | 'bordered'; // 테이블 스타일
+  buttonStyle: 'square' | 'rounded' | 'pill'; // 버튼 스타일
+  loadingIndicator: 'spinner' | 'skeleton' | 'progressBar'; // 로딩 인디케이터
+}
+
+// 타이포그래피 설정
+export interface TypographySettings {
+  fontScale: 'small' | 'default' | 'large'; // 전체 폰트 크기 스케일
+  lineHeight: 'tight' | 'normal' | 'relaxed'; // 줄 간격
+  headingStyle: 'bold' | 'semibold' | 'normal'; // 제목 굵기
+  headingCase: 'normal' | 'uppercase' | 'capitalize'; // 제목 대소문자
+}
+
+// 컬러 모드 설정
+export interface ColorModeSettings {
+  defaultMode: 'light' | 'dark' | 'system'; // 기본 모드
+  allowUserToggle: boolean; // 사용자 전환 허용
+  togglePosition: 'header' | 'sidebar' | 'footer' | 'hidden'; // 전환 버튼 위치
+  transitionDuration: 'instant' | 'fast' | 'normal'; // 전환 속도
+}
+
+// 컴포넌트 스타일 설정
+export interface ComponentStyleSettings {
+  density: 'compact' | 'default' | 'comfortable'; // UI 밀도
+  inputStyle: 'outline' | 'filled' | 'underline'; // 입력 필드 스타일
+  badgeStyle: 'solid' | 'outline' | 'soft'; // 배지 스타일
+  avatarStyle: 'circle' | 'rounded' | 'square'; // 아바타 스타일
+  iconSize: 'small' | 'default' | 'large'; // 아이콘 크기
+}
+
+// 접근성 설정
+export interface AccessibilitySettings {
+  highContrastMode: boolean; // 고대비 모드
+  fontSizeAdjustable: boolean; // 폰트 크기 조절 허용
+  reduceMotion: boolean; // 모션 감소
+  focusIndicator: 'default' | 'enhanced' | 'custom'; // 포커스 표시
+  screenReaderOptimized: boolean; // 스크린 리더 최적화
+}
+
+// 반응형 설정
+export interface ResponsiveSettings {
+  mobileBreakpoint: number; // 모바일 브레이크포인트 (px)
+  tabletBreakpoint: number; // 태블릿 브레이크포인트 (px)
+  tabletLayout: 'mobile' | 'desktop' | 'adaptive'; // 태블릿 레이아웃
+  mobileNavStyle: 'bottom' | 'top' | 'drawer'; // 모바일 네비게이션
 }
 
 export interface TenantSettingsDetail {
@@ -47,6 +128,13 @@ export interface TenantSettingsDetail {
   sidebarSettings: SidebarSettings | null;
   footerSettings: FooterSettings | null;
   contentSettings: ContentSettings | null;
+
+  // Extended UI Settings
+  typographySettings: TypographySettings | null;
+  colorModeSettings: ColorModeSettings | null;
+  componentStyleSettings: ComponentStyleSettings | null;
+  accessibilitySettings: AccessibilitySettings | null;
+  responsiveSettings: ResponsiveSettings | null;
 
   // General Settings
   defaultLanguage: string;
@@ -133,6 +221,11 @@ export interface UpdateLayoutSettingsRequest {
   sidebarSettings?: SidebarSettings;
   footerSettings?: FooterSettings;
   contentSettings?: ContentSettings;
+  typographySettings?: TypographySettings;
+  colorModeSettings?: ColorModeSettings;
+  componentStyleSettings?: ComponentStyleSettings;
+  accessibilitySettings?: AccessibilitySettings;
+  responsiveSettings?: ResponsiveSettings;
 }
 
 // 네비게이션 항목 타입


### PR DESCRIPTION
## Summary
- 테넌트 관리자(TA) 레이아웃 설정 페이지에 상세 커스터마이징 옵션 추가
- 실시간 미리보기 기능 추가 (데스크톱/태블릿/모바일 뷰 모드)
- 페이지 타입별 미리보기 탭 추가 (관리자/운영자/사용자)

## Changes

### 타입 정의 확장
- HeaderSettings: height, backgroundOpacity, navPosition, userMenuStyle, shadow, mobileMenuStyle
- SidebarSettings: width, menuGroupStyle, activeIndicator, itemSpacing, scrollbarStyle, bottomSection
- FooterSettings: layout, showSocialLinks, socialPlatforms, showCompanyInfo, companyInfoFields, showNewsletter
- ContentSettings: pageTransition, cardStyle, cardRadius, tableStyle, buttonStyle, loadingIndicator
- 신규 타입: TypographySettings, ColorModeSettings, ComponentStyleSettings, AccessibilitySettings, ResponsiveSettings

### 미리보기 기능
- 뷰 모드 전환 (데스크톱/태블릿/모바일)
- 페이지 타입 탭 (관리자/운영자/사용자 페이지)
- 다양한 UI 컴포넌트 실시간 미리보기 (카드, 버튼, 배지, 입력 필드, 테이블, 아바타)
- 설정 요약 패널

## Test plan
- [x] `/ta/branding/layout` 페이지 접근
- [x] 각 설정 카테고리 옵션 변경 시 미리보기 반영 확인
- [x] 뷰 모드 전환 (데스크톱/태블릿/모바일) 동작 확인
- [x] 페이지 타입 탭 (관리자/운영자/사용자) 전환 동작 확인
- [x] 다크 모드 전환 시 미리보기 반영 확인
- [ ] 저장 기능 동작 확인

Closes #296