### PR TITLE
[Design] TU 어드민 유저플로우 개선

### DIFF
--- a/src/components/common/AlertDialog/AlertDialog.tsx
+++ b/src/components/common/AlertDialog/AlertDialog.tsx
@@ -54,7 +54,7 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          "bg-white dark:bg-[#2a2a2a] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-gray-200 dark:border-white/10 p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-bg-default data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-border p-6 shadow-lg duration-200 sm:max-w-lg",
           className,
         )}
         {...props}
@@ -99,7 +99,7 @@ function AlertDialogTitle({
   return (
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
-      className={cn("text-lg font-semibold text-gray-900 dark:text-white", className)}
+      className={cn("text-lg font-semibold text-text-primary", className)}
       {...props}
     />
   );
@@ -112,7 +112,7 @@ function AlertDialogDescription({
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn("text-sm text-gray-600 dark:text-gray-300", className)}
+      className={cn("text-sm text-text-secondary", className)}
       {...props}
     />
   );

--- a/src/components/common/Sheet/Sheet.tsx
+++ b/src/components/common/Sheet/Sheet.tsx
@@ -58,7 +58,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "bg-bg-default data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&
@@ -72,7 +72,7 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+        <SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none text-text-secondary hover:text-text-primary">
           <XIcon className="size-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
@@ -108,7 +108,7 @@ function SheetTitle({
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn("text-foreground font-semibold", className)}
+      className={cn("text-text-primary font-semibold", className)}
       {...props}
     />
   );
@@ -121,7 +121,7 @@ function SheetDescription({
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-text-secondary text-sm", className)}
       {...props}
     />
   );

--- a/src/components/layout/mypage/MyPageSidebar.tsx
+++ b/src/components/layout/mypage/MyPageSidebar.tsx
@@ -100,7 +100,7 @@ export function MyPageSidebar({ onMenuItemClick }: MyPageSidebarProps) {
       const updatedUser = await userService.getMe();
       updateUser({ role: updatedUser.role });
 
-      toast.success(language === 'ko' ? '강의 개설 권한이 부여되었습니다.' : 'Designer permission granted.');
+      toast.success(language === 'ko' ? '강의 디자인 권한이 부여되었습니다.' : 'Designer permission granted.');
       setShowCreateCourseDialog(false);
       onMenuItemClick?.('create-course');
     } catch (error) {
@@ -117,7 +117,7 @@ export function MyPageSidebar({ onMenuItemClick }: MyPageSidebarProps) {
         const updatedUser = await userService.getMe();
         updateUser({ role: updatedUser.role });
 
-        toast.success(language === 'ko' ? '이미 강의 개설 권한이 있습니다.' : 'You already have designer permission.');
+        toast.success(language === 'ko' ? '이미 강의 디자인 권한이 있습니다.' : 'You already have designer permission.');
         setShowCreateCourseDialog(false);
         onMenuItemClick?.('create-course');
       } else {
@@ -128,21 +128,21 @@ export function MyPageSidebar({ onMenuItemClick }: MyPageSidebarProps) {
     }
   };
 
-  // 강의 개설 다이얼로그 설명 텍스트
+  // 강의 디자인 다이얼로그 설명 텍스트
   const getCreateCourseDialogDescription = () => {
     if (courseRoleStatus === 'OWNER') {
       return language === 'ko'
-        ? '이미 강의 소유자입니다. 새 강의를 만드시겠습니까?'
-        : 'You are already a course owner. Would you like to create a new course?';
+        ? '이미 강의 소유자입니다. 새 강의를 디자인하시겠습니까?'
+        : 'You are already a course owner. Would you like to design a new course?';
     }
     if (courseRoleStatus === 'DESIGNER') {
       return language === 'ko'
-        ? '이미 강의 개설 권한이 있습니다. 강의 설계 페이지로 이동하시겠습니까?'
-        : 'You already have course creation permission. Would you like to go to the course design page?';
+        ? '이미 강의 디자인 권한이 있습니다. 강의 디자인 페이지로 이동하시겠습니까?'
+        : 'You already have course design permission. Would you like to go to the course design page?';
     }
     return language === 'ko'
-      ? '강의 개설을 위해 디자이너 권한이 부여됩니다. 강의 설계 / 개설 페이지로 이동하시겠습니까?'
-      : 'Designer permission will be granted for course creation. Would you like to proceed to the course design / creation page?';
+      ? '강의 디자인을 위해 디자이너 권한이 부여됩니다. 강의 디자인 페이지로 이동하시겠습니까?'
+      : 'Designer permission will be granted for course design. Would you like to proceed to the course design page?';
   };
 
   // 현재 유저 롤로 subItem 필터링
@@ -380,12 +380,12 @@ export function MyPageSidebar({ onMenuItemClick }: MyPageSidebarProps) {
         </div>
       </div>
 
-      {/* 강의 개설 확인 다이얼로그 */}
+      {/* 강의 디자인 확인 다이얼로그 */}
       <AlertDialog open={showCreateCourseDialog} onOpenChange={setShowCreateCourseDialog}>
         <AlertDialogContent className={isDark ? 'bg-[#2a2a2a] border-white/10' : ''}>
           <AlertDialogHeader>
             <AlertDialogTitle className={isDark ? 'text-white' : ''}>
-              {language === 'ko' ? '강의 설계 / 개설' : 'Course Design / Creation'}
+              {language === 'ko' ? '강의 디자인' : 'Course Design'}
             </AlertDialogTitle>
             <AlertDialogDescription className={isDark ? 'text-gray-300' : ''}>
               {getCreateCourseDialogDescription()}

--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -249,9 +249,14 @@ export const tenantUserMenuData: MenuItem[] = [
       { id: 'my-courses', label: { ko: '강의 디자인', en: 'Course Design' }, icon: BookOpen, path: '/tu/teaching/courses' },
       { id: 'my-programs', label: { ko: '개설 신청 현황', en: 'Submission Status' }, icon: Package, path: '/tu/teaching/programs' },
       { id: 'my-assignments', label: { ko: '강의 운영', en: 'Course Operations' }, icon: CheckSquare, path: '/tu/teaching/assignments' },
-      { id: 'my-content', label: { ko: '내 콘텐츠', en: 'My Content' }, icon: PenTool, path: '/tu/teaching/content' },
       { id: 'my-roadmaps', label: { ko: '로드맵', en: 'Roadmaps' }, icon: Map, path: '/tu/teaching/roadmaps', roles: ['DESIGNER', 'OPERATOR', 'TENANT_ADMIN'] },
     ],
+  },
+  {
+    id: 'my-content',
+    label: { ko: '내 콘텐츠', en: 'My Content' },
+    icon: PenTool,
+    path: '/tu/teaching/content',
   },
   // '과정 둘러보기' 메뉴 제거 - 모드 스위처의 '학습자 모드'로 대체
 ];

--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -247,8 +247,8 @@ export const tenantUserMenuData: MenuItem[] = [
     icon: Briefcase,
     subItems: [
       { id: 'my-courses', label: { ko: '강의 디자인', en: 'Course Design' }, icon: BookOpen, path: '/tu/teaching/courses' },
-      { id: 'my-programs', label: { ko: '강의 개설', en: 'Course Creation' }, icon: Package, path: '/tu/teaching/programs' },
-      { id: 'my-assignments', label: { ko: '강의 관리', en: 'Course Management' }, icon: CheckSquare, path: '/tu/teaching/assignments' },
+      { id: 'my-programs', label: { ko: '개설 신청 현황', en: 'Submission Status' }, icon: Package, path: '/tu/teaching/programs' },
+      { id: 'my-assignments', label: { ko: '강의 운영', en: 'Course Operations' }, icon: CheckSquare, path: '/tu/teaching/assignments' },
       { id: 'my-content', label: { ko: '내 콘텐츠', en: 'My Content' }, icon: PenTool, path: '/tu/teaching/content' },
       { id: 'my-roadmaps', label: { ko: '로드맵', en: 'Roadmaps' }, icon: Map, path: '/tu/teaching/roadmaps', roles: ['DESIGNER', 'OPERATOR', 'TENANT_ADMIN'] },
     ],
@@ -282,7 +282,7 @@ export const myPageMenuData: MenuItem[] = [
     icon: Briefcase,
     subItems: [
       { id: 'my-courses', label: { ko: '내 강의', en: 'My Courses' }, icon: BookOpen, path: '/tu/b2c/mypage/teaching' },
-      { id: 'create-course', label: { ko: '강의 개설하기', en: 'Create Course' }, icon: FolderEdit, path: '/tu/teaching/courses/create', roles: ['USER', 'DESIGNER'] },
+      { id: 'create-course', label: { ko: '강의 디자인 시작하기', en: 'Start Course Design' }, icon: FolderEdit, path: '/tu/teaching/courses/create', roles: ['USER', 'DESIGNER'] },
       { id: 'teaching-stats', label: { ko: '내 강의 통계', en: 'Teaching Stats' }, icon: TrendingUp, path: '/tu/b2c/mypage/teaching/stats' },
     ],
   },

--- a/src/pages/tu/dashboard/TUDashboardPage.tsx
+++ b/src/pages/tu/dashboard/TUDashboardPage.tsx
@@ -12,7 +12,7 @@ import {
   ArrowRight,
 } from 'lucide-react';
 import { Button, IconStatCard, Card } from '@/components/common';
-import { useMyCourses, useMyPrograms, useMyAssignments } from '@/hooks/tu';
+import { useMyCourses, useMyPrograms, useMyInstructorStatistics } from '@/hooks/tu';
 
 interface TUDashboardPageProps {
   language?: 'ko' | 'en';
@@ -74,11 +74,11 @@ export function TUDashboardPage({ language = 'ko' }: Readonly<TUDashboardPagePro
   // API 훅
   const { data: coursesData, isLoading: isLoadingCourses } = useMyCourses();
   const { data: programsData, isLoading: isLoadingPrograms } = useMyPrograms();
-  const { data: assignmentsData, isLoading: isLoadingAssignments } = useMyAssignments();
+  const { data: statistics, isLoading: isLoadingStats } = useMyInstructorStatistics();
 
   const getText = (key: keyof typeof t) => t[key][language];
 
-  const isLoading = isLoadingCourses || isLoadingPrograms || isLoadingAssignments;
+  const isLoading = isLoadingCourses || isLoadingPrograms || isLoadingStats;
 
   if (isLoading) {
     return (
@@ -94,13 +94,13 @@ export function TUDashboardPage({ language = 'ko' }: Readonly<TUDashboardPagePro
   // 데이터 가공
   const courses = coursesData?.content || [];
   const programs = programsData?.content || [];
-  const assignments = assignmentsData?.content || [];
+  const courseTimeStats = statistics?.courseTimeStats || [];
 
   // 통계 계산
   const draftCourses = courses.filter((c) => !c.isComplete);
   const pendingPrograms = programs.filter((p) => p.status === 'PENDING');
   const approvedPrograms = programs.filter((p) => p.status === 'APPROVED');
-  const totalStudents = assignments.reduce((sum, a) => sum + (a.enrollmentCount || 0), 0);
+  const totalStudents = courseTimeStats.reduce((sum: number, stat) => sum + (stat.totalStudents || 0), 0);
 
   return (
     <div className="p-8 bg-bg-app_default min-h-screen">
@@ -130,7 +130,7 @@ export function TUDashboardPage({ language = 'ko' }: Readonly<TUDashboardPagePro
         <IconStatCard
           icon={<Users size={20} className="text-btn-brand" />}
           label={getText('statActive')}
-          value={`${assignments.length}개 / ${totalStudents}명`}
+          value={`${courseTimeStats.length}개 / ${totalStudents}명`}
         />
       </div>
 
@@ -257,7 +257,7 @@ export function TUDashboardPage({ language = 'ko' }: Readonly<TUDashboardPagePro
             </h3>
             <p className="text-sm text-text-secondary m-0">{getText('activeSectionSubtitle')}</p>
           </div>
-          {assignments.length > 0 && (
+          {courseTimeStats.length > 0 && (
             <Button
               variant="ghost"
               size="sm"
@@ -270,45 +270,42 @@ export function TUDashboardPage({ language = 'ko' }: Readonly<TUDashboardPagePro
           )}
         </div>
 
-        {assignments.length === 0 ? (
+        {courseTimeStats.length === 0 ? (
           <div className="py-8 text-center text-text-secondary text-sm">
             {getText('emptyActive')}
           </div>
         ) : (
           <div className="flex flex-col gap-3">
-            {assignments.slice(0, 5).map((assignment) => (
+            {courseTimeStats.slice(0, 5).map((stat) => (
               <div
-                key={assignment.courseTimeId}
+                key={stat.timeKey}
                 className="p-4 bg-bg-app_default rounded-lg flex justify-between items-center gap-4 cursor-pointer hover:bg-bg-secondary transition-colors"
-                onClick={() => navigate(`/tu/teaching/assignments/${assignment.courseTimeId}`)}
+                onClick={() => navigate(`/tu/teaching/assignments/${stat.timeKey}`)}
               >
                 <div className="flex-1 min-w-0">
                   <div className="text-text-primary font-medium truncate mb-1">
-                    {assignment.courseTimeTitle || assignment.programTitle}
-                  </div>
-                  <div className="text-sm text-text-secondary">
-                    {assignment.startDate} ~ {assignment.endDate}
+                    {stat.courseName} - {stat.timeName}
                   </div>
                 </div>
                 <div className="flex gap-6 items-center text-sm">
                   <div className="text-center">
                     <div className="text-text-secondary text-xs mb-1">{getText('students')}</div>
                     <div className="text-text-primary font-semibold">
-                      {assignment.enrollmentCount || 0}명
+                      {stat.totalStudents || 0}명
                     </div>
                   </div>
                   <div className="text-center">
                     <div className="text-text-secondary text-xs mb-1">{getText('completion')}</div>
                     <div
                       className={`font-semibold ${
-                        (assignment.completionRate || 0) >= 80
+                        (stat.completionRate || 0) >= 80
                           ? 'text-status-success_text'
-                          : (assignment.completionRate || 0) >= 50
+                          : (stat.completionRate || 0) >= 50
                           ? 'text-status-warning_text'
                           : 'text-text-primary'
                       }`}
                     >
-                      {assignment.completionRate || 0}%
+                      {stat.completionRate || 0}%
                     </div>
                   </div>
                 </div>

--- a/src/pages/tu/dashboard/TUDashboardPage.tsx
+++ b/src/pages/tu/dashboard/TUDashboardPage.tsx
@@ -1,0 +1,343 @@
+import { useNavigate } from 'react-router-dom';
+import {
+  BookOpen,
+  Users,
+  FileEdit,
+  Plus,
+  FolderPlus,
+  Loader2,
+  Clock,
+  Package,
+  CheckCircle,
+  ArrowRight,
+} from 'lucide-react';
+import { Button, IconStatCard, Card } from '@/components/common';
+import { useMyCourses, useMyPrograms, useMyAssignments } from '@/hooks/tu';
+
+interface TUDashboardPageProps {
+  language?: 'ko' | 'en';
+}
+
+const t = {
+  title: { ko: '강사 센터', en: 'Instructor Hub' },
+  subtitle: { ko: '강의 관리와 운영 현황을 확인하세요', en: 'Manage and monitor your courses' },
+
+  // 통계
+  statDraft: { ko: '작성중 강의', en: 'Draft Courses' },
+  statPending: { ko: '검토중', en: 'Pending Review' },
+  statApproved: { ko: '승인됨', en: 'Approved' },
+  statActive: { ko: '운영중 강의', en: 'Active Courses' },
+
+  // 작성중인 강의
+  draftSectionTitle: { ko: '작성중인 강의', en: 'Draft Courses' },
+  draftSectionSubtitle: { ko: '완료되지 않은 강의를 이어서 작성하세요', en: 'Continue working on incomplete courses' },
+  lastEdited: { ko: '마지막 수정', en: 'Last edited' },
+  continueButton: { ko: '이어서 작성', en: 'Continue' },
+  emptyDraft: { ko: '작성중인 강의가 없습니다', en: 'No draft courses' },
+  viewAll: { ko: '전체 보기', en: 'View All' },
+
+  // 개설 신청 현황
+  programSectionTitle: { ko: '개설 신청 현황', en: 'Submission Status' },
+  programSectionSubtitle: { ko: '프로그램 신청 및 승인 상태', en: 'Program submission and approval status' },
+  emptyProgram: { ko: '신청한 프로그램이 없습니다', en: 'No program submissions' },
+  statusPending: { ko: '검토중', en: 'Pending' },
+  statusApproved: { ko: '승인됨', en: 'Approved' },
+  statusRejected: { ko: '반려됨', en: 'Rejected' },
+
+  // 운영중인 강의
+  activeSectionTitle: { ko: '운영중인 강의', en: 'Active Courses' },
+  activeSectionSubtitle: { ko: '현재 진행중인 강의와 수강생 현황', en: 'Current courses and student statistics' },
+  students: { ko: '수강생', en: 'Students' },
+  completion: { ko: '완료율', en: 'Completion' },
+  emptyActive: { ko: '운영중인 강의가 없습니다', en: 'No active courses' },
+
+  // 빠른 시작
+  quickActionTitle: { ko: '빠른 시작', en: 'Quick Actions' },
+  createCourse: { ko: '새 강의 만들기', en: 'Create New Course' },
+  createContent: { ko: '콘텐츠 등록', en: 'Upload Content' },
+
+  // 로딩
+  loading: { ko: '데이터를 불러오는 중...', en: 'Loading data...' },
+};
+
+const STATUS_LABELS: Record<string, { ko: string; en: string }> = {
+  PENDING: { ko: '검토중', en: 'Pending' },
+  APPROVED: { ko: '승인됨', en: 'Approved' },
+  REJECTED: { ko: '반려됨', en: 'Rejected' },
+  DRAFT: { ko: '임시저장', en: 'Draft' },
+  CLOSED: { ko: '종료', en: 'Closed' },
+};
+
+export function TUDashboardPage({ language = 'ko' }: Readonly<TUDashboardPageProps>) {
+  const navigate = useNavigate();
+
+  // API 훅
+  const { data: coursesData, isLoading: isLoadingCourses } = useMyCourses();
+  const { data: programsData, isLoading: isLoadingPrograms } = useMyPrograms();
+  const { data: assignmentsData, isLoading: isLoadingAssignments } = useMyAssignments();
+
+  const getText = (key: keyof typeof t) => t[key][language];
+
+  const isLoading = isLoadingCourses || isLoadingPrograms || isLoadingAssignments;
+
+  if (isLoading) {
+    return (
+      <div className="p-8 bg-bg-app_default min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <Loader2 size={32} className="animate-spin text-text-secondary mx-auto mb-4" />
+          <p className="text-text-secondary">{getText('loading')}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // 데이터 가공
+  const courses = coursesData?.content || [];
+  const programs = programsData?.content || [];
+  const assignments = assignmentsData?.content || [];
+
+  // 통계 계산
+  const draftCourses = courses.filter((c) => !c.isComplete);
+  const pendingPrograms = programs.filter((p) => p.status === 'PENDING');
+  const approvedPrograms = programs.filter((p) => p.status === 'APPROVED');
+  const totalStudents = assignments.reduce((sum, a) => sum + (a.enrollmentCount || 0), 0);
+
+  return (
+    <div className="p-8 bg-bg-app_default min-h-screen">
+      {/* Header */}
+      <div className="mb-8">
+        <h1 className="text-text-primary mb-2">{getText('title')}</h1>
+        <p className="text-text-secondary m-0">{getText('subtitle')}</p>
+      </div>
+
+      {/* 요약 통계 (4개) */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-5 mb-8">
+        <IconStatCard
+          icon={<FileEdit size={20} className="text-status-warning" />}
+          label={getText('statDraft')}
+          value={draftCourses.length}
+        />
+        <IconStatCard
+          icon={<Clock size={20} className="text-status-warning" />}
+          label={getText('statPending')}
+          value={pendingPrograms.length}
+        />
+        <IconStatCard
+          icon={<CheckCircle size={20} className="text-status-success" />}
+          label={getText('statApproved')}
+          value={approvedPrograms.length}
+        />
+        <IconStatCard
+          icon={<Users size={20} className="text-btn-brand" />}
+          label={getText('statActive')}
+          value={`${assignments.length}개 / ${totalStudents}명`}
+        />
+      </div>
+
+      {/* 작성중인 강의 */}
+      <Card className="mb-6 p-6">
+        <div className="flex justify-between items-start mb-5">
+          <div>
+            <h3 className="text-text-primary mb-1 flex items-center gap-2">
+              <FileEdit size={18} className="text-status-warning" />
+              {getText('draftSectionTitle')}
+            </h3>
+            <p className="text-sm text-text-secondary m-0">{getText('draftSectionSubtitle')}</p>
+          </div>
+          {draftCourses.length > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-text-secondary"
+              onClick={() => navigate('/tu/teaching/courses')}
+            >
+              {getText('viewAll')}
+              <ArrowRight size={14} />
+            </Button>
+          )}
+        </div>
+
+        {draftCourses.length === 0 ? (
+          <div className="py-8 text-center text-text-secondary text-sm">
+            {getText('emptyDraft')}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {draftCourses.slice(0, 3).map((course) => (
+              <div
+                key={course.courseId}
+                className="p-4 bg-bg-app_default rounded-lg flex justify-between items-center gap-4"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="text-text-primary font-medium truncate mb-1">
+                    {course.title}
+                  </div>
+                  <div className="text-sm text-text-secondary">
+                    {getText('lastEdited')}: {new Date(course.updatedAt).toLocaleDateString('ko-KR')}
+                  </div>
+                </div>
+                <Button
+                  size="sm"
+                  onClick={() => navigate(`/tu/teaching/courses/create?courseId=${course.courseId}`)}
+                >
+                  {getText('continueButton')}
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+
+      {/* 개설 신청 현황 */}
+      <Card className="mb-6 p-6">
+        <div className="flex justify-between items-start mb-5">
+          <div>
+            <h3 className="text-text-primary mb-1 flex items-center gap-2">
+              <Package size={18} className="text-btn-brand" />
+              {getText('programSectionTitle')}
+            </h3>
+            <p className="text-sm text-text-secondary m-0">{getText('programSectionSubtitle')}</p>
+          </div>
+          {programs.length > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-text-secondary"
+              onClick={() => navigate('/tu/teaching/programs')}
+            >
+              {getText('viewAll')}
+              <ArrowRight size={14} />
+            </Button>
+          )}
+        </div>
+
+        {programs.length === 0 ? (
+          <div className="py-8 text-center text-text-secondary text-sm">
+            {getText('emptyProgram')}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {programs.slice(0, 5).map((program) => (
+              <div
+                key={program.id}
+                className="p-4 bg-bg-app_default rounded-lg flex justify-between items-center gap-4 cursor-pointer hover:bg-bg-secondary transition-colors"
+                onClick={() => navigate(`/tu/teaching/programs/${program.id}`)}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="text-text-primary font-medium truncate">
+                    {program.title}
+                  </div>
+                </div>
+                <span
+                  className={`px-2 py-1 rounded text-xs font-medium ${
+                    program.status === 'APPROVED'
+                      ? 'bg-status-success_background text-status-success_text'
+                      : program.status === 'PENDING'
+                      ? 'bg-status-warning_background text-status-warning_text'
+                      : program.status === 'REJECTED'
+                      ? 'bg-status-error_background text-status-error_text'
+                      : 'bg-bg-secondary text-text-secondary'
+                  }`}
+                >
+                  {STATUS_LABELS[program.status]?.[language] || program.status}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+
+      {/* 운영중인 강의 */}
+      <Card className="mb-6 p-6">
+        <div className="flex justify-between items-start mb-5">
+          <div>
+            <h3 className="text-text-primary mb-1 flex items-center gap-2">
+              <BookOpen size={18} className="text-status-success" />
+              {getText('activeSectionTitle')}
+            </h3>
+            <p className="text-sm text-text-secondary m-0">{getText('activeSectionSubtitle')}</p>
+          </div>
+          {assignments.length > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-text-secondary"
+              onClick={() => navigate('/tu/teaching/assignments')}
+            >
+              {getText('viewAll')}
+              <ArrowRight size={14} />
+            </Button>
+          )}
+        </div>
+
+        {assignments.length === 0 ? (
+          <div className="py-8 text-center text-text-secondary text-sm">
+            {getText('emptyActive')}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {assignments.slice(0, 5).map((assignment) => (
+              <div
+                key={assignment.courseTimeId}
+                className="p-4 bg-bg-app_default rounded-lg flex justify-between items-center gap-4 cursor-pointer hover:bg-bg-secondary transition-colors"
+                onClick={() => navigate(`/tu/teaching/assignments/${assignment.courseTimeId}`)}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="text-text-primary font-medium truncate mb-1">
+                    {assignment.courseTimeTitle || assignment.programTitle}
+                  </div>
+                  <div className="text-sm text-text-secondary">
+                    {assignment.startDate} ~ {assignment.endDate}
+                  </div>
+                </div>
+                <div className="flex gap-6 items-center text-sm">
+                  <div className="text-center">
+                    <div className="text-text-secondary text-xs mb-1">{getText('students')}</div>
+                    <div className="text-text-primary font-semibold">
+                      {assignment.enrollmentCount || 0}명
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <div className="text-text-secondary text-xs mb-1">{getText('completion')}</div>
+                    <div
+                      className={`font-semibold ${
+                        (assignment.completionRate || 0) >= 80
+                          ? 'text-status-success_text'
+                          : (assignment.completionRate || 0) >= 50
+                          ? 'text-status-warning_text'
+                          : 'text-text-primary'
+                      }`}
+                    >
+                      {assignment.completionRate || 0}%
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+
+      {/* 빠른 시작 */}
+      <Card className="p-6">
+        <h3 className="text-text-primary mb-4 flex items-center gap-2">
+          {getText('quickActionTitle')}
+        </h3>
+        <div className="flex gap-3 flex-wrap">
+          <Button onClick={() => navigate('/tu/teaching/courses/create')}>
+            <Plus size={18} />
+            {getText('createCourse')}
+          </Button>
+          <Button
+            variant="ghost"
+            className="border border-border"
+            onClick={() => navigate('/tu/teaching/content/create')}
+          >
+            <FolderPlus size={18} />
+            {getText('createContent')}
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/tu/dashboard/TUDashboardPage.tsx
+++ b/src/pages/tu/dashboard/TUDashboardPage.tsx
@@ -19,7 +19,7 @@ interface TUDashboardPageProps {
 }
 
 const t = {
-  title: { ko: '강사 센터', en: 'Instructor Hub' },
+  title: { ko: '대시보드', en: 'Dashboard' },
   subtitle: { ko: '강의 관리와 운영 현황을 확인하세요', en: 'Manage and monitor your courses' },
 
   // 통계

--- a/src/pages/tu/dashboard/index.ts
+++ b/src/pages/tu/dashboard/index.ts
@@ -1,0 +1,1 @@
+export { TUDashboardPage } from './TUDashboardPage';

--- a/src/pages/tu/index.ts
+++ b/src/pages/tu/index.ts
@@ -15,6 +15,7 @@ export {
   RoadmapListPage,
   RoadmapCreatePage,
 } from './teaching';
+export { TUDashboardPage } from './dashboard';
 export { SettingsLanguagePage } from './settings';
 export { LandingPage, CoursesExplorePage, RoadmapExplorePage, RoadmapDetailPage, CommunityPage, CommunityDetailPage, CartPage, WishlistPage, NotificationsPage, NotificationDetailPage, CourseDetailPage, InstructorProfilePage } from './main';
 export { CatalogPage, CatalogDetailPage } from './catalog';

--- a/src/pages/tu/teaching/assignments/MyAssignmentsPage.tsx
+++ b/src/pages/tu/teaching/assignments/MyAssignmentsPage.tsx
@@ -18,13 +18,13 @@ interface MyAssignmentsPageProps {
 }
 
 const t = {
-  title: { ko: '강의 관리', en: 'Course Management' },
-  subtitle: { ko: '배정된 강의와 통계를 확인하세요.', en: 'View your assigned courses and statistics.' },
+  title: { ko: '강의 운영', en: 'Course Operations' },
+  subtitle: { ko: '주강사·보조강사로 진행 중인 강의와 수강생 현황을 확인하세요', en: 'View courses you are teaching and student progress' },
   loading: { ko: '로딩 중...', en: 'Loading...' },
   error: { ko: '오류가 발생했습니다.', en: 'An error occurred.' },
-  noAssignments: { ko: '배정된 강의가 없습니다.', en: 'No assignments found.' },
-  noAssignmentsDesc: { ko: '아직 배정된 강의가 없습니다.', en: 'You have no assigned courses yet.' },
-  myAssignments: { ko: '강의 관리 목록', en: 'Course Management List' },
+  noAssignments: { ko: '진행 중인 강의가 없습니다', en: 'No active courses found' },
+  noAssignmentsDesc: { ko: '승인된 프로그램에 강사로 배정되면 여기에 표시됩니다', en: 'Courses will appear here when you are assigned as an instructor' },
+  myAssignments: { ko: '진행 중인 강의', en: 'Active Courses' },
   courseStats: { ko: '차수별 통계', en: 'Course Statistics' },
   filterAll: { ko: '전체', en: 'All' },
   filterActive: { ko: '활동 중', en: 'Active' },

--- a/src/pages/tu/teaching/content/MyContentPage.tsx
+++ b/src/pages/tu/teaching/content/MyContentPage.tsx
@@ -6,12 +6,8 @@ import {
   Plus,
   Search,
   Filter,
-  Eye,
-  Trash2,
   FileText,
   ChevronDown,
-  Archive,
-  RotateCcw,
   Loader2,
   Video,
   FileIcon,
@@ -25,7 +21,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button, Badge, ViewToggle, DataTable, DataTableColumnHeader, IconStatCard, Checkbox } from '@/components/common';
-import { useMyContents, useDeleteContent, useArchiveContent, useRestoreContent, useContentFolderTree } from '@/hooks/tu';
+import { useMyContents, useDeleteContent, useContentFolderTree } from '@/hooks/tu';
 import { learningObjectService } from '@/services/tu';
 import {
   ContentCard,
@@ -92,7 +88,6 @@ const t = {
   columnType: { ko: '유형', en: 'Type' },
   columnDate: { ko: '등록일', en: 'Date' },
   columnFile: { ko: '파일', en: 'File' },
-  columnActions: { ko: '액션', en: 'Actions' },
   organizeManage: { ko: '분류 및 관리', en: 'Organize' },
   moveToFolder: { ko: '폴더로 이동', en: 'Move to Folder' },
   selectedCount: { ko: '{count}개 선택됨', en: '{count} selected' },
@@ -146,8 +141,6 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
   const { data, isLoading, error } = useMyContents(params);
   const { data: folderTree = [] } = useContentFolderTree();
   const deleteContent = useDeleteContent();
-  const archiveContent = useArchiveContent();
-  const restoreContent = useRestoreContent();
 
   // 선택된 폴더 정보
   const selectedFolder = selectedFolderId ? findFolderById(folderTree, selectedFolderId) : null;
@@ -178,22 +171,6 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
       } else {
         alert(getText('error'));
       }
-    }
-  };
-
-  const handleArchive = async (id: number) => {
-    try {
-      await archiveContent.mutateAsync(id);
-    } catch (err) {
-      console.error('Archive failed:', err);
-    }
-  };
-
-  const handleRestore = async (id: number) => {
-    try {
-      await restoreContent.mutateAsync(id);
-    } catch (err) {
-      console.error('Restore failed:', err);
     }
   };
 
@@ -297,7 +274,7 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
         <DataTableColumnHeader column={column} title={getText('columnTitle')} />
       ),
       cell: ({ row }) => (
-        <p className="text-sm text-text-primary max-w-md truncate">
+        <p className="text-sm text-text-primary max-w-[200px] truncate overflow-hidden">
           {row.original.originalFileName}
         </p>
       ),
@@ -326,8 +303,8 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
       id: 'file',
       header: getText('columnFile'),
       cell: ({ row }) => (
-        <div className="flex flex-col gap-1">
-          <p className="text-sm text-text-primary truncate max-w-xs">
+        <div className="flex flex-col gap-1 max-w-[180px] overflow-hidden">
+          <p className="text-sm text-text-primary truncate">
             {row.original.originalFileName}
           </p>
           <p className="text-xs text-text-secondary">
@@ -335,45 +312,6 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
           </p>
         </div>
       ),
-    },
-    {
-      id: 'actions',
-      header: () => <div className="text-right">{getText('columnActions')}</div>,
-      cell: ({ row }) => {
-        const item = row.original;
-        return (
-          <div className="flex items-center justify-end gap-2" onClick={(e) => e.stopPropagation()}>
-            <button
-              onClick={() => handlePreview(item)}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-border rounded-lg text-sm text-text-primary hover:bg-bg-secondary transition-colors"
-            >
-              <Eye size={16} />
-            </button>
-            {item.status === 'ARCHIVED' ? (
-              <button
-                onClick={() => handleRestore(item.id)}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-border rounded-lg text-sm text-text-primary hover:bg-bg-secondary transition-colors"
-              >
-                <RotateCcw size={16} />
-              </button>
-            ) : (
-              <button
-                onClick={() => handleArchive(item.id)}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-border rounded-lg text-sm text-text-primary hover:bg-bg-secondary transition-colors"
-              >
-                <Archive size={16} />
-              </button>
-            )}
-            <button
-              onClick={() => handleDelete(item.id)}
-              disabled={deleteContent.isPending}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-border rounded-lg text-sm hover:bg-status-error/10 transition-colors"
-            >
-              <Trash2 size={16} className="text-status-error" />
-            </button>
-          </div>
-        );
-      },
     },
   ], [language, deleteContent.isPending, contents, selectedContentIds]);
 

--- a/src/pages/tu/teaching/courses/MyCoursesPage.tsx
+++ b/src/pages/tu/teaching/courses/MyCoursesPage.tsx
@@ -299,9 +299,9 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
 
           return (
             <div key={course.id} className="relative">
-              {/* Status Badge */}
+              {/* Status Badge - 썸네일 우측 하단 */}
               {!course.isComplete && (
-                <div className="absolute top-3 left-3 z-10 px-2 py-1 rounded-md bg-status-warning/20 text-status-warning text-xs font-medium flex items-center gap-1">
+                <div className="absolute top-[10rem] left-3 z-10 px-2 py-1 rounded-md bg-status-warning text-white text-xs font-medium flex items-center gap-1 shadow-sm">
                   <AlertTriangle size={12} />
                   {getText('incomplete')}
                 </div>
@@ -323,8 +323,7 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
               {/* Course Card */}
               <div className={cn(
                 'transition-all',
-                isSelected && 'ring-2 ring-btn-primary rounded-xl',
-                !course.isComplete && 'opacity-80'
+                isSelected && 'ring-2 ring-btn-primary rounded-xl'
               )}>
                 <CourseCard
                   course={course}
@@ -333,7 +332,6 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
                     courseCompletion: getText('courseCompletion'),
                     lessons: getText('lessons'),
                     manageCourse: getText('manageCourse'),
-                    editCourse: getText('editCourse'),
                   }}
                 />
               </div>

--- a/src/pages/tu/teaching/programs/MyProgramsPage.tsx
+++ b/src/pages/tu/teaching/programs/MyProgramsPage.tsx
@@ -5,7 +5,6 @@ import {
   Filter,
   Loader2,
   AlertCircle,
-  Eye,
   Edit2,
   Send,
   Trash2,
@@ -34,10 +33,10 @@ const DEFAULT_THUMBNAIL =
   'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=400&h=250&fit=crop';
 
 const t = {
-  title: { ko: '강의 개설', en: 'Course Creation' },
+  title: { ko: '개설 신청 현황', en: 'Submission Status' },
   subtitle: {
-    ko: '신청한 강의의 상태를 확인하고 관리하세요',
-    en: 'Check the status and manage your submitted courses',
+    ko: '디자인한 강의의 프로그램 개설 신청 및 승인 상태를 확인하세요',
+    en: 'Check the submission and approval status of your designed courses',
   },
   all: { ko: '전체', en: 'All' },
   draft: { ko: '임시저장', en: 'Draft' },
@@ -50,10 +49,10 @@ const t = {
   titleSort: { ko: '제목순', en: 'Title' },
   noPrograms: { ko: '신청한 프로그램이 없습니다', en: 'No programs found' },
   noProgramsDesc: {
-    ko: '강의계획에서 프로그램을 신청하면 여기에 표시됩니다',
-    en: 'Programs submitted from course plans will appear here',
+    ko: "'강의 디자인'에서 강의를 완성한 후 프로그램 개설을 신청하면 여기에 표시됩니다",
+    en: 'Complete your course in Course Design and submit for program creation to see it here',
   },
-  goToCourses: { ko: '강의계획으로 이동', en: 'Go to Course Plans' },
+  goToCourses: { ko: '강의 디자인으로 이동', en: 'Go to Course Design' },
   loading: { ko: '프로그램 목록을 불러오는 중...', en: 'Loading programs...' },
   error: { ko: '프로그램 목록을 불러오는데 실패했습니다', en: 'Failed to load programs' },
   retry: { ko: '다시 시도', en: 'Retry' },
@@ -76,6 +75,10 @@ const t = {
     en: 'Program submitted for review.',
   },
   deleteSuccess: { ko: '프로그램이 삭제되었습니다.', en: 'Program deleted.' },
+  flowGuideTitle: { ko: '강의 개설 절차', en: 'Course Creation Process' },
+  flowStep1: { ko: "'강의 디자인'에서 강의 콘텐츠를 구성하세요", en: 'Design your course content in Course Design' },
+  flowStep2: { ko: '완성된 강의로 프로그램 개설을 신청하세요', en: 'Submit your completed course for program creation' },
+  flowStep3: { ko: "관리자 승인 후 '강의 운영'에서 수강생을 관리할 수 있습니다", en: 'After approval, manage students in Course Operations' },
 };
 
 const statusBadgeVariant: Record<
@@ -106,7 +109,7 @@ export function MyProgramsPage({ language = 'ko' }: Readonly<MyProgramsPageProps
   const navigate = useNavigate();
   const [filterStatus, setFilterStatus] = useState<'all' | ProgramStatus>('all');
   const [sortBy, setSortBy] = useState<'recent' | 'title'>('recent');
-  const [viewMode, setViewMode] = useState<'grid' | 'list'>('list');
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
 
   const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
 
@@ -215,17 +218,6 @@ export function MyProgramsPage({ language = 'ko' }: Readonly<MyProgramsPageProps
           {/* View Toggle */}
           <div className="flex gap-1 bg-bg-secondary p-1 rounded-lg ml-2">
             <button
-              onClick={() => setViewMode('list')}
-              className={cn(
-                'p-2 rounded-md transition-colors',
-                viewMode === 'list'
-                  ? 'bg-btn-neutral text-white'
-                  : 'bg-transparent text-text-secondary hover:bg-bg-secondary'
-              )}
-            >
-              <List size={16} />
-            </button>
-            <button
               onClick={() => setViewMode('grid')}
               className={cn(
                 'p-2 rounded-md transition-colors',
@@ -235,6 +227,17 @@ export function MyProgramsPage({ language = 'ko' }: Readonly<MyProgramsPageProps
               )}
             >
               <LayoutGrid size={16} />
+            </button>
+            <button
+              onClick={() => setViewMode('list')}
+              className={cn(
+                'p-2 rounded-md transition-colors',
+                viewMode === 'list'
+                  ? 'bg-btn-neutral text-white'
+                  : 'bg-transparent text-text-secondary hover:bg-bg-secondary'
+              )}
+            >
+              <List size={16} />
             </button>
           </div>
         </div>
@@ -246,7 +249,11 @@ export function MyProgramsPage({ language = 'ko' }: Readonly<MyProgramsPageProps
           /* List View */
           <div className="flex flex-col gap-3">
             {sortedPrograms.map((program) => (
-              <Card key={program.id} className="p-4">
+              <Card
+                key={program.id}
+                className="p-4 cursor-pointer hover:shadow-md transition-shadow"
+                onClick={() => navigate(`/tu/teaching/programs/${program.id}`)}
+              >
                 <div className="flex items-center gap-4">
                   {/* Thumbnail */}
                   <div className="w-24 h-16 flex-shrink-0 rounded-lg overflow-hidden bg-bg-secondary">
@@ -271,11 +278,9 @@ export function MyProgramsPage({ language = 'ko' }: Readonly<MyProgramsPageProps
                         {PROGRAM_STATUS_LABELS[program.status]}
                       </Badge>
                     </div>
-                    {program.description && (
-                      <p className="text-text-secondary text-sm truncate">
-                        {program.description}
-                      </p>
-                    )}
+                    <p className="text-text-secondary text-sm truncate h-5">
+                      {program.description || '\u00A0'}
+                    </p>
                     <div className="flex gap-2 mt-1 text-xs text-text-secondary">
                       {program.level && (
                         <span>{PROGRAM_LEVEL_LABELS[program.level]}</span>
@@ -290,17 +295,7 @@ export function MyProgramsPage({ language = 'ko' }: Readonly<MyProgramsPageProps
                   </div>
 
                   {/* Actions */}
-                  <div className="flex gap-2 flex-shrink-0">
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="border border-border"
-                      onClick={() => navigate(`/tu/teaching/programs/${program.id}`)}
-                    >
-                      <Eye size={14} />
-                      {getText('view')}
-                    </Button>
-
+                  <div className="flex gap-2 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
                     {canEdit(program.status) && (
                       <Button
                         size="sm"
@@ -342,7 +337,11 @@ export function MyProgramsPage({ language = 'ko' }: Readonly<MyProgramsPageProps
           /* Grid View */
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {sortedPrograms.map((program) => (
-              <Card key={program.id} className="overflow-hidden">
+              <Card
+                key={program.id}
+                className="overflow-hidden cursor-pointer hover:shadow-md transition-shadow flex flex-col"
+                onClick={() => navigate(`/tu/teaching/programs/${program.id}`)}
+              >
                 {/* Thumbnail */}
                 <div className="aspect-video relative overflow-hidden bg-bg-secondary">
                   <img
@@ -362,19 +361,17 @@ export function MyProgramsPage({ language = 'ko' }: Readonly<MyProgramsPageProps
                 </div>
 
                 {/* Content */}
-                <div className="p-4">
-                  <h3 className="text-text-primary font-medium mb-2 line-clamp-2">
+                <div className="p-4 flex flex-col flex-1">
+                  <h3 className="text-text-primary font-medium mb-2 line-clamp-2 min-h-[3rem]">
                     {program.title}
                   </h3>
 
-                  {program.description && (
-                    <p className="text-text-secondary text-sm mb-3 line-clamp-2">
-                      {program.description}
-                    </p>
-                  )}
+                  <p className="text-text-secondary text-sm mb-3 line-clamp-2 min-h-[2.5rem]">
+                    {program.description || '\u00A0'}
+                  </p>
 
                   {/* Meta Info */}
-                  <div className="flex flex-wrap gap-2 text-xs text-text-secondary mb-4">
+                  <div className="flex flex-wrap gap-2 text-xs text-text-secondary mb-4 min-h-[1.75rem]">
                     {program.level && (
                       <span className="px-2 py-1 bg-bg-secondary rounded">
                         {PROGRAM_LEVEL_LABELS[program.level]}
@@ -393,17 +390,7 @@ export function MyProgramsPage({ language = 'ko' }: Readonly<MyProgramsPageProps
                   </div>
 
                   {/* Actions */}
-                  <div className="flex gap-2">
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="flex-1 border border-border"
-                      onClick={() => navigate(`/tu/teaching/programs/${program.id}`)}
-                    >
-                      <Eye size={14} />
-                      {getText('view')}
-                    </Button>
-
+                  <div className="flex gap-2 mt-auto" onClick={(e) => e.stopPropagation()}>
                     {canEdit(program.status) && (
                       <Button
                         size="sm"
@@ -445,10 +432,30 @@ export function MyProgramsPage({ language = 'ko' }: Readonly<MyProgramsPageProps
         )
       ) : (
         /* Empty State */
-        <div className="text-center py-20 px-5 bg-bg-secondary rounded-xl border border-border">
+        <div className="text-center py-16 px-5 bg-bg-secondary rounded-xl border border-border">
           <Package size={64} className="text-text-secondary mb-4 opacity-30 mx-auto" />
           <h3 className="text-text-primary mb-2">{getText('noPrograms')}</h3>
-          <p className="text-text-secondary mb-6">{getText('noProgramsDesc')}</p>
+          <p className="text-text-secondary mb-8">{getText('noProgramsDesc')}</p>
+
+          {/* 플로우 안내 */}
+          <div className="max-w-md mx-auto mb-8 text-left bg-bg-primary rounded-lg p-5 border border-border">
+            <p className="text-sm font-medium text-text-primary mb-3">{getText('flowGuideTitle')}</p>
+            <ol className="text-sm text-text-secondary space-y-2">
+              <li className="flex gap-2">
+                <span className="flex-shrink-0 w-5 h-5 rounded-full bg-btn-brand text-white text-xs flex items-center justify-center">1</span>
+                <span>{getText('flowStep1')}</span>
+              </li>
+              <li className="flex gap-2">
+                <span className="flex-shrink-0 w-5 h-5 rounded-full bg-btn-brand text-white text-xs flex items-center justify-center">2</span>
+                <span>{getText('flowStep2')}</span>
+              </li>
+              <li className="flex gap-2">
+                <span className="flex-shrink-0 w-5 h-5 rounded-full bg-btn-brand text-white text-xs flex items-center justify-center">3</span>
+                <span>{getText('flowStep3')}</span>
+              </li>
+            </ol>
+          </div>
+
           <Button onClick={() => navigate('/tu/teaching/courses')}>
             {getText('goToCourses')}
           </Button>

--- a/src/routes/tu.teaching.routes.tsx
+++ b/src/routes/tu.teaching.routes.tsx
@@ -17,8 +17,9 @@ import {
   TuProgramEditPage,
   RoadmapListPage,
   RoadmapCreatePage,
+  TUDashboardPage,
 } from '@/pages/tu';
-import { DashboardPage, PlaceholderPage } from './pages';
+import { PlaceholderPage } from './pages';
 
 function TenantUserWrapper() {
   return (
@@ -38,8 +39,8 @@ function TenantUserWrapper() {
  */
 export const tuTeachingRoutes = (
   <Route path="/tu" element={<TenantUserWrapper />}>
-    <Route index element={<DashboardPage />} />
-    <Route path="dashboard" element={<DashboardPage />} />
+    <Route index element={<TUDashboardPage />} />
+    <Route path="dashboard" element={<TUDashboardPage />} />
 
     {/* 내 강의계획 */}
     <Route path="teaching/courses" element={<MyCoursesPage />} />


### PR DESCRIPTION
## Summary

TU(Tenant User) 어드민 페이지의 유저플로우 및 UI/UX를 개선합니다.

## Related Issue

- Closes #299

## Changes

- TU 대시보드 페이지 신규 구현 (통계, 작성중 강의, 개설 신청 현황, 운영중 강의 섹션)
- 사이드바 메뉴명 개선 (강의 개설 → 개설 신청 현황, 강의 관리 → 강의 운영)
- MyProgramsPage: 제목/설명 개선 및 empty state에 플로우 안내 추가
- MyAssignmentsPage: 제목/설명 개선 (주강사·보조강사 역할 명시)
- MyCoursesPage: 미완성 배지 위치 및 스타일 조정
- 내 콘텐츠를 독립 메뉴로 분리, 리스트뷰 액션 컬럼 제거
- Sheet, AlertDialog 컴포넌트 다크모드 제거 (디자인 토큰 적용)
- 대시보드 페이지 제목 변경 (강사 센터 → 대시보드)

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [x] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

- 기존 hooks (useMyCourses, useMyPrograms, useMyAssignments) 재사용
- 다크모드 관련 하드코딩 색상을 디자인 토큰으로 교체