### PR TITLE
Fix/308 subdomain routing navigation

### DIFF
--- a/src/components/domain/tu/course/CourseCard.tsx
+++ b/src/components/domain/tu/course/CourseCard.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { Clock, Pencil } from 'lucide-react';
 import { Button, CategoryBadge } from '@/components/common';
+import { useSubdomainPath } from '@/hooks/common';
 import type { Course } from '@/types';
 
 export interface CourseCardLabels {
@@ -26,12 +27,13 @@ interface CourseCardProps {
  */
 export const CourseCard = ({ course, labels, onManage, onEdit }: Readonly<CourseCardProps>) => {
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
 
   const handleManage = () => {
     if (onManage) {
       onManage();
     } else {
-      navigate(`/tu/teaching/courses/${course.id}`);
+      navigate(prefixPath(`/tu/teaching/courses/${course.id}`));
     }
   };
 
@@ -39,7 +41,7 @@ export const CourseCard = ({ course, labels, onManage, onEdit }: Readonly<Course
     if (onEdit) {
       onEdit();
     } else {
-      navigate(`/tu/teaching/courses/${course.id}/edit`);
+      navigate(prefixPath(`/tu/teaching/courses/${course.id}/edit`));
     }
   };
 

--- a/src/components/landing/LandingCourseCard.tsx
+++ b/src/components/landing/LandingCourseCard.tsx
@@ -1,6 +1,7 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { Star, Heart, Loader2, Calendar, Users } from 'lucide-react';
 import { useAuthStore } from '@/store/common/authStore';
+import { useSubdomainPath } from '@/hooks/common';
 import { useCheckWishlistStatus, useToggleWishlist } from '@/hooks/tu';
 import { toast } from 'sonner';
 
@@ -48,6 +49,7 @@ export function LandingCourseCard({
   isOnDemand,
 }: LandingCourseCardProps) {
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
   const { isAuthenticated } = useAuthStore();
 
   // 찜 상태 확인 및 토글
@@ -63,7 +65,7 @@ export function LandingCourseCard({
 
     if (!isAuthenticated) {
       toast.error('로그인이 필요합니다.');
-      navigate('/auth/login', { state: { from: `/tu/b2c/times/${id}` } });
+      navigate('/login', { state: { from: prefixPath(`/tu/b2c/courses/${id}`) } });
       return;
     }
 
@@ -96,7 +98,7 @@ export function LandingCourseCard({
   };
 
   return (
-    <Link to={`/tu/b2c/courses/${id}`} className="group block h-full">
+    <Link to={prefixPath(`/tu/b2c/courses/${id}`)} className="group block h-full">
       <div className="h-full card-hover rounded-xl overflow-hidden landing-card-bg border landing-card-border">
         {/* 썸네일 영역 */}
         <div className="relative aspect-[16/10] overflow-hidden">

--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Search, ShoppingCart, Bell, Menu, X, LogOut, User, Sun, Moon, BookOpen, PlusCircle, Shield, Globe, Heart } from 'lucide-react';
 import { useAuth } from '@/hooks/common/auth';
-import { useMyProfile } from '@/hooks/common';
+import { useMyProfile, useSubdomainPath } from '@/hooks/common';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation } from '@/store/common/languageStore';
 import { useUnreadNotificationCount } from '@/hooks/tu';
@@ -13,6 +13,7 @@ export function LandingHeader() {
   const [searchQuery, setSearchQuery] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
   const { user, isAuthenticated, logout } = useAuth();
   const { data: profile } = useMyProfile();
   const { theme, toggleTheme } = useThemeStore();
@@ -51,7 +52,7 @@ export function LandingHeader() {
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     if (searchQuery.trim()) {
-      navigate(`/tu/b2c/search?search=${encodeURIComponent(searchQuery.trim())}`);
+      navigate(prefixPath(`/tu/b2c/search?search=${encodeURIComponent(searchQuery.trim())}`));
     }
   };
 
@@ -77,7 +78,7 @@ export function LandingHeader() {
           {/* Left: Logo & Menu */}
           <div className="flex items-center gap-8 ml-2 md:ml-4">
             {/* Logo */}
-            <Link to="/tu/b2c" className={`flex items-center gap-2 font-bold text-xl tracking-tight ${isDark ? '' : 'text-gray-900'}`}>
+            <Link to={prefixPath('/tu/b2c')} className={`flex items-center gap-2 font-bold text-xl tracking-tight ${isDark ? '' : 'text-gray-900'}`}>
               {fullLogoUrl ? (
                 <img src={fullLogoUrl} alt={tenantName} className="h-8 object-contain" />
               ) : (
@@ -90,13 +91,13 @@ export function LandingHeader() {
 
             {/* Desktop Nav Links */}
             <nav className={`hidden md:flex items-center gap-8 font-medium text-[15px] ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
-              <Link to="/tu/b2c/courses" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
+              <Link to={prefixPath('/tu/b2c/courses')} className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
                 강의 탐색
               </Link>
-              <Link to="/tu/b2c/roadmaps" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
+              <Link to={prefixPath('/tu/b2c/roadmaps')} className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
                 로드맵
               </Link>
-              <Link to="/tu/b2c/community" className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
+              <Link to={prefixPath('/tu/b2c/community')} className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
                 커뮤니티
               </Link>
             </nav>
@@ -140,7 +141,7 @@ export function LandingHeader() {
                 {isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
               </button>
               <Link
-                to="/tu/b2c/cart"
+                to={prefixPath('/tu/b2c/cart')}
                 className={`p-2 rounded-lg transition-colors relative ${
                   isDark
                     ? 'text-gray-400 hover:text-white hover:bg-white/10'
@@ -150,7 +151,7 @@ export function LandingHeader() {
                 <ShoppingCart className="h-5 w-5" />
               </Link>
               <Link
-                to="/tu/b2c/wishlist"
+                to={prefixPath('/tu/b2c/wishlist')}
                 className={`p-2 rounded-lg transition-colors relative ${
                   isDark
                     ? 'text-gray-400 hover:text-white hover:bg-white/10'
@@ -160,7 +161,7 @@ export function LandingHeader() {
                 <Heart className="h-5 w-5" />
               </Link>
               <Link
-                to="/tu/b2c/notifications"
+                to={prefixPath('/tu/b2c/notifications')}
                 className={`p-2 rounded-lg transition-colors relative ${
                   isDark
                     ? 'text-gray-400 hover:text-white hover:bg-white/10'
@@ -222,7 +223,7 @@ export function LandingHeader() {
                       {/* 메뉴 항목들 */}
                       <div className="py-2 space-y-1">
                         <Link
-                          to="/tu/b2c/mypage"
+                          to={prefixPath('/tu/b2c/mypage')}
                           onClick={() => setShowDropdown(false)}
                           className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors text-sm ${
                             isDark
@@ -234,7 +235,7 @@ export function LandingHeader() {
                           {t.landing.mypage}
                         </Link>
                         <Link
-                          to="/tu/b2c/mypage/teaching"
+                          to={prefixPath('/tu/b2c/mypage/teaching')}
                           onClick={() => setShowDropdown(false)}
                           className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors text-sm ${
                             isDark
@@ -251,7 +252,7 @@ export function LandingHeader() {
                       <div className={`py-2 border-t space-y-1 ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
                         <p className={`px-3 py-1 text-xs font-medium ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>{t.landing.settings}</p>
                         <Link
-                          to="/tu/b2c/mypage/profile"
+                          to={prefixPath('/tu/b2c/mypage/profile')}
                           onClick={() => setShowDropdown(false)}
                           className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm ${
                             isDark
@@ -263,7 +264,7 @@ export function LandingHeader() {
                           {t.landing.profileSecurity}
                         </Link>
                         <Link
-                          to="/tu/b2c/mypage/notifications"
+                          to={prefixPath('/tu/b2c/mypage/notifications')}
                           onClick={() => setShowDropdown(false)}
                           className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm ${
                             isDark
@@ -275,7 +276,7 @@ export function LandingHeader() {
                           {t.landing.notifications}
                         </Link>
                         <Link
-                          to="/tu/b2c/mypage/language"
+                          to={prefixPath('/tu/b2c/mypage/language')}
                           onClick={() => setShowDropdown(false)}
                           className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm ${
                             isDark

--- a/src/components/layout/mypage/MyPageLayout.tsx
+++ b/src/components/layout/mypage/MyPageLayout.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { MyPageSidebar } from './MyPageSidebar';
 import { LandingHeader, LandingFooter } from '@/components/landing';
 import { myPageMenuData } from '@/config/sidebar-menus';
@@ -11,14 +11,23 @@ interface MyPageLayoutProps {
 
 export function MyPageLayout({ children }: MyPageLayoutProps) {
   const navigate = useNavigate();
+  const { subdomain } = useParams<{ subdomain: string }>();
   const { isSidebarExpanded, language, toggleSidebar } = useUIStore();
   const isDarkMode = useIsDarkMode();
+
+  // 서브도메인이 있으면 경로에 프리픽스 추가
+  const prefixPath = (path: string) => {
+    if (subdomain) {
+      return `/${subdomain}${path}`;
+    }
+    return path;
+  };
 
   const handleMenuItemClick = (itemId: string) => {
     // Check top-level menu items
     const menuItem = myPageMenuData.find((item) => item.id === itemId);
     if (menuItem?.path) {
-      navigate(menuItem.path);
+      navigate(prefixPath(menuItem.path));
       return;
     }
 
@@ -26,7 +35,7 @@ export function MyPageLayout({ children }: MyPageLayoutProps) {
     for (const item of myPageMenuData) {
       const subItem = item.subItems?.find((sub) => sub.id === itemId);
       if (subItem?.path) {
-        navigate(subItem.path);
+        navigate(prefixPath(subItem.path));
         return;
       }
     }

--- a/src/components/layout/ta/TenantAdminLayout.tsx
+++ b/src/components/layout/ta/TenantAdminLayout.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { TenantAdminSidebar } from './TenantAdminSidebar';
 import { designTokens } from '@/styles/admin-design-tokens';
 import { tenantAdminMenuData } from '@/config/sidebar-menus';
@@ -11,14 +11,23 @@ interface TenantAdminLayoutProps {
 
 export function TenantAdminLayout({ children }: TenantAdminLayoutProps) {
   const navigate = useNavigate();
+  const { subdomain } = useParams<{ subdomain: string }>();
   const { isSidebarExpanded, language, toggleSidebar } = useUIStore();
   const isDarkMode = useIsDarkMode();
+
+  // 서브도메인이 있으면 경로에 프리픽스 추가
+  const prefixPath = (path: string) => {
+    if (subdomain) {
+      return `/${subdomain}${path}`;
+    }
+    return path;
+  };
 
   const handleMenuItemClick = (itemId: string) => {
     // Check top-level menu items
     const menuItem = tenantAdminMenuData.find((item) => item.id === itemId);
     if (menuItem?.path) {
-      navigate(menuItem.path);
+      navigate(prefixPath(menuItem.path));
       return;
     }
 
@@ -26,7 +35,7 @@ export function TenantAdminLayout({ children }: TenantAdminLayoutProps) {
     for (const item of tenantAdminMenuData) {
       const subItem = item.subItems?.find((sub) => sub.id === itemId);
       if (subItem?.path) {
-        navigate(subItem.path);
+        navigate(prefixPath(subItem.path));
         return;
       }
     }

--- a/src/components/layout/to/TenantOperatorLayout.tsx
+++ b/src/components/layout/to/TenantOperatorLayout.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { TenantOperatorSidebar } from './TenantOperatorSidebar';
 import { designTokens } from '@/styles/admin-design-tokens';
 import { tenantOperatorMenuData } from '@/config/sidebar-menus';
@@ -13,14 +13,23 @@ export function TenantOperatorLayout({
   children,
 }: TenantOperatorLayoutProps) {
   const navigate = useNavigate();
+  const { subdomain } = useParams<{ subdomain: string }>();
   const { isSidebarExpanded, language, toggleSidebar } = useUIStore();
   const isDarkMode = useIsDarkMode();
+
+  // 서브도메인이 있으면 경로에 프리픽스 추가
+  const prefixPath = (path: string) => {
+    if (subdomain) {
+      return `/${subdomain}${path}`;
+    }
+    return path;
+  };
 
   const handleMenuItemClick = (itemId: string) => {
     // Check top-level menu items
     const menuItem = tenantOperatorMenuData.find((item) => item.id === itemId);
     if (menuItem?.path) {
-      navigate(menuItem.path);
+      navigate(prefixPath(menuItem.path));
       return;
     }
 
@@ -28,7 +37,7 @@ export function TenantOperatorLayout({
     for (const item of tenantOperatorMenuData) {
       const subItem = item.subItems?.find((sub) => sub.id === itemId);
       if (subItem?.path) {
-        navigate(subItem.path);
+        navigate(prefixPath(subItem.path));
         return;
       }
     }

--- a/src/components/layout/tu/TenantUserLayout.tsx
+++ b/src/components/layout/tu/TenantUserLayout.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { TenantUserSidebar } from './TenantUserSidebar';
 import { designTokens } from '@/styles/admin-design-tokens';
 import { tenantUserMenuData } from '@/config/sidebar-menus';
@@ -11,14 +11,23 @@ interface TenantUserLayoutProps {
 
 export function TenantUserLayout({ children }: TenantUserLayoutProps) {
   const navigate = useNavigate();
+  const { subdomain } = useParams<{ subdomain: string }>();
   const { isSidebarExpanded, language, toggleSidebar } = useUIStore();
   const isDarkMode = useIsDarkMode();
+
+  // 서브도메인이 있으면 경로에 프리픽스 추가
+  const prefixPath = (path: string) => {
+    if (subdomain) {
+      return `/${subdomain}${path}`;
+    }
+    return path;
+  };
 
   const handleMenuItemClick = (itemId: string) => {
     // Check top-level menu items
     const menuItem = tenantUserMenuData.find((item) => item.id === itemId);
     if (menuItem?.path) {
-      navigate(menuItem.path);
+      navigate(prefixPath(menuItem.path));
       return;
     }
 
@@ -26,7 +35,7 @@ export function TenantUserLayout({ children }: TenantUserLayoutProps) {
     for (const item of tenantUserMenuData) {
       const subItem = item.subItems?.find((sub) => sub.id === itemId);
       if (subItem?.path) {
-        navigate(subItem.path);
+        navigate(prefixPath(subItem.path));
         return;
       }
     }

--- a/src/hooks/common/auth/useAuth.ts
+++ b/src/hooks/common/auth/useAuth.ts
@@ -34,50 +34,29 @@ export const useLogin = () => {
         name: userDetail.name,
         role: userDetail.role,
         tenantId: userDetail.tenantId,
+        tenantSubdomain: userDetail.tenantSubdomain,
       };
 
       setAuth(user, tokenResponse.accessToken, tokenResponse.refreshToken);
       toast.success(`${user.name}님, 환영합니다!`);
 
       // 역할별 리다이렉트 경로
-      const redirectPath: Record<string, string> = {
+      const roleBasePath: Record<string, string> = {
         SYSTEM_ADMIN: '/sa',
         TENANT_ADMIN: '/ta',
         OPERATOR: '/to',
         DESIGNER: '/tu/teaching',
-        USER: '/tu',
+        USER: '/tu/b2c',
       };
-      const targetPath = redirectPath[user.role] || '/';
+      const basePath = roleBasePath[user.role] || '/tu/b2c';
 
-      // 테넌트 subdomain/customDomain이 있으면 해당 URL로 리다이렉트
-      const tenantDomain = userDetail.tenantCustomDomain || userDetail.tenantSubdomain;
-      if (tenantDomain && user.role !== 'SYSTEM_ADMIN') {
-        // 현재 호스트가 이미 테넌트 도메인인지 확인
-        const currentHost = window.location.hostname;
-        const isAlreadyOnTenantDomain =
-          currentHost === userDetail.tenantCustomDomain ||
-          currentHost.startsWith(`${userDetail.tenantSubdomain}.`);
+      // 테넌트 subdomain이 있으면 경로에 포함 (SA 제외, default는 생략)
+      let targetPath = basePath;
+      const subdomain = userDetail.tenantSubdomain;
+      const isDefaultSubdomain = !subdomain || subdomain === 'default' || subdomain === 'www';
 
-        if (!isAlreadyOnTenantDomain) {
-          // 테넌트 도메인으로 리다이렉트 (프로토콜과 포트 유지)
-          const protocol = window.location.protocol;
-          const port = window.location.port ? `:${window.location.port}` : '';
-
-          // customDomain이 있으면 그대로 사용, 없으면 subdomain.baseDomain 형태로 구성
-          let tenantUrl: string;
-          if (userDetail.tenantCustomDomain) {
-            tenantUrl = `${protocol}//${userDetail.tenantCustomDomain}${port}${targetPath}`;
-          } else {
-            // 현재 도메인에서 base domain 추출 (localhost의 경우 그대로 사용)
-            const baseDomain = currentHost === 'localhost'
-              ? 'localhost'
-              : currentHost.split('.').slice(-2).join('.');
-            tenantUrl = `${protocol}//${userDetail.tenantSubdomain}.${baseDomain}${port}${targetPath}`;
-          }
-
-          window.location.href = tenantUrl;
-          return;
-        }
+      if (!isDefaultSubdomain && user.role !== 'SYSTEM_ADMIN') {
+        targetPath = `/${subdomain}${basePath}`;
       }
 
       navigate(targetPath);

--- a/src/hooks/common/index.ts
+++ b/src/hooks/common/index.ts
@@ -1,6 +1,7 @@
 export { useDebounce } from './useDebounce';
 export { useLocalStorage } from './useLocalStorage';
 export { useIsMobile } from './useIsMobile';
+export { useSubdomainPath } from './useSubdomainPath';
 
 // Auth Hooks
 export {

--- a/src/hooks/common/useAuthQueries.ts
+++ b/src/hooks/common/useAuthQueries.ts
@@ -31,10 +31,11 @@ export const useMe = () => {
 
 /**
  * 로그인 뮤테이션 훅
- * 성공 시 사용자 정보를 반환하여 role 기반 리다이렉트가 가능하도록 함
+ * 성공 시 role 기반 리다이렉트 수행
  */
 export const useLogin = () => {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const setAuth = useAuthStore((state) => state.setAuth);
   const setTokens = useAuthStore((state) => state.setTokens);
 
@@ -47,7 +48,6 @@ export const useLogin = () => {
 
       // 토큰으로 사용자 정보 조회
       const userDetail = await userService.getMe();
-      console.log('userDetail from API:', userDetail);
       const user = {
         id: userDetail.userId,
         email: userDetail.email,
@@ -56,12 +56,32 @@ export const useLogin = () => {
         tenantId: userDetail.tenantId,
         tenantSubdomain: userDetail.tenantSubdomain,
       };
-      console.log('user object for redirect:', user);
       setAuth(user, tokenData.accessToken, tokenData.refreshToken);
       queryClient.invalidateQueries({ queryKey: authKeys.me() });
 
-      // 사용자 정보 반환 (role 기반 리다이렉트를 위해)
-      return user;
+      return { user, userDetail };
+    },
+    onSuccess: ({ user, userDetail }) => {
+      // 역할별 리다이렉트 경로
+      const roleBasePath: Record<string, string> = {
+        SYSTEM_ADMIN: '/sa',
+        TENANT_ADMIN: '/ta',
+        OPERATOR: '/to',
+        DESIGNER: '/tu/teaching',
+        USER: '/tu/b2c',
+      };
+      const basePath = roleBasePath[user.role] || '/tu/b2c';
+
+      // 테넌트 subdomain이 있으면 경로에 포함 (SA 제외, default는 생략)
+      let targetPath = basePath;
+      const subdomain = userDetail.tenantSubdomain;
+      const isDefaultSubdomain = !subdomain || subdomain === 'default' || subdomain === 'www';
+
+      if (!isDefaultSubdomain && user.role !== 'SYSTEM_ADMIN') {
+        targetPath = `/${subdomain}${basePath}`;
+      }
+
+      navigate(targetPath);
     },
   });
 };

--- a/src/hooks/common/useSubdomainPath.ts
+++ b/src/hooks/common/useSubdomainPath.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+
+/**
+ * 서브도메인 기반 경로 프리픽스 훅
+ * URL에서 subdomain 파라미터를 추출하여 경로 앞에 추가
+ *
+ * @example
+ * const { prefixPath } = useSubdomainPath();
+ * // URL이 /mzc/ta/dashboard 일 때
+ * prefixPath('/ta/settings') // => '/mzc/ta/settings'
+ * // URL이 /ta/dashboard 일 때 (서브도메인 없음)
+ * prefixPath('/ta/settings') // => '/ta/settings'
+ */
+export function useSubdomainPath() {
+  const { subdomain } = useParams<{ subdomain: string }>();
+
+  const prefixPath = useCallback(
+    (path: string) => {
+      if (subdomain) {
+        return `/${subdomain}${path}`;
+      }
+      return path;
+    },
+    [subdomain]
+  );
+
+  return { subdomain, prefixPath };
+}

--- a/src/pages/admin/auth/AdminLoginPage.tsx
+++ b/src/pages/admin/auth/AdminLoginPage.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Eye, EyeOff, LogIn, Shield } from 'lucide-react';
 import { Checkbox } from '@/components/common/Checkbox';
 import { useLogin } from '@/hooks/common';
-import { ROLE_REDIRECT_PATH } from '@/types/common/auth.types';
 import { designTokens } from '@/styles/admin-design-tokens';
 
 /**
@@ -11,7 +10,6 @@ import { designTokens } from '@/styles/admin-design-tokens';
  * 어드민 디자인 토큰 사용
  */
 export const AdminLoginPage = () => {
-  const navigate = useNavigate();
   const loginMutation = useLogin();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -46,23 +44,8 @@ export const AdminLoginPage = () => {
     setErrors({});
 
     try {
-      const user = await loginMutation.mutateAsync({ email, password });
-      console.log('[AdminLoginPage] user:', user);
-      console.log('[AdminLoginPage] tenantSubdomain:', user.tenantSubdomain);
-      console.log('[AdminLoginPage] role:', user.role);
-
-      // Role에 따른 기본 경로
-      const basePath = ROLE_REDIRECT_PATH[user.role] || '/';
-      console.log('[AdminLoginPage] basePath:', basePath);
-
-      // 테넌트 서브도메인이 있으면 prefix로 추가 (SA 제외)
-      let redirectPath = basePath;
-      if (user.tenantSubdomain && user.role !== 'SYSTEM_ADMIN') {
-        redirectPath = `/${user.tenantSubdomain}${basePath}`;
-      }
-      console.log('[AdminLoginPage] redirectPath:', redirectPath);
-
-      navigate(redirectPath);
+      // useLogin hook의 onSuccess에서 서브도메인 리다이렉트 처리
+      await loginMutation.mutateAsync({ email, password });
     } catch {
       setErrors({ general: '이메일 또는 비밀번호가 올바르지 않습니다.' });
     }

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Eye, EyeOff, LogIn, Sun, Moon } from 'lucide-react';
 import { Checkbox } from '@/components/common/Checkbox';
 import { useLogin } from '@/hooks/common';
-import { ROLE_REDIRECT_PATH } from '@/types/common/auth.types';
 import { useThemeStore } from '@/store/common/themeStore';
 
 /**
@@ -11,7 +10,6 @@ import { useThemeStore } from '@/store/common/themeStore';
  * 다크/라이트 모드 지원
  */
 export const LoginPage = () => {
-  const navigate = useNavigate();
   const loginMutation = useLogin();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -48,18 +46,8 @@ export const LoginPage = () => {
     setErrors({});
 
     try {
-      const user = await loginMutation.mutateAsync({ email, password });
-
-      // Role에 따른 기본 경로
-      const basePath = ROLE_REDIRECT_PATH[user.role] || '/';
-
-      // 테넌트 서브도메인이 있으면 prefix로 추가 (SA 제외)
-      let redirectPath = basePath;
-      if (user.tenantSubdomain && user.role !== 'SYSTEM_ADMIN') {
-        redirectPath = `/${user.tenantSubdomain}${basePath}`;
-      }
-
-      navigate(redirectPath);
+      // useLogin hook의 onSuccess에서 서브도메인 리다이렉트 처리
+      await loginMutation.mutateAsync({ email, password });
     } catch {
       setErrors({ general: '이메일 또는 비밀번호가 올바르지 않습니다.' });
     }

--- a/src/pages/sa/tenants/TenantDetailPage.tsx
+++ b/src/pages/sa/tenants/TenantDetailPage.tsx
@@ -212,6 +212,7 @@ export function TenantDetailPage() {
     if (!formState) return;
 
     try {
+      // 백엔드 UpdateTenantRequest DTO에 맞는 필드만 전송
       await updateMutation.mutateAsync({
         id: tenantId,
         request: {
@@ -219,24 +220,6 @@ export function TenantDetailPage() {
           status: formState.status,
           plan: formState.plan,
           customDomain: formState.customDomain || undefined,
-          adminName: formState.adminName,
-          adminEmail: formState.adminEmail,
-          branding: {
-            tenantId: tenantId,
-            logoUrl: formState.branding.logoUrl || undefined,
-            faviconUrl: formState.branding.faviconUrl || undefined,
-            primaryColor: formState.branding.primaryColor,
-            secondaryColor: formState.branding.secondaryColor || undefined,
-          },
-          settings: {
-            tenantId: tenantId,
-            allowSelfRegistration: false,
-            requireEmailVerification: false,
-            defaultLanguage: 'ko',
-            timezone: 'Asia/Seoul',
-            maxStorageGB: formState.settings.maxStorageGB,
-            maxUsersCount: formState.settings.maxUsersCount,
-          },
         },
       });
     } catch (err) {

--- a/src/pages/tu/learning/LearningDetailPage.tsx
+++ b/src/pages/tu/learning/LearningDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { useSubdomainPath } from '@/hooks/common';
 import {
   ArrowLeft,
   PlayCircle,
@@ -135,6 +136,7 @@ function CurriculumListItem({ item, isDark }: CurriculumListItemProps) {
 export function LearningDetailPage() {
   const { enrollmentId } = useParams<{ enrollmentId: string }>();
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
   const { t } = useTranslation();
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
@@ -162,7 +164,7 @@ export function LearningDetailPage() {
     try {
       await cancelEnrollment.mutateAsync(enrollment.id);
       setCancelDialogOpen(false);
-      navigate('/tu/b2c/mypage/learning');
+      navigate(prefixPath('/tu/b2c/mypage/learning'));
     } catch (error) {
       console.error('Failed to cancel enrollment:', error);
     }
@@ -171,7 +173,7 @@ export function LearningDetailPage() {
   const handleContinueLearning = () => {
     // 미완료 아이템 중 첫 번째 아이템으로 이동, 없으면 첫 아이템
     const nextItem = mockCurriculum.find((item) => !item.completed) || mockCurriculum[0];
-    navigate(`/tu/b2c/mypage/learning/${enrollmentId}/player/${nextItem?.id || ''}`);
+    navigate(prefixPath(`/tu/b2c/mypage/learning/${enrollmentId}/player/${nextItem?.id || ''}`));
   };
 
   // Loading State
@@ -191,7 +193,7 @@ export function LearningDetailPage() {
         <h3 className={`text-lg font-medium mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
           {t.learning.enrollmentNotFound}
         </h3>
-        <Button onClick={() => navigate('/tu/b2c/mypage/learning')}>
+        <Button onClick={() => navigate(prefixPath('/tu/b2c/mypage/learning'))}>
           {t.learning.backToLearning}
         </Button>
       </div>
@@ -208,7 +210,7 @@ export function LearningDetailPage() {
         <Button
           variant="ghost"
           className={`mb-6 gap-2 ${isDark ? 'text-gray-400 hover:text-white hover:bg-white/10' : ''}`}
-          onClick={() => navigate('/tu/b2c/mypage/learning')}
+          onClick={() => navigate(prefixPath('/tu/b2c/mypage/learning'))}
         >
           <ArrowLeft className="w-4 h-4" />
           {t.learning.backToLearning}

--- a/src/pages/tu/main/CartPage.tsx
+++ b/src/pages/tu/main/CartPage.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Trash2, ShoppingCart, ChevronRight, Loader2, Heart, Plus, Check } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
+import { useSubdomainPath } from '@/hooks/common';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
 import { useCart, useRemoveFromCart, useRemoveFromCartBulk, useAddToCart, useMyWishlist, useEnrollBulk } from '@/hooks/tu';
@@ -24,6 +25,7 @@ export function CartPage() {
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
 
   // Cart React Query 훅
   const { data: cartItems = [], isLoading: isCartLoading, error: cartError } = useCart();
@@ -135,7 +137,7 @@ export function CartPage() {
           );
 
           // 내 학습 페이지로 이동
-          navigate('/tu/b2c/mypage/learning');
+          navigate(prefixPath('/tu/b2c/mypage/learning'));
         }
 
         if (failureCount > 0) {
@@ -240,7 +242,7 @@ export function CartPage() {
               관심 있는 강의를 담아보세요!
             </p>
             <Link
-              to="/tu/b2c/courses"
+              to={prefixPath('/tu/b2c/courses')}
               className="inline-flex items-center gap-2 landing-btn-primary px-6 py-3 rounded-full text-white font-medium"
             >
               강의 둘러보기 <ChevronRight className="w-4 h-4" />
@@ -304,7 +306,7 @@ export function CartPage() {
                           />
                           <div className="flex-1 min-w-0">
                             <Link
-                              to={`/tu/b2c/times/${item.courseTimeId}`}
+                              to={prefixPath(`/tu/b2c/times/${item.courseTimeId}`)}
                               className={`font-semibold mb-1 line-clamp-1 hover:text-[#6778ff] transition-colors block ${isDark ? 'text-white' : 'text-gray-900'}`}
                             >
                               {item.courseTimeTitle}
@@ -398,7 +400,7 @@ export function CartPage() {
                           />
                           <div className="flex-1 min-w-0">
                             <Link
-                              to={`/tu/b2c/times/${item.courseTimeId}`}
+                              to={prefixPath(`/tu/b2c/times/${item.courseTimeId}`)}
                               className={`font-semibold mb-1 line-clamp-1 hover:text-[#6778ff] transition-colors block ${isDark ? 'text-white' : 'text-gray-900'}`}
                             >
                               {item.courseTimeTitle}

--- a/src/pages/tu/main/CommunityDetailPage.tsx
+++ b/src/pages/tu/main/CommunityDetailPage.tsx
@@ -4,6 +4,7 @@
  */
 import { useState, useEffect, useRef } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useSubdomainPath } from '@/hooks/common';
 import {
   ArrowLeft,
   Heart,
@@ -406,6 +407,7 @@ function CommentItem({ comment, isDark, onReply, onLike, onDelete, isReply = fal
 export function CommunityDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
   const postId = id ? parseInt(id, 10) : 0;
 
   const { theme } = useThemeStore();
@@ -534,7 +536,7 @@ export function CommunityDetailPage() {
     try {
       await deletePostMutation.mutateAsync(postId);
       toast.success('게시글이 삭제되었습니다.');
-      navigate('/tu/b2c/community');
+      navigate(prefixPath('/tu/b2c/community'));
     } catch (err) {
       console.error('게시글 삭제 실패:', err);
       toast.error('게시글 삭제에 실패했습니다.');
@@ -702,7 +704,7 @@ export function CommunityDetailPage() {
       <div className={`min-h-screen flex items-center justify-center ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
         <div className="text-center">
           <p className={`text-xl ${isDark ? 'text-white' : 'text-gray-900'}`}>게시글을 불러올 수 없습니다.</p>
-          <Link to="/tu/b2c/community" className="text-[#6778ff] hover:underline mt-4 inline-block">
+          <Link to={prefixPath('/tu/b2c/community')} className="text-[#6778ff] hover:underline mt-4 inline-block">
             커뮤니티로 돌아가기
           </Link>
         </div>
@@ -1085,7 +1087,7 @@ export function CommunityDetailPage() {
                 }`}
               >
                 {/* 강의 썸네일 */}
-                <Link to={`/tu/b2c/courses/${post.relatedCourse.id}`}>
+                <Link to={prefixPath(`/tu/b2c/courses/${post.relatedCourse.id}`)}>
                   <img
                     src={post.relatedCourse.thumbnailUrl || 'https://via.placeholder.com/320x180'}
                     alt={post.relatedCourse.title}
@@ -1095,7 +1097,7 @@ export function CommunityDetailPage() {
 
                 <div className="p-4">
                   {/* 강의 제목 */}
-                  <Link to={`/tu/b2c/courses/${post.relatedCourse.id}`}>
+                  <Link to={prefixPath(`/tu/b2c/courses/${post.relatedCourse.id}`)}>
                     <h3
                       className={`font-semibold mb-2 line-clamp-2 hover:text-[#6778ff] transition-colors ${
                         isDark ? 'text-white' : 'text-gray-900'
@@ -1133,7 +1135,7 @@ export function CommunityDetailPage() {
                   </div>
 
                   {/* 강의 보기 버튼 */}
-                  <Link to={`/tu/b2c/courses/${post.relatedCourse.id}`}>
+                  <Link to={prefixPath(`/tu/b2c/courses/${post.relatedCourse.id}`)}>
                     <Button className="w-full gap-2">
                       강의 상세보기
                       <ChevronRight className="w-4 h-4" />

--- a/src/pages/tu/main/CommunityPage.tsx
+++ b/src/pages/tu/main/CommunityPage.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { MessageSquare, Loader2, ChevronRight, ChevronLeft, Users, BookOpen, Hash, Sparkles, Heart } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
+import { useSubdomainPath } from '@/hooks/common';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
 import { useCommunityPosts, useCommunityCategories, useCreatePost, useMyPosts, useCommentedPosts } from '@/hooks/tu';
@@ -174,6 +175,7 @@ export function CommunityPage() {
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
   const createPostMutation = useCreatePost();
   const { isAuthenticated } = useAuth();
 
@@ -426,7 +428,7 @@ export function CommunityPage() {
                 {popularPosts.left.map((post) => (
                   <Link
                     key={post.id}
-                    to={`/tu/b2c/community/${post.id}`}
+                    to={prefixPath(`/tu/b2c/community/${post.id}`)}
                     className="flex items-center gap-3 group"
                   >
                     <span className="text-sm landing-text-primary group-hover:text-[#6778ff] transition-colors truncate flex-1">
@@ -450,7 +452,7 @@ export function CommunityPage() {
                   {popularPosts.right.map((post) => (
                     <Link
                       key={post.id}
-                      to={`/tu/b2c/community/${post.id}`}
+                      to={prefixPath(`/tu/b2c/community/${post.id}`)}
                       className="flex items-center gap-3 group"
                     >
                       <span className="text-sm landing-text-primary group-hover:text-[#6778ff] transition-colors truncate flex-1">
@@ -480,7 +482,7 @@ export function CommunityPage() {
                 나의 커뮤니티
               </h2>
               <Link
-                to="/tu/b2c/mypage/posts"
+                to={prefixPath('/tu/b2c/mypage/posts')}
                 className="text-sm landing-text-secondary hover:opacity-80 flex items-center gap-1 transition-colors"
               >
                 더 보기 <ChevronRight className="w-4 h-4" />
@@ -502,7 +504,7 @@ export function CommunityPage() {
                     <h3 className="font-semibold landing-text-primary">내가 쓴 글</h3>
                   </div>
                   <Link
-                    to="/tu/b2c/mypage/posts"
+                    to={prefixPath('/tu/b2c/mypage/posts')}
                     className="text-xs landing-text-muted hover:text-[#6778ff] transition-colors flex items-center gap-1"
                   >
                     전체보기 <ChevronRight className="w-3 h-3" />
@@ -513,7 +515,7 @@ export function CommunityPage() {
                     {myPostsData.posts.slice(0, 3).map((post) => (
                       <Link
                         key={post.id}
-                        to={`/tu/b2c/community/${post.id}`}
+                        to={prefixPath(`/tu/b2c/community/${post.id}`)}
                         className={`block p-3 rounded-xl transition-colors ${
                           isDark ? 'hover:bg-white/5' : 'hover:bg-gray-50'
                         }`}
@@ -556,7 +558,7 @@ export function CommunityPage() {
                     <h3 className="font-semibold landing-text-primary">참여한 글</h3>
                   </div>
                   <Link
-                    to="/tu/b2c/mypage/comments"
+                    to={prefixPath('/tu/b2c/mypage/comments')}
                     className="text-xs landing-text-muted hover:text-[#10b981] transition-colors flex items-center gap-1"
                   >
                     전체보기 <ChevronRight className="w-3 h-3" />
@@ -567,7 +569,7 @@ export function CommunityPage() {
                     {commentedPostsData.posts.slice(0, 3).map((post) => (
                       <Link
                         key={post.id}
-                        to={`/tu/b2c/community/${post.id}`}
+                        to={prefixPath(`/tu/b2c/community/${post.id}`)}
                         className={`block p-3 rounded-xl transition-colors ${
                           isDark ? 'hover:bg-white/5' : 'hover:bg-gray-50'
                         }`}
@@ -589,7 +591,7 @@ export function CommunityPage() {
                   <div className="text-center py-6">
                     <p className="text-sm landing-text-muted mb-3">아직 참여한 글이 없어요</p>
                     <Link
-                      to="/tu/b2c/community"
+                      to={prefixPath('/tu/b2c/community')}
                       className="text-sm text-[#10b981] hover:underline"
                     >
                       커뮤니티 둘러보기
@@ -612,7 +614,7 @@ export function CommunityPage() {
                     <h3 className="font-semibold landing-text-primary">관심 글</h3>
                   </div>
                   <Link
-                    to="/tu/b2c/mypage/posts?tab=liked"
+                    to={prefixPath('/tu/b2c/mypage/posts?tab=liked')}
                     className="text-xs landing-text-muted hover:text-[#f43f5e] transition-colors flex items-center gap-1"
                   >
                     전체보기 <ChevronRight className="w-3 h-3" />
@@ -622,7 +624,7 @@ export function CommunityPage() {
                 <div className="text-center py-6">
                   <p className="text-sm landing-text-muted mb-3">좋아요한 글을 모아보세요</p>
                   <Link
-                    to="/tu/b2c/community"
+                    to={prefixPath('/tu/b2c/community')}
                     className="text-sm text-[#f43f5e] hover:underline"
                   >
                     글 둘러보기
@@ -710,7 +712,7 @@ export function CommunityPage() {
                               : 'bg-[#6778ff]/10 text-[#6778ff]'
                           }`}
                         >
-                          <Link to={`/tu/b2c/community?search=${encodeURIComponent(tag)}`}>
+                          <Link to={prefixPath(`/tu/b2c/community?search=${encodeURIComponent(tag)}`)}>
                             #{tag}
                           </Link>
                           <button
@@ -737,7 +739,7 @@ export function CommunityPage() {
                     {recommendedPosts.map((post) => (
                       <Link
                         key={post.id}
-                        to={`/tu/b2c/community/${post.id}`}
+                        to={prefixPath(`/tu/b2c/community/${post.id}`)}
                         className={`block p-3 rounded-xl transition-colors ${
                           isDark ? 'hover:bg-white/5' : 'hover:bg-white'
                         }`}
@@ -793,7 +795,7 @@ export function CommunityPage() {
                 </p>
               </div>
               <Link
-                to="/tu/b2c/community?category=tech"
+                to={prefixPath('/tu/b2c/community?category=tech')}
                 className="text-sm landing-text-secondary hover:opacity-80 flex items-center gap-1 transition-colors"
               >
                 더 보기 <ChevronRight className="w-4 h-4" />
@@ -820,7 +822,7 @@ export function CommunityPage() {
                   {extendedNews.map((news, index) => (
                     <Link
                       key={`${news.id}-${index}`}
-                      to={`/tu/b2c/community/${news.id}`}
+                      to={prefixPath(`/tu/b2c/community/${news.id}`)}
                       className={`group block rounded-2xl p-6 transition-all duration-300 border flex-shrink-0 w-[calc(33.333%-16px)] ${
                         isDark
                           ? 'glass border-white/10 hover:border-[#6778ff]/50'
@@ -910,7 +912,7 @@ export function CommunityPage() {
                 {filteredPosts.map((post) => (
                   <Link
                     key={post.id}
-                    to={`/tu/b2c/community/${post.id}`}
+                    to={prefixPath(`/tu/b2c/community/${post.id}`)}
                     className={`flex items-start gap-4 px-6 py-5 transition-colors ${
                       isDark ? 'hover:bg-white/5' : 'hover:bg-gray-50'
                     }`}
@@ -982,7 +984,7 @@ export function CommunityPage() {
           if (USE_API) {
             const result = await createPostMutation.mutateAsync(data);
             setIsWriteModalOpen(false);
-            navigate(`/tu/b2c/community/${result.id}`);
+            navigate(prefixPath(`/tu/b2c/community/${result.id}`));
           } else {
             console.log('New post data:', data);
             setIsWriteModalOpen(false);

--- a/src/pages/tu/main/CourseDetailPage.tsx
+++ b/src/pages/tu/main/CourseDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
+import { useSubdomainPath } from '@/hooks/common';
 import {
   Clock,
   Users,
@@ -157,6 +158,7 @@ export function CourseDetailPage() {
   const { id } = useParams<{ id: string }>();
   const courseTimeId = id ? parseInt(id, 10) : 0;
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
 
   // CourseTime 상세 조회
   const { data: courseTime, isLoading, error } = useCourseTimeDetail(courseTimeId);
@@ -206,7 +208,7 @@ export function CourseDetailPage() {
   const handleWishlistToggle = async () => {
     if (!isAuthenticated) {
       toast.error('로그인이 필요합니다.');
-      navigate('/auth/login', { state: { from: `/tu/b2c/times/${courseTimeId}` } });
+      navigate('/auth/login', { state: { from: prefixPath(`/tu/b2c/times/${courseTimeId}`) } });
       return;
     }
 
@@ -263,7 +265,7 @@ export function CourseDetailPage() {
   const handleAddToCart = async () => {
     if (!isAuthenticated) {
       toast.error('로그인이 필요합니다.');
-      navigate('/auth/login', { state: { from: `/tu/b2c/times/${courseTimeId}` } });
+      navigate('/auth/login', { state: { from: prefixPath(`/tu/b2c/times/${courseTimeId}`) } });
       return;
     }
 
@@ -279,7 +281,7 @@ export function CourseDetailPage() {
     // 로그인 체크
     if (!isAuthenticated) {
       toast.error('로그인이 필요합니다.');
-      navigate('/auth/login', { state: { from: `/tu/b2c/courses/${courseTimeId}` } });
+      navigate('/auth/login', { state: { from: prefixPath(`/tu/b2c/courses/${courseTimeId}`) } });
       return;
     }
 
@@ -294,7 +296,7 @@ export function CourseDetailPage() {
       onSuccess: () => {
         toast.success('수강 신청이 완료되었습니다.');
         // 내 학습 페이지로 이동
-        navigate('/tu/b2c/mypage/learning');
+        navigate(prefixPath('/tu/b2c/mypage/learning'));
       },
       onError: (error: Error & { response?: { data?: { error?: { message?: string } } } }) => {
         const message = error.response?.data?.error?.message || '수강 신청에 실패했습니다.';
@@ -328,7 +330,7 @@ export function CourseDetailPage() {
           <p className={`text-xl ${isDark ? 'text-white' : 'text-gray-900'}`}>
             강의를 불러올 수 없습니다.
           </p>
-          <Link to="/tu/b2c/courses" className="text-[#6778ff] hover:underline mt-4 inline-block">
+          <Link to={prefixPath('/tu/b2c/courses')} className="text-[#6778ff] hover:underline mt-4 inline-block">
             강의 목록으로 돌아가기
           </Link>
         </div>
@@ -630,7 +632,7 @@ export function CourseDetailPage() {
                     {isAlreadyEnrolled ? (
                       <>
                         <button
-                          onClick={() => navigate(`/tu/b2c/mypage/learning/${existingEnrollment?.id}`)}
+                          onClick={() => navigate(prefixPath(`/tu/b2c/mypage/learning/${existingEnrollment?.id}`))}
                           className="w-full landing-btn-primary py-4 rounded-xl text-white font-bold text-lg flex items-center justify-center gap-2"
                         >
                           <PlayCircle className="w-5 h-5" />

--- a/src/pages/tu/main/NotificationsPage.tsx
+++ b/src/pages/tu/main/NotificationsPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSubdomainPath } from '@/hooks/common';
 import { Bell, CheckCheck, Trash2, Settings, Heart, MessageSquare, BookOpen, Megaphone, Loader2, FileText, AlertCircle } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
@@ -58,6 +59,7 @@ export function NotificationsPage() {
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
   const [activeType, setActiveType] = useState<NotificationType | 'all'>('all');
 
   // React Query 훅
@@ -234,7 +236,7 @@ export function NotificationsPage() {
                   key={notification.id}
                   onClick={() => {
                     markAsRead(notification.id);
-                    navigate(`/tu/b2c/notifications/${notification.id}`);
+                    navigate(prefixPath(`/tu/b2c/notifications/${notification.id}`));
                   }}
                   className={`rounded-xl p-4 flex gap-4 cursor-pointer transition-all border ${
                     isDark

--- a/src/pages/tu/main/WishlistPage.tsx
+++ b/src/pages/tu/main/WishlistPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Trash2, Heart, ChevronRight, Clock, Loader2 } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
+import { useSubdomainPath } from '@/hooks/common';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
 import { useMyWishlist, useRemoveFromWishlist } from '@/hooks/tu/useWishlistQueries';
@@ -30,6 +31,7 @@ function formatPrice(price: string | null | undefined, isFree: boolean): string 
 export function WishlistPage() {
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
+  const { prefixPath } = useSubdomainPath();
   const { isAuthenticated } = useAuthStore();
 
   // 페이징 상태
@@ -144,7 +146,7 @@ export function WishlistPage() {
               관심 있는 강의에 하트를 눌러 저장해보세요!
             </p>
             <Link
-              to="/tu/b2c/courses"
+              to={prefixPath('/tu/b2c/courses')}
               className="inline-flex items-center gap-2 landing-btn-primary px-6 py-3 rounded-full text-white font-medium"
             >
               강의 둘러보기 <ChevronRight className="w-4 h-4" />
@@ -163,7 +165,7 @@ export function WishlistPage() {
                   }`}
                 >
                   {/* Image */}
-                  <Link to={`/tu/b2c/times/${item.courseTimeId}`} className="block relative">
+                  <Link to={prefixPath(`/tu/b2c/times/${item.courseTimeId}`)} className="block relative">
                     <div className="w-full aspect-video bg-gradient-to-br from-[#6778ff]/20 to-[#a855f7]/20 flex items-center justify-center">
                       {item.thumbnailUrl ? (
                         <img
@@ -184,7 +186,7 @@ export function WishlistPage() {
 
                   {/* Content */}
                   <div className="p-4">
-                    <Link to={`/tu/b2c/times/${item.courseTimeId}`}>
+                    <Link to={prefixPath(`/tu/b2c/times/${item.courseTimeId}`)}>
                       <h3 className={`font-semibold mb-2 line-clamp-2 group-hover:text-[#6778ff] transition-colors ${
                         isDark ? 'text-white' : 'text-gray-900'
                       }`}>
@@ -215,7 +217,7 @@ export function WishlistPage() {
                     {/* Actions */}
                     <div className="flex gap-2">
                       <Link
-                        to={`/tu/b2c/times/${item.courseTimeId}`}
+                        to={prefixPath(`/tu/b2c/times/${item.courseTimeId}`)}
                         className="flex-1 py-2.5 rounded-lg font-medium text-sm landing-btn-primary text-white flex items-center justify-center gap-2"
                       >
                         상세보기
@@ -283,7 +285,7 @@ export function WishlistPage() {
                 찜한 강의를 기반으로 추천 강의를 준비하고 있어요.
               </p>
               <Link
-                to="/tu/b2c/courses"
+                to={prefixPath('/tu/b2c/courses')}
                 className={`inline-flex items-center gap-2 font-medium transition-colors ${
                   isDark ? 'text-[#6778ff] hover:text-[#8b99ff]' : 'text-[#6778ff] hover:text-[#5566ee]'
                 }`}

--- a/src/routes/ta.routes.tsx
+++ b/src/routes/ta.routes.tsx
@@ -40,8 +40,9 @@ function TenantAdminWrapper() {
   );
 }
 
-export const taRoutes = (
-  <Route path="/:subdomain/ta" element={<TenantAdminWrapper />}>
+// TA 하위 라우트
+const taChildRoutes = (
+  <>
     <Route index element={<DashboardPage />} />
     <Route path="dashboard" element={<DashboardPage />} />
     {/* 시스템 기반 관리 */}
@@ -73,5 +74,18 @@ export const taRoutes = (
     <Route path="settings/appearance" element={<SettingsAppearancePage />} />
     <Route path="settings/tenant-settings" element={<TenantSettingsPage />} />
     <Route path="settings/user-management" element={<UserManagementSettingsPage />} />
-  </Route>
+  </>
+);
+
+export const taRoutes = (
+  <>
+    {/* 기본 테넌트용 (subdomain 없음) */}
+    <Route path="/ta" element={<TenantAdminWrapper />}>
+      {taChildRoutes}
+    </Route>
+    {/* 특정 테넌트용 (subdomain 있음) */}
+    <Route path="/:subdomain/ta" element={<TenantAdminWrapper />}>
+      {taChildRoutes}
+    </Route>
+  </>
 );


### PR DESCRIPTION
## Summary

TU(Tenant User) 페이지에서 서브도메인 기반 라우팅이 정상 동작하도록 수정하고, SA 페이지의 테넌트 수정 버그를 수정했습니다.

## Related Issue

- Closes #308

## Changes

- `useSubdomainPath` 훅 생성 - 서브도메인 경로 프리픽싱을 위한 공통 유틸리티 훅
- TU 페이지들에 서브도메인 라우팅 적용:
  - CommunityPage, NotificationsPage
  - CourseDetailPage, LearningDetailPage, CommunityDetailPage
  - CartPage, WishlistPage
  - LandingHeader, LandingCourseCard, CourseCard
- SA TenantDetailPage 테넌트 수정 버그 수정 - 백엔드 DTO에 맞는 필드만 전송하도록 수정

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 서브도메인 라우팅: `/mzc/tu/b2c/courses` 형태의 경로가 유지되도록 모든 Link, navigate 호출에 `prefixPath()` 적용
- 테넌트 수정 버그: 프론트엔드에서 백엔드 `UpdateTenantRequest` DTO에 없는 필드(adminName, adminEmail, branding, settings)를 전송하던 문제 수정
