### PR TITLE
feat: TU 랜딩 페이지에 TA 브랜딩 설정 통합

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -125,7 +125,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -400,7 +399,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -3620,7 +3618,6 @@
       "resolved": "https://registry.npmjs.org/@svta/cml-xml/-/cml-xml-1.0.1.tgz",
       "integrity": "sha512-11LkJa5kDEcsRMWkVI1ABH3KLCxGoiSVe4kQ293ItVj8ncTTQ7htmCGiJDjS+Cmy35UgF3e/vc0ysJIiWRTx2g==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -3814,7 +3811,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3825,7 +3821,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3881,7 +3876,6 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -4143,7 +4137,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4458,7 +4451,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5015,8 +5007,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5166,7 +5157,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5969,7 +5959,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6567,7 +6556,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6790,7 +6778,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6821,7 +6808,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6897,7 +6883,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7100,8 +7085,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7600,7 +7584,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7672,7 +7655,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7891,7 +7873,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7985,7 +7966,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,15 @@
 import { BrowserRouter } from 'react-router-dom';
 import { AppRoutes } from '@/routes';
 import { Toaster } from '@/components/common/Sonner/Sonner';
+import { TenantBrandingProvider } from '@/contexts/TenantBrandingContext';
 
 function App() {
   return (
     <BrowserRouter>
-      <AppRoutes />
-      <Toaster />
+      <TenantBrandingProvider>
+        <AppRoutes />
+        <Toaster />
+      </TenantBrandingProvider>
     </BrowserRouter>
   );
 }

--- a/src/components/domain/ta/BannerImageDropzone.tsx
+++ b/src/components/domain/ta/BannerImageDropzone.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
-import { Upload, X, ImageIcon, Smartphone, Monitor } from 'lucide-react';
+import { Upload, X, ImageIcon, Smartphone, Monitor, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
 import { designTokens } from '@/styles/admin-design-tokens';
 import { cn } from '@/utils/cn';
+import axiosInstance from '@/services/common/api/axiosInstance';
 
 interface BannerImageDropzoneProps {
   value?: string;
@@ -26,18 +28,40 @@ export const BannerImageDropzone = ({
   className,
 }: BannerImageDropzoneProps) => {
   const [isDragActive, setIsDragActive] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const uploadImage = async (file: File): Promise<string> => {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const response = await axiosInstance.post<{ url: string }>(
+      '/community/images/upload',
+      formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      }
+    );
+
+    return response.data.url;
+  };
 
   const onDrop = useCallback(
-    (acceptedFiles: File[]) => {
+    async (acceptedFiles: File[]) => {
       const file = acceptedFiles[0];
       if (file) {
-        const reader = new FileReader();
-        reader.onload = () => {
-          const result = reader.result as string;
-          onChange(result);
-        };
-        reader.readAsDataURL(file);
-        onFileSelect?.(file);
+        setIsUploading(true);
+        try {
+          const imageUrl = await uploadImage(file);
+          onChange(imageUrl);
+          onFileSelect?.(file);
+        } catch (error) {
+          console.error('Image upload failed:', error);
+          toast.error('이미지 업로드에 실패했습니다.');
+        } finally {
+          setIsUploading(false);
+        }
       }
     },
     [onChange, onFileSelect]
@@ -49,7 +73,8 @@ export const BannerImageDropzone = ({
       'image/*': ['.png', '.jpg', '.jpeg', '.gif', '.webp'],
     },
     maxFiles: 1,
-    maxSize: 10 * 1024 * 1024, // 10MB
+    maxSize: 5 * 1024 * 1024, // 5MB (서버 제한)
+    disabled: isUploading,
     onDragEnter: () => setIsDragActive(true),
     onDragLeave: () => setIsDragActive(false),
   });
@@ -133,6 +158,19 @@ export const BannerImageDropzone = ({
               </div>
             </div>
           </>
+        ) : isUploading ? (
+          <div className="absolute inset-0 flex flex-col items-center justify-center p-4 text-center">
+            <Loader2
+              className="w-8 h-8 animate-spin mb-3"
+              style={{ color: designTokens.button.brand_default }}
+            />
+            <p
+              className="text-sm font-medium"
+              style={{ color: designTokens.text.primary }}
+            >
+              업로드 중...
+            </p>
+          </div>
         ) : (
           <div className="absolute inset-0 flex flex-col items-center justify-center p-4 text-center">
             <div

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -2,34 +2,58 @@ import { useState, useEffect } from 'react';
 import { ChevronLeft, ChevronRight, Sparkles, Rocket, Zap } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from '@/store/common/languageStore';
+import { useDisplayableBanners } from '@/hooks/tu';
+import type { BannerResponse } from '@/types/ta/banner.types';
 
-const slideData = [
+interface DefaultSlide {
+  type: 'default';
+  id: number;
+  title: string;
+  highlight: string;
+  subtitleKey: 'slide1Subtitle' | 'slide2Subtitle' | 'slide3Subtitle';
+  descKey: 'slide1Desc' | 'slide2Desc' | 'slide3Desc';
+  badge: string;
+  icon: typeof Sparkles;
+  gradientClass: string;
+}
+
+interface BannerSlide {
+  type: 'banner';
+  banner: BannerResponse;
+}
+
+type Slide = DefaultSlide | BannerSlide;
+
+const defaultSlides: DefaultSlide[] = [
   {
+    type: 'default',
     id: 1,
     title: 'Empower Your',
     highlight: 'Future',
-    subtitleKey: 'slide1Subtitle' as const,
-    descKey: 'slide1Desc' as const,
+    subtitleKey: 'slide1Subtitle',
+    descKey: 'slide1Desc',
     badge: 'MZC LEARN',
     icon: Sparkles,
     gradientClass: 'gradient-text',
   },
   {
+    type: 'default',
     id: 2,
     title: 'Build Your',
     highlight: 'Career',
-    subtitleKey: 'slide2Subtitle' as const,
-    descKey: 'slide2Desc' as const,
+    subtitleKey: 'slide2Subtitle',
+    descKey: 'slide2Desc',
     badge: 'ROADMAP',
     icon: Rocket,
     gradientClass: 'gradient-text-purple',
   },
   {
+    type: 'default',
     id: 3,
     title: 'Master',
     highlight: 'Cloud',
-    subtitleKey: 'slide3Subtitle' as const,
-    descKey: 'slide3Desc' as const,
+    subtitleKey: 'slide3Subtitle',
+    descKey: 'slide3Desc',
     badge: 'CLOUD',
     icon: Zap,
     gradientClass: 'gradient-text',
@@ -42,17 +66,30 @@ export function HeroSection() {
   const [direction, setDirection] = useState<'left' | 'right'>('right');
   const { t } = useTranslation();
 
+  // TA 배너 가져오기
+  const { data: banners = [] } = useDisplayableBanners('MAIN_TOP');
+
+  // 배너 슬라이드 + 기본 슬라이드 합치기 (배너 먼저)
+  const allSlides: Slide[] = [
+    ...banners.map((banner): BannerSlide => ({ type: 'banner', banner })),
+    ...defaultSlides,
+  ];
+
+  const totalSlides = allSlides.length;
+
   useEffect(() => {
+    if (totalSlides <= 1) return;
+
     const timer = setInterval(() => {
       setDirection('right');
       setIsAnimating(true);
       setTimeout(() => {
-        setCurrentSlide((prev) => (prev + 1) % slideData.length);
+        setCurrentSlide((prev) => (prev + 1) % totalSlides);
         setIsAnimating(false);
       }, 300);
     }, 5000);
     return () => clearInterval(timer);
-  }, []);
+  }, [totalSlides]);
 
   const goToSlide = (index: number) => {
     if (isAnimating || index === currentSlide) return;
@@ -69,7 +106,7 @@ export function HeroSection() {
     setDirection('left');
     setIsAnimating(true);
     setTimeout(() => {
-      setCurrentSlide((prev) => (prev - 1 + slideData.length) % slideData.length);
+      setCurrentSlide((prev) => (prev - 1 + totalSlides) % totalSlides);
       setIsAnimating(false);
     }, 300);
   };
@@ -79,13 +116,16 @@ export function HeroSection() {
     setDirection('right');
     setIsAnimating(true);
     setTimeout(() => {
-      setCurrentSlide((prev) => (prev + 1) % slideData.length);
+      setCurrentSlide((prev) => (prev + 1) % totalSlides);
       setIsAnimating(false);
     }, 300);
   };
 
-  const slide = slideData[currentSlide];
-  const IconComponent = slide.icon;
+  const currentSlideData = allSlides[currentSlide];
+  const isDefaultSlide = currentSlideData?.type === 'default';
+  const defaultSlide = isDefaultSlide ? currentSlideData : null;
+  const bannerSlide = !isDefaultSlide ? currentSlideData : null;
+  const IconComponent = defaultSlide?.icon ?? Sparkles;
 
   return (
     <div className="w-full overflow-hidden relative animated-bg py-8 md:py-12">
@@ -97,79 +137,109 @@ export function HeroSection() {
       </div>
 
       <div className="w-full px-4 md:px-8 lg:px-16 h-[400px] md:h-[500px] flex items-center justify-between relative">
-        {/* Text Content */}
-        <div
-          className={`z-10 max-w-2xl space-y-6 transition-all duration-500 ease-out ${
-            isAnimating
-              ? `opacity-0 ${direction === 'right' ? '-translate-x-8' : 'translate-x-8'}`
-              : 'opacity-100 translate-x-0'
-          }`}
-        >
-          <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-xs font-bold bg-white/10 text-white border border-white/20">
-            <IconComponent className="w-4 h-4" />
-            {slide.badge}
-          </span>
-
-          <div className="space-y-2">
-            <h2 className="text-4xl md:text-6xl lg:text-7xl font-extrabold text-white leading-tight">
-              {slide.title}
-            </h2>
-            <h2
-              className={`text-4xl md:text-6xl lg:text-7xl font-extrabold leading-tight ${slide.gradientClass}`}
+        {/* 배너 슬라이드일 때 - 이미지 표시 */}
+        {bannerSlide && (
+          <div
+            className={`absolute inset-0 z-10 transition-all duration-500 ease-out ${
+              isAnimating
+                ? `opacity-0 ${direction === 'right' ? '-translate-x-8' : 'translate-x-8'}`
+                : 'opacity-100 translate-x-0'
+            }`}
+          >
+            <a
+              href={bannerSlide.banner.linkUrl || undefined}
+              target={bannerSlide.banner.linkTarget || '_self'}
+              className={`block w-full h-full ${bannerSlide.banner.linkUrl ? 'cursor-pointer' : ''}`}
+              onClick={(e) => !bannerSlide.banner.linkUrl && e.preventDefault()}
             >
-              {slide.highlight}
-            </h2>
+              <img
+                src={bannerSlide.banner.imageUrl}
+                alt={bannerSlide.banner.title}
+                className="w-full h-full object-contain"
+              />
+              {/* 그라디언트 오버레이 */}
+              <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent pointer-events-none" />
+            </a>
           </div>
+        )}
 
-          <p className="text-xl md:text-2xl font-medium text-gray-300 whitespace-pre-line leading-relaxed">
-            {t.hero[slide.subtitleKey]}
-          </p>
-
-          <p className="text-base md:text-lg text-gray-500">{t.hero[slide.descKey]}</p>
-
-          <div className="flex gap-4 pt-4">
-            <Link
-              to="/tu/b2c/courses"
-              className="landing-btn-primary px-8 py-4 rounded-full text-white font-bold text-base flex items-center gap-2"
+        {/* 기본 슬라이드일 때 - 텍스트 콘텐츠 */}
+        {defaultSlide && (
+          <>
+            <div
+              className={`z-10 max-w-2xl space-y-6 transition-all duration-500 ease-out ${
+                isAnimating
+                  ? `opacity-0 ${direction === 'right' ? '-translate-x-8' : 'translate-x-8'}`
+                  : 'opacity-100 translate-x-0'
+              }`}
             >
-              {t.hero.getStarted}
-              <ChevronRight className="w-5 h-5" />
-            </Link>
-            <Link
-              to="/tu/b2c/mypage/learning"
-              className="landing-btn-outline px-8 py-4 rounded-full text-white font-medium text-base"
-            >
-              {t.hero.explore}
-            </Link>
-          </div>
-        </div>
+              <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-xs font-bold bg-white/10 text-white border border-white/20">
+                <IconComponent className="w-4 h-4" />
+                {defaultSlide.badge}
+              </span>
 
-        {/* Right Side - Abstract Shape */}
-        <div
-          className={`hidden lg:flex absolute right-8 top-1/2 -translate-y-1/2 items-center justify-center transition-all duration-500 ease-out ${
-            isAnimating ? `opacity-0 scale-95` : 'opacity-100 scale-100'
-          }`}
-        >
-          <div className="relative w-80 h-80">
-            <div className="absolute inset-0 bg-gradient-to-br from-[#6778ff]/30 to-[#a855f7]/30 rounded-full blur-2xl animate-pulse"></div>
-            <div className="absolute inset-8 bg-gradient-to-br from-[#70f2a0]/20 to-[#6bc2f0]/20 rounded-full blur-xl"></div>
-            <div className="absolute inset-16 glass rounded-full flex items-center justify-center">
-              <IconComponent className="w-16 h-16 text-white/80" />
+              <div className="space-y-2">
+                <h2 className="text-4xl md:text-6xl lg:text-7xl font-extrabold text-white leading-tight">
+                  {defaultSlide.title}
+                </h2>
+                <h2
+                  className={`text-4xl md:text-6xl lg:text-7xl font-extrabold leading-tight ${defaultSlide.gradientClass}`}
+                >
+                  {defaultSlide.highlight}
+                </h2>
+              </div>
+
+              <p className="text-xl md:text-2xl font-medium text-gray-300 whitespace-pre-line leading-relaxed">
+                {t.hero[defaultSlide.subtitleKey]}
+              </p>
+
+              <p className="text-base md:text-lg text-gray-500">{t.hero[defaultSlide.descKey]}</p>
+
+              <div className="flex gap-4 pt-4">
+                <Link
+                  to="/tu/b2c/courses"
+                  className="landing-btn-primary px-8 py-4 rounded-full text-white font-bold text-base flex items-center gap-2"
+                >
+                  {t.hero.getStarted}
+                  <ChevronRight className="w-5 h-5" />
+                </Link>
+                <Link
+                  to="/tu/b2c/mypage/learning"
+                  className="landing-btn-outline px-8 py-4 rounded-full text-white font-medium text-base"
+                >
+                  {t.hero.explore}
+                </Link>
+              </div>
             </div>
-          </div>
-        </div>
+
+            {/* Right Side - Abstract Shape (기본 슬라이드에서만) */}
+            <div
+              className={`hidden lg:flex absolute right-8 top-1/2 -translate-y-1/2 items-center justify-center transition-all duration-500 ease-out ${
+                isAnimating ? `opacity-0 scale-95` : 'opacity-100 scale-100'
+              }`}
+            >
+              <div className="relative w-80 h-80">
+                <div className="absolute inset-0 bg-gradient-to-br from-[#6778ff]/30 to-[#a855f7]/30 rounded-full blur-2xl animate-pulse"></div>
+                <div className="absolute inset-8 bg-gradient-to-br from-[#70f2a0]/20 to-[#6bc2f0]/20 rounded-full blur-xl"></div>
+                <div className="absolute inset-16 glass rounded-full flex items-center justify-center">
+                  <IconComponent className="w-16 h-16 text-white/80" />
+                </div>
+              </div>
+            </div>
+          </>
+        )}
 
         {/* Navigation Arrows */}
         <button
           onClick={prevSlide}
-          className="absolute left-4 top-1/2 -translate-y-1/2 p-3 rounded-full glass hover:bg-white/20 transition-all"
+          className="absolute left-4 top-1/2 -translate-y-1/2 p-3 rounded-full glass hover:bg-white/20 transition-all z-20"
           aria-label={t.hero.prevSlide}
         >
           <ChevronLeft className="w-6 h-6 text-white" />
         </button>
         <button
           onClick={nextSlide}
-          className="absolute right-4 lg:right-[380px] top-1/2 -translate-y-1/2 p-3 rounded-full glass hover:bg-white/20 transition-all"
+          className="absolute right-4 top-1/2 -translate-y-1/2 p-3 rounded-full glass hover:bg-white/20 transition-all z-20"
           aria-label={t.hero.nextSlide}
         >
           <ChevronRight className="w-6 h-6 text-white" />
@@ -177,8 +247,8 @@ export function HeroSection() {
       </div>
 
       {/* Dots */}
-      <div className="absolute bottom-8 left-1/2 -translate-x-1/2 flex gap-3">
-        {slideData.map((_, index) => (
+      <div className="absolute bottom-8 left-1/2 -translate-x-1/2 flex gap-3 z-20">
+        {allSlides.map((_, index) => (
           <button
             key={index}
             onClick={() => goToSlide(index)}

--- a/src/components/landing/LandingBannerCarousel.tsx
+++ b/src/components/landing/LandingBannerCarousel.tsx
@@ -1,0 +1,150 @@
+import { useState, useEffect, useCallback } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useDisplayableBanners } from '@/hooks/tu';
+import type { BannerPosition } from '@/types/ta/banner.types';
+
+interface LandingBannerCarouselProps {
+  position?: BannerPosition;
+  autoPlayInterval?: number;
+  className?: string;
+}
+
+/**
+ * 랜딩 페이지 배너 캐러셀
+ * - 테넌트 관리자가 등록한 배너를 자동 슬라이드로 표시
+ * - 위치별 필터링 지원
+ */
+export function LandingBannerCarousel({
+  position = 'MAIN_TOP',
+  autoPlayInterval = 5000,
+  className = '',
+}: LandingBannerCarouselProps) {
+  const { data: banners = [], isLoading } = useDisplayableBanners(position);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  // 자동 슬라이드
+  useEffect(() => {
+    if (banners.length <= 1) return;
+
+    const timer = setInterval(() => {
+      setIsAnimating(true);
+      setTimeout(() => {
+        setCurrentIndex((prev) => (prev + 1) % banners.length);
+        setIsAnimating(false);
+      }, 300);
+    }, autoPlayInterval);
+
+    return () => clearInterval(timer);
+  }, [banners.length, autoPlayInterval]);
+
+  const goToSlide = useCallback(
+    (index: number) => {
+      if (isAnimating || index === currentIndex) return;
+      setIsAnimating(true);
+      setTimeout(() => {
+        setCurrentIndex(index);
+        setIsAnimating(false);
+      }, 300);
+    },
+    [isAnimating, currentIndex]
+  );
+
+  const prevSlide = useCallback(() => {
+    if (isAnimating || banners.length <= 1) return;
+    setIsAnimating(true);
+    setTimeout(() => {
+      setCurrentIndex((prev) => (prev - 1 + banners.length) % banners.length);
+      setIsAnimating(false);
+    }, 300);
+  }, [isAnimating, banners.length]);
+
+  const nextSlide = useCallback(() => {
+    if (isAnimating || banners.length <= 1) return;
+    setIsAnimating(true);
+    setTimeout(() => {
+      setCurrentIndex((prev) => (prev + 1) % banners.length);
+      setIsAnimating(false);
+    }, 300);
+  }, [isAnimating, banners.length]);
+
+  // 로딩 중이거나 배너가 없으면 렌더링하지 않음
+  if (isLoading || banners.length === 0) {
+    return null;
+  }
+
+  const currentBanner = banners[currentIndex];
+
+  const handleBannerClick = () => {
+    if (currentBanner.linkUrl) {
+      window.open(currentBanner.linkUrl, currentBanner.linkTarget || '_self');
+    }
+  };
+
+  return (
+    <div className={`relative w-full overflow-hidden ${className}`}>
+      {/* 배너 이미지 */}
+      <div
+        className={`relative w-full aspect-[3/1] md:aspect-[4/1] transition-all duration-500 ease-out ${
+          isAnimating ? 'opacity-0 scale-[1.02]' : 'opacity-100 scale-100'
+        } ${currentBanner.linkUrl ? 'cursor-pointer' : ''}`}
+        onClick={handleBannerClick}
+      >
+        <img
+          src={currentBanner.imageUrl}
+          alt={currentBanner.title}
+          className="w-full h-full object-cover"
+        />
+        {/* 그라디언트 오버레이 */}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/30 to-transparent pointer-events-none" />
+      </div>
+
+      {/* 네비게이션 화살표 (배너가 2개 이상일 때만) */}
+      {banners.length > 1 && (
+        <>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              prevSlide();
+            }}
+            className="absolute left-4 top-1/2 -translate-y-1/2 p-3 rounded-full bg-black/30 hover:bg-black/50 transition-all backdrop-blur-sm"
+            aria-label="이전 배너"
+          >
+            <ChevronLeft className="w-6 h-6 text-white" />
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              nextSlide();
+            }}
+            className="absolute right-4 top-1/2 -translate-y-1/2 p-3 rounded-full bg-black/30 hover:bg-black/50 transition-all backdrop-blur-sm"
+            aria-label="다음 배너"
+          >
+            <ChevronRight className="w-6 h-6 text-white" />
+          </button>
+        </>
+      )}
+
+      {/* 인디케이터 도트 (배너가 2개 이상일 때만) */}
+      {banners.length > 1 && (
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-2">
+          {banners.map((_, index) => (
+            <button
+              key={index}
+              onClick={(e) => {
+                e.stopPropagation();
+                goToSlide(index);
+              }}
+              aria-label={`${index + 1}번 배너로 이동`}
+              className={`h-2 rounded-full transition-all duration-300 ${
+                index === currentIndex
+                  ? 'w-8 bg-white'
+                  : 'w-2 bg-white/50 hover:bg-white/70'
+              }`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/landing/LandingFooter.tsx
+++ b/src/components/landing/LandingFooter.tsx
@@ -1,11 +1,24 @@
 import { Youtube, Instagram } from 'lucide-react';
 import { useTranslation } from '@/store/common/languageStore';
 import { useTenantBranding } from '@/contexts/TenantBrandingContext';
+import { usePublicLayout } from '@/hooks/tu';
+import { useAuth } from '@/hooks/common/auth';
 
 export function LandingFooter() {
   const { t } = useTranslation();
   const { branding } = useTenantBranding();
+  const { isAuthenticated } = useAuth();
+  const { data: layoutData } = usePublicLayout(isAuthenticated);
   const tenantName = branding?.tenantName || 'MEGAZONECLOUD';
+
+  // 푸터 설정
+  const footerSettings = layoutData?.footerSettings;
+  const socialLinks = footerSettings?.socialLinks;
+
+  // 푸터가 비활성화되어 있으면 렌더링하지 않음
+  if (footerSettings?.enabled === false) {
+    return null;
+  }
 
   return (
     <footer className="landing-footer-wrapper landing-text-secondary text-sm py-16">
@@ -26,49 +39,92 @@ export function LandingFooter() {
             </div>
 
             {/* Social Links */}
-            <div className="flex items-center gap-4">
-              <a
-                href="#"
-                className="p-3 rounded-full landing-social-btn transition-colors"
-                aria-label="X (Twitter)"
-              >
-                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-                </svg>
-              </a>
-              <a
-                href="#"
-                className="p-3 rounded-full landing-social-btn transition-colors"
-                aria-label="YouTube"
-              >
-                <Youtube className="w-5 h-5" />
-              </a>
-              <a
-                href="#"
-                className="p-3 rounded-full landing-social-btn transition-colors"
-                aria-label="Instagram"
-              >
-                <Instagram className="w-5 h-5" />
-              </a>
-              <a
-                href="#"
-                className="p-3 rounded-full landing-social-btn transition-colors"
-                aria-label="LinkedIn"
-              >
-                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-                </svg>
-              </a>
-              <a
-                href="#"
-                className="p-3 rounded-full landing-social-btn transition-colors"
-                aria-label="GitHub"
-              >
-                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
-                </svg>
-              </a>
-            </div>
+            {footerSettings?.showSocialLinks !== false && (
+              <div className="flex items-center gap-4">
+                {/* Twitter/X */}
+                {socialLinks?.twitter && (
+                  <a
+                    href={socialLinks.twitter}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="p-3 rounded-full landing-social-btn transition-colors"
+                    aria-label="X (Twitter)"
+                  >
+                    <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                    </svg>
+                  </a>
+                )}
+                {/* YouTube */}
+                {socialLinks?.youtube && (
+                  <a
+                    href={socialLinks.youtube}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="p-3 rounded-full landing-social-btn transition-colors"
+                    aria-label="YouTube"
+                  >
+                    <Youtube className="w-5 h-5" />
+                  </a>
+                )}
+                {/* Instagram */}
+                {socialLinks?.instagram && (
+                  <a
+                    href={socialLinks.instagram}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="p-3 rounded-full landing-social-btn transition-colors"
+                    aria-label="Instagram"
+                  >
+                    <Instagram className="w-5 h-5" />
+                  </a>
+                )}
+                {/* LinkedIn */}
+                {socialLinks?.linkedin && (
+                  <a
+                    href={socialLinks.linkedin}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="p-3 rounded-full landing-social-btn transition-colors"
+                    aria-label="LinkedIn"
+                  >
+                    <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+                    </svg>
+                  </a>
+                )}
+                {/* Facebook */}
+                {socialLinks?.facebook && (
+                  <a
+                    href={socialLinks.facebook}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="p-3 rounded-full landing-social-btn transition-colors"
+                    aria-label="Facebook"
+                  >
+                    <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
+                    </svg>
+                  </a>
+                )}
+                {/* 소셜 링크가 설정되지 않은 경우 기본 아이콘 표시 */}
+                {!socialLinks && (
+                  <>
+                    <a href="#" className="p-3 rounded-full landing-social-btn transition-colors" aria-label="X (Twitter)">
+                      <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                      </svg>
+                    </a>
+                    <a href="#" className="p-3 rounded-full landing-social-btn transition-colors" aria-label="YouTube">
+                      <Youtube className="w-5 h-5" />
+                    </a>
+                    <a href="#" className="p-3 rounded-full landing-social-btn transition-colors" aria-label="Instagram">
+                      <Instagram className="w-5 h-5" />
+                    </a>
+                  </>
+                )}
+              </div>
+            )}
           </div>
         </div>
 
@@ -85,9 +141,11 @@ export function LandingFooter() {
               {t.footer.emailPolicy}
             </a>
           </div>
-          <p className="text-[12px] landing-text-muted">
-            &copy; {new Date().getFullYear()} MEGAZONECLOUD Corp. All rights reserved.
-          </p>
+          {footerSettings?.showCopyright !== false && (
+            <p className="text-[12px] landing-text-muted">
+              &copy; {new Date().getFullYear()} {tenantName}. All rights reserved.
+            </p>
+          )}
         </div>
       </div>
     </footer>

--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -5,8 +5,16 @@ import { useAuth } from '@/hooks/common/auth';
 import { useMyProfile, useSubdomainPath } from '@/hooks/common';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation } from '@/store/common/languageStore';
-import { useUnreadNotificationCount } from '@/hooks/tu';
+import { useUnreadNotificationCount, usePublicNavigation } from '@/hooks/tu';
 import { useTenantBranding } from '@/contexts/TenantBrandingContext';
+import type { NavigationItemResponse } from '@/types/tu/branding.types';
+
+// 기본 네비게이션 메뉴 (fallback)
+const DEFAULT_NAV_ITEMS: NavigationItemResponse[] = [
+  { id: 1, label: '강의 탐색', icon: 'BookOpen', path: '/tu/b2c/courses', enabled: true, displayOrder: 1, target: null, createdAt: '', updatedAt: '' },
+  { id: 2, label: '로드맵', icon: 'Map', path: '/tu/b2c/roadmaps', enabled: true, displayOrder: 2, target: null, createdAt: '', updatedAt: '' },
+  { id: 3, label: '커뮤니티', icon: 'Users', path: '/tu/b2c/community', enabled: true, displayOrder: 3, target: null, createdAt: '', updatedAt: '' },
+];
 
 export function LandingHeader() {
   const [showBanner, setShowBanner] = useState(true);
@@ -22,6 +30,10 @@ export function LandingHeader() {
   const { data: unreadCountData } = useUnreadNotificationCount(isAuthenticated);
   const unreadCount = unreadCountData?.count || 0;
   const { branding } = useTenantBranding();
+  const { data: navigationItems } = usePublicNavigation(isAuthenticated);
+
+  // 네비게이션 메뉴 (TA 설정 또는 기본값)
+  const navItems = navigationItems && navigationItems.length > 0 ? navigationItems : DEFAULT_NAV_ITEMS;
 
   // API Base URL
   const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api').replace('/api', '');
@@ -91,15 +103,30 @@ export function LandingHeader() {
 
             {/* Desktop Nav Links */}
             <nav className={`hidden md:flex items-center gap-8 font-medium text-[15px] ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
-              <Link to={prefixPath('/tu/b2c/courses')} className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
-                강의 탐색
-              </Link>
-              <Link to={prefixPath('/tu/b2c/roadmaps')} className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
-                로드맵
-              </Link>
-              <Link to={prefixPath('/tu/b2c/community')} className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}>
-                커뮤니티
-              </Link>
+              {navItems.map((item) => {
+                const isExternal = item.path.startsWith('http');
+                const linkPath = isExternal ? item.path : prefixPath(item.path);
+
+                return isExternal ? (
+                  <a
+                    key={item.id}
+                    href={linkPath}
+                    target={item.target || '_blank'}
+                    rel="noopener noreferrer"
+                    className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}
+                  >
+                    {item.label}
+                  </a>
+                ) : (
+                  <Link
+                    key={item.id}
+                    to={linkPath}
+                    className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}
+                  >
+                    {item.label}
+                  </Link>
+                );
+              })}
             </nav>
           </div>
 

--- a/src/components/landing/index.ts
+++ b/src/components/landing/index.ts
@@ -2,3 +2,4 @@ export { LandingHeader } from './LandingHeader';
 export { HeroSection } from './HeroSection';
 export { LandingCourseCard } from './LandingCourseCard';
 export { LandingFooter } from './LandingFooter';
+export { LandingBannerCarousel } from './LandingBannerCarousel';

--- a/src/contexts/TenantBrandingContext.tsx
+++ b/src/contexts/TenantBrandingContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, ReactNode, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useLocation } from 'react-router-dom';
 import { usePublicBranding } from '@/hooks/tu/usePublicBranding';
 import { useBrandingApply } from '@/hooks/tu/useBrandingApply';
 import { extractTenantIdentifier } from '@/utils/tenantUtils';
@@ -44,7 +45,13 @@ function useAuthenticatedBranding(enabled: boolean) {
 
 export function TenantBrandingProvider({ children }: { children: ReactNode }) {
   const { isAuthenticated, user } = useAuthStore();
-  const tenantIdentifier = extractTenantIdentifier();
+  const location = useLocation();
+
+  // 경로 변경 시 tenant identifier 재추출 (useMemo로 경로 기반 재계산)
+  const tenantIdentifier = useMemo(() => {
+    return extractTenantIdentifier();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.pathname]);
 
   // SA 사용자인지 확인 (tenantId가 없는 인증된 사용자)
   const isSystemAdmin = isAuthenticated && !user?.tenantId;

--- a/src/hooks/ta/index.ts
+++ b/src/hooks/ta/index.ts
@@ -48,3 +48,15 @@ export {
   useActivityStats,
   useRecentActivities,
 } from './useAnalyticsQueries';
+
+export {
+  bannerKeys,
+  useBanners,
+  useBanner,
+  usePublicBanners,
+  useCreateBanner,
+  useUpdateBanner,
+  useDeleteBanner,
+  useActivateBanner,
+  useDeactivateBanner,
+} from './useBannerQueries';

--- a/src/hooks/ta/useBannerQueries.ts
+++ b/src/hooks/ta/useBannerQueries.ts
@@ -1,0 +1,137 @@
+/**
+ * TA 배너 관련 React Query 훅
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { bannerService } from '@/services/ta/bannerService';
+import type {
+  CreateBannerRequest,
+  UpdateBannerRequest,
+  BannerListParams,
+  BannerPosition,
+} from '@/types/ta/banner.types';
+
+// ============================================
+// Query Keys
+// ============================================
+
+export const bannerKeys = {
+  all: ['ta-banners'] as const,
+  lists: () => [...bannerKeys.all, 'list'] as const,
+  list: (params?: BannerListParams) => [...bannerKeys.lists(), params] as const,
+  details: () => [...bannerKeys.all, 'detail'] as const,
+  detail: (id: number) => [...bannerKeys.details(), id] as const,
+  public: (position?: BannerPosition) => [...bannerKeys.all, 'public', position] as const,
+};
+
+// ============================================
+// 배너 조회 훅
+// ============================================
+
+/**
+ * 배너 목록 조회
+ */
+export const useBanners = (params?: BannerListParams) => {
+  return useQuery({
+    queryKey: bannerKeys.list(params),
+    queryFn: () => bannerService.getBanners(params),
+  });
+};
+
+/**
+ * 배너 상세 조회
+ */
+export const useBanner = (id: number) => {
+  return useQuery({
+    queryKey: bannerKeys.detail(id),
+    queryFn: () => bannerService.getBanner(id),
+    enabled: !!id,
+  });
+};
+
+/**
+ * 공개 배너 조회 (TU용)
+ */
+export const usePublicBanners = (position?: BannerPosition) => {
+  return useQuery({
+    queryKey: bannerKeys.public(position),
+    queryFn: () => bannerService.getPublicBanners(position),
+  });
+};
+
+// ============================================
+// 배너 변이 훅
+// ============================================
+
+/**
+ * 배너 생성
+ */
+export const useCreateBanner = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateBannerRequest) => bannerService.createBanner(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: bannerKeys.lists() });
+    },
+  });
+};
+
+/**
+ * 배너 수정
+ */
+export const useUpdateBanner = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: { id: number; request: UpdateBannerRequest }) =>
+      bannerService.updateBanner(id, request),
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries({ queryKey: bannerKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: bannerKeys.detail(id) });
+    },
+  });
+};
+
+/**
+ * 배너 삭제
+ */
+export const useDeleteBanner = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => bannerService.deleteBanner(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: bannerKeys.lists() });
+    },
+  });
+};
+
+/**
+ * 배너 활성화
+ */
+export const useActivateBanner = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => bannerService.activateBanner(id),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: bannerKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: bannerKeys.detail(id) });
+    },
+  });
+};
+
+/**
+ * 배너 비활성화
+ */
+export const useDeactivateBanner = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => bannerService.deactivateBanner(id),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: bannerKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: bannerKeys.detail(id) });
+    },
+  });
+};

--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -263,3 +263,15 @@ export {
   useIssueCertificate,
   useReissueCertificate,
 } from './useCertificateQueries';
+
+// Public Banner Hooks (공개 배너)
+export {
+  publicBannerKeys,
+  useDisplayableBanners,
+} from './usePublicBannerQueries';
+
+// Public Layout Hooks (공개 레이아웃)
+export {
+  usePublicLayout,
+  usePublicNavigation,
+} from './usePublicLayout';

--- a/src/hooks/tu/useBrandingApply.ts
+++ b/src/hooks/tu/useBrandingApply.ts
@@ -5,11 +5,21 @@ import type { PublicBrandingResponse } from '@/types/tu/branding.types';
  * 색상을 어둡게 만드는 유틸리티 (hover 상태용)
  */
 function darkenColor(hex: string, percent: number = 15): string {
-  // hex를 RGB로 변환
   const num = parseInt(hex.replace('#', ''), 16);
   const r = Math.max(0, ((num >> 16) & 0xff) - Math.round(255 * percent / 100));
   const g = Math.max(0, ((num >> 8) & 0xff) - Math.round(255 * percent / 100));
   const b = Math.max(0, (num & 0xff) - Math.round(255 * percent / 100));
+  return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, '0')}`;
+}
+
+/**
+ * 색상을 밝게 만드는 유틸리티 (hover 상태용)
+ */
+function lightenColor(hex: string, percent: number = 15): string {
+  const num = parseInt(hex.replace('#', ''), 16);
+  const r = Math.min(255, ((num >> 16) & 0xff) + Math.round(255 * percent / 100));
+  const g = Math.min(255, ((num >> 8) & 0xff) + Math.round(255 * percent / 100));
+  const b = Math.min(255, (num & 0xff) + Math.round(255 * percent / 100));
   return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, '0')}`;
 }
 
@@ -26,7 +36,10 @@ export function useBrandingApply(branding: PublicBrandingResponse | null | undef
 
     // ===== Landing 페이지용 CSS 변수 =====
     if (branding.primaryColor) {
+      const primaryHover = lightenColor(branding.primaryColor, 12);
       root.style.setProperty('--landing-primary-color', branding.primaryColor);
+      root.style.setProperty('--landing-primary-hover', primaryHover);
+
       // gradient-text 업데이트
       const gradientFrom = branding.primaryColor;
       const gradientTo = branding.secondaryColor || branding.primaryColor;
@@ -35,7 +48,9 @@ export function useBrandingApply(branding: PublicBrandingResponse | null | undef
     }
 
     if (branding.secondaryColor) {
+      const secondaryHover = lightenColor(branding.secondaryColor, 12);
       root.style.setProperty('--landing-secondary-color', branding.secondaryColor);
+      root.style.setProperty('--landing-secondary-hover', secondaryHover);
     }
 
     if (branding.accentColor) {

--- a/src/hooks/tu/usePublicBannerQueries.ts
+++ b/src/hooks/tu/usePublicBannerQueries.ts
@@ -1,0 +1,24 @@
+/**
+ * TU 공개 배너 관련 React Query 훅
+ */
+import { useQuery } from '@tanstack/react-query';
+import { publicBannerService } from '@/services/tu/publicBannerService';
+import type { BannerPosition } from '@/types/ta/banner.types';
+
+// Query Keys
+export const publicBannerKeys = {
+  all: ['tu-public-banners'] as const,
+  displayable: (position?: BannerPosition) =>
+    [...publicBannerKeys.all, 'displayable', position] as const,
+};
+
+/**
+ * 노출 가능한 공개 배너 조회
+ * @param position 배너 위치 필터 (선택)
+ */
+export const useDisplayableBanners = (position?: BannerPosition) => {
+  return useQuery({
+    queryKey: publicBannerKeys.displayable(position),
+    queryFn: () => publicBannerService.getDisplayableBanners(position),
+  });
+};

--- a/src/hooks/tu/usePublicLayout.ts
+++ b/src/hooks/tu/usePublicLayout.ts
@@ -1,0 +1,68 @@
+/**
+ * TU용 공개 레이아웃 조회 Hook
+ */
+import { useQuery } from '@tanstack/react-query';
+import { tenantSettingsService } from '@/services/ta/tenantSettingsService';
+import type { PublicLayoutResponse, NavigationItemResponse } from '@/types/tu/branding.types';
+
+/** 기본 레이아웃 */
+const DEFAULT_LAYOUT: PublicLayoutResponse = {
+  headerSettings: {
+    style: 'fixed',
+    height: 'default',
+    showLogo: true,
+    showSearch: true,
+    showNotifications: true,
+  },
+  footerSettings: {
+    enabled: true,
+    showLinks: true,
+    showCopyright: true,
+    showSocialLinks: true,
+  },
+  contentSettings: {
+    maxWidth: 'xl',
+    padding: 'normal',
+  },
+  navigationItems: [],
+};
+
+/**
+ * 공개 레이아웃 조회 Hook (인증된 사용자용)
+ */
+export function usePublicLayout(enabled: boolean = true) {
+  return useQuery<PublicLayoutResponse>({
+    queryKey: ['public-layout'],
+    queryFn: async () => {
+      try {
+        return await tenantSettingsService.getPublicLayout();
+      } catch {
+        return DEFAULT_LAYOUT;
+      }
+    },
+    enabled,
+    staleTime: 1000 * 60 * 30, // 30분 캐싱
+    gcTime: 1000 * 60 * 60, // 1시간 GC
+    retry: 1,
+  });
+}
+
+/**
+ * 활성화된 네비게이션 조회 Hook (인증된 사용자용)
+ */
+export function usePublicNavigation(enabled: boolean = true) {
+  return useQuery<NavigationItemResponse[]>({
+    queryKey: ['public-navigation'],
+    queryFn: async () => {
+      try {
+        return await tenantSettingsService.getPublicNavigation();
+      } catch {
+        return [];
+      }
+    },
+    enabled,
+    staleTime: 1000 * 60 * 30,
+    gcTime: 1000 * 60 * 60,
+    retry: 1,
+  });
+}

--- a/src/index.css
+++ b/src/index.css
@@ -204,7 +204,7 @@
 }
 
 .gradient-text {
-  background: linear-gradient(90deg, #70f2a0, #6778ff, #6bc2f0, #70f2a0);
+  background: linear-gradient(90deg, var(--landing-accent-color, #70f2a0), var(--landing-primary-color, #6778ff), #6bc2f0, var(--landing-accent-color, #70f2a0));
   background-size: 300% 100%;
   -webkit-background-clip: text;
   background-clip: text;
@@ -213,7 +213,7 @@
 }
 
 .gradient-text-purple {
-  background: linear-gradient(90deg, #a855f7, #6366f1, #06b6d4, #a855f7);
+  background: linear-gradient(90deg, var(--landing-secondary-color, #a855f7), var(--landing-primary-color, #6366f1), #06b6d4, var(--landing-secondary-color, #a855f7));
   background-size: 300% 100%;
   -webkit-background-clip: text;
   background-clip: text;
@@ -236,25 +236,25 @@
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
 
-/* Hover glow effect */
+/* Hover glow effect - Uses dynamic branding variables */
 .hover-glow {
   transition: all 0.3s ease;
 }
 
 .hover-glow:hover {
-  box-shadow: 0 0 30px rgba(103, 120, 255, 0.3);
+  box-shadow: 0 0 30px color-mix(in srgb, var(--landing-primary-color, #6778ff) 30%, transparent);
 }
 
-/* Landing Button styles */
+/* Landing Button styles - Uses dynamic branding variables */
 .landing-btn-primary {
-  background: linear-gradient(135deg, #6778ff 0%, #a855f7 100%);
+  background: linear-gradient(135deg, var(--landing-primary-color, #6778ff) 0%, var(--landing-secondary-color, #a855f7) 100%);
   transition: all 0.3s ease;
 }
 
 .landing-btn-primary:hover {
-  background: linear-gradient(135deg, #8b99ff 0%, #c084fc 100%);
+  background: linear-gradient(135deg, var(--landing-primary-hover, #8b99ff) 0%, var(--landing-secondary-hover, #c084fc) 100%);
   transform: translateY(-2px);
-  box-shadow: 0 10px 30px rgba(103, 120, 255, 0.4);
+  box-shadow: 0 10px 30px color-mix(in srgb, var(--landing-primary-color, #6778ff) 40%, transparent);
 }
 
 .landing-btn-outline {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { TenantBrandingProvider } from '@/contexts/TenantBrandingContext';
 import App from './App';
 import './index.css';
 
@@ -17,9 +16,7 @@ const queryClient = new QueryClient({
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <TenantBrandingProvider>
-        <App />
-      </TenantBrandingProvider>
+      <App />
     </QueryClientProvider>
   </StrictMode>
 );

--- a/src/pages/ta/branding/BannerManagementPage.tsx
+++ b/src/pages/ta/branding/BannerManagementPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { DateRange } from 'react-day-picker';
+import { toast } from 'sonner';
 import {
   ImageIcon,
   Trash2,
@@ -14,6 +15,7 @@ import {
   Pencil,
   Save,
   X,
+  Loader2,
 } from 'lucide-react';
 import {
   DndContext,
@@ -25,7 +27,6 @@ import {
   type DragEndEvent,
 } from '@dnd-kit/core';
 import {
-  arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
   useSortable,
@@ -47,6 +48,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   TagInput,
   EmptyState,
   Tooltip,
@@ -64,8 +66,20 @@ import {
   TargetingSelector,
   BannerPreview,
 } from '@/components/domain/ta';
+import {
+  useBanners,
+  useCreateBanner,
+  useUpdateBanner,
+  useDeleteBanner,
+  useActivateBanner,
+  useDeactivateBanner,
+} from '@/hooks/ta';
+import type {
+  BannerResponse,
+  CreateBannerRequest,
+} from '@/types/ta/banner.types';
 
-// 타겟팅 데이터 타입
+// 타겟팅 데이터 타입 (UI용)
 interface TargetingData {
   departments: string[];
   jobRoles: string[];
@@ -73,79 +87,28 @@ interface TargetingData {
   ranks: string[];
 }
 
-// 배너 타입 정의
-interface Banner {
-  id: string;
+// 확장된 배너 타입 (UI용 필드 포함)
+interface BannerFormData {
   title: string;
   pcImageUrl: string;
   mobileImageUrl?: string;
   linkUrl?: string;
   hiddenTags: string[];
   isActive: boolean;
-  order: number;
   startDate?: Date;
   endDate?: Date;
   isAllTarget: boolean;
   targeting: TargetingData;
 }
 
-// 샘플 배너 데이터
-const sampleBanners: Banner[] = [
-  {
-    id: '1',
-    title: '2025 신입사원 필수교육',
-    pcImageUrl: 'https://images.unsplash.com/photo-1522071820081-009f0129c71c?w=1200&h=400&fit=crop',
-    mobileImageUrl: 'https://images.unsplash.com/photo-1522071820081-009f0129c71c?w=600&h=400&fit=crop',
-    linkUrl: 'https://learning.company.com/courses/new-employee-2025',
-    hiddenTags: ['신입사원', '필수교육'],
-    isActive: true,
-    order: 1,
-    isAllTarget: true,
-    targeting: { departments: [], jobRoles: [], positions: [], ranks: [] },
-  },
-  {
-    id: '2',
-    title: '리더십 캠프 2025',
-    pcImageUrl: 'https://images.unsplash.com/photo-1552664730-d307ca884978?w=1200&h=400&fit=crop',
-    linkUrl: 'https://learning.company.com/events/leadership-camp',
-    hiddenTags: ['리더십', '캠프'],
-    isActive: true,
-    order: 2,
-    startDate: new Date('2025-01-01'),
-    endDate: new Date('2025-03-31'),
-    isAllTarget: false,
-    targeting: {
-      departments: [],
-      jobRoles: [],
-      positions: ['team_leader', 'dept_leader'],
-      ranks: ['manager', 'deputy', 'general'],
-    },
-  },
-  {
-    id: '3',
-    title: 'AI 활용 업무 효율화',
-    pcImageUrl: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=1200&h=400&fit=crop',
-    mobileImageUrl: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=600&h=400&fit=crop',
-    linkUrl: 'https://learning.company.com/courses/ai-productivity',
-    hiddenTags: ['AI', '업무효율'],
-    isActive: false,
-    order: 3,
-    isAllTarget: false,
-    targeting: {
-      departments: ['dev', 'marketing'],
-      jobRoles: [],
-      positions: [],
-      ranks: [],
-    },
-  },
-];
-
 // 드래그 가능한 배너 아이템 컴포넌트
 interface SortableBannerItemProps {
-  banner: Banner;
+  banner: BannerResponse;
   onEdit: () => void;
   onToggleActive: () => void;
   onDelete: () => void;
+  isToggling: boolean;
+  isDeleting: boolean;
 }
 
 function SortableBannerItem({
@@ -153,6 +116,8 @@ function SortableBannerItem({
   onEdit,
   onToggleActive,
   onDelete,
+  isToggling,
+  isDeleting,
 }: SortableBannerItemProps) {
   const {
     attributes,
@@ -161,23 +126,12 @@ function SortableBannerItem({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: banner.id });
+  } = useSortable({ id: banner.id.toString() });
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
-  };
-
-  const getTargetLabel = () => {
-    if (banner.isAllTarget) return '전체';
-    const { targeting } = banner;
-    const totalSelected =
-      targeting.departments.length +
-      targeting.jobRoles.length +
-      targeting.positions.length +
-      targeting.ranks.length;
-    return totalSelected > 0 ? `${totalSelected}개 조건` : '미설정';
   };
 
   return (
@@ -218,7 +172,7 @@ function SortableBannerItem({
       <div
         className="w-32 h-20 rounded-lg bg-cover bg-center flex-shrink-0 border"
         style={{
-          backgroundImage: `url(${banner.pcImageUrl})`,
+          backgroundImage: `url(${banner.imageUrl})`,
           borderColor: designTokens.bg.border,
         }}
       />
@@ -240,26 +194,10 @@ function SortableBannerItem({
           </Badge>
         </div>
         <div className="flex items-center gap-2 flex-wrap">
-          {/* 태그 */}
-          {banner.hiddenTags.slice(0, 3).map((tag) => (
-            <Badge key={tag} variant="gray" className="text-xs">
-              #{tag}
-            </Badge>
-          ))}
-          {banner.hiddenTags.length > 3 && (
-            <Badge variant="gray" className="text-xs">
-              +{banner.hiddenTags.length - 3}
-            </Badge>
-          )}
-          {/* 구분선 */}
-          <span style={{ color: designTokens.bg.border }}>|</span>
           {/* 대상 */}
-          <Badge
-            variant={banner.isAllTarget ? 'indigo' : 'blue'}
-            className="text-xs"
-          >
+          <Badge variant="indigo" className="text-xs">
             <Users className="w-3 h-3 mr-1" />
-            {getTargetLabel()}
+            전체
           </Badge>
           {/* 기간 */}
           {banner.startDate && banner.endDate && (
@@ -313,6 +251,7 @@ function SortableBannerItem({
             <TooltipTrigger asChild>
               <button
                 onClick={onToggleActive}
+                disabled={isToggling}
                 className="p-2.5 rounded-lg transition-colors"
                 style={{
                   backgroundColor: banner.isActive
@@ -320,7 +259,12 @@ function SortableBannerItem({
                     : designTokens.bg.secondary,
                 }}
               >
-                {banner.isActive ? (
+                {isToggling ? (
+                  <Loader2
+                    className="w-4 h-4 animate-spin"
+                    style={{ color: designTokens.text.secondary }}
+                  />
+                ) : banner.isActive ? (
                   <Eye
                     className="w-4 h-4"
                     style={{ color: designTokens.status.success_text }}
@@ -345,13 +289,21 @@ function SortableBannerItem({
             <TooltipTrigger asChild>
               <button
                 onClick={onDelete}
+                disabled={isDeleting}
                 className="p-2.5 rounded-lg transition-colors"
                 style={{ backgroundColor: designTokens.status.error_background }}
               >
-                <Trash2
-                  className="w-4 h-4"
-                  style={{ color: designTokens.status.error_text }}
-                />
+                {isDeleting ? (
+                  <Loader2
+                    className="w-4 h-4 animate-spin"
+                    style={{ color: designTokens.status.error_text }}
+                  />
+                ) : (
+                  <Trash2
+                    className="w-4 h-4"
+                    style={{ color: designTokens.status.error_text }}
+                  />
+                )}
               </button>
             </TooltipTrigger>
             <TooltipContent>삭제</TooltipContent>
@@ -431,16 +383,38 @@ function SlidePanel({ isOpen, onClose, title, children }: SlidePanelProps) {
  * - PC/Mobile 미리보기
  */
 export const BannerManagementPage = () => {
-  const [banners, setBanners] = useState<Banner[]>(sampleBanners);
-  const [selectedBanner, setSelectedBanner] = useState<Banner | null>(null);
+  // API Hooks
+  const { data: banners = [], isLoading, refetch } = useBanners();
+  const createBannerMutation = useCreateBanner();
+  const updateBannerMutation = useUpdateBanner();
+  const deleteBannerMutation = useDeleteBanner();
+  const activateBannerMutation = useActivateBanner();
+  const deactivateBannerMutation = useDeactivateBanner();
+
+  // Local State
+  const [selectedBanner, setSelectedBanner] = useState<BannerResponse | null>(null);
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
   const [editingTags, setEditingTags] = useState<string[]>([]);
   const [activeTab, setActiveTab] = useState<string>('basic');
+  const [togglingId, setTogglingId] = useState<number | null>(null);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+
+  // 편집 폼 상태
+  const [editForm, setEditForm] = useState<BannerFormData>({
+    title: '',
+    pcImageUrl: '',
+    mobileImageUrl: '',
+    linkUrl: '',
+    hiddenTags: [],
+    isActive: true,
+    isAllTarget: true,
+    targeting: { departments: [], jobRoles: [], positions: [], ranks: [] },
+  });
 
   // 새 배너 상태
-  const [newBanner, setNewBanner] = useState<Partial<Banner>>({
+  const [newBanner, setNewBanner] = useState<Partial<BannerFormData>>({
     title: '',
     pcImageUrl: '',
     mobileImageUrl: '',
@@ -465,42 +439,73 @@ export const BannerManagementPage = () => {
     })
   );
 
-  // 드래그 종료 핸들러
+  // 드래그 종료 핸들러 (순서 변경은 현재 지원하지 않음)
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
 
     if (over && active.id !== over.id) {
-      setBanners((items) => {
-        const oldIndex = items.findIndex((item) => item.id === active.id);
-        const newIndex = items.findIndex((item) => item.id === over.id);
-        const newItems = arrayMove(items, oldIndex, newIndex);
-        return newItems.map((item: Banner, idx: number) => ({ ...item, order: idx + 1 }));
-      });
+      // 순서 변경 API가 없어 로컬에서만 순서 변경 UI를 보여줌
+      toast.info('배너 순서 변경 기능은 준비 중입니다.');
     }
   };
 
-  const toggleBannerActive = (id: string) => {
-    setBanners(
-      banners.map((b) => (b.id === id ? { ...b, isActive: !b.isActive } : b))
-    );
-    if (selectedBanner?.id === id) {
-      setSelectedBanner((prev) =>
-        prev ? { ...prev, isActive: !prev.isActive } : null
-      );
-    }
+  const toggleBannerActive = (banner: BannerResponse) => {
+    setTogglingId(banner.id);
+
+    const mutation = banner.isActive ? deactivateBannerMutation : activateBannerMutation;
+    const successMessage = banner.isActive ? '배너가 비활성화되었습니다.' : '배너가 활성화되었습니다.';
+
+    mutation.mutate(banner.id, {
+      onSuccess: () => {
+        toast.success(successMessage);
+        refetch();
+      },
+      onError: () => {
+        toast.error('배너 상태 변경에 실패했습니다.');
+      },
+      onSettled: () => {
+        setTogglingId(null);
+      },
+    });
   };
 
-  const deleteBanner = (id: string) => {
-    setBanners(banners.filter((b) => b.id !== id));
-    if (selectedBanner?.id === id) {
-      setSelectedBanner(null);
-      setIsPanelOpen(false);
-    }
+  const deleteBanner = (id: number) => {
+    if (!confirm('정말로 이 배너를 삭제하시겠습니까?')) return;
+
+    setDeletingId(id);
+    deleteBannerMutation.mutate(id, {
+      onSuccess: () => {
+        toast.success('배너가 삭제되었습니다.');
+        if (selectedBanner?.id === id) {
+          setSelectedBanner(null);
+          setIsPanelOpen(false);
+        }
+        refetch();
+      },
+      onError: () => {
+        toast.error('배너 삭제에 실패했습니다.');
+      },
+      onSettled: () => {
+        setDeletingId(null);
+      },
+    });
   };
 
-  const openEditPanel = (banner: Banner) => {
+  const openEditPanel = (banner: BannerResponse) => {
     setSelectedBanner(banner);
-    setEditingTags(banner.hiddenTags);
+    setEditForm({
+      title: banner.title,
+      pcImageUrl: banner.imageUrl,
+      mobileImageUrl: banner.mobileImageUrl || '',
+      linkUrl: banner.linkUrl || '',
+      hiddenTags: [],
+      isActive: banner.isActive,
+      startDate: banner.startDate ? new Date(banner.startDate) : undefined,
+      endDate: banner.endDate ? new Date(banner.endDate) : undefined,
+      isAllTarget: true,
+      targeting: { departments: [], jobRoles: [], positions: [], ranks: [] },
+    });
+    setEditingTags([]);
     setActiveTab('basic');
     setIsPanelOpen(true);
   };
@@ -512,50 +517,92 @@ export const BannerManagementPage = () => {
     }, 300);
   };
 
-  const updateSelectedBanner = <K extends keyof Banner>(
+  const updateEditForm = <K extends keyof BannerFormData>(
     key: K,
-    value: Banner[K]
+    value: BannerFormData[K]
   ) => {
-    if (!selectedBanner) return;
-
-    const updated = { ...selectedBanner, [key]: value };
-    setSelectedBanner(updated);
-    setBanners(banners.map((b) => (b.id === selectedBanner.id ? updated : b)));
+    setEditForm((prev) => ({ ...prev, [key]: value }));
   };
 
-  const updateSelectedBannerTags = (tags: string[]) => {
+  const updateEditFormTags = (tags: string[]) => {
     setEditingTags(tags);
-    if (selectedBanner) {
-      updateSelectedBanner('hiddenTags', tags);
-    }
+    updateEditForm('hiddenTags', tags);
+  };
+
+  const handleSaveEdit = () => {
+    if (!selectedBanner) return;
+
+    // LocalDate 형식 (YYYY-MM-DD)으로 변환
+    const formatDate = (date: Date | undefined) => {
+      if (!date) return undefined;
+      return date.toISOString().split('T')[0];
+    };
+
+    updateBannerMutation.mutate(
+      {
+        id: selectedBanner.id,
+        request: {
+          title: editForm.title,
+          imageUrl: editForm.pcImageUrl,
+          linkUrl: editForm.linkUrl || undefined,
+          isActive: editForm.isActive,
+          startDate: formatDate(editForm.startDate),
+          endDate: formatDate(editForm.endDate),
+        },
+      },
+      {
+        onSuccess: () => {
+          toast.success('배너가 수정되었습니다.');
+          closePanel();
+          refetch();
+        },
+        onError: () => {
+          toast.error('배너 수정에 실패했습니다.');
+        },
+      }
+    );
   };
 
   const handleAddBanner = () => {
-    if (!newBanner.title || !newBanner.pcImageUrl) return;
+    if (!newBanner.title || !newBanner.pcImageUrl) {
+      toast.error('필수 항목을 입력해주세요.');
+      return;
+    }
 
-    const banner: Banner = {
-      id: Date.now().toString(),
-      title: newBanner.title,
-      pcImageUrl: newBanner.pcImageUrl,
-      mobileImageUrl: newBanner.mobileImageUrl,
-      linkUrl: newBanner.linkUrl,
-      hiddenTags: newBannerTags,
-      isActive: newBanner.isActive ?? true,
-      order: banners.length + 1,
-      startDate: newBannerDateRange?.from,
-      endDate: newBannerDateRange?.to,
-      isAllTarget: newBanner.isAllTarget ?? true,
-      targeting: newBanner.targeting ?? {
-        departments: [],
-        jobRoles: [],
-        positions: [],
-        ranks: [],
-      },
+    // LocalDate 형식 (YYYY-MM-DD)으로 변환
+    const formatDate = (date: Date | undefined): string | null => {
+      if (!date) return null;
+      return date.toISOString().split('T')[0];
     };
 
-    setBanners([...banners, banner]);
-    setShowAddModal(false);
-    resetNewBannerForm();
+    const request: CreateBannerRequest = {
+      title: newBanner.title,
+      imageUrl: newBanner.pcImageUrl,
+      position: 'MAIN_TOP',
+      linkUrl: newBanner.linkUrl || null,
+      linkTarget: newBanner.linkUrl ? '_self' : null,
+      sortOrder: null,
+      startDate: formatDate(newBannerDateRange?.from),
+      endDate: formatDate(newBannerDateRange?.to),
+      description: null,
+    };
+
+    console.log('Creating banner with request:', request);
+
+    createBannerMutation.mutate(request, {
+      onSuccess: () => {
+        toast.success('배너가 추가되었습니다.');
+        setShowAddModal(false);
+        resetNewBannerForm();
+        refetch();
+      },
+      onError: (error: unknown) => {
+        console.error('Banner creation error:', error);
+        const axiosError = error as { response?: { data?: { message?: string } } };
+        const message = axiosError?.response?.data?.message || '배너 추가에 실패했습니다.';
+        toast.error(message);
+      },
+    });
   };
 
   const resetNewBannerForm = () => {
@@ -572,6 +619,14 @@ export const BannerManagementPage = () => {
     setNewBannerTags([]);
     setNewBannerDateRange(undefined);
   };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <Loader2 className="w-8 h-8 animate-spin" style={{ color: designTokens.text.secondary }} />
+      </div>
+    );
+  }
 
   return (
     <div
@@ -644,7 +699,7 @@ export const BannerManagementPage = () => {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext
-                  items={banners.map((b) => b.id)}
+                  items={banners.map((b) => b.id.toString())}
                   strategy={verticalListSortingStrategy}
                 >
                   <div className="space-y-3">
@@ -653,8 +708,10 @@ export const BannerManagementPage = () => {
                         key={banner.id}
                         banner={banner}
                         onEdit={() => openEditPanel(banner)}
-                        onToggleActive={() => toggleBannerActive(banner.id)}
+                        onToggleActive={() => toggleBannerActive(banner)}
                         onDelete={() => deleteBanner(banner.id)}
+                        isToggling={togglingId === banner.id}
+                        isDeleting={deletingId === banner.id}
                       />
                     ))}
                   </div>
@@ -694,8 +751,8 @@ export const BannerManagementPage = () => {
               <div>
                 <Label className="mb-2 block text-sm">배너 제목 (관리용)</Label>
                 <Input
-                  value={selectedBanner.title}
-                  onChange={(e) => updateSelectedBanner('title', e.target.value)}
+                  value={editForm.title}
+                  onChange={(e) => updateEditForm('title', e.target.value)}
                   placeholder="배너를 식별할 수 있는 제목을 입력하세요"
                 />
               </div>
@@ -703,15 +760,15 @@ export const BannerManagementPage = () => {
               {/* 이미지 업로드 */}
               <div className="space-y-4">
                 <BannerImageDropzone
-                  value={selectedBanner.pcImageUrl}
-                  onChange={(url) => updateSelectedBanner('pcImageUrl', url)}
+                  value={editForm.pcImageUrl}
+                  onChange={(url) => updateEditForm('pcImageUrl', url)}
                   label="PC 배너 이미지"
                   recommendedSize="1200x400px"
                   deviceType="pc"
                 />
                 <BannerImageDropzone
-                  value={selectedBanner.mobileImageUrl}
-                  onChange={(url) => updateSelectedBanner('mobileImageUrl', url)}
+                  value={editForm.mobileImageUrl}
+                  onChange={(url) => updateEditForm('mobileImageUrl', url)}
                   label="Mobile 배너 이미지 (선택)"
                   recommendedSize="600x400px"
                   aspectRatio="aspect-[3/2]"
@@ -726,8 +783,8 @@ export const BannerManagementPage = () => {
                   연결 URL
                 </Label>
                 <Input
-                  value={selectedBanner.linkUrl || ''}
-                  onChange={(e) => updateSelectedBanner('linkUrl', e.target.value)}
+                  value={editForm.linkUrl || ''}
+                  onChange={(e) => updateEditForm('linkUrl', e.target.value)}
                   placeholder="https://example.com/course/123"
                 />
                 <p
@@ -749,7 +806,7 @@ export const BannerManagementPage = () => {
                 </p>
                 <TagInput
                   value={editingTags}
-                  onChange={updateSelectedBannerTags}
+                  onChange={updateEditFormTags}
                   placeholder="태그 입력 후 Enter"
                 />
               </div>
@@ -762,16 +819,16 @@ export const BannerManagementPage = () => {
                 </Label>
                 <DateRangePicker
                   date={
-                    selectedBanner.startDate && selectedBanner.endDate
+                    editForm.startDate && editForm.endDate
                       ? {
-                          from: selectedBanner.startDate,
-                          to: selectedBanner.endDate,
+                          from: editForm.startDate,
+                          to: editForm.endDate,
                         }
                       : undefined
                   }
                   onDateChange={(range) => {
-                    updateSelectedBanner('startDate', range?.from);
-                    updateSelectedBanner('endDate', range?.to);
+                    updateEditForm('startDate', range?.from);
+                    updateEditForm('endDate', range?.to);
                   }}
                   placeholder="기간을 선택하세요"
                   className="w-full"
@@ -799,19 +856,37 @@ export const BannerManagementPage = () => {
                   </p>
                 </div>
                 <Switch
-                  checked={selectedBanner.isActive}
-                  onCheckedChange={() => toggleBannerActive(selectedBanner.id)}
+                  checked={editForm.isActive}
+                  onCheckedChange={(checked) => updateEditForm('isActive', checked)}
                 />
               </div>
+
+              {/* 저장 버튼 */}
+              <Button
+                onClick={handleSaveEdit}
+                disabled={updateBannerMutation.isPending}
+                className="w-full gap-2"
+                style={{
+                  backgroundColor: designTokens.button.brand_default,
+                  color: designTokens.button.brand_text,
+                }}
+              >
+                {updateBannerMutation.isPending ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Save className="w-4 h-4" />
+                )}
+                저장
+              </Button>
             </TabsContent>
 
             {/* 노출 대상 탭 */}
             <TabsContent value="targeting">
               <TargetingSelector
-                value={selectedBanner.targeting}
-                onChange={(targeting) => updateSelectedBanner('targeting', targeting)}
-                isAllTarget={selectedBanner.isAllTarget}
-                onAllTargetChange={(isAll) => updateSelectedBanner('isAllTarget', isAll)}
+                value={editForm.targeting}
+                onChange={(targeting) => updateEditForm('targeting', targeting)}
+                isAllTarget={editForm.isAllTarget}
+                onAllTargetChange={(isAll) => updateEditForm('isAllTarget', isAll)}
               />
             </TabsContent>
 
@@ -820,11 +895,11 @@ export const BannerManagementPage = () => {
               <BannerPreview
                 banners={[
                   {
-                    id: selectedBanner.id,
-                    title: selectedBanner.title,
-                    pcImageUrl: selectedBanner.pcImageUrl,
-                    mobileImageUrl: selectedBanner.mobileImageUrl,
-                    linkUrl: selectedBanner.linkUrl,
+                    id: selectedBanner.id.toString(),
+                    title: editForm.title,
+                    pcImageUrl: editForm.pcImageUrl,
+                    mobileImageUrl: editForm.mobileImageUrl,
+                    linkUrl: editForm.linkUrl,
                     isActive: true,
                   },
                 ]}
@@ -842,16 +917,19 @@ export const BannerManagementPage = () => {
               <Monitor className="w-5 h-5" />
               배너 미리보기
             </DialogTitle>
+            <DialogDescription>
+              활성화된 배너가 홈 화면에 어떻게 표시되는지 미리 확인합니다.
+            </DialogDescription>
           </DialogHeader>
           <BannerPreview
             banners={banners
               .filter((b) => b.isActive)
               .map((b) => ({
-                id: b.id,
+                id: b.id.toString(),
                 title: b.title,
-                pcImageUrl: b.pcImageUrl,
-                mobileImageUrl: b.mobileImageUrl,
-                linkUrl: b.linkUrl,
+                pcImageUrl: b.imageUrl,
+                mobileImageUrl: b.mobileImageUrl ?? undefined,
+                linkUrl: b.linkUrl ?? undefined,
                 isActive: b.isActive,
               }))}
           />
@@ -866,6 +944,9 @@ export const BannerManagementPage = () => {
               <Plus className="w-5 h-5" />
               새 배너 추가
             </DialogTitle>
+            <DialogDescription>
+              홈 화면에 표시할 새 배너를 등록합니다.
+            </DialogDescription>
           </DialogHeader>
 
           <div className="space-y-6 py-4">
@@ -986,14 +1067,18 @@ export const BannerManagementPage = () => {
             </Button>
             <Button
               onClick={handleAddBanner}
-              disabled={!newBanner.title || !newBanner.pcImageUrl}
+              disabled={!newBanner.title || !newBanner.pcImageUrl || createBannerMutation.isPending}
               className="gap-1"
               style={{
                 backgroundColor: designTokens.button.brand_default,
                 color: designTokens.button.brand_text,
               }}
             >
-              <Save className="w-4 h-4" />
+              {createBannerMutation.isPending ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Save className="w-4 h-4" />
+              )}
               저장
             </Button>
           </div>
@@ -1001,4 +1086,4 @@ export const BannerManagementPage = () => {
       </Dialog>
     </div>
   );
-}
+};

--- a/src/pages/tu/main/LandingPage.tsx
+++ b/src/pages/tu/main/LandingPage.tsx
@@ -182,7 +182,7 @@ export function LandingPage() {
       <LandingHeader />
 
       <main>
-        {/* Hero Section */}
+        {/* Hero Section (TA 배너 + 기본 슬라이드 통합) */}
         <HeroSection />
 
         {/* Search/Category Bar */}

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -68,6 +68,9 @@ export const API_ENDPOINTS = {
     NAVIGATION_ITEM: (id: number) => `/tenant/settings/navigation/${id}`,
     NAVIGATION_REORDER: '/tenant/settings/navigation/reorder',
     NAVIGATION_RESET: '/tenant/settings/navigation/reset',
+    // TU용 공개 API
+    LAYOUT_PUBLIC: '/tenant/settings/layout/public',
+    NAVIGATION_PUBLIC: '/tenant/settings/navigation/public',
   },
 
   // User Groups (TA)
@@ -282,6 +285,15 @@ export const API_ENDPOINTS = {
   SYSTEM_SETTINGS: {
     BASE: '/admin/system/settings',
     TENANT_DEFAULTS: '/admin/system/tenant-defaults',
+  },
+
+  // Banners (TA)
+  BANNERS: {
+    BASE: '/banners',
+    BY_ID: (id: number) => `/banners/${id}`,
+    ACTIVATE: (id: number) => `/banners/${id}/activate`,
+    DEACTIVATE: (id: number) => `/banners/${id}/deactivate`,
+    PUBLIC: '/banners/public/displayable',
   },
 
   // Certificates (수료증) - TU

--- a/src/services/ta/bannerService.ts
+++ b/src/services/ta/bannerService.ts
@@ -1,0 +1,113 @@
+/**
+ * TA 배너 관리 API 서비스
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type {
+  BannerResponse,
+  CreateBannerRequest,
+  UpdateBannerRequest,
+  BannerListParams,
+  BannerPosition,
+} from '@/types/ta/banner.types';
+
+/**
+ * 요청 객체에서 undefined 값만 제거 (null은 유지)
+ */
+function cleanRequest<T extends object>(obj: T): Partial<T> {
+  const cleaned: Partial<T> = {};
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const value = obj[key];
+      // undefined는 제외, null은 유지
+      if (value === undefined) continue;
+      cleaned[key as keyof T] = value;
+    }
+  }
+  return cleaned;
+}
+
+export const bannerService = {
+  /**
+   * 배너 목록 조회
+   */
+  async getBanners(params?: BannerListParams): Promise<BannerResponse[]> {
+    const { data } = await axiosInstance.get<BannerResponse[]>(
+      API_ENDPOINTS.BANNERS.BASE,
+      { params }
+    );
+    return data;
+  },
+
+  /**
+   * 배너 상세 조회
+   */
+  async getBanner(id: number): Promise<BannerResponse> {
+    const { data } = await axiosInstance.get<BannerResponse>(
+      API_ENDPOINTS.BANNERS.BY_ID(id)
+    );
+    return data;
+  },
+
+  /**
+   * 배너 생성
+   */
+  async createBanner(request: CreateBannerRequest): Promise<BannerResponse> {
+    const cleanedRequest = cleanRequest(request);
+    const { data } = await axiosInstance.post<BannerResponse>(
+      API_ENDPOINTS.BANNERS.BASE,
+      cleanedRequest
+    );
+    return data;
+  },
+
+  /**
+   * 배너 수정
+   */
+  async updateBanner(id: number, request: UpdateBannerRequest): Promise<BannerResponse> {
+    const cleanedRequest = cleanRequest(request);
+    const { data } = await axiosInstance.put<BannerResponse>(
+      API_ENDPOINTS.BANNERS.BY_ID(id),
+      cleanedRequest
+    );
+    return data;
+  },
+
+  /**
+   * 배너 삭제
+   */
+  async deleteBanner(id: number): Promise<void> {
+    await axiosInstance.delete(API_ENDPOINTS.BANNERS.BY_ID(id));
+  },
+
+  /**
+   * 배너 활성화
+   */
+  async activateBanner(id: number): Promise<BannerResponse> {
+    const { data } = await axiosInstance.put<BannerResponse>(
+      API_ENDPOINTS.BANNERS.ACTIVATE(id)
+    );
+    return data;
+  },
+
+  /**
+   * 배너 비활성화
+   */
+  async deactivateBanner(id: number): Promise<BannerResponse> {
+    const { data } = await axiosInstance.put<BannerResponse>(
+      API_ENDPOINTS.BANNERS.DEACTIVATE(id)
+    );
+    return data;
+  },
+
+  /**
+   * 공개 배너 조회 (TU용, 인증 불필요)
+   */
+  async getPublicBanners(position?: BannerPosition): Promise<BannerResponse[]> {
+    const { data } = await axiosInstance.get<BannerResponse[]>(
+      API_ENDPOINTS.BANNERS.PUBLIC,
+      { params: position ? { position } : undefined }
+    );
+    return data;
+  },
+};

--- a/src/services/ta/index.ts
+++ b/src/services/ta/index.ts
@@ -3,3 +3,4 @@ export { groupService } from './groupService';
 export { tenantSettingsService } from './tenantSettingsService';
 export { taDashboardService } from './dashboardService';
 export { analyticsService } from './analyticsService';
+export { bannerService } from './bannerService';

--- a/src/services/ta/tenantSettingsService.ts
+++ b/src/services/ta/tenantSettingsService.ts
@@ -9,7 +9,11 @@ import type {
   UpdateBrandingRequest,
   UpdateUserManagementRequest,
 } from '@/types/admin';
-import type { PublicBrandingResponse } from '@/types/tu/branding.types';
+import type {
+  PublicBrandingResponse,
+  PublicLayoutResponse,
+  NavigationItemResponse,
+} from '@/types/tu/branding.types';
 
 /** 기본 브랜딩 (fallback) */
 const DEFAULT_BRANDING: PublicBrandingResponse = {
@@ -65,6 +69,26 @@ export const tenantSettingsService = {
     const { data } = await axiosInstance.patch<TenantSettingsDetail>(
       API_ENDPOINTS.TENANT_SETTINGS.USER_MANAGEMENT,
       request
+    );
+    return data;
+  },
+
+  // ============================================
+  // TU용 공개 API
+  // ============================================
+
+  /** 공개 레이아웃 조회 (TU용, 인증된 사용자) */
+  async getPublicLayout(): Promise<PublicLayoutResponse> {
+    const { data } = await axiosInstance.get<PublicLayoutResponse>(
+      API_ENDPOINTS.TENANT_SETTINGS.LAYOUT_PUBLIC
+    );
+    return data;
+  },
+
+  /** 활성화된 네비게이션 항목 조회 (TU용) */
+  async getPublicNavigation(): Promise<NavigationItemResponse[]> {
+    const { data } = await axiosInstance.get<NavigationItemResponse[]>(
+      API_ENDPOINTS.TENANT_SETTINGS.NAVIGATION_PUBLIC
     );
     return data;
   },

--- a/src/services/tu/publicBannerService.ts
+++ b/src/services/tu/publicBannerService.ts
@@ -1,0 +1,21 @@
+/**
+ * 공개 배너 API 서비스
+ * 인증 없이 접근 가능한 테넌트 배너 조회
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type { BannerResponse, BannerPosition } from '@/types/ta/banner.types';
+
+export const publicBannerService = {
+  /**
+   * 공개 배너 조회 (인증 불필요)
+   * @param position 배너 위치 필터 (선택)
+   */
+  async getDisplayableBanners(position?: BannerPosition): Promise<BannerResponse[]> {
+    const { data } = await axiosInstance.get<BannerResponse[]>(
+      API_ENDPOINTS.BANNERS.PUBLIC,
+      { params: position ? { position } : undefined }
+    );
+    return data;
+  },
+};

--- a/src/services/tu/publicBrandingService.ts
+++ b/src/services/tu/publicBrandingService.ts
@@ -16,7 +16,7 @@ export const publicBrandingService = {
     type: 'subdomain' | 'customDomain' = 'subdomain'
   ): Promise<PublicBrandingResponse> {
     const { data } = await axiosInstance.get<PublicBrandingResponse>(
-      '/api/public/tenants/branding',
+      '/public/tenants/branding',
       {
         params: { identifier, type },
       }

--- a/src/types/ta/banner.types.ts
+++ b/src/types/ta/banner.types.ts
@@ -1,0 +1,86 @@
+/**
+ * TA 배너 관련 타입 정의
+ */
+
+// 배너 위치 enum
+export type BannerPosition =
+  | 'MAIN_TOP'
+  | 'MAIN_MIDDLE'
+  | 'COURSE_LIST'
+  | 'LEARNING_HOME'
+  | 'LOGIN';
+
+// 링크 타겟
+export type LinkTarget = '_self' | '_blank';
+
+// 배너 응답 (백엔드 BannerResponse와 일치)
+export interface BannerResponse {
+  id: number;
+  title: string;
+  imageUrl: string;
+  linkUrl: string | null;
+  linkTarget: string | null;
+  position: BannerPosition;
+  sortOrder: number | null;
+  isActive: boolean;
+  startDate: string | null;
+  endDate: string | null;
+  description: string | null;
+  isDisplayable: boolean;
+  createdAt: string;
+  updatedAt: string;
+  // UI용 추가 필드 (백엔드에는 없음)
+  mobileImageUrl?: string | null;
+}
+
+// 배너 생성 요청
+export interface CreateBannerRequest {
+  title: string;
+  imageUrl: string;
+  position: BannerPosition;
+  linkUrl?: string | null;
+  linkTarget?: string | null;
+  sortOrder?: number | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  description?: string | null;
+}
+
+// 배너 수정 요청
+export interface UpdateBannerRequest {
+  title?: string;
+  imageUrl?: string;
+  linkUrl?: string | null;
+  linkTarget?: string | null;
+  position?: BannerPosition;
+  sortOrder?: number | null;
+  isActive?: boolean;
+  startDate?: string | null;
+  endDate?: string | null;
+  description?: string | null;
+}
+
+// 배너 목록 조회 파라미터
+export interface BannerListParams {
+  position?: BannerPosition;
+  isActive?: boolean;
+}
+
+// 공개 배너 조회 파라미터
+export interface PublicBannerParams {
+  position?: BannerPosition;
+}
+
+/**
+ * 요청 객체에서 undefined 값 제거
+ * JSON.stringify는 undefined를 무시하지만, 명시적으로 제거하는 것이 안전
+ */
+export function cleanRequest<T extends Record<string, unknown>>(obj: T): Partial<T> {
+  const cleaned: Partial<T> = {};
+  for (const key in obj) {
+    if (obj[key] !== undefined) {
+      cleaned[key] = obj[key];
+    }
+  }
+  return cleaned;
+}

--- a/src/types/tu/branding.types.ts
+++ b/src/types/tu/branding.types.ts
@@ -12,3 +12,75 @@ export interface PublicBrandingResponse {
   headingFont: string | null;
   bodyFont: string | null;
 }
+
+/**
+ * 네비게이션 아이템 타입
+ */
+export interface NavigationItemResponse {
+  id: number;
+  label: string;
+  icon: string;
+  path: string;
+  enabled: boolean;
+  displayOrder: number;
+  target: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * 헤더 설정 타입
+ */
+export interface HeaderSettings {
+  style?: 'fixed' | 'sticky' | 'static';
+  height?: 'compact' | 'default' | 'large';
+  showLogo?: boolean;
+  showSearch?: boolean;
+  showNotifications?: boolean;
+  backgroundOpacity?: number;
+  navigationPosition?: 'left' | 'center' | 'right';
+  userMenuStyle?: 'dropdown' | 'drawer';
+  showShadow?: boolean;
+  mobileMenuStyle?: 'drawer' | 'fullscreen';
+}
+
+/**
+ * 푸터 설정 타입
+ */
+export interface FooterSettings {
+  enabled?: boolean;
+  showLinks?: boolean;
+  showCopyright?: boolean;
+  showSocialLinks?: boolean;
+  socialLinks?: {
+    facebook?: string;
+    twitter?: string;
+    instagram?: string;
+    youtube?: string;
+    linkedin?: string;
+  };
+  companyInfoFields?: string[];
+  showNewsletter?: boolean;
+}
+
+/**
+ * 콘텐츠 설정 타입
+ */
+export interface ContentSettings {
+  maxWidth?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'full';
+  padding?: 'none' | 'compact' | 'normal' | 'relaxed';
+  pageTransition?: 'none' | 'fade' | 'slide';
+  cardStyle?: 'flat' | 'bordered' | 'elevated';
+  tableStyle?: 'simple' | 'striped' | 'bordered';
+  buttonStyle?: 'square' | 'rounded' | 'pill';
+}
+
+/**
+ * 공개 레이아웃 정보 타입 (TU용)
+ */
+export interface PublicLayoutResponse {
+  headerSettings: HeaderSettings | null;
+  footerSettings: FooterSettings | null;
+  contentSettings: ContentSettings | null;
+  navigationItems: NavigationItemResponse[];
+}

--- a/src/utils/tenantUtils.ts
+++ b/src/utils/tenantUtils.ts
@@ -4,6 +4,7 @@
  * 도메인 구조:
  * - Subdomain: {subdomain}.mzclearn.com
  * - Custom Domain: company.com
+ * - Path-based (개발): localhost:3000/{subdomain}/tu/*
  */
 
 export interface TenantIdentifier {
@@ -12,18 +13,50 @@ export interface TenantIdentifier {
 }
 
 /**
- * 현재 호스트네임에서 테넌트 식별자 추출
+ * URL 경로에서 서브도메인 추출 (개발 환경용)
+ * 경로 패턴: /{subdomain}/tu/* 또는 /{subdomain}/ta/*
+ *
+ * @example
+ * /mzc/tu/b2c/courses → 'mzc'
+ * /samsung/ta/dashboard → 'samsung'
+ */
+export function extractSubdomainFromPath(): string | null {
+  const pathname = window.location.pathname;
+
+  // 경로 기반 서브도메인 패턴: /{subdomain}/(tu|ta|to)/...
+  const regex = /^\/([^/]+)\/(tu|ta|to)(\/|$)/;
+  const match = regex.exec(pathname);
+  const subdomain = match?.[1];
+
+  if (subdomain) {
+    // 시스템 경로는 제외
+    if (['admin', 'sa', 'auth', 'public'].includes(subdomain)) {
+      return null;
+    }
+    return subdomain;
+  }
+
+  return null;
+}
+
+/**
+ * 현재 호스트네임 또는 경로에서 테넌트 식별자 추출
  *
  * 예시:
  * - samsung.mzclearn.com → { type: 'subdomain', identifier: 'samsung' }
  * - company.com → { type: 'customDomain', identifier: 'company.com' }
+ * - localhost:3000/mzc/tu/b2c → { type: 'subdomain', identifier: 'mzc' } (경로 기반)
  * - localhost:3000 → null (개발 환경, 기본 테넌트)
  */
 export function extractTenantIdentifier(): TenantIdentifier | null {
   const hostname = window.location.hostname;
 
-  // 로컬 개발 환경
+  // 로컬 개발 환경 - 경로 기반 서브도메인 확인
   if (hostname === 'localhost' || hostname === '127.0.0.1') {
+    const pathSubdomain = extractSubdomainFromPath();
+    if (pathSubdomain) {
+      return { type: 'subdomain', identifier: pathSubdomain };
+    }
     return null; // 기본 브랜딩 사용
   }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
         target: 'http://localhost:8080',
         changeOrigin: true,
       },
+      '/uploads': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

TA(Tenant Admin)에서 설정한 브랜딩 관리 항목들(레이아웃, 네비게이션, 푸터, 배너)을 TU(Tenant User) 랜딩 페이지에 동적으로 적용했습니다.

## Related Issue

- Closes #311

## Changes

- `branding.types.ts`에 `PublicLayoutResponse`, `NavigationItemResponse`, `FooterSettings` 등 타입 정의 추가
- `usePublicLayout`, `usePublicNavigation` 커스텀 훅 구현 (React Query 기반, 30분 캐싱)
- `LandingHeader` 컴포넌트에 동적 네비게이션 메뉴 적용 (내부/외부 링크 지원)
- `LandingFooter` 컴포넌트에 동적 소셜 링크 및 저작권 표시 적용
- `LandingBannerCarousel` 컴포넌트 추가 (배너 관리 기능)
- 배너 관리 API 서비스 및 훅 추가 (`useBannerQueries`, `usePublicBannerQueries`)
- Vite 설정에 `/uploads` 프록시 추가 (이미지 업로드 지원)
- `tenantSettingsService`에 공개 레이아웃/네비게이션 API 메서드 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

<!-- 배포 후 TA에서 네비게이션/푸터/배너 설정 시 TU 랜딩 페이지에 실시간 반영되는 스크린샷 추가 예정 -->

## Additional Notes

- 백엔드 PR과 함께 배포되어야 정상 작동합니다
- 네비게이션 메뉴는 TA 설정값이 없으면 기본 메뉴(강의 탐색, 로드맵, 커뮤니티) 표시
- 푸터 설정에서 `enabled: false` 시 푸터 전체가 숨겨집니다
- 배너는 표시 기간(`displayStartDate`, `displayEndDate`) 및 우선순위(`priority`)에 따라 자동 관리
