### PR TITLE
refactor: TU 어드민 페이지 UX 개선

### DIFF
--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -247,8 +247,8 @@ export const tenantUserMenuData: MenuItem[] = [
     icon: Briefcase,
     subItems: [
       { id: 'my-courses', label: { ko: '강의 디자인', en: 'Course Design' }, icon: BookOpen, path: '/tu/teaching/courses' },
-      { id: 'my-programs', label: { ko: '개설 신청 현황', en: 'Submission Status' }, icon: Package, path: '/tu/teaching/programs' },
       { id: 'my-assignments', label: { ko: '강의 운영', en: 'Course Operations' }, icon: CheckSquare, path: '/tu/teaching/assignments' },
+      { id: 'my-programs', label: { ko: '개설 신청 현황', en: 'Submission Status' }, icon: Package, path: '/tu/teaching/programs' },
       { id: 'my-roadmaps', label: { ko: '로드맵', en: 'Roadmaps' }, icon: Map, path: '/tu/teaching/roadmaps', roles: ['DESIGNER', 'OPERATOR', 'TENANT_ADMIN'] },
     ],
   },

--- a/src/pages/tu/teaching/assignments/MyAssignmentsPage.tsx
+++ b/src/pages/tu/teaching/assignments/MyAssignmentsPage.tsx
@@ -3,7 +3,7 @@
  */
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Loader2, CalendarDays, FileText } from 'lucide-react';
+import { Loader2, CalendarDays, FileText, BookOpen } from 'lucide-react';
 import { Button } from '@/components/common';
 import { useMyAssignments, useMyInstructorStatistics } from '@/hooks/tu';
 import {
@@ -24,6 +24,7 @@ const t = {
   error: { ko: '오류가 발생했습니다.', en: 'An error occurred.' },
   noAssignments: { ko: '진행 중인 강의가 없습니다', en: 'No active courses found' },
   noAssignmentsDesc: { ko: '승인된 프로그램에 강사로 배정되면 여기에 표시됩니다', en: 'Courses will appear here when you are assigned as an instructor' },
+  goToCourseDesign: { ko: '강의 디자인으로 이동', en: 'Go to Course Design' },
   myAssignments: { ko: '진행 중인 강의', en: 'Active Courses' },
   courseStats: { ko: '차수별 통계', en: 'Course Statistics' },
   filterAll: { ko: '전체', en: 'All' },
@@ -131,7 +132,14 @@ export function MyAssignmentsPage({ language = 'ko' }: Readonly<MyAssignmentsPag
                 <div className="text-center py-12">
                   <CalendarDays size={48} className="mx-auto mb-3 text-text-placeholder" />
                   <p className="text-text-secondary mb-1">{getText('noAssignments')}</p>
-                  <p className="text-sm text-text-placeholder">{getText('noAssignmentsDesc')}</p>
+                  <p className="text-sm text-text-placeholder mb-4">{getText('noAssignmentsDesc')}</p>
+                  <Button
+                    variant="outline"
+                    onClick={() => navigate('/tu/teaching/courses')}
+                  >
+                    <BookOpen size={16} />
+                    {getText('goToCourseDesign')}
+                  </Button>
                 </div>
               )}
 

--- a/src/pages/tu/teaching/assignments/MyAssignmentsPage.tsx
+++ b/src/pages/tu/teaching/assignments/MyAssignmentsPage.tsx
@@ -1,7 +1,6 @@
 /**
  * 강의 관리 페이지 (TU - 강사 본인용)
  */
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Loader2, CalendarDays, FileText, BookOpen } from 'lucide-react';
 import { Button } from '@/components/common';
@@ -11,7 +10,6 @@ import {
   AssignmentCard,
   CourseTimeStatCard,
 } from '@/components/domain/tu/assignment';
-import type { AssignmentStatus } from '@/types/tu';
 
 interface MyAssignmentsPageProps {
   language?: 'ko' | 'en';
@@ -27,18 +25,11 @@ const t = {
   goToCourseDesign: { ko: '강의 디자인으로 이동', en: 'Go to Course Design' },
   myAssignments: { ko: '진행 중인 강의', en: 'Active Courses' },
   courseStats: { ko: '차수별 통계', en: 'Course Statistics' },
-  filterAll: { ko: '전체', en: 'All' },
-  filterActive: { ko: '활동 중', en: 'Active' },
-  filterReplaced: { ko: '교체됨', en: 'Replaced' },
-  filterCancelled: { ko: '취소됨', en: 'Cancelled' },
   assignmentCount: { ko: '건', en: ' items' },
 };
 
-type StatusFilter = AssignmentStatus | 'all';
-
 export function MyAssignmentsPage({ language = 'ko' }: Readonly<MyAssignmentsPageProps>) {
   const navigate = useNavigate();
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
 
   const getText = (key: keyof typeof t) => t[key][language];
 
@@ -49,11 +40,8 @@ export function MyAssignmentsPage({ language = 'ko' }: Readonly<MyAssignmentsPag
   const isLoading = assignmentsLoading || statsLoading;
   const error = assignmentsError;
 
-  // 필터링된 배정 목록
-  const filteredAssignments = assignments?.filter((assignment) => {
-    if (statusFilter === 'all') return true;
-    return assignment.status === statusFilter;
-  }) ?? [];
+  // 활성 상태의 배정만 표시 (ACTIVE만)
+  const activeAssignments = assignments?.filter((assignment) => assignment.status === 'ACTIVE') ?? [];
 
   // 에러 상태
   if (error) {
@@ -103,32 +91,18 @@ export function MyAssignmentsPage({ language = 'ko' }: Readonly<MyAssignmentsPag
           {/* 배정 목록 섹션 */}
           {!isLoading && (
             <>
-              {/* 필터 */}
+              {/* 섹션 헤더 */}
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-lg font-medium text-text-primary">
                   {getText('myAssignments')}
                 </h2>
-                <div className="flex gap-2">
-                  {(['all', 'ACTIVE', 'REPLACED', 'CANCELLED'] as const).map((status) => (
-                    <Button
-                      key={status}
-                      variant={statusFilter === status ? 'neutral' : 'ghost'}
-                      size="sm"
-                      onClick={() => setStatusFilter(status)}
-                    >
-                      {status === 'all' ? getText('filterAll') : getText(`filter${status.charAt(0) + status.slice(1).toLowerCase()}` as keyof typeof t)}
-                    </Button>
-                  ))}
-                </div>
+                <p className="text-sm text-text-secondary">
+                  {activeAssignments.length}{getText('assignmentCount')}
+                </p>
               </div>
 
-              {/* 배정 개수 */}
-              <p className="text-sm text-text-secondary mb-4">
-                {filteredAssignments.length}{getText('assignmentCount')}
-              </p>
-
               {/* 빈 상태 */}
-              {filteredAssignments.length === 0 && (
+              {activeAssignments.length === 0 && (
                 <div className="text-center py-12">
                   <CalendarDays size={48} className="mx-auto mb-3 text-text-placeholder" />
                   <p className="text-text-secondary mb-1">{getText('noAssignments')}</p>
@@ -144,9 +118,9 @@ export function MyAssignmentsPage({ language = 'ko' }: Readonly<MyAssignmentsPag
               )}
 
               {/* 배정 카드 그리드 */}
-              {filteredAssignments.length > 0 && (
+              {activeAssignments.length > 0 && (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
-                  {filteredAssignments.map((assignment) => (
+                  {activeAssignments.map((assignment) => (
                     <AssignmentCard
                       key={assignment.id}
                       assignment={assignment}

--- a/src/pages/tu/teaching/content/MyContentPage.tsx
+++ b/src/pages/tu/teaching/content/MyContentPage.tsx
@@ -345,6 +345,10 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
               <p className="text-text-secondary text-sm m-0">{getText('subtitle')}</p>
             </div>
             <div className="flex items-center gap-2">
+              <Button onClick={() => navigate('/tu/teaching/content/create')}>
+                <Plus size={20} />
+                <span>{getText('createContent')}</span>
+              </Button>
               <Button
                 variant="ghost"
                 className="border border-border"
@@ -352,10 +356,6 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
               >
                 <FolderTree size={20} />
                 <span>{getText('organizeManage')}</span>
-              </Button>
-              <Button onClick={() => navigate('/tu/teaching/content/create')}>
-                <Plus size={20} />
-                <span>{getText('createContent')}</span>
               </Button>
             </div>
           </div>

--- a/src/pages/tu/teaching/programs/MyProgramsPage.tsx
+++ b/src/pages/tu/teaching/programs/MyProgramsPage.tsx
@@ -58,7 +58,7 @@ const t = {
   retry: { ko: '다시 시도', en: 'Retry' },
   view: { ko: '상세보기', en: 'View' },
   edit: { ko: '수정', en: 'Edit' },
-  submit: { ko: '신청', en: 'Submit' },
+  submit: { ko: '신청 준비', en: 'Prepare Submit' },
   delete: { ko: '삭제', en: 'Delete' },
   notSet: { ko: '미설정', en: 'Not set' },
   hours: { ko: '시간', en: 'hours' },


### PR DESCRIPTION
## Summary
유저테스트 전 TU 어드민 페이지의 사용자 플로우 및 UX 개선

## Related Issue
- Closes #304

## Changes
- 개설 신청 현황: '신청' 버튼 텍스트를 '신청 준비'로 변경 (실제로는 edit 페이지로 이동)
- 메뉴 순서 변경: 강의 디자인 → 강의 운영 → 개설 신청 현황 → 로드맵 (플로우 순서 반영)
- 내 콘텐츠: 버튼 순서 변경 (콘텐츠 등록 먼저, 분류 및 관리 나중)
- 강의 운영 Empty State: '강의 디자인으로 이동' 버튼 추가
- 강의 운영 페이지 불필요한 필터 제거 (ACTIVE 상태만 표시)

## Type of Change
- [ ] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [x] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist
- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes
- UI/UX만 변경하는 PR이라 테스트 코드 추가 불필요
- 구조 변경이 없어 문서 업데이트 불필요