### PR TITLE
feat: 테넌트 기능 설정 UI 및 프로필 미완성 리다이렉트 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,16 @@ import { BrowserRouter } from 'react-router-dom';
 import { AppRoutes } from '@/routes';
 import { Toaster } from '@/components/common/Sonner/Sonner';
 import { TenantBrandingProvider } from '@/contexts/TenantBrandingContext';
+import { TenantFeaturesProvider } from '@/contexts/TenantFeaturesContext';
 
 function App() {
   return (
     <BrowserRouter>
       <TenantBrandingProvider>
-        <AppRoutes />
-        <Toaster />
+        <TenantFeaturesProvider>
+          <AppRoutes />
+          <Toaster />
+        </TenantFeaturesProvider>
       </TenantBrandingProvider>
     </BrowserRouter>
   );

--- a/src/components/domain/admin/RoleBadge.tsx
+++ b/src/components/domain/admin/RoleBadge.tsx
@@ -3,11 +3,11 @@ import { Badge } from '@/components/common/Badge';
 // 배지 variant 타입
 type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline' | 'success' | 'warning' | 'error' | 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'indigo' | 'purple' | 'gray';
 
-// 시스템 역할
-export type SystemRole = 'SUPER_ADMIN' | 'SYSTEM_ADMIN' | 'TENANT_ADMIN' | 'OPERATOR' | 'USER';
+// 시스템 역할 (백엔드 TenantRole enum과 동기화)
+export type SystemRole = 'SYSTEM_ADMIN' | 'TENANT_ADMIN' | 'OPERATOR' | 'DESIGNER' | 'INSTRUCTOR' | 'USER';
 
-// 강의 역할
-export type CourseRole = 'DESIGNER' | 'OWNER' | 'INSTRUCTOR' | 'TUTOR' | 'VIEWER';
+// 강의 역할 (백엔드 CourseRole enum과 동기화)
+export type CourseRole = 'DESIGNER' | 'OWNER' | 'INSTRUCTOR';
 
 interface RoleBadgeProps {
   role: SystemRole | CourseRole;
@@ -18,10 +18,11 @@ const systemRoleConfig: Record<
   SystemRole,
   { label: { ko: string; en: string }; variant: BadgeVariant }
 > = {
-  SUPER_ADMIN: { label: { ko: '최고 관리자', en: 'Super Admin' }, variant: 'purple' },
   SYSTEM_ADMIN: { label: { ko: '시스템 관리자', en: 'System Admin' }, variant: 'purple' },
   TENANT_ADMIN: { label: { ko: '테넌트 관리자', en: 'Tenant Admin' }, variant: 'indigo' },
   OPERATOR: { label: { ko: '운영자', en: 'Operator' }, variant: 'blue' },
+  DESIGNER: { label: { ko: '강의 개설자', en: 'Designer' }, variant: 'orange' },
+  INSTRUCTOR: { label: { ko: '강사', en: 'Instructor' }, variant: 'green' },
   USER: { label: { ko: '사용자', en: 'User' }, variant: 'gray' },
 };
 
@@ -32,8 +33,6 @@ const courseRoleConfig: Record<
   DESIGNER: { label: { ko: '설계자', en: 'Designer' }, variant: 'orange' },
   OWNER: { label: { ko: '소유자', en: 'Owner' }, variant: 'green' },
   INSTRUCTOR: { label: { ko: '강사', en: 'Instructor' }, variant: 'blue' },
-  TUTOR: { label: { ko: '튜터', en: 'Tutor' }, variant: 'indigo' },
-  VIEWER: { label: { ko: '열람자', en: 'Viewer' }, variant: 'gray' },
 };
 
 export function RoleBadge({ role, className }: RoleBadgeProps) {

--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -49,6 +49,8 @@ import {
   Zap,
   FolderTree,
   Map,
+  ToggleRight,
+  Tags,
 } from 'lucide-react';
 import type { MenuItem } from '@/types';
 
@@ -169,6 +171,15 @@ export const tenantAdminMenuData: MenuItem[] = [
       { id: 'realtime-data', label: { ko: '실시간 데이터 현황', en: 'Real-time Data Status' }, icon: Activity, path: '/ta/analytics/realtime' },
       { id: 'analytics-export', label: { ko: '통계 조회 및 내보내기', en: 'Analytics & Export' }, icon: Download, path: '/ta/analytics/export' },
       { id: 'log-history', label: { ko: '이력 분석 및 로그 관리', en: 'Log & History Analysis' }, icon: FileText, path: '/ta/analytics/logs' },
+    ],
+  },
+  {
+    id: 'feature-settings',
+    label: { ko: '기능 설정', en: 'Feature Settings' },
+    icon: ToggleRight,
+    subItems: [
+      { id: 'feature-onoff', label: { ko: '기능 On/Off', en: 'Feature On/Off' }, icon: ToggleRight, path: '/ta/features' },
+      { id: 'custom-categories', label: { ko: '카테고리 관리', en: 'Category Management' }, icon: Tags, path: '/ta/features/categories' },
     ],
   },
   {

--- a/src/contexts/TenantFeaturesContext.tsx
+++ b/src/contexts/TenantFeaturesContext.tsx
@@ -1,0 +1,117 @@
+import { createContext, useContext, ReactNode, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useAuthStore } from '@/store/common/authStore';
+import { tenantFeaturesService } from '@/services/ta/tenantFeaturesService';
+import type { TenantFeaturesResponse } from '@/services/ta/tenantFeaturesService';
+
+interface TenantFeaturesContextValue {
+  features: TenantFeaturesResponse | null | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  // 편의 메서드
+  isFeatureEnabled: (feature: keyof TenantFeaturesResponse) => boolean;
+}
+
+const TenantFeaturesContext = createContext<TenantFeaturesContextValue | undefined>(undefined);
+
+/** 기본 기능 설정 (SA 등 tenantId가 없는 사용자용) */
+const DEFAULT_FEATURES: TenantFeaturesResponse = {
+  communityEnabled: true,
+  userCourseCreationEnabled: false,
+  cartEnabled: true,
+  wishlistEnabled: true,
+  instructorTabEnabled: true,
+};
+
+/**
+ * 인증된 사용자용 기능 설정 조회 Hook
+ */
+function useAuthenticatedFeatures(enabled: boolean) {
+  return useQuery({
+    queryKey: ['tenant-features', 'authenticated'],
+    queryFn: () => tenantFeaturesService.getFeatures(),
+    enabled,
+    staleTime: 1000 * 60 * 30, // 30분 캐싱
+    gcTime: 1000 * 60 * 60, // 1시간 가비지 컬렉션
+    retry: 1,
+  });
+}
+
+/**
+ * 공개 기능 설정 조회 Hook (비로그인 사용자용)
+ */
+function usePublicFeatures(enabled: boolean) {
+  return useQuery({
+    queryKey: ['tenant-features', 'public'],
+    queryFn: () => tenantFeaturesService.getPublicFeatures(),
+    enabled,
+    staleTime: 1000 * 60 * 30,
+    gcTime: 1000 * 60 * 60,
+    retry: 1,
+  });
+}
+
+export function TenantFeaturesProvider({ children }: { children: ReactNode }) {
+  const { isAuthenticated, user } = useAuthStore();
+
+  // SA 사용자인지 확인 (tenantId가 없는 인증된 사용자)
+  const isSystemAdmin = isAuthenticated && !user?.tenantId;
+
+  // 1. 인증된 사용자(tenantId 있음): tenantId 기반 기능 설정 조회
+  const {
+    data: authFeatures,
+    isLoading: authLoading,
+    error: authError,
+  } = useAuthenticatedFeatures(isAuthenticated && !!user?.tenantId);
+
+  // 2. 비로그인 사용자: 공개 API로 기능 설정 조회
+  const {
+    data: publicFeatures,
+    isLoading: publicLoading,
+    error: publicError,
+  } = usePublicFeatures(!isAuthenticated);
+
+  // 기능 설정 결정 로직
+  const { features, isLoading, error } = useMemo(() => {
+    // SA 사용자: 기본 기능 설정 사용
+    if (isSystemAdmin) {
+      return { features: DEFAULT_FEATURES, isLoading: false, error: null };
+    }
+    // 인증된 사용자(tenantId 있음): authFeatures 사용
+    if (isAuthenticated && user?.tenantId) {
+      return { features: authFeatures, isLoading: authLoading, error: authError };
+    }
+    // 비로그인 사용자: publicFeatures 사용
+    return { features: publicFeatures, isLoading: publicLoading, error: publicError };
+  }, [isSystemAdmin, isAuthenticated, user?.tenantId, authFeatures, authLoading, authError, publicFeatures, publicLoading, publicError]);
+
+  // 편의 메서드
+  const isFeatureEnabled = (feature: keyof TenantFeaturesResponse): boolean => {
+    if (!features) return true; // 로딩 중이거나 에러 시 기본적으로 활성화
+    return features[feature] ?? true;
+  };
+
+  return (
+    <TenantFeaturesContext.Provider value={{ features, isLoading, error, isFeatureEnabled }}>
+      {children}
+    </TenantFeaturesContext.Provider>
+  );
+}
+
+export function useTenantFeatures() {
+  const context = useContext(TenantFeaturesContext);
+  if (context === undefined) {
+    throw new Error('useTenantFeatures must be used within TenantFeaturesProvider');
+  }
+  return context;
+}
+
+/**
+ * 특정 기능이 활성화되어 있는지 확인하는 훅
+ * @param feature 확인할 기능 키
+ * @returns 기능 활성화 여부
+ */
+export function useIsFeatureEnabled(feature: keyof TenantFeaturesResponse): boolean {
+  const { isFeatureEnabled } = useTenantFeatures();
+  return isFeatureEnabled(feature);
+}

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,0 +1,6 @@
+export { TenantBrandingProvider, useTenantBranding } from './TenantBrandingContext';
+export {
+  TenantFeaturesProvider,
+  useTenantFeatures,
+  useIsFeatureEnabled,
+} from './TenantFeaturesContext';

--- a/src/hooks/common/useAuthQueries.ts
+++ b/src/hooks/common/useAuthQueries.ts
@@ -62,6 +62,18 @@ export const useLogin = () => {
       return { user, userDetail };
     },
     onSuccess: ({ user, userDetail }) => {
+      // 테넌트 subdomain 처리
+      const subdomain = userDetail.tenantSubdomain;
+      const isDefaultSubdomain = !subdomain || subdomain === 'default' || subdomain === 'www';
+      const subdomainPrefix = (!isDefaultSubdomain && user.role !== 'SYSTEM_ADMIN') ? `/${subdomain}` : '';
+
+      // 프로필 미완성 시 프로필 수정 페이지로 리다이렉트 (단체 계정 생성 사용자)
+      if (userDetail.profileCompleted === false) {
+        const profileEditPath = `${subdomainPrefix}/tu/b2c/mypage/profile`;
+        navigate(profileEditPath, { state: { profileIncomplete: true } });
+        return;
+      }
+
       // 역할별 리다이렉트 경로
       const roleBasePath: Record<string, string> = {
         SYSTEM_ADMIN: '/sa',
@@ -71,15 +83,7 @@ export const useLogin = () => {
         USER: '/tu/b2c',
       };
       const basePath = roleBasePath[user.role] || '/tu/b2c';
-
-      // 테넌트 subdomain이 있으면 경로에 포함 (SA 제외, default는 생략)
-      let targetPath = basePath;
-      const subdomain = userDetail.tenantSubdomain;
-      const isDefaultSubdomain = !subdomain || subdomain === 'default' || subdomain === 'www';
-
-      if (!isDefaultSubdomain && user.role !== 'SYSTEM_ADMIN') {
-        targetPath = `/${subdomain}${basePath}`;
-      }
+      const targetPath = `${subdomainPrefix}${basePath}`;
 
       navigate(targetPath);
     },

--- a/src/hooks/ta/index.ts
+++ b/src/hooks/ta/index.ts
@@ -60,3 +60,20 @@ export {
   useActivateBanner,
   useDeactivateBanner,
 } from './useBannerQueries';
+
+export {
+  tenantFeaturesKeys,
+  useTenantFeatures,
+  usePublicTenantFeatures,
+  useUpdateTenantFeatures,
+} from './useTenantFeaturesQueries';
+
+export {
+  tenantCategoryKeys,
+  useTenantCategories,
+  usePublicTenantCategories,
+  useCreateTenantCategory,
+  useUpdateTenantCategory,
+  useDeleteTenantCategory,
+  useReorderTenantCategories,
+} from './useTenantCategoryQueries';

--- a/src/hooks/ta/useTenantCategoryQueries.ts
+++ b/src/hooks/ta/useTenantCategoryQueries.ts
@@ -1,0 +1,88 @@
+/**
+ * Tenant Category React Query Hooks (TA - Tenant Admin)
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { tenantCategoryService } from '@/services/ta';
+import type { TenantCategoryRequest } from '@/services/ta/tenantCategoryService';
+
+// Query Keys
+export const tenantCategoryKeys = {
+  all: ['tenantCategories'] as const,
+  list: () => [...tenantCategoryKeys.all, 'list'] as const,
+  public: () => [...tenantCategoryKeys.all, 'public'] as const,
+};
+
+// ============================================
+// Queries
+// ============================================
+
+/** 카테고리 목록 조회 */
+export const useTenantCategories = () => {
+  return useQuery({
+    queryKey: tenantCategoryKeys.list(),
+    queryFn: () => tenantCategoryService.getCategories(),
+  });
+};
+
+/** 공개 카테고리 목록 조회 (활성화된 것만) */
+export const usePublicTenantCategories = () => {
+  return useQuery({
+    queryKey: tenantCategoryKeys.public(),
+    queryFn: () => tenantCategoryService.getPublicCategories(),
+  });
+};
+
+// ============================================
+// Mutations
+// ============================================
+
+/** 카테고리 생성 */
+export const useCreateTenantCategory = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: TenantCategoryRequest) =>
+      tenantCategoryService.createCategory(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantCategoryKeys.all });
+    },
+  });
+};
+
+/** 카테고리 수정 */
+export const useUpdateTenantCategory = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: { id: number; request: TenantCategoryRequest }) =>
+      tenantCategoryService.updateCategory(id, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantCategoryKeys.all });
+    },
+  });
+};
+
+/** 카테고리 삭제 */
+export const useDeleteTenantCategory = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => tenantCategoryService.deleteCategory(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantCategoryKeys.all });
+    },
+  });
+};
+
+/** 카테고리 순서 변경 */
+export const useReorderTenantCategories = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (categoryIds: number[]) =>
+      tenantCategoryService.reorderCategories(categoryIds),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantCategoryKeys.all });
+    },
+  });
+};

--- a/src/hooks/ta/useTenantFeaturesQueries.ts
+++ b/src/hooks/ta/useTenantFeaturesQueries.ts
@@ -1,0 +1,49 @@
+/**
+ * Tenant Features React Query Hooks (TA - Tenant Admin)
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { tenantFeaturesService } from '@/services/ta';
+import type { UpdateTenantFeaturesRequest } from '@/services/ta/tenantFeaturesService';
+
+// Query Keys
+export const tenantFeaturesKeys = {
+  all: ['tenantFeatures'] as const,
+  detail: () => [...tenantFeaturesKeys.all, 'detail'] as const,
+};
+
+// ============================================
+// Queries
+// ============================================
+
+/** 테넌트 기능 설정 조회 */
+export const useTenantFeatures = () => {
+  return useQuery({
+    queryKey: tenantFeaturesKeys.detail(),
+    queryFn: () => tenantFeaturesService.getFeatures(),
+  });
+};
+
+/** 공개 테넌트 기능 설정 조회 (인증 불필요) */
+export const usePublicTenantFeatures = () => {
+  return useQuery({
+    queryKey: [...tenantFeaturesKeys.all, 'public'] as const,
+    queryFn: () => tenantFeaturesService.getPublicFeatures(),
+  });
+};
+
+// ============================================
+// Mutations
+// ============================================
+
+/** 테넌트 기능 설정 수정 */
+export const useUpdateTenantFeatures = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: UpdateTenantFeaturesRequest) =>
+      tenantFeaturesService.updateFeatures(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantFeaturesKeys.all });
+    },
+  });
+};

--- a/src/pages/common/settings/SettingsPage.tsx
+++ b/src/pages/common/settings/SettingsPage.tsx
@@ -2,7 +2,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { Shield, Bell, Globe, Palette, LucideIcon, ArrowLeft } from 'lucide-react';
 import { SettingsCard, Button } from '@/components/common';
 
-type UserRole = 'USER' | 'OPERATOR' | 'TENANT_ADMIN' | 'SUPER_ADMIN';
+type UserRole = 'USER' | 'INSTRUCTOR' | 'DESIGNER' | 'OPERATOR' | 'TENANT_ADMIN' | 'SYSTEM_ADMIN';
 
 interface SettingCardData {
   id: string;
@@ -54,7 +54,7 @@ const getSettingCards = (userRole: UserRole): SettingCardData[] => {
 
 // URL 경로에서 역할 추출
 const getRoleFromPath = (pathname: string): UserRole => {
-  if (pathname.startsWith('/sa')) return 'SUPER_ADMIN';
+  if (pathname.startsWith('/sa')) return 'SYSTEM_ADMIN';
   if (pathname.startsWith('/ta')) return 'TENANT_ADMIN';
   if (pathname.startsWith('/to')) return 'OPERATOR';
   return 'USER';

--- a/src/pages/ta/automation/AutoEnrollmentRulesPage.tsx
+++ b/src/pages/ta/automation/AutoEnrollmentRulesPage.tsx
@@ -707,7 +707,7 @@ export const AutoEnrollmentRulesPage = () => {
 
       {/* 규칙 생성/수정 모달 */}
       <Dialog open={showCreateModal} onOpenChange={setShowCreateModal}>
-        <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+        <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto" aria-describedby={undefined}>
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Zap className="w-5 h-5" />

--- a/src/pages/ta/features/FeatureSettingsPage.tsx
+++ b/src/pages/ta/features/FeatureSettingsPage.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useState } from 'react';
+import {
+  Save,
+  RotateCcw,
+  ToggleRight,
+  MessageCircle,
+  BookOpen,
+  ShoppingCart,
+  Heart,
+  GraduationCap,
+} from 'lucide-react';
+import { AdminPageHeader } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Switch } from '@/components/common/Switch';
+import { useTenantFeatures, useUpdateTenantFeatures } from '@/hooks/ta';
+import type { UpdateTenantFeaturesRequest } from '@/services/ta/tenantFeaturesService';
+
+interface FeatureItem {
+  key: keyof UpdateTenantFeaturesRequest;
+  label: string;
+  description: string;
+  icon: React.ElementType;
+}
+
+const FEATURES: FeatureItem[] = [
+  {
+    key: 'communityEnabled',
+    label: '커뮤니티 기능',
+    description: '사용자들이 커뮤니티에서 질문하고 토론할 수 있습니다',
+    icon: MessageCircle,
+  },
+  {
+    key: 'userCourseCreationEnabled',
+    label: '사용자 강좌 생성',
+    description: '일반 사용자가 직접 강좌를 생성할 수 있습니다',
+    icon: BookOpen,
+  },
+  {
+    key: 'cartEnabled',
+    label: '장바구니 기능',
+    description: '사용자가 강좌를 장바구니에 담을 수 있습니다',
+    icon: ShoppingCart,
+  },
+  {
+    key: 'wishlistEnabled',
+    label: '찜하기 기능',
+    description: '사용자가 강좌를 찜 목록에 추가할 수 있습니다',
+    icon: Heart,
+  },
+  {
+    key: 'instructorTabEnabled',
+    label: '강사 탭 표시',
+    description: '강좌 상세에서 강사 정보 탭을 표시합니다',
+    icon: GraduationCap,
+  },
+];
+
+export function FeatureSettingsPage() {
+  const { data: features, isLoading } = useTenantFeatures();
+  const updateMutation = useUpdateTenantFeatures();
+
+  const [formData, setFormData] = useState<UpdateTenantFeaturesRequest>({
+    communityEnabled: true,
+    userCourseCreationEnabled: false,
+    cartEnabled: true,
+    wishlistEnabled: true,
+    instructorTabEnabled: true,
+  });
+
+  const [hasChanges, setHasChanges] = useState(false);
+
+  useEffect(() => {
+    if (features) {
+      setFormData({
+        communityEnabled: features.communityEnabled,
+        userCourseCreationEnabled: features.userCourseCreationEnabled,
+        cartEnabled: features.cartEnabled,
+        wishlistEnabled: features.wishlistEnabled,
+        instructorTabEnabled: features.instructorTabEnabled,
+      });
+    }
+  }, [features]);
+
+  useEffect(() => {
+    if (features) {
+      const changed =
+        formData.communityEnabled !== features.communityEnabled ||
+        formData.userCourseCreationEnabled !== features.userCourseCreationEnabled ||
+        formData.cartEnabled !== features.cartEnabled ||
+        formData.wishlistEnabled !== features.wishlistEnabled ||
+        formData.instructorTabEnabled !== features.instructorTabEnabled;
+      setHasChanges(changed);
+    }
+  }, [formData, features]);
+
+  const handleToggle = (key: keyof UpdateTenantFeaturesRequest, value: boolean) => {
+    setFormData((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
+  };
+
+  const handleSave = async () => {
+    await updateMutation.mutateAsync(formData);
+  };
+
+  const handleReset = () => {
+    if (features) {
+      setFormData({
+        communityEnabled: features.communityEnabled,
+        userCourseCreationEnabled: features.userCourseCreationEnabled,
+        cartEnabled: features.cartEnabled,
+        wishlistEnabled: features.wishlistEnabled,
+        instructorTabEnabled: features.instructorTabEnabled,
+      });
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+          <div className="h-64 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="기능 On/Off"
+        description="테넌트에서 사용할 기능을 활성화하거나 비활성화합니다"
+        actions={
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={handleReset} disabled={!hasChanges}>
+              <RotateCcw className="mr-2 h-4 w-4" />
+              초기화
+            </Button>
+            <Button onClick={handleSave} disabled={updateMutation.isPending || !hasChanges}>
+              <Save className="mr-2 h-4 w-4" />
+              {updateMutation.isPending ? '저장 중...' : '저장'}
+            </Button>
+          </div>
+        }
+      />
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <ToggleRight className="h-5 w-5 text-brand-primary" />
+            <CardTitle>기능 설정</CardTitle>
+          </div>
+          <CardDescription>
+            각 기능의 토글 스위치를 사용하여 테넌트에서 해당 기능을 활성화하거나 비활성화할 수 있습니다.
+            변경 사항은 저장 후 즉시 적용됩니다.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-1">
+            {FEATURES.map((feature, index) => {
+              const Icon = feature.icon;
+              const isEnabled = formData[feature.key] ?? false;
+              return (
+                <div key={feature.key}>
+                  <div className="flex items-center justify-between py-4">
+                    <div className="flex items-center gap-4">
+                      <div
+                        className={`p-2 rounded-lg ${
+                          isEnabled
+                            ? 'bg-brand-primary/10 text-brand-primary'
+                            : 'bg-gray-100 text-gray-400'
+                        }`}
+                      >
+                        <Icon className="h-5 w-5" />
+                      </div>
+                      <div>
+                        <p className="font-medium text-gray-900">{feature.label}</p>
+                        <p className="text-sm text-text-secondary">{feature.description}</p>
+                      </div>
+                    </div>
+                    <Switch
+                      checked={isEnabled}
+                      onCheckedChange={(checked) => handleToggle(feature.key, checked)}
+                    />
+                  </div>
+                  {index < FEATURES.length - 1 && <hr className="border-gray-100" />}
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+
+      {hasChanges && (
+        <div className="mt-4 p-4 bg-amber-50 border border-amber-200 rounded-lg">
+          <p className="text-sm text-amber-800">
+            변경 사항이 있습니다. 저장 버튼을 눌러 변경 사항을 적용하세요.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/ta/features/TenantCategoryPage.tsx
+++ b/src/pages/ta/features/TenantCategoryPage.tsx
@@ -1,0 +1,392 @@
+import { useState } from 'react';
+import {
+  Plus,
+  Pencil,
+  Trash2,
+  GripVertical,
+  Tags,
+  Check,
+  X,
+} from 'lucide-react';
+import { AdminPageHeader } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Label } from '@/components/common/Label';
+import { Switch } from '@/components/common/Switch';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/common/Dialog';
+import {
+  useTenantCategories,
+  useCreateTenantCategory,
+  useUpdateTenantCategory,
+  useDeleteTenantCategory,
+  useReorderTenantCategories,
+} from '@/hooks/ta';
+import type { TenantCategoryResponse, TenantCategoryRequest } from '@/services/ta/tenantCategoryService';
+
+interface CategoryFormData {
+  name: string;
+  slug: string;
+  description: string;
+  icon: string;
+  enabled: boolean;
+}
+
+const initialFormData: CategoryFormData = {
+  name: '',
+  slug: '',
+  description: '',
+  icon: '',
+  enabled: true,
+};
+
+export function TenantCategoryPage() {
+  const { data: categories, isLoading } = useTenantCategories();
+  const createMutation = useCreateTenantCategory();
+  const updateMutation = useUpdateTenantCategory();
+  const deleteMutation = useDeleteTenantCategory();
+  const reorderMutation = useReorderTenantCategories();
+
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [editingCategory, setEditingCategory] = useState<TenantCategoryResponse | null>(null);
+  const [deletingCategory, setDeletingCategory] = useState<TenantCategoryResponse | null>(null);
+  const [formData, setFormData] = useState<CategoryFormData>(initialFormData);
+
+  // 드래그 앤 드롭 상태
+  const [draggedItem, setDraggedItem] = useState<number | null>(null);
+
+  const handleOpenCreate = () => {
+    setEditingCategory(null);
+    setFormData(initialFormData);
+    setIsDialogOpen(true);
+  };
+
+  const handleOpenEdit = (category: TenantCategoryResponse) => {
+    setEditingCategory(category);
+    setFormData({
+      name: category.name,
+      slug: category.slug,
+      description: category.description || '',
+      icon: category.icon || '',
+      enabled: category.enabled,
+    });
+    setIsDialogOpen(true);
+  };
+
+  const handleOpenDelete = (category: TenantCategoryResponse) => {
+    setDeletingCategory(category);
+    setIsDeleteDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setIsDialogOpen(false);
+    setEditingCategory(null);
+    setFormData(initialFormData);
+  };
+
+  const handleCloseDeleteDialog = () => {
+    setIsDeleteDialogOpen(false);
+    setDeletingCategory(null);
+  };
+
+  const handleSave = async () => {
+    const request: TenantCategoryRequest = {
+      name: formData.name,
+      slug: formData.slug,
+      description: formData.description || null,
+      icon: formData.icon || null,
+      enabled: formData.enabled,
+    };
+
+    if (editingCategory) {
+      await updateMutation.mutateAsync({ id: editingCategory.id, request });
+    } else {
+      await createMutation.mutateAsync(request);
+    }
+    handleCloseDialog();
+  };
+
+  const handleDelete = async () => {
+    if (deletingCategory) {
+      await deleteMutation.mutateAsync(deletingCategory.id);
+      handleCloseDeleteDialog();
+    }
+  };
+
+  const generateSlug = (name: string) => {
+    return name
+      .toLowerCase()
+      .replace(/[^a-z0-9가-힣]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '');
+  };
+
+  const handleNameChange = (name: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      name,
+      // 새로 만들 때만 slug 자동 생성
+      slug: editingCategory ? prev.slug : generateSlug(name),
+    }));
+  };
+
+  // 드래그 앤 드롭 핸들러
+  const handleDragStart = (e: React.DragEvent, index: number) => {
+    setDraggedItem(index);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+  };
+
+  const handleDrop = async (e: React.DragEvent, targetIndex: number) => {
+    e.preventDefault();
+    if (draggedItem === null || draggedItem === targetIndex || !categories) return;
+
+    const newCategories = [...categories];
+    const [removed] = newCategories.splice(draggedItem, 1);
+    newCategories.splice(targetIndex, 0, removed);
+
+    const categoryIds = newCategories.map((c) => c.id);
+    await reorderMutation.mutateAsync(categoryIds);
+    setDraggedItem(null);
+  };
+
+  const handleDragEnd = () => {
+    setDraggedItem(null);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+          <div className="h-64 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="카테고리 관리"
+        description="테넌트의 커스텀 강의 카테고리를 관리합니다"
+        actions={
+          <Button onClick={handleOpenCreate}>
+            <Plus className="mr-2 h-4 w-4" />
+            카테고리 추가
+          </Button>
+        }
+      />
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Tags className="h-5 w-5 text-brand-primary" />
+            <CardTitle>카테고리 목록</CardTitle>
+          </div>
+          <CardDescription>
+            드래그 앤 드롭으로 카테고리 순서를 변경할 수 있습니다.
+            활성화된 카테고리만 사용자에게 표시됩니다.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {categories && categories.length > 0 ? (
+            <div className="space-y-2">
+              {categories.map((category, index) => (
+                <div
+                  key={category.id}
+                  draggable
+                  onDragStart={(e) => handleDragStart(e, index)}
+                  onDragOver={handleDragOver}
+                  onDrop={(e) => handleDrop(e, index)}
+                  onDragEnd={handleDragEnd}
+                  className={`flex items-center justify-between p-4 border rounded-lg cursor-move transition-all ${
+                    draggedItem === index
+                      ? 'opacity-50 border-brand-primary bg-brand-primary/5'
+                      : 'hover:bg-gray-50'
+                  } ${!category.enabled ? 'opacity-60' : ''}`}
+                >
+                  <div className="flex items-center gap-4">
+                    <GripVertical className="h-5 w-5 text-gray-400" />
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium">{category.name}</span>
+                        <span className="text-sm text-gray-500">({category.slug})</span>
+                        {!category.enabled && (
+                          <span className="px-2 py-0.5 text-xs bg-gray-100 text-gray-600 rounded">
+                            비활성
+                          </span>
+                        )}
+                      </div>
+                      {category.description && (
+                        <p className="text-sm text-text-secondary mt-1">
+                          {category.description}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleOpenEdit(category)}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleOpenDelete(category)}
+                    >
+                      <Trash2 className="h-4 w-4 text-red-500" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-center py-12">
+              <Tags className="h-12 w-12 text-gray-300 mx-auto mb-4" />
+              <p className="text-gray-500 mb-4">아직 생성된 카테고리가 없습니다</p>
+              <Button onClick={handleOpenCreate}>
+                <Plus className="mr-2 h-4 w-4" />
+                첫 카테고리 만들기
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 생성/수정 다이얼로그 */}
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {editingCategory ? '카테고리 수정' : '새 카테고리 추가'}
+            </DialogTitle>
+            <DialogDescription>
+              {editingCategory
+                ? '카테고리 정보를 수정합니다'
+                : '새로운 강의 카테고리를 추가합니다'}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="name">카테고리 이름 *</Label>
+              <Input
+                id="name"
+                value={formData.name}
+                onChange={(e) => handleNameChange(e.target.value)}
+                placeholder="예: 프로그래밍"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="slug">슬러그 (URL 경로) *</Label>
+              <Input
+                id="slug"
+                value={formData.slug}
+                onChange={(e) => setFormData({ ...formData, slug: e.target.value })}
+                placeholder="예: programming"
+              />
+              <p className="text-xs text-gray-500">
+                URL에 사용되는 고유 식별자입니다. 영문, 숫자, 하이픈만 사용 가능합니다.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="description">설명</Label>
+              <Input
+                id="description"
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                placeholder="카테고리에 대한 간단한 설명"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="icon">아이콘</Label>
+              <Input
+                id="icon"
+                value={formData.icon}
+                onChange={(e) => setFormData({ ...formData, icon: e.target.value })}
+                placeholder="예: code, book, star"
+              />
+              <p className="text-xs text-gray-500">
+                Lucide 아이콘 이름을 입력하세요.
+              </p>
+            </div>
+            <div className="flex items-center justify-between">
+              <div>
+                <Label>활성화</Label>
+                <p className="text-sm text-gray-500">
+                  비활성화된 카테고리는 사용자에게 표시되지 않습니다
+                </p>
+              </div>
+              <Switch
+                checked={formData.enabled}
+                onCheckedChange={(checked) =>
+                  setFormData({ ...formData, enabled: checked })
+                }
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={handleCloseDialog}>
+              <X className="mr-2 h-4 w-4" />
+              취소
+            </Button>
+            <Button
+              onClick={handleSave}
+              disabled={
+                !formData.name ||
+                !formData.slug ||
+                createMutation.isPending ||
+                updateMutation.isPending
+              }
+            >
+              <Check className="mr-2 h-4 w-4" />
+              {createMutation.isPending || updateMutation.isPending
+                ? '저장 중...'
+                : '저장'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* 삭제 확인 다이얼로그 */}
+      <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>카테고리 삭제</DialogTitle>
+            <DialogDescription>
+              &quot;{deletingCategory?.name}&quot; 카테고리를 삭제하시겠습니까?
+              이 작업은 되돌릴 수 없습니다.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={handleCloseDeleteDialog}>
+              취소
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? '삭제 중...' : '삭제'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/ta/features/index.ts
+++ b/src/pages/ta/features/index.ts
@@ -1,0 +1,2 @@
+export { FeatureSettingsPage } from './FeatureSettingsPage';
+export { TenantCategoryPage } from './TenantCategoryPage';

--- a/src/pages/ta/index.ts
+++ b/src/pages/ta/index.ts
@@ -13,3 +13,6 @@ export { RealtimePage, ExportPage, LogsPage } from './analytics';
 
 // Settings
 export { TenantSettingsPage, UserManagementSettingsPage } from './settings';
+
+// Features
+export { FeatureSettingsPage, TenantCategoryPage } from './features';

--- a/src/pages/ta/users/OperatorsPage.tsx
+++ b/src/pages/ta/users/OperatorsPage.tsx
@@ -24,18 +24,20 @@ import { useUsers } from '@/hooks/ta';
 import type { SystemRole } from '@/types/admin';
 
 const roleLabels: Record<SystemRole, string> = {
-  SUPER_ADMIN: '슈퍼 관리자',
   SYSTEM_ADMIN: '시스템 관리자',
   TENANT_ADMIN: '테넌트 관리자',
   OPERATOR: '운영자',
+  DESIGNER: '강의 개설자',
+  INSTRUCTOR: '강사',
   USER: '일반 사용자',
 };
 
 const roleColors: Record<SystemRole, string> = {
-  SUPER_ADMIN: 'bg-red-100 text-red-700',
   SYSTEM_ADMIN: 'bg-purple-100 text-purple-700',
   TENANT_ADMIN: 'bg-blue-100 text-blue-700',
   OPERATOR: 'bg-green-100 text-green-700',
+  DESIGNER: 'bg-orange-100 text-orange-700',
+  INSTRUCTOR: 'bg-emerald-100 text-emerald-700',
   USER: 'bg-gray-100 text-gray-700',
 };
 

--- a/src/pages/ta/users/UserDetailPage.tsx
+++ b/src/pages/ta/users/UserDetailPage.tsx
@@ -488,6 +488,8 @@ export function UserDetailPage() {
                       </SelectTrigger>
                       <SelectContent>
                         <SelectItem value="USER">일반 사용자</SelectItem>
+                        <SelectItem value="INSTRUCTOR">강사</SelectItem>
+                        <SelectItem value="DESIGNER">강의 개설자</SelectItem>
                         <SelectItem value="OPERATOR">운영자</SelectItem>
                         <SelectItem value="TENANT_ADMIN">테넌트 관리자</SelectItem>
                       </SelectContent>

--- a/src/pages/ta/users/UsersPage.tsx
+++ b/src/pages/ta/users/UsersPage.tsx
@@ -579,6 +579,18 @@ export function UsersPage() {
               <Badge variant="gray" className="ml-2">{usersData.totalElements}</Badge>
             )}
           </TabsTrigger>
+          <TabsTrigger value="INSTRUCTOR">
+            강사
+            {usersData && roleFilter === 'INSTRUCTOR' && (
+              <Badge variant="gray" className="ml-2">{usersData.totalElements}</Badge>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="DESIGNER">
+            강의 개설자
+            {usersData && roleFilter === 'DESIGNER' && (
+              <Badge variant="gray" className="ml-2">{usersData.totalElements}</Badge>
+            )}
+          </TabsTrigger>
           <TabsTrigger value="OPERATOR">
             운영자
             {usersData && roleFilter === 'OPERATOR' && (
@@ -713,6 +725,8 @@ export function UsersPage() {
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="USER">일반 사용자</SelectItem>
+                    <SelectItem value="INSTRUCTOR">강사</SelectItem>
+                    <SelectItem value="DESIGNER">강의 개설자</SelectItem>
                     <SelectItem value="OPERATOR">운영자</SelectItem>
                     <SelectItem value="TENANT_ADMIN">테넌트 관리자</SelectItem>
                   </SelectContent>
@@ -782,6 +796,8 @@ export function UsersPage() {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="USER">일반 사용자</SelectItem>
+                  <SelectItem value="INSTRUCTOR">강사</SelectItem>
+                  <SelectItem value="DESIGNER">강의 개설자</SelectItem>
                   <SelectItem value="OPERATOR">운영자</SelectItem>
                 </SelectContent>
               </Select>

--- a/src/pages/tu/mypage/ProfilePage.tsx
+++ b/src/pages/tu/mypage/ProfilePage.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
-import { User, Camera, Save, Loader2, Lock, Mail, Calendar, AlertTriangle, CheckCircle, Shield } from 'lucide-react';
+import { useLocation } from 'react-router-dom';
+import { User, Camera, Save, Loader2, Lock, Mail, Calendar, AlertTriangle, CheckCircle, Shield, Info } from 'lucide-react';
 import { toast } from 'sonner';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation, useLanguageStore } from '@/store/common/languageStore';
@@ -39,6 +40,10 @@ export function ProfilePage() {
   const { language } = useLanguageStore();
   const isDark = theme === 'dark';
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const location = useLocation();
+
+  // 프로필 미완성 상태로 리다이렉트 된 경우 (단체 계정 생성 사용자)
+  const profileIncomplete = location.state?.profileIncomplete === true;
 
   // API Hooks
   const { data: profile, isLoading: isLoadingProfile } = useMyProfile();
@@ -236,6 +241,20 @@ export function ProfilePage() {
   return (
     <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
       <div className="max-w-3xl mx-auto">
+        {/* 프로필 미완성 안내 메시지 */}
+        {profileIncomplete && (
+          <Alert className={`mb-6 ${isDark ? 'bg-blue-500/10 border-blue-500/30' : 'bg-blue-50 border-blue-200'}`}>
+            <Info className={`w-5 h-5 ${isDark ? 'text-blue-400' : 'text-blue-600'}`} />
+            <AlertDescription className={isDark ? 'text-blue-400' : 'text-blue-700'}>
+              <span className="font-medium">프로필 정보를 완성해주세요.</span>
+              <br />
+              <span className="text-sm">
+                단체 계정으로 생성된 계정입니다. 원활한 서비스 이용을 위해 이름 등 프로필 정보를 입력해주세요.
+              </span>
+            </AlertDescription>
+          </Alert>
+        )}
+
         {/* Header */}
         <div className="mb-8">
           <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>

--- a/src/routes/ta.routes.tsx
+++ b/src/routes/ta.routes.tsx
@@ -23,6 +23,8 @@ import {
   LogsPage,
   TenantSettingsPage,
   UserManagementSettingsPage,
+  FeatureSettingsPage,
+  TenantCategoryPage,
 } from '@/pages/ta';
 import { BannerManagementPage } from '@/pages/ta/branding/BannerManagementPage';
 import { EmployeeListPage } from '@/pages/ta/users/EmployeeListPage';
@@ -67,6 +69,9 @@ const taChildRoutes = (
     <Route path="analytics/realtime" element={<RealtimePage />} />
     <Route path="analytics/export" element={<ExportPage />} />
     <Route path="analytics/logs" element={<LogsPage />} />
+    {/* 기능 설정 */}
+    <Route path="features" element={<FeatureSettingsPage />} />
+    <Route path="features/categories" element={<TenantCategoryPage />} />
     {/* 설정 */}
     <Route path="settings" element={<SettingsPage />} />
     <Route path="settings/security" element={<SettingsSecurityPage />} />

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -305,6 +305,20 @@ export const API_ENDPOINTS = {
     PUBLIC: '/banners/public/displayable',
   },
 
+  // Tenant Features (TA)
+  TENANT_FEATURES: {
+    BASE: '/tenant/settings/features',
+    PUBLIC: '/tenant/settings/features/public',
+  },
+
+  // Tenant Categories (TA)
+  TENANT_CATEGORIES: {
+    BASE: '/tenant/categories',
+    PUBLIC: '/tenant/categories/public',
+    BY_ID: (id: number) => `/tenant/categories/${id}`,
+    REORDER: '/tenant/categories/reorder',
+  },
+
   // Certificates (수료증) - TU
   CERTIFICATES: {
     BASE: '/certificates',

--- a/src/services/ta/index.ts
+++ b/src/services/ta/index.ts
@@ -4,3 +4,5 @@ export { tenantSettingsService } from './tenantSettingsService';
 export { taDashboardService } from './dashboardService';
 export { analyticsService } from './analyticsService';
 export { bannerService } from './bannerService';
+export { tenantFeaturesService } from './tenantFeaturesService';
+export { tenantCategoryService } from './tenantCategoryService';

--- a/src/services/ta/tenantCategoryService.ts
+++ b/src/services/ta/tenantCategoryService.ts
@@ -1,0 +1,83 @@
+/**
+ * TA 테넌트 카테고리 관리 API 서비스
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+
+// ============================================
+// 타입 정의
+// ============================================
+
+export interface TenantCategoryResponse {
+  id: number;
+  name: string;
+  slug: string;
+  description: string | null;
+  icon: string | null;
+  displayOrder: number;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TenantCategoryRequest {
+  name: string;
+  slug: string;
+  description?: string | null;
+  icon?: string | null;
+  enabled?: boolean;
+}
+
+// ============================================
+// API 서비스
+// ============================================
+
+export const tenantCategoryService = {
+  /** 카테고리 목록 조회 */
+  async getCategories(): Promise<TenantCategoryResponse[]> {
+    const { data } = await axiosInstance.get<TenantCategoryResponse[]>(
+      API_ENDPOINTS.TENANT_CATEGORIES.BASE
+    );
+    return data;
+  },
+
+  /** 활성화된 카테고리만 조회 (공개) */
+  async getPublicCategories(): Promise<TenantCategoryResponse[]> {
+    const { data } = await axiosInstance.get<TenantCategoryResponse[]>(
+      API_ENDPOINTS.TENANT_CATEGORIES.PUBLIC
+    );
+    return data;
+  },
+
+  /** 카테고리 생성 */
+  async createCategory(request: TenantCategoryRequest): Promise<TenantCategoryResponse> {
+    const { data } = await axiosInstance.post<TenantCategoryResponse>(
+      API_ENDPOINTS.TENANT_CATEGORIES.BASE,
+      request
+    );
+    return data;
+  },
+
+  /** 카테고리 수정 */
+  async updateCategory(id: number, request: TenantCategoryRequest): Promise<TenantCategoryResponse> {
+    const { data } = await axiosInstance.put<TenantCategoryResponse>(
+      API_ENDPOINTS.TENANT_CATEGORIES.BY_ID(id),
+      request
+    );
+    return data;
+  },
+
+  /** 카테고리 삭제 */
+  async deleteCategory(id: number): Promise<void> {
+    await axiosInstance.delete(API_ENDPOINTS.TENANT_CATEGORIES.BY_ID(id));
+  },
+
+  /** 카테고리 순서 변경 */
+  async reorderCategories(categoryIds: number[]): Promise<TenantCategoryResponse[]> {
+    const { data } = await axiosInstance.put<TenantCategoryResponse[]>(
+      API_ENDPOINTS.TENANT_CATEGORIES.REORDER,
+      categoryIds
+    );
+    return data;
+  },
+};

--- a/src/services/ta/tenantFeaturesService.ts
+++ b/src/services/ta/tenantFeaturesService.ts
@@ -1,0 +1,56 @@
+/**
+ * TA 테넌트 기능 On/Off 관리 API 서비스
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+
+// ============================================
+// 타입 정의
+// ============================================
+
+export interface TenantFeaturesResponse {
+  communityEnabled: boolean;
+  userCourseCreationEnabled: boolean;
+  cartEnabled: boolean;
+  wishlistEnabled: boolean;
+  instructorTabEnabled: boolean;
+}
+
+export interface UpdateTenantFeaturesRequest {
+  communityEnabled?: boolean;
+  userCourseCreationEnabled?: boolean;
+  cartEnabled?: boolean;
+  wishlistEnabled?: boolean;
+  instructorTabEnabled?: boolean;
+}
+
+// ============================================
+// API 서비스
+// ============================================
+
+export const tenantFeaturesService = {
+  /** 테넌트 기능 설정 조회 */
+  async getFeatures(): Promise<TenantFeaturesResponse> {
+    const { data } = await axiosInstance.get<TenantFeaturesResponse>(
+      API_ENDPOINTS.TENANT_FEATURES.BASE
+    );
+    return data;
+  },
+
+  /** 테넌트 기능 설정 수정 */
+  async updateFeatures(request: UpdateTenantFeaturesRequest): Promise<TenantFeaturesResponse> {
+    const { data } = await axiosInstance.put<TenantFeaturesResponse>(
+      API_ENDPOINTS.TENANT_FEATURES.BASE,
+      request
+    );
+    return data;
+  },
+
+  /** 공개 기능 설정 조회 (인증 불필요) */
+  async getPublicFeatures(): Promise<TenantFeaturesResponse> {
+    const { data } = await axiosInstance.get<TenantFeaturesResponse>(
+      API_ENDPOINTS.TENANT_FEATURES.PUBLIC
+    );
+    return data;
+  },
+};

--- a/src/services/ta/userService.ts
+++ b/src/services/ta/userService.ts
@@ -22,9 +22,21 @@ export const userService = {
 
   /** 사용자 목록 조회 */
   async getUsers(params?: UserListParams): Promise<UserListResponse> {
+    // 프론트엔드 파라미터를 백엔드 API 파라미터로 매핑
+    // undefined 값은 제외하여 쿼리 파라미터로 전달되지 않도록 함
+    const apiParams: Record<string, string | number | undefined> = {};
+
+    if (params) {
+      if (params.search) apiParams.keyword = params.search;
+      if (params.systemRole) apiParams.role = params.systemRole;
+      if (params.status) apiParams.status = params.status;
+      if (params.page !== undefined) apiParams.page = params.page;
+      if (params.size !== undefined) apiParams.size = params.size;
+    }
+
     const { data } = await axiosInstance.get<UserListResponse>(
       API_ENDPOINTS.USERS.BASE,
-      { params }
+      { params: Object.keys(apiParams).length > 0 ? apiParams : undefined }
     );
     return data;
   },
@@ -48,9 +60,10 @@ export const userService = {
 
   /** 사용자 역할 변경 */
   async updateRole(id: number, request: UpdateUserRoleRequest): Promise<AdminUser> {
-    const { data } = await axiosInstance.patch<AdminUser>(
+    // 백엔드는 PUT 메서드와 { role: TenantRole } 형식을 기대
+    const { data } = await axiosInstance.put<AdminUser>(
       API_ENDPOINTS.USERS.ROLE(id),
-      request
+      { role: request.systemRole }
     );
     return data;
   },

--- a/src/types/admin/user.types.ts
+++ b/src/types/admin/user.types.ts
@@ -3,8 +3,10 @@
  */
 
 export type UserStatus = 'ACTIVE' | 'INACTIVE' | 'PENDING' | 'BLOCKED';
-export type SystemRole = 'SUPER_ADMIN' | 'SYSTEM_ADMIN' | 'TENANT_ADMIN' | 'OPERATOR' | 'USER';
-export type CourseRole = 'DESIGNER' | 'OWNER' | 'INSTRUCTOR' | 'TUTOR' | 'VIEWER';
+// 백엔드 TenantRole enum과 동기화: SYSTEM_ADMIN, TENANT_ADMIN, OPERATOR, DESIGNER, INSTRUCTOR, USER
+export type SystemRole = 'SYSTEM_ADMIN' | 'TENANT_ADMIN' | 'OPERATOR' | 'DESIGNER' | 'INSTRUCTOR' | 'USER';
+// 백엔드 CourseRole enum과 동기화: DESIGNER, OWNER, INSTRUCTOR
+export type CourseRole = 'DESIGNER' | 'OWNER' | 'INSTRUCTOR';
 
 export interface AdminUser {
   id: number;

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -12,8 +12,8 @@ export interface ApiResponse<T> {
   };
 }
 
-// 사용자 역할
-export type TenantRole = 'USER' | 'OPERATOR' | 'TENANT_ADMIN' | 'SUPER_ADMIN';
+// 사용자 역할 (백엔드 TenantRole enum과 동기화)
+export type TenantRole = 'USER' | 'INSTRUCTOR' | 'DESIGNER' | 'OPERATOR' | 'TENANT_ADMIN' | 'SYSTEM_ADMIN';
 
 // 사용자 상태
 export type UserStatus = 'ACTIVE' | 'INACTIVE' | 'SUSPENDED' | 'WITHDRAWN';

--- a/src/types/common/auth.types.ts
+++ b/src/types/common/auth.types.ts
@@ -68,6 +68,7 @@ export interface UserDetailResponse {
   tenantCustomDomain?: string;
   createdAt: string;
   updatedAt: string;
+  profileCompleted?: boolean;  // 프로필 완성 여부 (단체 계정 생성 시 false)
 }
 
 // --- Auth Store 타입 ---


### PR DESCRIPTION
## Summary

테넌트 기능 On/Off 설정 UI와 단체 계정 생성 사용자의 프로필 미완성 시 자동 리다이렉트 기능을 구현합니다.

## Related Issue

- Closes #323
- Closes #321

## Changes

### 테넌트 기능 설정 UI
- FeatureSettingsPage 추가 (테넌트 기능 On/Off 설정 페이지)
- TenantCategoryPage 추가 (테넌트별 카테고리 관리 페이지)
- TenantFeaturesContext 추가 (기능 설정 전역 상태 관리)
- 사이드바 메뉴에 기능 설정 메뉴 추가

### 사용자 관리 개선
- UsersPage 역할 필터링 수정 (INSTRUCTOR, DESIGNER 탭 추가)
- userService API 파라미터 매핑 수정 (systemRole->role, search->keyword)
- RoleBadge에 INSTRUCTOR, DESIGNER 역할 표시 추가

### 프로필 미완성 리다이렉트
- 로그인 후 profileCompleted === false인 경우 프로필 수정 페이지로 자동 리다이렉트
- ProfilePage에 프로필 완성 안내 메시지 추가

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 백엔드 PR과 함께 병합되어야 합니다
