### PR TITLE
feat: 로그인 후 서브도메인 기반 URL 리다이렉트 및 테넌트 관리 버그 수정 (#302)

### DIFF
--- a/src/contexts/TenantBrandingContext.tsx
+++ b/src/contexts/TenantBrandingContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, ReactNode } from 'react';
+import { createContext, useContext, ReactNode, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { usePublicBranding } from '@/hooks/tu/usePublicBranding';
 import { useBrandingApply } from '@/hooks/tu/useBrandingApply';
@@ -14,6 +14,19 @@ interface TenantBrandingContextValue {
 }
 
 const TenantBrandingContext = createContext<TenantBrandingContextValue | undefined>(undefined);
+
+/** 기본 브랜딩 (SA 등 tenantId가 없는 사용자용) */
+const DEFAULT_BRANDING: PublicBrandingResponse = {
+  tenantName: 'MZC Learning Platform',
+  primaryColor: '#3B82F6',
+  secondaryColor: '#10B981',
+  logoUrl: null,
+  darkLogoUrl: null,
+  faviconUrl: null,
+  accentColor: null,
+  headingFont: null,
+  bodyFont: null,
+};
 
 /**
  * 인증된 사용자용 브랜딩 조회 Hook
@@ -33,7 +46,10 @@ export function TenantBrandingProvider({ children }: { children: ReactNode }) {
   const { isAuthenticated, user } = useAuthStore();
   const tenantIdentifier = extractTenantIdentifier();
 
-  // 1. 인증된 사용자: tenantId 기반 브랜딩 조회
+  // SA 사용자인지 확인 (tenantId가 없는 인증된 사용자)
+  const isSystemAdmin = isAuthenticated && !user?.tenantId;
+
+  // 1. 인증된 사용자(tenantId 있음): tenantId 기반 브랜딩 조회
   const {
     data: authBranding,
     isLoading: authLoading,
@@ -50,10 +66,19 @@ export function TenantBrandingProvider({ children }: { children: ReactNode }) {
     tenantIdentifier?.type
   );
 
-  // 인증된 사용자는 authBranding 우선, 아니면 publicBranding
-  const branding = isAuthenticated && user?.tenantId ? authBranding : publicBranding;
-  const isLoading = isAuthenticated && user?.tenantId ? authLoading : publicLoading;
-  const error = isAuthenticated && user?.tenantId ? authError : publicError;
+  // 브랜딩 결정 로직
+  const { branding, isLoading, error } = useMemo(() => {
+    // SA 사용자: 기본 브랜딩 사용
+    if (isSystemAdmin) {
+      return { branding: DEFAULT_BRANDING, isLoading: false, error: null };
+    }
+    // 인증된 사용자(tenantId 있음): authBranding 사용
+    if (isAuthenticated && user?.tenantId) {
+      return { branding: authBranding, isLoading: authLoading, error: authError };
+    }
+    // 비로그인 사용자: publicBranding 사용
+    return { branding: publicBranding, isLoading: publicLoading, error: publicError };
+  }, [isSystemAdmin, isAuthenticated, user?.tenantId, authBranding, authLoading, authError, publicBranding, publicLoading, publicError]);
 
   // 브랜딩을 전역 CSS 변수로 적용
   useBrandingApply(branding);

--- a/src/hooks/common/useAuthQueries.ts
+++ b/src/hooks/common/useAuthQueries.ts
@@ -47,13 +47,16 @@ export const useLogin = () => {
 
       // 토큰으로 사용자 정보 조회
       const userDetail = await userService.getMe();
+      console.log('userDetail from API:', userDetail);
       const user = {
         id: userDetail.userId,
         email: userDetail.email,
         name: userDetail.name,
         role: userDetail.role,
         tenantId: userDetail.tenantId,
+        tenantSubdomain: userDetail.tenantSubdomain,
       };
+      console.log('user object for redirect:', user);
       setAuth(user, tokenData.accessToken, tokenData.refreshToken);
       queryClient.invalidateQueries({ queryKey: authKeys.me() });
 

--- a/src/pages/admin/auth/AdminLoginPage.tsx
+++ b/src/pages/admin/auth/AdminLoginPage.tsx
@@ -47,9 +47,21 @@ export const AdminLoginPage = () => {
 
     try {
       const user = await loginMutation.mutateAsync({ email, password });
+      console.log('[AdminLoginPage] user:', user);
+      console.log('[AdminLoginPage] tenantSubdomain:', user.tenantSubdomain);
+      console.log('[AdminLoginPage] role:', user.role);
 
-      // Role에 따른 리다이렉트
-      const redirectPath = ROLE_REDIRECT_PATH[user.role] || '/';
+      // Role에 따른 기본 경로
+      const basePath = ROLE_REDIRECT_PATH[user.role] || '/';
+      console.log('[AdminLoginPage] basePath:', basePath);
+
+      // 테넌트 서브도메인이 있으면 prefix로 추가 (SA 제외)
+      let redirectPath = basePath;
+      if (user.tenantSubdomain && user.role !== 'SYSTEM_ADMIN') {
+        redirectPath = `/${user.tenantSubdomain}${basePath}`;
+      }
+      console.log('[AdminLoginPage] redirectPath:', redirectPath);
+
       navigate(redirectPath);
     } catch {
       setErrors({ general: '이메일 또는 비밀번호가 올바르지 않습니다.' });

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -50,8 +50,15 @@ export const LoginPage = () => {
     try {
       const user = await loginMutation.mutateAsync({ email, password });
 
-      // Role에 따른 리다이렉트
-      const redirectPath = ROLE_REDIRECT_PATH[user.role] || '/';
+      // Role에 따른 기본 경로
+      const basePath = ROLE_REDIRECT_PATH[user.role] || '/';
+
+      // 테넌트 서브도메인이 있으면 prefix로 추가 (SA 제외)
+      let redirectPath = basePath;
+      if (user.tenantSubdomain && user.role !== 'SYSTEM_ADMIN') {
+        redirectPath = `/${user.tenantSubdomain}${basePath}`;
+      }
+
       navigate(redirectPath);
     } catch {
       setErrors({ general: '이메일 또는 비밀번호가 올바르지 않습니다.' });

--- a/src/pages/sa/tenants/TenantDetailPage.tsx
+++ b/src/pages/sa/tenants/TenantDetailPage.tsx
@@ -36,7 +36,7 @@ import type { TenantStatus, PlanType, TenantDetail } from '@/types/admin';
 
 // Mock 데이터
 const MOCK_TENANT: TenantDetail = {
-  id: 1,
+  tenantId: 1,
   code: 'mzc',
   name: '메가존클라우드',
   type: 'B2B',

--- a/src/pages/sa/tenants/TenantsPage.tsx
+++ b/src/pages/sa/tenants/TenantsPage.tsx
@@ -98,8 +98,14 @@ export function TenantsPage() {
 
   const { register, handleSubmit, reset, setValue, watch } = useForm<TenantFormData>({
     defaultValues: {
+      code: '',
+      name: '',
       type: 'B2B',
       plan: 'BASIC',
+      subdomain: '',
+      adminEmail: '',
+      adminName: '',
+      status: 'ACTIVE',
     },
   });
 
@@ -196,7 +202,7 @@ export function TenantsPage() {
   ];
 
   const handleViewDetail = (tenant: Tenant) => {
-    navigate(`/sa/tenants/${tenant.id}`);
+    navigate(`/sa/tenants/${tenant.tenantId}`);
   };
 
   const handleEdit = (tenant: Tenant) => {
@@ -214,7 +220,7 @@ export function TenantsPage() {
     if (!deleteTarget) return;
 
     try {
-      await deleteMutation.mutateAsync(deleteTarget.id);
+      await deleteMutation.mutateAsync(deleteTarget.tenantId);
       toast.success(`'${deleteTarget.name}' 테넌트가 삭제되었습니다.`);
       setDeleteTarget(null);
     } catch {
@@ -227,6 +233,7 @@ export function TenantsPage() {
     reset({
       type: 'B2B',
       plan: 'BASIC',
+      status: 'ACTIVE',
       code: '',
       name: '',
       subdomain: '',
@@ -245,7 +252,7 @@ export function TenantsPage() {
           status: data.status,
           plan: data.plan,
         };
-        await updateMutation.mutateAsync({ id: selectedTenant.id, request: updateData });
+        await updateMutation.mutateAsync({ id: selectedTenant.tenantId, request: updateData });
         toast.success('테넌트가 수정되었습니다.');
         setIsCreateDialogOpen(false);
       } else {

--- a/src/routes/ta.routes.tsx
+++ b/src/routes/ta.routes.tsx
@@ -41,7 +41,7 @@ function TenantAdminWrapper() {
 }
 
 export const taRoutes = (
-  <Route path="/ta" element={<TenantAdminWrapper />}>
+  <Route path="/:subdomain/ta" element={<TenantAdminWrapper />}>
     <Route index element={<DashboardPage />} />
     <Route path="dashboard" element={<DashboardPage />} />
     {/* 시스템 기반 관리 */}

--- a/src/routes/to.routes.tsx
+++ b/src/routes/to.routes.tsx
@@ -33,7 +33,7 @@ function TenantOperatorWrapper() {
 }
 
 export const toRoutes = (
-  <Route path="/to" element={<TenantOperatorWrapper />}>
+  <Route path="/:subdomain/to" element={<TenantOperatorWrapper />}>
     <Route index element={<DashboardPage />} />
     <Route path="dashboard" element={<DashboardPage />} />
     {/* 교육 과정 탐색 */}

--- a/src/routes/tu.b2c.routes.tsx
+++ b/src/routes/tu.b2c.routes.tsx
@@ -18,41 +18,54 @@ import {
 /**
  * TU B2C 라우트 - 메인 페이지 (사이드바 없음)
  *
- * 경로: /tu/b2c/*
+ * 경로: /:subdomain/tu/b2c/* 또는 /tu/b2c/* (기본)
  * - 랜딩, 강의 탐색, 로드맵, 커뮤니티, 장바구니, 위시리스트, 알림
  */
 export const tuB2cRoutes = (
   <>
-    {/* 랜딩 페이지 */}
+    {/* 랜딩 페이지 - subdomain 포함 */}
+    <Route path="/:subdomain/tu/b2c" element={<LandingPage />} />
     <Route path="/tu/b2c" element={<LandingPage />} />
 
     {/* 통합 검색 */}
     <Route path="/tu/b2c/search" element={<SearchPage />} />
 
     {/* 강의 탐색 */}
+    <Route path="/:subdomain/tu/b2c/courses" element={<CoursesExplorePage />} />
+    <Route path="/:subdomain/tu/b2c/courses/:id" element={<CourseDetailPage />} />
     <Route path="/tu/b2c/courses" element={<CoursesExplorePage />} />
     <Route path="/tu/b2c/courses/:id" element={<CourseDetailPage />} />
 
     {/* 차수(Times) 상세 - CourseTime 기반 */}
+    <Route path="/:subdomain/tu/b2c/times/:id" element={<CourseDetailPage />} />
     <Route path="/tu/b2c/times/:id" element={<CourseDetailPage />} />
 
     {/* 로드맵 */}
+    <Route path="/:subdomain/tu/b2c/roadmaps" element={<RoadmapExplorePage />} />
+    <Route path="/:subdomain/tu/b2c/roadmaps/:id" element={<RoadmapDetailPage />} />
     <Route path="/tu/b2c/roadmaps" element={<RoadmapExplorePage />} />
     <Route path="/tu/b2c/roadmaps/:id" element={<RoadmapDetailPage />} />
 
     {/* 커뮤니티 */}
+    <Route path="/:subdomain/tu/b2c/community" element={<CommunityPage />} />
+    <Route path="/:subdomain/tu/b2c/community/:id" element={<CommunityDetailPage />} />
     <Route path="/tu/b2c/community" element={<CommunityPage />} />
     <Route path="/tu/b2c/community/:id" element={<CommunityDetailPage />} />
 
     {/* 장바구니 & 위시리스트 */}
+    <Route path="/:subdomain/tu/b2c/cart" element={<CartPage />} />
+    <Route path="/:subdomain/tu/b2c/wishlist" element={<WishlistPage />} />
     <Route path="/tu/b2c/cart" element={<CartPage />} />
     <Route path="/tu/b2c/wishlist" element={<WishlistPage />} />
 
     {/* 알림 */}
+    <Route path="/:subdomain/tu/b2c/notifications" element={<NotificationsPage />} />
+    <Route path="/:subdomain/tu/b2c/notifications/:id" element={<NotificationDetailPage />} />
     <Route path="/tu/b2c/notifications" element={<NotificationsPage />} />
     <Route path="/tu/b2c/notifications/:id" element={<NotificationDetailPage />} />
 
     {/* 강사 프로필 */}
+    <Route path="/:subdomain/tu/b2c/instructors/:instructorId" element={<InstructorProfilePage />} />
     <Route path="/tu/b2c/instructors/:instructorId" element={<InstructorProfilePage />} />
   </>
 );

--- a/src/routes/tu.mypage.routes.tsx
+++ b/src/routes/tu.mypage.routes.tsx
@@ -35,10 +35,30 @@ function MyPageWrapper() {
 /**
  * TU MyPage 라우트 - 마이페이지 (사이드바 있음, 로그인 필요)
  *
- * 경로: /tu/b2c/mypage/*
+ * 경로: /:subdomain/tu/b2c/mypage/* 또는 /tu/b2c/mypage/*
  * - 내 정보, 내 수강 강의, 내 강의 관리, 설정
  */
 export const tuMyPageRoutes = (
+  <>
+  <Route path="/:subdomain/tu/b2c/mypage" element={<MyPageWrapper />}>
+    <Route index element={<MyPageHome />} />
+    <Route path="profile" element={<ProfilePage />} />
+    <Route path="learning" element={<MyLearningPage />} />
+    <Route path="learning/:enrollmentId" element={<LearningDetailPage />} />
+    <Route path="learning/:enrollmentId/player" element={<LearningPlayerPage />} />
+    <Route path="learning/:enrollmentId/player/:itemId" element={<LearningPlayerPage />} />
+    <Route path="completed" element={<CompletedCoursesPage />} />
+    <Route path="certificates" element={<CertificationsPage />} />
+    <Route path="teaching" element={<MyTeachingPage />} />
+    <Route path="teaching/stats" element={<TeachingStatsPage />} />
+    <Route path="posts" element={<MyPostsPage />} />
+    <Route path="comments" element={<MyCommentsPage />} />
+    <Route path="settings" element={<SettingsPage />} />
+    <Route path="settings/security" element={<SettingsSecurityPage />} />
+    <Route path="settings/notifications" element={<SettingsNotificationsPage />} />
+    <Route path="settings/language" element={<SettingsLanguagePage />} />
+    <Route path="settings/appearance" element={<SettingsAppearancePage />} />
+  </Route>
   <Route path="/tu/b2c/mypage" element={<MyPageWrapper />}>
     <Route index element={<MyPageHome />} />
     <Route path="profile" element={<ProfilePage />} />
@@ -66,4 +86,5 @@ export const tuMyPageRoutes = (
     <Route path="settings/language" element={<SettingsLanguagePage />} />
     <Route path="settings/appearance" element={<SettingsAppearancePage />} />
   </Route>
+  </>
 );

--- a/src/routes/tu.teaching.routes.tsx
+++ b/src/routes/tu.teaching.routes.tsx
@@ -40,8 +40,8 @@ function TenantUserWrapper() {
 export const tuTeachingRoutes = (
   <>
   <Route path="/:subdomain/tu" element={<TenantUserWrapper />}>
-    <Route index element={<DashboardPage />} />
-    <Route path="dashboard" element={<DashboardPage />} />
+    <Route index element={<TUDashboardPage />} />
+    <Route path="dashboard" element={<TUDashboardPage />} />
     <Route path="teaching/courses" element={<MyCoursesPage />} />
     <Route path="teaching/courses/create" element={<CourseCreatePage />} />
     <Route path="teaching/courses/:courseId" element={<TeachingCourseDetailPage />} />

--- a/src/routes/tu.teaching.routes.tsx
+++ b/src/routes/tu.teaching.routes.tsx
@@ -34,10 +34,33 @@ function TenantUserWrapper() {
 /**
  * TU Teaching 라우트 - 강의 관리 (사이드바 있음)
  *
- * 경로: /tu/teaching/*
+ * 경로: /:subdomain/tu/teaching/* 또는 /tu/teaching/*
  * - 내 강의 관리, 콘텐츠 관리, 과제 관리
  */
 export const tuTeachingRoutes = (
+  <>
+  <Route path="/:subdomain/tu" element={<TenantUserWrapper />}>
+    <Route index element={<DashboardPage />} />
+    <Route path="dashboard" element={<DashboardPage />} />
+    <Route path="teaching/courses" element={<MyCoursesPage />} />
+    <Route path="teaching/courses/create" element={<CourseCreatePage />} />
+    <Route path="teaching/courses/:courseId" element={<TeachingCourseDetailPage />} />
+    <Route path="teaching/courses/:courseId/edit" element={<CourseEditPage />} />
+    <Route path="teaching/courses/:courseId/apply" element={<CourseApplyPage />} />
+    <Route path="teaching/programs" element={<MyProgramsPage />} />
+    <Route path="teaching/programs/:programId" element={<TuProgramDetailPage />} />
+    <Route path="teaching/programs/:programId/edit" element={<TuProgramEditPage />} />
+    <Route path="teaching/content" element={<MyContentPage />} />
+    <Route path="teaching/content/create" element={<TuContentCreatePage />} />
+    <Route path="teaching/content/:id" element={<ContentDetailPage />} />
+    <Route path="teaching/assignments" element={<MyAssignmentsPage />} />
+    <Route path="teaching/assignments/:id" element={<AssignmentDetailPage />} />
+    <Route path="teaching/roadmaps" element={<RoadmapListPage />} />
+    <Route path="teaching/roadmaps/create" element={<RoadmapCreatePage />} />
+    <Route path="teaching/roadmaps/:id" element={<PlaceholderPage title="로드맵 상세" />} />
+    <Route path="teaching/roadmaps/:id/edit" element={<RoadmapCreatePage />} />
+    <Route path="catalog" element={<PlaceholderPage title="과정 둘러보기" />} />
+  </Route>
   <Route path="/tu" element={<TenantUserWrapper />}>
     <Route index element={<TUDashboardPage />} />
     <Route path="dashboard" element={<TUDashboardPage />} />
@@ -72,4 +95,5 @@ export const tuTeachingRoutes = (
     {/* 교육 과정 탐색 */}
     <Route path="catalog" element={<PlaceholderPage title="과정 둘러보기" />} />
   </Route>
+  </>
 );

--- a/src/services/sa/tenantService.ts
+++ b/src/services/sa/tenantService.ts
@@ -29,11 +29,11 @@ export const tenantService = {
 
   /** 테넌트 생성 (관리자 계정도 함께 생성됨) */
   async create(request: CreateTenantRequest): Promise<CreateTenantResponse> {
-    const { data } = await axiosInstance.post<{ data: CreateTenantResponse }>(
+    const { data } = await axiosInstance.post<CreateTenantResponse>(
       API_ENDPOINTS.TENANTS.BASE,
       request
     );
-    return data.data;
+    return data;
   },
 
   /** 테넌트 목록 조회 */
@@ -55,10 +55,12 @@ export const tenantService = {
 
   /** 테넌트 수정 */
   async update(id: number, request: UpdateTenantDetailRequest): Promise<TenantDetail> {
+    console.log('[tenantService.update] request:', request);
     const { data } = await axiosInstance.put<TenantDetail>(
       API_ENDPOINTS.TENANTS.BY_ID(id),
       request
     );
+    console.log('[tenantService.update] response:', data);
     return data;
   },
 

--- a/src/services/ta/tenantSettingsService.ts
+++ b/src/services/ta/tenantSettingsService.ts
@@ -11,13 +11,27 @@ import type {
 } from '@/types/admin';
 import type { PublicBrandingResponse } from '@/types/tu/branding.types';
 
+/** 기본 브랜딩 (fallback) */
+const DEFAULT_BRANDING: PublicBrandingResponse = {
+  tenantName: 'MZC Learning Platform',
+  primaryColor: '#3B82F6',
+  secondaryColor: '#10B981',
+  logoUrl: null,
+  darkLogoUrl: null,
+  faviconUrl: null,
+  accentColor: null,
+  headingFont: null,
+  bodyFont: null,
+};
+
 export const tenantSettingsService = {
   /** 현재 테넌트 브랜딩 조회 (로그인 사용자용) */
   async getBranding(): Promise<PublicBrandingResponse> {
     const { data } = await axiosInstance.get<{ data: PublicBrandingResponse }>(
       API_ENDPOINTS.TENANT_SETTINGS.BRANDING
     );
-    return data.data;
+    // data.data가 null/undefined인 경우 기본 브랜딩 반환
+    return data.data ?? DEFAULT_BRANDING;
   },
 
   /** 테넌트 설정 조회 */

--- a/src/types/admin/tenant.types.ts
+++ b/src/types/admin/tenant.types.ts
@@ -7,7 +7,7 @@ export type TenantType = 'B2C' | 'B2B';
 export type PlanType = 'BASIC' | 'PRO' | 'ENTERPRISE';
 
 export interface Tenant {
-  id: number;
+  tenantId: number;
   code: string;
   name: string;
   type: TenantType;

--- a/src/types/common/auth.types.ts
+++ b/src/types/common/auth.types.ts
@@ -78,6 +78,7 @@ export interface AuthUser {
   name: string;
   role: TenantRole;
   tenantId?: number;
+  tenantSubdomain?: string;
 }
 
 // --- 역할 라벨 맵 ---


### PR DESCRIPTION
## Summary

로그인 후 테넌트 서브도메인 기반으로 URL을 리다이렉트하는 기능 구현 및 테넌트 생성/수정 관련 버그 수정

## Related Issue

- Closes #302

## Changes

- `AuthUser` 타입에 `tenantSubdomain` 필드 추가
- `LoginPage`, `AdminLoginPage`에서 서브도메인 기반 리다이렉트 로직 구현 (예: `/mzc/ta/dashboard`)
- `ta`, `to`, `tu` 라우트에 `/:subdomain/*` 경로 추가
- 테넌트 생성 시 성공했는데 실패 메시지 표시되는 버그 수정 (`data.data` 중복 접근 제거)
- 테넌트 수정 다이얼로그에서 Select controlled/uncontrolled 경고 해결

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

- Backend PR과 함께 머지되어야 합니다 (테넌트 상태 변경 API 수정)