### PR TITLE
fix(to): 사용자 관리 API 응답 필드명 동기화

### DIFF
--- a/src/pages/to/enrollment/EnrollmentManagementPage.tsx
+++ b/src/pages/to/enrollment/EnrollmentManagementPage.tsx
@@ -741,17 +741,17 @@ export function EnrollmentManagementPage({ language = 'ko' }: Readonly<Enrollmen
               <div className="border border-border rounded-lg max-h-[300px] overflow-auto">
                 {users.map((user) => (
                   <label
-                    key={user.userId}
+                    key={user.id}
                     className="flex items-center gap-3 p-3 hover:bg-bg-secondary cursor-pointer border-b border-border last:border-0"
                   >
                     <input
                       type="checkbox"
-                      checked={selectedUserIds.includes(user.userId)}
+                      checked={selectedUserIds.includes(user.id)}
                       onChange={(e) => {
                         if (e.target.checked) {
-                          setSelectedUserIds([...selectedUserIds, user.userId]);
+                          setSelectedUserIds([...selectedUserIds, user.id]);
                         } else {
-                          setSelectedUserIds(selectedUserIds.filter((id) => id !== user.userId));
+                          setSelectedUserIds(selectedUserIds.filter((id) => id !== user.id));
                         }
                       }}
                       className="w-4 h-4 rounded border-border"

--- a/src/pages/to/enrollment/EnrollmentTab.tsx
+++ b/src/pages/to/enrollment/EnrollmentTab.tsx
@@ -731,17 +731,17 @@ export function EnrollmentTab({ courseTimeId, language = 'ko' }: Readonly<Enroll
               <div className="border border-border rounded-lg max-h-[300px] overflow-auto">
                 {users.map((user) => (
                   <label
-                    key={user.userId}
+                    key={user.id}
                     className="flex items-center gap-3 p-3 hover:bg-bg-secondary cursor-pointer border-b border-border last:border-0"
                   >
                     <input
                       type="checkbox"
-                      checked={selectedUserIds.includes(user.userId)}
+                      checked={selectedUserIds.includes(user.id)}
                       onChange={(e) => {
                         if (e.target.checked) {
-                          setSelectedUserIds([...selectedUserIds, user.userId]);
+                          setSelectedUserIds([...selectedUserIds, user.id]);
                         } else {
-                          setSelectedUserIds(selectedUserIds.filter((id) => id !== user.userId));
+                          setSelectedUserIds(selectedUserIds.filter((id) => id !== user.id));
                         }
                       }}
                       className="w-4 h-4 rounded border-border"

--- a/src/pages/to/instructor/InstructorAssignmentsPage.tsx
+++ b/src/pages/to/instructor/InstructorAssignmentsPage.tsx
@@ -279,10 +279,10 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
         );
       })
       .map((user) => ({
-        value: String(user.userId),
+        value: String(user.id),
         label: user.name,
         email: user.email,
-        isAssigned: assignedInstructorIds.has(user.userId),
+        isAssigned: assignedInstructorIds.has(user.id),
       }));
   }, [allUsers, instructorSearch, assignedInstructorIds]);
 

--- a/src/pages/to/user/UserManagementPage.tsx
+++ b/src/pages/to/user/UserManagementPage.tsx
@@ -204,8 +204,8 @@ export function UserManagementPage({ language = 'ko' }: Readonly<UserManagementP
   const changeStatus = useChangeUserStatus();
 
   // 사용자 상세 정보 및 수강/강사 통계 조회
-  const selectedUserId = selectedUserForDetail?.userId ?? 0;
-  const isDesigner = selectedUserForDetail?.role === 'DESIGNER';
+  const selectedUserId = selectedUserForDetail?.id ?? 0;
+  const isDesigner = selectedUserForDetail?.systemRole === 'DESIGNER';
   const { data: userDetail, isLoading: isDetailLoading } = useUser(selectedUserId);
   const { data: enrollmentStats, isLoading: isStatsLoading } = useUserEnrollmentStats(selectedUserId);
   const { data: instructorStats, isLoading: isInstructorStatsLoading } = useUserInstructorStats(selectedUserId, isDesigner);
@@ -214,7 +214,7 @@ export function UserManagementPage({ language = 'ko' }: Readonly<UserManagementP
   const filteredUsers = useMemo(() => {
     const allUsers = data?.content ?? [];
     return allUsers.filter(
-      (user) => user.role !== 'SYSTEM_ADMIN' && user.role !== 'TENANT_ADMIN' && user.role !== 'OPERATOR'
+      (user) => user.systemRole !== 'SYSTEM_ADMIN' && user.systemRole !== 'TENANT_ADMIN' && user.systemRole !== 'OPERATOR'
     );
   }, [data?.content]);
 
@@ -254,7 +254,7 @@ export function UserManagementPage({ language = 'ko' }: Readonly<UserManagementP
 
     try {
       await changeStatus.mutateAsync({
-        id: selectedUser.userId,
+        id: selectedUser.id,
         request: {
           status: targetStatus,
           ...(statusReason && { reason: statusReason }),
@@ -322,7 +322,7 @@ export function UserManagementPage({ language = 'ko' }: Readonly<UserManagementP
               {row.original.name}
             </p>
             <p className="text-xs text-text-secondary mt-0.5">
-              ID: {row.original.userId}
+              ID: {row.original.id}
             </p>
           </div>
         ),
@@ -339,13 +339,13 @@ export function UserManagementPage({ language = 'ko' }: Readonly<UserManagementP
         ),
       },
       {
-        accessorKey: 'role',
+        accessorKey: 'systemRole',
         header: ({ column }) => (
           <DataTableColumnHeader column={column} title={getText('columnRole')} />
         ),
         cell: ({ row }) => (
-          <Badge variant={roleBadgeVariant[row.original.role]}>
-            {TENANT_ROLE_LABELS[row.original.role]}
+          <Badge variant={roleBadgeVariant[row.original.systemRole]}>
+            {TENANT_ROLE_LABELS[row.original.systemRole]}
           </Badge>
         ),
       },
@@ -695,7 +695,7 @@ export function UserManagementPage({ language = 'ko' }: Readonly<UserManagementP
                         ID
                       </dt>
                       <dd className="text-sm font-medium text-text-primary">
-                        {selectedUserForDetail.userId}
+                        {selectedUserForDetail.id}
                       </dd>
                     </div>
 
@@ -727,8 +727,8 @@ export function UserManagementPage({ language = 'ko' }: Readonly<UserManagementP
                         {getText('columnRole')}
                       </dt>
                       <dd>
-                        <Badge variant={roleBadgeVariant[userDetail?.role ?? selectedUserForDetail.role]}>
-                          {TENANT_ROLE_LABELS[userDetail?.role ?? selectedUserForDetail.role]}
+                        <Badge variant={roleBadgeVariant[userDetail?.role ?? selectedUserForDetail.systemRole]}>
+                          {TENANT_ROLE_LABELS[userDetail?.role ?? selectedUserForDetail.systemRole]}
                         </Badge>
                       </dd>
                     </div>

--- a/src/services/ta/tenantSettingsService.ts
+++ b/src/services/ta/tenantSettingsService.ts
@@ -14,10 +14,10 @@ import type { PublicBrandingResponse } from '@/types/tu/branding.types';
 export const tenantSettingsService = {
   /** 현재 테넌트 브랜딩 조회 (로그인 사용자용) */
   async getBranding(): Promise<PublicBrandingResponse> {
-    const { data } = await axiosInstance.get<{ data: PublicBrandingResponse }>(
+    const { data } = await axiosInstance.get<PublicBrandingResponse>(
       API_ENDPOINTS.TENANT_SETTINGS.BRANDING
     );
-    return data.data;
+    return data;
   },
 
   /** 테넌트 설정 조회 */

--- a/src/types/to/user.types.ts
+++ b/src/types/to/user.types.ts
@@ -29,11 +29,14 @@ export interface CourseRoleResponse {
 
 /** 사용자 목록 응답 */
 export interface UserListResponse {
-  userId: number;
+  id: number;
   email: string;
   name: string;
-  role: TenantRole;
+  profileImageUrl: string | null;
+  systemRole: TenantRole;
   status: UserStatus;
+  organizationName: string | null;
+  lastLoginAt: string | null;
   createdAt: string;
 }
 


### PR DESCRIPTION
## Summary

TO 사용자 관리 페이지에서 백엔드 API 응답 필드명 변경에 따른 프론트엔드 동기화

## Related Issue

- Closes #

## Changes

- `UserListResponse` 타입 백엔드 API 변경사항 반영
  - `userId` → `id`
  - `role` → `systemRole`
  - `profileImageUrl`, `organizationName`, `lastLoginAt` 필드 추가
- `tenantSettingsService.getBranding()` axios interceptor 중복 추출 수정
  - interceptor가 이미 `response.data.data` 추출하므로 `return data` 사용
- TO 페이지들 필드명 참조 업데이트
  - UserManagementPage
  - EnrollmentManagementPage
  - EnrollmentTab
  - InstructorAssignmentsPage

## Type of Change

- [x] Fix: 버그 수정

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes

- axios interceptor가 `response.data.data`를 자동 추출하는 패턴 사용 중
- 서비스에서 `return data.data`가 아닌 `return data` 사용 필요