### PR TITLE
feat: 로드맵 파괴적 수정 제한 UX 구현 #324

### DIFF
--- a/src/pages/tu/teaching/roadmaps/RoadmapCreatePage.tsx
+++ b/src/pages/tu/teaching/roadmaps/RoadmapCreatePage.tsx
@@ -102,7 +102,8 @@ export function RoadmapCreatePage({ language = 'ko' }: Readonly<{ language?: 'ko
     if (roadmapData && isEditMode) {
       setTitle(roadmapData.title);
       setDescription(roadmapData.description || '');
-      setOriginalStatus(roadmapData.status);
+      // 백엔드에서 소문자로 응답하므로 대문자로 정규화
+      setOriginalStatus(roadmapData.status.toUpperCase() as 'PUBLISHED' | 'DRAFT');
       setEnrolledStudents(roadmapData.enrolledStudents);
 
       const programIds = roadmapData.programs.map((p) => p.id);

--- a/src/pages/tu/teaching/roadmaps/RoadmapCreatePage.tsx
+++ b/src/pages/tu/teaching/roadmaps/RoadmapCreatePage.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { ArrowLeft, Plus, GripVertical, X, Search, Loader2 } from 'lucide-react';
+import { ArrowLeft, Plus, GripVertical, X, Search, Loader2, AlertTriangle } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button, Card, CardContent, CardHeader, CardTitle, Input, Textarea, Badge } from '@/components/common';
 import {
@@ -10,6 +10,11 @@ import {
   useRoadmap,
   useMyPrograms,
 } from '@/hooks/tu';
+import {
+  isDestructiveUpdate,
+  isDestructiveUpdateRestricted,
+  analyzeProgramChanges,
+} from '@/utils/roadmapUtils';
 
 const t = {
   createRoadmap: { ko: '로드맵 생성', en: 'Create Roadmap' },
@@ -45,6 +50,18 @@ const t = {
   titleRequired: { ko: '제목을 입력해주세요', en: 'Please enter a title' },
   coursesRequired: { ko: '최소 1개 이상의 강의를 추가해주세요', en: 'Please add at least one course' },
   noAvailableCourses: { ko: '추가 가능한 강의가 없습니다', en: 'No available courses' },
+  destructiveUpdateWarning: {
+    ko: '수강생이 있는 공개된 로드맵은 프로그램 삭제 또는 순서 변경이 불가능합니다',
+    en: 'Cannot delete or reorder programs in published roadmap with enrollments',
+  },
+  cannotDeleteRestricted: {
+    ko: '수강생이 있어 삭제할 수 없습니다',
+    en: 'Cannot delete (has enrollments)',
+  },
+  cannotReorderRestricted: {
+    ko: '수강생이 있어 순서 변경이 불가능합니다',
+    en: 'Cannot reorder (has enrollments)',
+  },
 };
 
 interface SelectedProgram {
@@ -64,6 +81,8 @@ export function RoadmapCreatePage({ language = 'ko' }: Readonly<{ language?: 'ko
   const [selectedPrograms, setSelectedPrograms] = useState<SelectedProgram[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [originalStatus, setOriginalStatus] = useState<'PUBLISHED' | 'DRAFT' | null>(null);
+  const [originalProgramIds, setOriginalProgramIds] = useState<number[]>([]);
+  const [enrolledStudents, setEnrolledStudents] = useState(0);
 
   const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
 
@@ -84,6 +103,10 @@ export function RoadmapCreatePage({ language = 'ko' }: Readonly<{ language?: 'ko
       setTitle(roadmapData.title);
       setDescription(roadmapData.description || '');
       setOriginalStatus(roadmapData.status);
+      setEnrolledStudents(roadmapData.enrolledStudents);
+
+      const programIds = roadmapData.programs.map((p) => p.id);
+      setOriginalProgramIds(programIds);
       setSelectedPrograms(
         roadmapData.programs.map((p) => ({
           id: p.id,
@@ -121,6 +144,29 @@ export function RoadmapCreatePage({ language = 'ko' }: Readonly<{ language?: 'ko
     setSelectedPrograms(selectedPrograms.filter((p) => p.id !== programId));
   };
 
+  // 파괴적 업데이트 검증
+  const destructiveValidation = useMemo(() => {
+    if (!isEditMode || !originalStatus) {
+      return {
+        isRestricted: false,
+        isDestructive: false,
+        changes: { added: [], removed: [], reordered: false },
+      };
+    }
+
+    const currentIds = selectedPrograms.map((p) => p.id);
+    const isRestricted = isDestructiveUpdateRestricted(originalStatus, enrolledStudents);
+    const isDestructive = isDestructiveUpdate(originalProgramIds, currentIds);
+    const changes = analyzeProgramChanges(originalProgramIds, currentIds);
+
+    return {
+      isRestricted,
+      isDestructive,
+      changes,
+      shouldBlock: isRestricted && isDestructive,
+    };
+  }, [isEditMode, originalStatus, enrolledStudents, originalProgramIds, selectedPrograms]);
+
   const handleSave = async (isDraft: boolean) => {
     // 유효성 검사
     if (!title.trim()) {
@@ -130,6 +176,12 @@ export function RoadmapCreatePage({ language = 'ko' }: Readonly<{ language?: 'ko
 
     if (!isDraft && selectedPrograms.length === 0) {
       toast.error(getText('coursesRequired'));
+      return;
+    }
+
+    // 파괴적 업데이트 사전 검증 (PUBLISHED 상태로 저장 시도 시만 검증)
+    if (!isDraft && destructiveValidation.shouldBlock) {
+      toast.error(getText('destructiveUpdateWarning'));
       return;
     }
 
@@ -168,6 +220,13 @@ export function RoadmapCreatePage({ language = 'ko' }: Readonly<{ language?: 'ko
       // mutation의 onSuccess가 완료된 후 페이지 이동
       navigate('/tu/teaching/roadmaps');
     } catch (error: any) {
+      // RM007 에러 처리 (파괴적 업데이트 차단)
+      if (error?.response?.data?.code === 'RM007') {
+        toast.error(getText('destructiveUpdateWarning'));
+        return;
+      }
+
+      // 일반 에러 처리
       if (isDraft) {
         toast.error(getText('draftError'));
       } else if (isEditMode) {
@@ -324,6 +383,35 @@ export function RoadmapCreatePage({ language = 'ko' }: Readonly<{ language?: 'ko
         </Card>
       </div>
 
+      {/* Destructive Update Warning */}
+      {destructiveValidation.shouldBlock && (
+        <Card className="mt-6 border-status-error bg-status-error/5">
+          <CardContent className="p-4">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="text-status-error shrink-0 mt-0.5" size={20} />
+              <div>
+                <p className="font-medium text-text-primary m-0 mb-1">
+                  {getText('destructiveUpdateWarning')}
+                </p>
+                <p className="text-sm text-text-secondary m-0">
+                  현재 수강생: {enrolledStudents}명
+                </p>
+                {destructiveValidation.changes.removed.length > 0 && (
+                  <p className="text-sm text-text-secondary m-0 mt-1">
+                    • {destructiveValidation.changes.removed.length}개 프로그램 삭제 감지
+                  </p>
+                )}
+                {destructiveValidation.changes.reordered && (
+                  <p className="text-sm text-text-secondary m-0 mt-1">
+                    • 프로그램 순서 변경 감지
+                  </p>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Action Buttons */}
       <div className="flex justify-end gap-3 mt-8">
         <Button variant="outline" onClick={() => navigate('/tu/teaching/roadmaps')} disabled={isSaving}>
@@ -344,7 +432,7 @@ export function RoadmapCreatePage({ language = 'ko' }: Readonly<{ language?: 'ko
         </Button>
         <Button
           onClick={() => handleSave(false)}
-          disabled={!title || selectedPrograms.length === 0 || isSaving}
+          disabled={!title || selectedPrograms.length === 0 || isSaving || destructiveValidation.shouldBlock}
         >
           {isSaving && (createMutation.isPending || updateMutation.isPending) && (
             <Loader2 size={16} className="animate-spin mr-2" />

--- a/src/pages/tu/teaching/roadmaps/RoadmapCreatePage.tsx
+++ b/src/pages/tu/teaching/roadmaps/RoadmapCreatePage.tsx
@@ -3,6 +3,23 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { ArrowLeft, Plus, GripVertical, X, Search, Loader2, AlertTriangle, Info, Lock } from 'lucide-react';
 import { toast } from 'sonner';
 import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import {
   Button,
   Card,
   CardContent,
@@ -165,6 +182,29 @@ export function RoadmapCreatePage({ language = 'ko' }: Readonly<{ language?: 'ko
     setSelectedPrograms(selectedPrograms.filter((p) => p.id !== programId));
   };
 
+  // 드래그 앤 드롭 센서 설정
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  // 드래그 종료 핸들러
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      setSelectedPrograms((items) => {
+        const oldIndex = items.findIndex((item) => item.id === active.id);
+        const newIndex = items.findIndex((item) => item.id === over.id);
+        return arrayMove(items, oldIndex, newIndex);
+      });
+    }
+  };
+
   // 파괴적 업데이트 검증
   const destructiveValidation = useMemo(() => {
     if (!isEditMode || !originalStatus) {
@@ -285,10 +325,10 @@ export function RoadmapCreatePage({ language = 'ko' }: Readonly<{ language?: 'ko
 
       {/* 제한 상태 안내 배너 */}
       {destructiveValidation.isRestricted && (
-        <Card className="mb-6 border-status-info bg-status-info/5">
+        <Card className="mb-6 border-primary bg-primary/5">
           <CardContent className="p-4">
             <div className="flex items-start gap-3">
-              <Info className="text-status-info shrink-0 mt-0.5" size={20} />
+              <Info className="text-primary shrink-0 mt-0.5" size={20} />
               <div>
                 <p className="font-medium text-text-primary m-0 mb-1">
                   {getText('restrictedModeInfo')}
@@ -351,66 +391,34 @@ export function RoadmapCreatePage({ language = 'ko' }: Readonly<{ language?: 'ko
                   <p className="text-sm">{getText('noCoursesDesc')}</p>
                 </div>
               ) : (
-                <div className="flex flex-col gap-2">
-                  {selectedPrograms.map((program, index) => {
-                    // 기존 프로그램인지 확인 (삭제/순서변경 제한 대상)
-                    const isOriginalProgram = originalProgramIds.includes(program.id);
-                    const isActionRestricted = destructiveValidation.isRestricted && isOriginalProgram;
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragEnd={handleDragEnd}
+                >
+                  <SortableContext
+                    items={selectedPrograms.map((p) => p.id)}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    <div className="flex flex-col gap-2">
+                      {selectedPrograms.map((program, index) => {
+                        const isOriginalProgram = originalProgramIds.includes(program.id);
+                        const isActionRestricted = destructiveValidation.isRestricted && isOriginalProgram;
 
-                    return (
-                      <div
-                        key={program.id}
-                        className={`flex items-center gap-3 p-3 bg-bg-secondary rounded-lg border ${
-                          isActionRestricted ? 'border-border bg-bg-secondary/50' : 'border-border'
-                        }`}
-                      >
-                        {/* 드래그 핸들 - 제한 상태에서 비활성화 */}
-                        {isActionRestricted ? (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <div className="cursor-not-allowed">
-                                <Lock size={18} className="text-text-disabled" />
-                              </div>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p>{getText('cannotReorderRestricted')}</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        ) : (
-                          <GripVertical size={18} className="text-text-secondary cursor-grab" />
-                        )}
-                        <Badge variant="outline" className="shrink-0">
-                          {getText('step')} {index + 1}
-                        </Badge>
-                        <div className="flex-1 min-w-0">
-                          <p className="font-medium text-text-primary m-0 truncate">{program.title}</p>
-                          <p className="text-sm text-text-secondary m-0">
-                            {program.category} · {program.duration}
-                          </p>
-                        </div>
-                        {/* 삭제 버튼 - 제한 상태에서 비활성화 */}
-                        {isActionRestricted ? (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <div>
-                                <Button variant="ghost" size="icon" disabled>
-                                  <X size={18} className="text-text-disabled" />
-                                </Button>
-                              </div>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p>{getText('cannotDeleteRestricted')}</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        ) : (
-                          <Button variant="ghost" size="icon" onClick={() => removeProgram(program.id)}>
-                            <X size={18} />
-                          </Button>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
+                        return (
+                          <SortableProgramItem
+                            key={program.id}
+                            program={program}
+                            index={index}
+                            isActionRestricted={isActionRestricted}
+                            getText={getText}
+                            onRemove={removeProgram}
+                          />
+                        );
+                      })}
+                    </div>
+                  </SortableContext>
+                </DndContext>
               )}
             </CardContent>
           </Card>
@@ -521,6 +529,117 @@ export function RoadmapCreatePage({ language = 'ko' }: Readonly<{ language?: 'ko
           {getText('publish')}
         </Button>
       </div>
+    </div>
+  );
+}
+
+/** 정렬 가능한 프로그램 아이템 컴포넌트 */
+interface SortableProgramItemProps {
+  program: SelectedProgram;
+  index: number;
+  isActionRestricted: boolean;
+  getText: (key: keyof typeof t) => string;
+  onRemove: (id: number) => void;
+}
+
+function SortableProgramItem({
+  program,
+  index,
+  isActionRestricted,
+  getText,
+  onRemove,
+}: Readonly<SortableProgramItemProps>) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: program.id,
+    disabled: isActionRestricted,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center gap-3 p-3 bg-bg-secondary rounded-lg border ${
+        isActionRestricted ? 'border-border bg-bg-secondary/50' : 'border-border'
+      } ${isDragging ? 'opacity-50 shadow-lg z-50' : ''}`}
+    >
+      {/* 드래그 핸들 - 제한 상태에서 비활성화 */}
+      {isActionRestricted ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div
+              className="cursor-not-allowed"
+              aria-disabled="true"
+              aria-label={getText('cannotReorderRestricted')}
+              role="button"
+            >
+              <Lock size={18} className="text-text-disabled" aria-hidden="true" />
+            </div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{getText('cannotReorderRestricted')}</p>
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        <button
+          {...attributes}
+          {...listeners}
+          className="cursor-grab active:cursor-grabbing touch-none"
+          aria-label="드래그하여 순서 변경"
+        >
+          <GripVertical size={18} className="text-text-secondary" />
+        </button>
+      )}
+      <Badge variant="outline" className="shrink-0">
+        {getText('step')} {index + 1}
+      </Badge>
+      <div className="flex-1 min-w-0">
+        <p className="font-medium text-text-primary m-0 truncate">{program.title}</p>
+        <p className="text-sm text-text-secondary m-0">
+          {program.category} · {program.duration}
+        </p>
+      </div>
+      {/* 삭제 버튼 - 제한 상태에서 비활성화 */}
+      {isActionRestricted ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div>
+              <Button
+                variant="ghost"
+                size="icon"
+                disabled
+                aria-disabled="true"
+                aria-label={getText('cannotDeleteRestricted')}
+              >
+                <X size={18} className="text-text-disabled" aria-hidden="true" />
+              </Button>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{getText('cannotDeleteRestricted')}</p>
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => onRemove(program.id)}
+          aria-label={`${program.title} 삭제`}
+        >
+          <X size={18} aria-hidden="true" />
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/pages/tu/teaching/roadmaps/RoadmapCreatePage.tsx
+++ b/src/pages/tu/teaching/roadmaps/RoadmapCreatePage.tsx
@@ -1,8 +1,20 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { ArrowLeft, Plus, GripVertical, X, Search, Loader2, AlertTriangle } from 'lucide-react';
+import { ArrowLeft, Plus, GripVertical, X, Search, Loader2, AlertTriangle, Info, Lock } from 'lucide-react';
 import { toast } from 'sonner';
-import { Button, Card, CardContent, CardHeader, CardTitle, Input, Textarea, Badge } from '@/components/common';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Textarea,
+  Badge,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/common';
 import {
   useCreateRoadmap,
   useUpdateRoadmap,
@@ -61,6 +73,14 @@ const t = {
   cannotReorderRestricted: {
     ko: '수강생이 있어 순서 변경이 불가능합니다',
     en: 'Cannot reorder (has enrollments)',
+  },
+  restrictedModeInfo: {
+    ko: '수강생이 있는 공개된 로드맵입니다. 기존 프로그램의 삭제 및 순서 변경이 제한됩니다.',
+    en: 'This is a published roadmap with enrollments. Deletion and reordering of existing programs is restricted.',
+  },
+  newProgramsAllowed: {
+    ko: '새로운 프로그램 추가는 가능합니다.',
+    en: 'Adding new programs is allowed.',
   },
 };
 
@@ -263,6 +283,28 @@ export function RoadmapCreatePage({ language = 'ko' }: Readonly<{ language?: 'ko
         </h1>
       </div>
 
+      {/* 제한 상태 안내 배너 */}
+      {destructiveValidation.isRestricted && (
+        <Card className="mb-6 border-status-info bg-status-info/5">
+          <CardContent className="p-4">
+            <div className="flex items-start gap-3">
+              <Info className="text-status-info shrink-0 mt-0.5" size={20} />
+              <div>
+                <p className="font-medium text-text-primary m-0 mb-1">
+                  {getText('restrictedModeInfo')}
+                </p>
+                <p className="text-sm text-text-secondary m-0">
+                  • 현재 수강생: {enrolledStudents}명
+                </p>
+                <p className="text-sm text-text-secondary m-0">
+                  • {getText('newProgramsAllowed')}
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Left Column - Basic Info & Course List */}
         <div className="flex flex-col gap-6">
@@ -310,26 +352,64 @@ export function RoadmapCreatePage({ language = 'ko' }: Readonly<{ language?: 'ko
                 </div>
               ) : (
                 <div className="flex flex-col gap-2">
-                  {selectedPrograms.map((program, index) => (
-                    <div
-                      key={program.id}
-                      className="flex items-center gap-3 p-3 bg-bg-secondary rounded-lg border border-border"
-                    >
-                      <GripVertical size={18} className="text-text-secondary cursor-grab" />
-                      <Badge variant="outline" className="shrink-0">
-                        {getText('step')} {index + 1}
-                      </Badge>
-                      <div className="flex-1 min-w-0">
-                        <p className="font-medium text-text-primary m-0 truncate">{program.title}</p>
-                        <p className="text-sm text-text-secondary m-0">
-                          {program.category} · {program.duration}
-                        </p>
+                  {selectedPrograms.map((program, index) => {
+                    // 기존 프로그램인지 확인 (삭제/순서변경 제한 대상)
+                    const isOriginalProgram = originalProgramIds.includes(program.id);
+                    const isActionRestricted = destructiveValidation.isRestricted && isOriginalProgram;
+
+                    return (
+                      <div
+                        key={program.id}
+                        className={`flex items-center gap-3 p-3 bg-bg-secondary rounded-lg border ${
+                          isActionRestricted ? 'border-border bg-bg-secondary/50' : 'border-border'
+                        }`}
+                      >
+                        {/* 드래그 핸들 - 제한 상태에서 비활성화 */}
+                        {isActionRestricted ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <div className="cursor-not-allowed">
+                                <Lock size={18} className="text-text-disabled" />
+                              </div>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>{getText('cannotReorderRestricted')}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <GripVertical size={18} className="text-text-secondary cursor-grab" />
+                        )}
+                        <Badge variant="outline" className="shrink-0">
+                          {getText('step')} {index + 1}
+                        </Badge>
+                        <div className="flex-1 min-w-0">
+                          <p className="font-medium text-text-primary m-0 truncate">{program.title}</p>
+                          <p className="text-sm text-text-secondary m-0">
+                            {program.category} · {program.duration}
+                          </p>
+                        </div>
+                        {/* 삭제 버튼 - 제한 상태에서 비활성화 */}
+                        {isActionRestricted ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <div>
+                                <Button variant="ghost" size="icon" disabled>
+                                  <X size={18} className="text-text-disabled" />
+                                </Button>
+                              </div>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>{getText('cannotDeleteRestricted')}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <Button variant="ghost" size="icon" onClick={() => removeProgram(program.id)}>
+                            <X size={18} />
+                          </Button>
+                        )}
                       </div>
-                      <Button variant="ghost" size="icon" onClick={() => removeProgram(program.id)}>
-                        <X size={18} />
-                      </Button>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               )}
             </CardContent>

--- a/src/pages/tu/teaching/roadmaps/RoadmapListPage.tsx
+++ b/src/pages/tu/teaching/roadmaps/RoadmapListPage.tsx
@@ -187,7 +187,7 @@ export function RoadmapListPage({ language = 'ko' }: Readonly<{ language?: 'ko' 
                   <div className="flex-1">
                     <div className="flex items-center gap-3 mb-2">
                       <h3 className="text-lg font-semibold text-text-primary m-0">{roadmap.title}</h3>
-                      <Badge variant={roadmap.status.toUpperCase() === 'PUBLISHED' ? 'default' : 'secondary'}>
+                      <Badge variant={roadmap.status.toUpperCase() === 'PUBLISHED' ? 'success' : 'warning'}>
                         {roadmap.status.toUpperCase() === 'PUBLISHED' ? getText('published') : getText('draft')}
                       </Badge>
                     </div>

--- a/src/pages/tu/teaching/roadmaps/RoadmapListPage.tsx
+++ b/src/pages/tu/teaching/roadmaps/RoadmapListPage.tsx
@@ -187,8 +187,8 @@ export function RoadmapListPage({ language = 'ko' }: Readonly<{ language?: 'ko' 
                   <div className="flex-1">
                     <div className="flex items-center gap-3 mb-2">
                       <h3 className="text-lg font-semibold text-text-primary m-0">{roadmap.title}</h3>
-                      <Badge variant={roadmap.status === 'PUBLISHED' ? 'default' : 'secondary'}>
-                        {roadmap.status === 'PUBLISHED' ? getText('published') : getText('draft')}
+                      <Badge variant={roadmap.status.toUpperCase() === 'PUBLISHED' ? 'default' : 'secondary'}>
+                        {roadmap.status.toUpperCase() === 'PUBLISHED' ? getText('published') : getText('draft')}
                       </Badge>
                     </div>
                     <p className="text-text-secondary text-sm mb-3 m-0">{roadmap.description}</p>

--- a/src/utils/roadmapUtils.ts
+++ b/src/utils/roadmapUtils.ts
@@ -1,0 +1,100 @@
+/**
+ * 로드맵 관련 유틸리티 함수
+ */
+
+/**
+ * 로드맵 업데이트가 파괴적인지 검사
+ *
+ * Safe 업데이트: 메타데이터 변경, 프로그램 추가 (기존 순서 유지)
+ * Destructive 업데이트: 프로그램 삭제, 순서 변경
+ *
+ * @param currentProgramIds - 현재 프로그램 ID 배열
+ * @param newProgramIds - 새로운 프로그램 ID 배열
+ * @returns 파괴적 업데이트 여부
+ *
+ * @example
+ * // 프로그램 추가 (Safe)
+ * isDestructiveUpdate([1, 2], [1, 2, 3]) // false
+ *
+ * @example
+ * // 프로그램 삭제 (Destructive)
+ * isDestructiveUpdate([1, 2, 3], [1, 2]) // true
+ *
+ * @example
+ * // 순서 변경 (Destructive)
+ * isDestructiveUpdate([1, 2, 3], [2, 1, 3]) // true
+ */
+export function isDestructiveUpdate(
+  currentProgramIds: number[],
+  newProgramIds: number[]
+): boolean {
+  // 1. 프로그램 삭제 검사: 기존 프로그램이 새 목록에 없는 경우
+  const hasDeletedProgram = currentProgramIds.some((id) => !newProgramIds.includes(id));
+  if (hasDeletedProgram) {
+    return true;
+  }
+
+  // 2. 순서 변경 검사: 기존 프로그램의 상대적 순서가 변경된 경우
+  // 기존 프로그램들이 새 목록에서도 같은 상대적 순서를 유지하는지 확인
+  const existingInNew = newProgramIds.filter((id) => currentProgramIds.includes(id));
+  const existingInCurrent = currentProgramIds.filter((id) => newProgramIds.includes(id));
+
+  // 배열 순서 비교
+  const hasOrderChanged = JSON.stringify(existingInNew) !== JSON.stringify(existingInCurrent);
+
+  return hasOrderChanged;
+}
+
+/**
+ * 로드맵이 파괴적 수정 제한 대상인지 확인
+ *
+ * @param status - 로드맵 상태
+ * @param enrolledStudents - 수강생 수
+ * @returns 파괴적 수정 제한 여부
+ *
+ * @example
+ * isDestructiveUpdateRestricted('PUBLISHED', 5) // true
+ * isDestructiveUpdateRestricted('DRAFT', 5) // false
+ * isDestructiveUpdateRestricted('PUBLISHED', 0) // false
+ */
+export function isDestructiveUpdateRestricted(
+  status: string,
+  enrolledStudents: number
+): boolean {
+  return status === 'PUBLISHED' && enrolledStudents > 0;
+}
+
+/**
+ * 프로그램 ID 배열에서 변경 사항 분석
+ *
+ * @param currentIds - 현재 프로그램 ID 배열
+ * @param newIds - 새로운 프로그램 ID 배열
+ * @returns 변경 사항 분석 결과
+ */
+export interface ProgramChanges {
+  added: number[];
+  removed: number[];
+  reordered: boolean;
+}
+
+export function analyzeProgramChanges(
+  currentIds: number[],
+  newIds: number[]
+): ProgramChanges {
+  // 추가된 프로그램
+  const added = newIds.filter((id) => !currentIds.includes(id));
+
+  // 삭제된 프로그램
+  const removed = currentIds.filter((id) => !newIds.includes(id));
+
+  // 순서 변경 여부
+  const existingInNew = newIds.filter((id) => currentIds.includes(id));
+  const existingInCurrent = currentIds.filter((id) => newIds.includes(id));
+  const reordered = JSON.stringify(existingInNew) !== JSON.stringify(existingInCurrent);
+
+  return {
+    added,
+    removed,
+    reordered,
+  };
+}

--- a/src/utils/roadmapUtils.ts
+++ b/src/utils/roadmapUtils.ts
@@ -61,7 +61,9 @@ export function isDestructiveUpdateRestricted(
   status: string,
   enrolledStudents: number
 ): boolean {
-  return status === 'PUBLISHED' && enrolledStudents > 0;
+  // 백엔드에서 status를 소문자로 반환 (published, draft)
+  const normalizedStatus = status.toUpperCase();
+  return normalizedStatus === 'PUBLISHED' && enrolledStudents > 0;
 }
 
 /**


### PR DESCRIPTION
## Summary

수강생이 있는 공개된 로드맵에서 파괴적 수정(프로그램 삭제/순서 변경)을 프론트엔드에서 사전 차단하고, 사용자에게 명확한 피드백을 제공합니다. 또한 드래그 앤 드롭을 통한 프로그램 순서 변경 기능을 구현했습니다.

## Related Issue

- Closes #324

## Changes

- 파괴적 수정 감지 유틸리티 함수 추가 (`src/utils/roadmapUtils.ts`)
  - `isDestructiveUpdate()`: 프로그램 삭제/순서 변경 감지
  - `isDestructiveUpdateRestricted()`: 제한 대상 여부 확인
  - `analyzeProgramChanges()`: 변경 사항 상세 분석
- 로드맵 수정 페이지 UX 개선 (`RoadmapCreatePage.tsx`)
  - 제한 상태 안내 배너 (파란색 Info 카드)
  - 기존 프로그램 삭제 버튼 비활성화 + 툴팁
  - 드래그 핸들 → Lock 아이콘 변경 + 툴팁
  - @dnd-kit을 활용한 드래그 앤 드롭 순서 변경
  - 접근성 속성 추가 (aria-disabled, aria-label)
- 로드맵 목록 페이지 개선 (`RoadmapListPage.tsx`)
  - 상태 배지 색상 구분 (공개: success/초록, 임시저장: warning/주황)
  - 백엔드 소문자 응답 정규화 (toUpperCase)
- RM007 에러 코드 핸들링

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### 테스트 시나리오
1. PUBLISHED + 수강생 있는 로드맵 수정 시 → 제한 배너 표시, 기존 프로그램 삭제/드래그 불가
2. 새 프로그램 추가 → 정상 동작 (삭제/드래그 가능)
3. DRAFT 로드맵 → 모든 수정 가능
4. 수강생 0명인 PUBLISHED 로드맵 → 모든 수정 가능