### PR TITLE
[Fix] Course Create/Edit 페이지 임시저장 시 회차/콘텐츠 저장 및 복원

### DIFF
--- a/src/pages/tu/teaching/courses/CourseCreatePage.tsx
+++ b/src/pages/tu/teaching/courses/CourseCreatePage.tsx
@@ -16,7 +16,7 @@ import { courseService, categoryService } from '@/services/common';
 import type { CourseFormData } from '@/types';
 import type { CategoryResponse, CreateCourseRequest } from '@/types/common';
 import type { CurriculumItem } from '@/types/tu';
-import { isCurriculumFolder, isCurriculumContent } from '@/types/tu';
+import { isCurriculumFolder, isCurriculumContent, convertHierarchyToCurriculumItems } from '@/types/tu';
 import { Step1BasicInfo, Step3Review, translations } from './components';
 import { Step2CurriculumTree } from './components/Step2CurriculumTree';
 import type { TranslationKey } from './components';
@@ -58,6 +58,17 @@ async function createCurriculumItemsRecursively(
         description: item.description || undefined,
       });
     }
+  }
+}
+
+/**
+ * 기존 회차/콘텐츠를 모두 삭제
+ * 루트 레벨 항목만 삭제 (하위 항목은 cascade 삭제됨)
+ */
+async function deleteAllCurriculumItems(courseId: number): Promise<void> {
+  const hierarchy = await courseService.getItemsHierarchy(courseId);
+  for (const item of hierarchy) {
+    await courseService.deleteItem(courseId, item.itemId);
   }
 }
 
@@ -117,7 +128,15 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
 
       setIsLoading(true);
       try {
-        const course = await courseService.getCourse(courseId);
+        // 기본 정보와 회차 계층구조를 병렬로 조회
+        const [course, hierarchyData] = await Promise.all([
+          courseService.getCourse(courseId),
+          courseService.getItemsHierarchy(courseId),
+        ]);
+
+        // 회차 계층구조를 CurriculumItem 형태로 변환
+        const curriculumItems = convertHierarchyToCurriculumItems(hierarchyData);
+
         setFormData((prev) => ({
           ...prev,
           title: course.title,
@@ -129,6 +148,7 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
           startDate: course.startDate || '',
           endDate: course.endDate || '',
           tags: course.tags || [],
+          curriculumItems,
           isDraft: !course.isComplete,
           lastSaved: course.updatedAt,
         }));
@@ -169,22 +189,49 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
         tags: formData.tags.length > 0 ? formData.tags : undefined,
       };
 
+      let targetCourseId = courseId;
+
       if (courseId) {
         // 기존 강의 수정
         await courseService.update(courseId, request);
+
+        // 기존 회차/콘텐츠 삭제 후 재생성
+        if (formData.curriculumItems.length > 0) {
+          await deleteAllCurriculumItems(courseId);
+          await createCurriculumItemsRecursively(courseId, formData.curriculumItems, null);
+        }
       } else {
         // 새 강의 생성
         const response = await courseService.create(request);
+        targetCourseId = response.courseId;
         setCourseId(response.courseId);
         // URL 업데이트 (뒤로가기 시에도 courseId 유지)
         navigate(`/tu/teaching/courses/create?courseId=${response.courseId}`, { replace: true });
+
+        // 회차/콘텐츠 생성
+        if (formData.curriculumItems.length > 0) {
+          await createCurriculumItemsRecursively(response.courseId, formData.curriculumItems, null);
+        }
       }
 
-      setFormData((prev) => ({
-        ...prev,
-        isDraft: true,
-        lastSaved: new Date().toISOString(),
-      }));
+      // 저장 후 최신 회차 계층구조 다시 로드하여 ID 동기화
+      if (targetCourseId) {
+        const hierarchyData = await courseService.getItemsHierarchy(targetCourseId);
+        const curriculumItems = convertHierarchyToCurriculumItems(hierarchyData);
+        setFormData((prev) => ({
+          ...prev,
+          curriculumItems,
+          isDraft: true,
+          lastSaved: new Date().toISOString(),
+        }));
+      } else {
+        setFormData((prev) => ({
+          ...prev,
+          isDraft: true,
+          lastSaved: new Date().toISOString(),
+        }));
+      }
+
       alert('저장되었습니다.');
     } catch (error) {
       console.error('저장 실패:', error);

--- a/src/pages/tu/teaching/courses/CourseEditPage.tsx
+++ b/src/pages/tu/teaching/courses/CourseEditPage.tsx
@@ -12,15 +12,60 @@ import { cn } from '@/utils/cn';
 import { Button } from '@/components/common';
 import { categoryService } from '@/services/common';
 import { useCourse, useCourseItemsHierarchy, useUpdateCourse } from '@/hooks/tu/useCourseQueries';
+import { courseService } from '@/services/common';
 import type { CourseFormData } from '@/types';
 import type { CategoryResponse, UpdateCourseRequest } from '@/types/common';
-import { convertHierarchyToCurriculumItems } from '@/types/tu/curriculum.types';
+import type { CurriculumItem } from '@/types/tu';
+import { convertHierarchyToCurriculumItems, isCurriculumFolder, isCurriculumContent } from '@/types/tu/curriculum.types';
 import { Step1BasicInfo, Step3Review, translations } from './components';
 import { Step2CurriculumTree } from './components/Step2CurriculumTree';
 import type { TranslationKey } from './components';
 
 interface CourseEditPageProps {
   language?: 'ko' | 'en';
+}
+
+/**
+ * 커리큘럼 트리를 재귀적으로 순회하며 API 호출
+ */
+async function createCurriculumItemsRecursively(
+  courseId: number,
+  items: CurriculumItem[],
+  parentId: number | null
+): Promise<void> {
+  for (const item of items) {
+    if (isCurriculumFolder(item)) {
+      const folderResponse = await courseService.createFolder(courseId, {
+        folderName: item.name,
+        parentId: parentId ?? undefined,
+      });
+      if (item.children.length > 0) {
+        await createCurriculumItemsRecursively(
+          courseId,
+          item.children,
+          folderResponse.itemId
+        );
+      }
+    } else if (isCurriculumContent(item)) {
+      await courseService.createItem(courseId, {
+        itemName: item.name,
+        parentId: parentId ?? undefined,
+        contentId: item.contentId,
+        displayName: item.displayName || undefined,
+        description: item.description || undefined,
+      });
+    }
+  }
+}
+
+/**
+ * 기존 회차/콘텐츠를 모두 삭제
+ */
+async function deleteAllCurriculumItems(courseId: number): Promise<void> {
+  const hierarchy = await courseService.getItemsHierarchy(courseId);
+  for (const item of hierarchy) {
+    await courseService.deleteItem(courseId, item.itemId);
+  }
 }
 
 export function CourseEditPage({ language = 'ko' }: Readonly<CourseEditPageProps>) {
@@ -102,9 +147,55 @@ export function CourseEditPage({ language = 'ko' }: Readonly<CourseEditPageProps
   const handleGoToStep = (step: number) => setCurrentStep(step);
   const handleClose = () => navigate('/tu/teaching/courses');
 
-  const handleSaveDraft = () => {
-    setFormData({ ...formData, isDraft: true, lastSaved: new Date().toISOString() });
-    alert('임시저장되었습니다.');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSaveDraft = async () => {
+    if (!formData.title) {
+      alert('강의명을 입력해주세요.');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const request: UpdateCourseRequest = {
+        title: formData.title,
+        description: formData.description || undefined,
+        thumbnailUrl: formData.thumbnailUrl || undefined,
+        level: formData.level || undefined,
+        type: formData.type || undefined,
+        categoryId: formData.categoryId ?? undefined,
+        startDate: formData.startDate || undefined,
+        endDate: formData.endDate || undefined,
+        tags: formData.tags.length > 0 ? formData.tags : undefined,
+      };
+
+      // 기본 정보 업데이트
+      await courseService.update(courseIdNum, request);
+
+      // 기존 회차/콘텐츠 삭제 후 재생성
+      if (formData.curriculumItems.length > 0) {
+        await deleteAllCurriculumItems(courseIdNum);
+        await createCurriculumItemsRecursively(courseIdNum, formData.curriculumItems, null);
+      }
+
+      // 저장 후 최신 회차 계층구조 다시 로드하여 ID 동기화
+      const hierarchyData = await courseService.getItemsHierarchy(courseIdNum);
+      const curriculumItems = convertHierarchyToCurriculumItems(hierarchyData);
+
+      setFormData((prev) => ({
+        ...prev,
+        curriculumItems,
+        isDraft: true,
+        lastSaved: new Date().toISOString(),
+      }));
+
+      alert('임시저장되었습니다.');
+    } catch (error) {
+      console.error('저장 실패:', error);
+      alert('저장에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const handleSubmit = async () => {
@@ -262,9 +353,14 @@ export function CourseEditPage({ language = 'ko' }: Readonly<CourseEditPageProps
                 {getText('previous')}
               </Button>
             )}
-            <Button variant="ghost" onClick={handleSaveDraft} className="border border-border">
-              <Save size={18} />
-              {getText('saveDraft')}
+            <Button
+              variant="ghost"
+              onClick={handleSaveDraft}
+              disabled={isSaving}
+              className="border border-border"
+            >
+              {isSaving ? <Loader2 size={18} className="animate-spin" /> : <Save size={18} />}
+              {isSaving ? '저장 중...' : getText('saveDraft')}
             </Button>
           </div>
 

--- a/src/types/tu/index.ts
+++ b/src/types/tu/index.ts
@@ -208,6 +208,7 @@ export {
   createContentItem,
   findItemInTree,
   findParentInTree,
+  convertHierarchyToCurriculumItems,
 } from './curriculum.types';
 
 // CourseTime Catalog (학습자용 차수 카탈로그)


### PR DESCRIPTION
## Summary

- CourseCreatePage: 임시저장 시 회차/콘텐츠도 함께 저장하도록 수정
- CourseCreatePage: 데이터 로드 시 회차 계층구조 조회 추가 (기존 강의 재방문 시 회차/콘텐츠 복원)
- CourseEditPage: 임시저장 시 실제 백엔드 저장 구현 (기존에는 로컬 상태만 업데이트)
- types/tu/index.ts: `convertHierarchyToCurriculumItems` export 추가

## 변경 내용

### CourseCreatePage
- `loadExistingCourse()`: 기본 정보와 함께 회차 계층구조도 병렬로 조회
- `handleSaveDraft()`: 임시저장 시 회차/콘텐츠 저장 로직 추가
  - 새 강의: 기본 정보 생성 후 회차/콘텐츠 생성
  - 기존 강의: 기본 정보 업데이트 + 기존 회차 삭제 후 재생성
  - 저장 후 최신 계층구조 다시 로드하여 ID 동기화

### CourseEditPage
- `handleSaveDraft()`: 로컬 상태만 업데이트 → 실제 백엔드 저장으로 변경
- 저장 버튼에 로딩 상태 표시 추가

## Test plan

- [ ] CourseCreatePage에서 회차/콘텐츠 추가 후 임시저장 → 저장 확인
- [ ] CourseCreatePage에서 임시저장 후 페이지 새로고침 → 회차/콘텐츠 복원 확인
- [ ] CourseEditPage에서 회차/콘텐츠 수정 후 임시저장 → 저장 확인
- [ ] CourseEditPage에서 임시저장 후 페이지 새로고침 → 변경사항 유지 확인

Closes #319