### PR TITLE
[UI] MyCoursesPage 버튼 배치 및 문구 개선

### DIFF
--- a/src/components/domain/tu/course/CourseCard.tsx
+++ b/src/components/domain/tu/course/CourseCard.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Clock, Pencil } from 'lucide-react';
 import { Button, CategoryBadge } from '@/components/common';
@@ -17,6 +18,9 @@ interface CourseCardProps {
   labels: CourseCardLabels;
   onManage?: () => void;
   onEdit?: () => void;
+  hideActions?: boolean;
+  /** 커스텀 액션 버튼 영역 (hideActions와 함께 사용) */
+  renderActions?: ReactNode;
 }
 
 /**
@@ -25,7 +29,7 @@ interface CourseCardProps {
  * - 콘텐츠 완성도 진행 바
  * - 마지막 접근 시간, 관리/수정 버튼
  */
-export const CourseCard = ({ course, labels, onManage, onEdit }: Readonly<CourseCardProps>) => {
+export const CourseCard = ({ course, labels, onManage, onEdit, hideActions = false, renderActions }: Readonly<CourseCardProps>) => {
   const navigate = useNavigate();
   const { prefixPath } = useSubdomainPath();
 
@@ -87,16 +91,22 @@ export const CourseCard = ({ course, labels, onManage, onEdit }: Readonly<Course
         </div>
 
         {/* Action Buttons */}
-        <div className="flex gap-2 mt-4">
-          <Button className="flex-1" onClick={handleManage}>
-            {labels.manageCourse}
-          </Button>
-          {labels.editCourse && (
-            <Button variant="ghost" className="border border-border" onClick={handleEdit}>
-              <Pencil size={16} />
-            </Button>
-          )}
-        </div>
+        {renderActions ? (
+          <div className="flex gap-2 mt-4">{renderActions}</div>
+        ) : (
+          !hideActions && (
+            <div className="flex gap-2 mt-4">
+              <Button className="flex-1" onClick={handleManage}>
+                {labels.manageCourse}
+              </Button>
+              {labels.editCourse && (
+                <Button variant="ghost" className="border border-border" onClick={handleEdit}>
+                  <Pencil size={16} />
+                </Button>
+              )}
+            </div>
+          )
+        )}
       </div>
     </div>
   );

--- a/src/pages/tu/teaching/courses/MyCoursesPage.tsx
+++ b/src/pages/tu/teaching/courses/MyCoursesPage.tsx
@@ -54,9 +54,9 @@ const t = {
   lessons: { ko: '차시', en: 'Lessons' },
   manageCourse: { ko: '과정 관리', en: 'Manage Course' },
   editCourse: { ko: '수정', en: 'Edit' },
-  noCourses: { ko: '개설한 과정이 없습니다', en: 'No courses created yet' },
-  noCoursesDesc: { ko: '새로운 과정을 개설하여 학생들과 지식을 공유하세요', en: 'Create a new course to share knowledge with students' },
-  createNewCourse: { ko: '과정 개설하기', en: 'Create Course' },
+  noCourses: { ko: '작성한 강의 계획서가 없습니다', en: 'No course plans yet' },
+  noCoursesDesc: { ko: '새로운 강의 계획서를 설계하여 학습 여정을 구성하세요', en: 'Design a new course plan to structure the learning journey' },
+  createNewCourse: { ko: '강의 계획서 만들기', en: 'Create Course Plan' },
   loading: { ko: '강의 목록을 불러오는 중...', en: 'Loading courses...' },
   error: { ko: '강의 목록을 불러오는데 실패했습니다', en: 'Failed to load courses' },
   retry: { ko: '다시 시도', en: 'Retry' },
@@ -292,9 +292,6 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
       {/* Course Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {sortedCourses.map((course) => {
-          const courseResponse = courseResponses.find(
-            (r) => String(r.courseId) === course.id
-          );
           const isSelected = selectedCourseIds.has(course.id);
 
           return (
@@ -333,24 +330,27 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
                     lessons: getText('lessons'),
                     manageCourse: getText('manageCourse'),
                   }}
-                />
-              </div>
-
-              {/* Action Buttons */}
-              {courseResponse && (
-                <div className="mt-2 flex gap-2">
-                  {course.isComplete ? (
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="flex-1 border border-border"
-                      onClick={() => navigate(`/tu/teaching/courses/${course.id}/apply`)}
-                    >
-                      <Send size={14} />
-                      {getText('applyProgram')}
-                    </Button>
-                  ) : (
-                    <>
+                  renderActions={
+                    course.isComplete ? (
+                      <>
+                        <Button
+                          size="sm"
+                          className="flex-1"
+                          onClick={() => navigate(`/tu/teaching/courses/${course.id}`)}
+                        >
+                          {getText('manageCourse')}
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="flex-1 border border-border"
+                          onClick={() => navigate(`/tu/teaching/courses/${course.id}/apply`)}
+                        >
+                          <Send size={14} />
+                          {getText('applyProgram')}
+                        </Button>
+                      </>
+                    ) : (
                       <Button
                         size="sm"
                         variant="ghost"
@@ -360,19 +360,10 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
                         <Edit size={14} />
                         {getText('continueEditing')}
                       </Button>
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        className="border border-border opacity-50 cursor-not-allowed"
-                        disabled
-                        title={getText('incompleteWarning')}
-                      >
-                        <Send size={14} />
-                      </Button>
-                    </>
-                  )}
-                </div>
-              )}
+                    )
+                  }
+                />
+              </div>
             </div>
           );
         })}


### PR DESCRIPTION
## Summary

- 빈 상태 문구를 "강의 계획서" 컨셉에 맞게 수정
- 버튼을 카드 내부로 이동하여 시각적 통일성 확보
- 상태별 버튼 분기: 미완성(이어서 작성), 완성(과정 관리 + 프로그램 신청)
- CourseCard에 `renderActions` prop 추가

## Test plan

- [ ] 강의 계획서가 없을 때 빈 상태 문구 확인
- [ ] 미완성 카드에서 "이어서 작성" 버튼만 표시되는지 확인
- [ ] 완성 카드에서 "과정 관리" + "프로그램 신청" 버튼 표시 확인
- [ ] 버튼이 카드 내부(회색 둥근사각형)에 위치하는지 확인

Closes #325