### PR TITLE
fix: 커뮤니티 새 글 작성 시 이미지가 표시되지 않는 문제 수정

### DIFF
--- a/src/components/domain/community/WritePostModal.tsx
+++ b/src/components/domain/community/WritePostModal.tsx
@@ -94,6 +94,9 @@ export function WritePostModal({
             img.preview === preview ? { ...img, uploading: false, url } : img
           )
         );
+        // 업로드 완료 후 자동으로 본문에 이미지 마크다운 추가
+        const imageMarkdown = `\n![이미지](${url})\n`;
+        setContent(prev => prev + imageMarkdown);
         setErrors(prev => ({ ...prev, images: undefined }));
       } catch {
         setImages(prev => prev.filter(img => img.preview !== preview));
@@ -421,7 +424,7 @@ export function WritePostModal({
               <p className="mt-2 text-sm text-red-500">{errors.images}</p>
             )}
             <p className={`mt-2 text-xs ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
-              이미지를 업로드 후 클릭하여 본문에 삽입할 수 있습니다. (최대 5MB)
+              이미지 업로드 시 자동으로 본문에 삽입됩니다. (최대 5MB)
             </p>
           </div>
 


### PR DESCRIPTION
## Summary

커뮤니티 새 글 작성 시 이미지가 게시 후 표시되지 않는 문제 수정

## Related Issue

- N/A

## Changes

- 이미지 업로드 완료 후 자동으로 본문에 마크다운 형식으로 삽입되도록 수정
- 안내 문구 업데이트: "이미지 업로드 시 자동으로 본문에 삽입됩니다"

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

**원인 분석:**
- 새 글 작성: 이미지가 `images` 배열에만 저장되고 `content`에 추가되지 않음
- 수정: 이미지 업로드 시 `editContent`에 마크다운이 바로 추가됨

수정 모드와 동일하게 새 글 작성에서도 이미지 업로드 완료 시 자동으로 본문에 마크다운을 삽입하도록 수정했습니다.