### PR TITLE
fix: 수료증 미리보기 모달 중복 닫기 버튼 제거

### DIFF
--- a/src/components/domain/tu/certificate/CertificatePreviewModal.tsx
+++ b/src/components/domain/tu/certificate/CertificatePreviewModal.tsx
@@ -1,4 +1,4 @@
-import { Award, Calendar, User, Download, X, Building2, BookOpen, Hash, Loader2 } from 'lucide-react';
+import { Award, Calendar, User, Download, Building2, BookOpen, Hash, Loader2 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import {
   Dialog,
@@ -73,14 +73,9 @@ export const CertificatePreviewModal = ({
       >
         {/* 헤더 */}
         <DialogHeader className={cn('p-4 border-b', isDark ? 'border-gray-700' : 'border-gray-200')}>
-          <div className="flex items-center justify-between">
-            <DialogTitle className={isDark ? 'text-white' : 'text-gray-900'}>
-              {labels.title}
-            </DialogTitle>
-            <Button variant="ghost" size="sm" onClick={onClose}>
-              <X className="w-4 h-4" />
-            </Button>
-          </div>
+          <DialogTitle className={isDark ? 'text-white' : 'text-gray-900'}>
+            {labels.title}
+          </DialogTitle>
         </DialogHeader>
 
         {/* 수료증 본문 */}


### PR DESCRIPTION
## Summary

수료증 미리보기 모달에서 닫기 버튼이 2개 표시되는 문제 수정

## Related Issue

- N/A

## Changes

- DialogHeader 내 커스텀 X 버튼 제거 (DialogContent 기본 닫기 버튼과 중복)
- 사용하지 않는 X 아이콘 import 제거

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

DialogContent 컴포넌트에 기본 닫기 버튼이 포함되어 있어, DialogHeader에 추가한 커스텀 X 버튼과 중복 표시되는 문제였습니다.