### PR TITLE
[Design] SA 어드민 UIUX 개선

### DIFF
--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -67,8 +67,8 @@ export const superAdminMenuData: MenuItem[] = [
     label: { ko: '테넌트 관리', en: 'Tenant Management' },
     icon: Building2,
     subItems: [
-      { id: 'tenant-crud', label: { ko: '테넌트 생성/조회/수정/삭제', en: 'Tenant CRUD' }, icon: Building2, path: '/sa/tenants' },
-      { id: 'license-billing', label: { ko: '요금제 및 라이선스 관리', en: 'License & Billing Mgmt' }, icon: CreditCard, path: '/sa/tenants/billing' },
+      { id: 'tenant-crud', label: { ko: '테넌트 목록', en: 'Tenant List' }, icon: Building2, path: '/sa/tenants' },
+      { id: 'license-billing', label: { ko: '구독 관리', en: 'Subscription Management' }, icon: CreditCard, path: '/sa/tenants/billing' },
       { id: 'overall-status', label: { ko: '전체 현황 조회', en: 'Overall Status' }, icon: PieChart, path: '/sa/tenants/status' },
     ],
   },
@@ -79,7 +79,7 @@ export const superAdminMenuData: MenuItem[] = [
     subItems: [
       { id: 'domain-ssl', label: { ko: '도메인 및 SSL 설정', en: 'Domain & SSL Setup' }, icon: Globe, path: '/sa/system/domain' },
       { id: 'operator-mgmt', label: { ko: '운영자 관리', en: 'Operator Management' }, icon: UserCog, path: '/sa/system/operators' },
-      { id: 'global-branding', label: { ko: '글로벌 브랜딩/템플릿 기본값 설정', en: 'Global Branding/Template Defaults' }, icon: Palette, path: '/sa/system/branding' },
+      { id: 'global-branding', label: { ko: '브랜딩 설정', en: 'Branding Settings' }, icon: Palette, path: '/sa/system/branding' },
       { id: 'email-templates', label: { ko: '이메일 템플릿 관리', en: 'Email Template Mgmt' }, icon: Mail, path: '/sa/system/email-templates' },
     ],
   },
@@ -88,8 +88,8 @@ export const superAdminMenuData: MenuItem[] = [
     label: { ko: '글로벌 공지 관리', en: 'Global Notice Management' },
     icon: Megaphone,
     subItems: [
-      { id: 'notice-register', label: { ko: '전체 공지사항 등록 및 수정', en: 'Notice Registration & Edit' }, icon: FileEdit, path: '/sa/notices' },
-      { id: 'notice-distribution', label: { ko: '공지사항 배포 관리', en: 'Notice Distribution Mgmt' }, icon: Send, path: '/sa/notices/distribution' },
+      { id: 'notice-register', label: { ko: '공지사항', en: 'Notices' }, icon: FileEdit, path: '/sa/notices' },
+      { id: 'notice-distribution', label: { ko: '배포 관리', en: 'Distribution' }, icon: Send, path: '/sa/notices/distribution' },
     ],
   },
   {
@@ -97,7 +97,7 @@ export const superAdminMenuData: MenuItem[] = [
     label: { ko: '데이터 및 로그 분석', en: 'Log & Activity Analysis' },
     icon: Database,
     subItems: [
-      { id: 'usage-trend', label: { ko: '전체 사용량 트렌드 및 통계', en: 'Overall Usage Trend & Stats' }, icon: TrendingUp, path: '/sa/analytics/usage' },
+      { id: 'usage-trend', label: { ko: '사용량 통계', en: 'Usage Statistics' }, icon: TrendingUp, path: '/sa/analytics/usage' },
       { id: 'activity-analysis', label: { ko: '활동 분석', en: 'Activity Analysis' }, icon: Activity, path: '/sa/analytics/activity' },
       { id: 'log-management', label: { ko: '로그 관리', en: 'Log Management' }, icon: FileText, path: '/sa/analytics/logs' },
     ],

--- a/src/pages/common/settings/SettingsNotificationsPage.tsx
+++ b/src/pages/common/settings/SettingsNotificationsPage.tsx
@@ -1,47 +1,54 @@
 import { Bell, Construction } from 'lucide-react';
-import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation } from '@/store/common/languageStore';
+import { designTokens } from '@/styles/admin-design-tokens';
 import { Card, CardHeader, CardTitle, CardContent, EmptyState } from '@/components/common';
 
 export function SettingsNotificationsPage() {
-  const { theme } = useThemeStore();
   const { t } = useTranslation();
-  const isDark = theme === 'dark';
-
-  const cardClass = isDark
-    ? 'bg-white/5 border-white/10'
-    : 'bg-white border-gray-200 shadow-sm';
 
   return (
-    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
-      <div className="max-w-3xl mx-auto">
+    <div
+      style={{
+        padding: '40px',
+        backgroundColor: designTokens.bg.app_default,
+        minHeight: '100%',
+        overflowY: 'auto',
+      }}
+    >
+      <div style={{ maxWidth: '800px', margin: '0 auto' }}>
         {/* Header */}
-        <div className="mb-8">
-          <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            {t.mypage.notifications}
-          </h1>
-          <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
-            {t.settings.notificationsDesc}
-          </p>
-        </div>
+        <h1
+          style={{
+            color: designTokens.text.primary,
+            fontSize: '24px',
+            fontWeight: 600,
+            marginBottom: '8px',
+          }}
+        >
+          {t.mypage.notifications}
+        </h1>
+        <p style={{ color: designTokens.text.secondary, marginBottom: '32px' }}>
+          {t.settings.notificationsDesc}
+        </p>
 
         {/* Notifications Card */}
-        <Card className={cardClass}>
-          <CardHeader>
+        <Card>
+          <CardHeader className="border-b px-6 py-4">
             <div className="flex items-center gap-3">
-              <Bell className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
-              <CardTitle className={isDark ? 'text-white' : 'text-gray-900'}>
+              <Bell className="w-5 h-5" style={{ color: designTokens.text.secondary }} />
+              <CardTitle className="text-lg font-medium">
                 {t.settings.notificationSettings}
               </CardTitle>
             </div>
           </CardHeader>
-          <CardContent>
+          <CardContent className="px-6 py-6">
             {/* Under Development Placeholder */}
             <EmptyState
               icon={Construction}
               title={t.common.comingSoon}
               description={t.settings.notificationsComingSoon}
-              className={`border-2 border-dashed rounded-lg ${isDark ? 'border-white/10' : 'border-gray-200'}`}
+              className="border-2 border-dashed rounded-lg"
+              style={{ borderColor: designTokens.bg.border }}
             />
           </CardContent>
         </Card>

--- a/src/pages/common/settings/SettingsNotificationsPage.tsx
+++ b/src/pages/common/settings/SettingsNotificationsPage.tsx
@@ -47,8 +47,7 @@ export function SettingsNotificationsPage() {
               icon={Construction}
               title={t.common.comingSoon}
               description={t.settings.notificationsComingSoon}
-              className="border-2 border-dashed rounded-lg"
-              style={{ borderColor: designTokens.bg.border }}
+              className="border-2 border-dashed rounded-lg border-border"
             />
           </CardContent>
         </Card>

--- a/src/pages/common/settings/SettingsSecurityPage.tsx
+++ b/src/pages/common/settings/SettingsSecurityPage.tsx
@@ -12,8 +12,8 @@ import {
   Loader2,
 } from 'lucide-react';
 import { toast } from 'sonner';
-import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation, useLanguageStore } from '@/store/common/languageStore';
+import { designTokens } from '@/styles/admin-design-tokens';
 import {
   Button,
   Input,
@@ -47,10 +47,8 @@ export function SettingsSecurityPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const { theme } = useThemeStore();
   const { t } = useTranslation();
   const { language } = useLanguageStore();
-  const isDark = theme === 'dark';
 
   // API Hooks
   const { data: profile, isLoading: isLoadingProfile } = useMyProfile();
@@ -226,42 +224,47 @@ export function SettingsSecurityPage() {
     });
   };
 
-  const cardClass = isDark
-    ? 'bg-white/5 border-white/10'
-    : 'bg-white border-gray-200 shadow-sm';
-
-  const inputClass = isDark
-    ? 'bg-white/5 border-white/10 text-white placeholder:text-gray-500'
-    : 'bg-white border-gray-200 text-gray-900';
-
-  const readonlyInputClass = isDark
-    ? 'bg-white/5 border-white/10 text-gray-400'
-    : 'bg-gray-50 border-gray-200 text-gray-500';
-
   if (isLoadingProfile) {
     return (
-      <div className={`flex items-center justify-center min-h-full ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
-        <Loader2 className={`w-8 h-8 animate-spin ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
+      <div
+        className="flex items-center justify-center min-h-full"
+        style={{ backgroundColor: designTokens.bg.app_default }}
+      >
+        <Loader2 className="w-8 h-8 animate-spin" style={{ color: designTokens.text.secondary }} />
       </div>
     );
   }
 
   return (
-    <div className={`min-h-full p-6 sm:p-10 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
-      <div className="max-w-3xl mx-auto">
-        <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+    <div
+      style={{
+        padding: '40px',
+        backgroundColor: designTokens.bg.app_default,
+        minHeight: '100%',
+        overflowY: 'auto',
+      }}
+    >
+      <div style={{ maxWidth: '800px', margin: '0 auto' }}>
+        <h1
+          style={{
+            color: designTokens.text.primary,
+            fontSize: '24px',
+            fontWeight: 600,
+            marginBottom: '8px',
+          }}
+        >
           {t.profileSecurity.title}
         </h1>
-        <p className={`mb-8 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+        <p style={{ color: designTokens.text.secondary, marginBottom: '32px' }}>
           {t.profileSecurity.description}
         </p>
 
         {/* Profile Information Section */}
-        <Card className={`mb-6 ${cardClass}`}>
-          <CardHeader className={`border-b px-6 py-4 ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
+        <Card className="mb-6">
+          <CardHeader className="border-b px-6 py-4">
             <div className="flex items-center gap-3">
-              <Shield className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
-              <CardTitle className={`text-lg font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              <Shield className="w-5 h-5" style={{ color: designTokens.text.secondary }} />
+              <CardTitle className="text-lg font-medium">
                 {t.profileSecurity.profileInfo}
               </CardTitle>
             </div>
@@ -269,18 +272,19 @@ export function SettingsSecurityPage() {
           <CardContent className="px-6 py-6">
             {/* Profile Image */}
             <div className="mb-6">
-              <Label className={`mb-3 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+              <Label className="mb-3 text-sm" style={{ color: designTokens.text.secondary }}>
                 {t.profileSecurity.profileImage}
               </Label>
               <div className="flex items-center gap-4 mt-3">
                 <div className="relative">
-                  <div className={`w-20 h-20 rounded-full flex items-center justify-center overflow-hidden ${
-                    isDark ? 'bg-gradient-to-r from-[#6778ff] to-[#a855f7]' : 'bg-blue-100'
-                  }`}>
+                  <div
+                    className="w-20 h-20 rounded-full flex items-center justify-center overflow-hidden"
+                    style={{ backgroundColor: designTokens.badge.blue.bg }}
+                  >
                     {profileImagePreview ? (
                       <img src={profileImagePreview} alt="Profile" className="w-full h-full object-cover" />
                     ) : (
-                      <User className={`w-10 h-10 ${isDark ? 'text-white' : 'text-blue-600'}`} />
+                      <User className="w-10 h-10" style={{ color: designTokens.badge.blue.text }} />
                     )}
                   </div>
                   <button
@@ -303,10 +307,10 @@ export function SettingsSecurityPage() {
                   />
                 </div>
                 <div>
-                  <p className={`text-sm ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                  <p className="text-sm" style={{ color: designTokens.text.primary }}>
                     {t.profileSecurity.imageGuide}
                   </p>
-                  <p className="text-xs mt-1 text-gray-500">
+                  <p className="text-xs mt-1" style={{ color: designTokens.text.secondary }}>
                     {t.profileSecurity.imageClickGuide}
                   </p>
                 </div>
@@ -315,19 +319,18 @@ export function SettingsSecurityPage() {
 
             {/* Name */}
             <div className="mb-5">
-              <Label className={`mb-2 block text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+              <Label className="mb-2 block text-sm" style={{ color: designTokens.text.secondary }}>
                 {t.profileSecurity.name}
               </Label>
               <Input
                 value={profileData.name}
                 onChange={(e) => setProfileData((prev) => ({ ...prev, name: e.target.value }))}
-                className={inputClass}
               />
             </div>
 
             {/* Email (Read-only) */}
             <div className="mb-5">
-              <Label className={`flex items-center gap-2 mb-2 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+              <Label className="flex items-center gap-2 mb-2 text-sm" style={{ color: designTokens.text.secondary }}>
                 <Mail className="w-4 h-4" />
                 {t.profileSecurity.email}
               </Label>
@@ -335,13 +338,18 @@ export function SettingsSecurityPage() {
                 type="email"
                 value={profile?.email || ''}
                 readOnly
-                className={`w-full px-3 py-2.5 rounded-md text-sm cursor-not-allowed border ${readonlyInputClass}`}
+                className="w-full px-3 py-2.5 rounded-md text-sm cursor-not-allowed border"
+                style={{
+                  backgroundColor: designTokens.bg.app_default,
+                  borderColor: designTokens.bg.border,
+                  color: designTokens.text.secondary,
+                }}
               />
             </div>
 
             {/* Join Date (Read-only) */}
             <div className="mb-6">
-              <Label className={`flex items-center gap-2 mb-2 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+              <Label className="flex items-center gap-2 mb-2 text-sm" style={{ color: designTokens.text.secondary }}>
                 <Calendar className="w-4 h-4" />
                 {t.profileSecurity.joinDate}
               </Label>
@@ -349,7 +357,12 @@ export function SettingsSecurityPage() {
                 type="text"
                 value={formatDate(profile?.createdAt)}
                 readOnly
-                className={`w-full px-3 py-2.5 rounded-md text-sm cursor-not-allowed border ${readonlyInputClass}`}
+                className="w-full px-3 py-2.5 rounded-md text-sm cursor-not-allowed border"
+                style={{
+                  backgroundColor: designTokens.bg.app_default,
+                  borderColor: designTokens.bg.border,
+                  color: designTokens.text.secondary,
+                }}
               />
             </div>
 
@@ -368,18 +381,18 @@ export function SettingsSecurityPage() {
         </Card>
 
         {/* Password Change Section */}
-        <Card className={`mb-6 ${cardClass}`}>
-          <CardHeader className={`border-b px-6 py-4 ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
+        <Card className="mb-6">
+          <CardHeader className="border-b px-6 py-4">
             <div className="flex items-center gap-3">
-              <Lock className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
-              <CardTitle className={`text-lg font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              <Lock className="w-5 h-5" style={{ color: designTokens.text.secondary }} />
+              <CardTitle className="text-lg font-medium">
                 {t.profileSecurity.passwordChange}
               </CardTitle>
             </div>
           </CardHeader>
           <CardContent className="px-6 py-6">
             <div className="mb-5">
-              <Label className={`mb-2 block text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+              <Label className="mb-2 block text-sm" style={{ color: designTokens.text.secondary }}>
                 {t.profileSecurity.currentPassword}
               </Label>
               <Input
@@ -388,12 +401,11 @@ export function SettingsSecurityPage() {
                 onChange={(e) =>
                   setPasswordData((prev) => ({ ...prev, currentPassword: e.target.value }))
                 }
-                className={inputClass}
               />
             </div>
 
             <div className="mb-5">
-              <Label className={`mb-2 block text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+              <Label className="mb-2 block text-sm" style={{ color: designTokens.text.secondary }}>
                 {t.profileSecurity.newPassword}
               </Label>
               <Input
@@ -402,15 +414,14 @@ export function SettingsSecurityPage() {
                 onChange={(e) =>
                   setPasswordData((prev) => ({ ...prev, newPassword: e.target.value }))
                 }
-                className={inputClass}
               />
-              <p className="text-xs mt-1.5 text-gray-500">
+              <p className="text-xs mt-1.5" style={{ color: designTokens.text.secondary }}>
                 {t.profileSecurity.passwordMinLength}
               </p>
             </div>
 
             <div className="mb-6">
-              <Label className={`mb-2 block text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+              <Label className="mb-2 block text-sm" style={{ color: designTokens.text.secondary }}>
                 {t.profileSecurity.confirmPassword}
               </Label>
               <Input
@@ -419,7 +430,6 @@ export function SettingsSecurityPage() {
                 onChange={(e) =>
                   setPasswordData((prev) => ({ ...prev, confirmPassword: e.target.value }))
                 }
-                className={inputClass}
               />
             </div>
 
@@ -438,18 +448,18 @@ export function SettingsSecurityPage() {
 
         {/* Design Authority Section (User Role Only) */}
         {isUserRole && (
-          <Card className={`mb-6 ${cardClass}`}>
-            <CardHeader className={`border-b px-6 py-4 ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
+          <Card className="mb-6">
+            <CardHeader className="border-b px-6 py-4">
               <div className="flex items-center gap-3">
-                <CheckCircle className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
-                <CardTitle className={`text-lg font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                <CheckCircle className="w-5 h-5" style={{ color: designTokens.text.secondary }} />
+                <CardTitle className="text-lg font-medium">
                   {t.profileSecurity.coursePermission}
                 </CardTitle>
               </div>
             </CardHeader>
             <CardContent className="px-6 py-6">
               <div className="mb-5">
-                <Label className={`mb-3 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                <Label className="mb-3 text-sm" style={{ color: designTokens.text.secondary }}>
                   {t.profileSecurity.currentPermissionStatus}
                 </Label>
                 <div className="mt-3">
@@ -461,7 +471,7 @@ export function SettingsSecurityPage() {
 
               {designAuthStatus === 'USER' && (
                 <div>
-                  <p className={`text-sm mb-4 leading-relaxed ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  <p className="text-sm mb-4 leading-relaxed" style={{ color: designTokens.text.secondary }}>
                     {t.profileSecurity.permissionRequestDesc}
                   </p>
                   <Button onClick={handleRequestDesignAuth} disabled={isRequestPending}>
@@ -478,9 +488,15 @@ export function SettingsSecurityPage() {
               )}
 
               {(designAuthStatus === 'DESIGNER' || designAuthStatus === 'OWNER') && (
-                <Alert className={`flex items-center gap-3 ${isDark ? 'bg-green-500/10 border-green-500/30' : 'bg-green-50 border-green-200'}`}>
-                  <CheckCircle className={`w-5 h-5 ${isDark ? 'text-green-400' : 'text-green-600'}`} />
-                  <AlertDescription className={isDark ? 'text-green-400' : 'text-green-700'}>
+                <Alert
+                  className="flex items-center gap-3"
+                  style={{
+                    backgroundColor: designTokens.badge.green.bg,
+                    borderColor: designTokens.badge.green.text,
+                  }}
+                >
+                  <CheckCircle className="w-5 h-5" style={{ color: designTokens.badge.green.text }} />
+                  <AlertDescription style={{ color: designTokens.badge.green.text }}>
                     {t.profileSecurity.permissionEnabled}
                   </AlertDescription>
                 </Alert>
@@ -490,18 +506,24 @@ export function SettingsSecurityPage() {
         )}
 
         {/* Account Management Section */}
-        <Card className={cardClass}>
-          <CardHeader className={`border-b px-6 py-4 ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
+        <Card>
+          <CardHeader className="border-b px-6 py-4">
             <div className="flex items-center gap-3">
-              <AlertTriangle className={`w-5 h-5 ${isDark ? 'text-orange-400' : 'text-orange-500'}`} />
-              <CardTitle className={`text-lg font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              <AlertTriangle className="w-5 h-5" style={{ color: designTokens.badge.orange.text }} />
+              <CardTitle className="text-lg font-medium">
                 {t.profileSecurity.accountManagement}
               </CardTitle>
             </div>
           </CardHeader>
           <CardContent className="px-6 py-6">
-            <Alert className={`mb-4 ${isDark ? 'bg-orange-500/10 border-orange-500/30' : 'bg-orange-50 border-orange-200'}`}>
-              <AlertDescription className={isDark ? 'text-orange-400' : 'text-orange-700'}>
+            <Alert
+              className="mb-4"
+              style={{
+                backgroundColor: designTokens.badge.orange.bg,
+                borderColor: designTokens.badge.orange.text,
+              }}
+            >
+              <AlertDescription style={{ color: designTokens.badge.orange.text }}>
                 {t.profileSecurity.accountDeleteWarning}
               </AlertDescription>
             </Alert>
@@ -510,7 +532,7 @@ export function SettingsSecurityPage() {
               <AlertDialogTrigger asChild>
                 <Button
                   variant="outline"
-                  className={`text-red-500 border-red-500 ${isDark ? 'hover:bg-red-500/10' : 'hover:bg-red-50'}`}
+                  className="text-red-500 border-red-500 hover:bg-red-50"
                 >
                   {t.profileSecurity.withdraw}
                 </Button>

--- a/src/pages/sa/billing/BillingPage.tsx
+++ b/src/pages/sa/billing/BillingPage.tsx
@@ -77,8 +77,8 @@ export function BillingPage() {
   return (
     <div className="p-6">
       <AdminPageHeader
-        title="요금제 및 라이선스 관리"
-        description="테넌트 요금제와 결제 현황을 관리합니다"
+        title="구독 관리"
+        description="테넌트 구독 및 결제 현황을 관리합니다"
         actions={
           <Button variant="outline">
             <Download className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- SA 사이드바 메뉴명 간소화 (6개 메뉴 → 짧고 명확한 이름으로 변경)
- 설정 페이지 어드민 스타일 통일 (isDark 분기 제거 → designTokens 기반)
- 구독 관리 페이지 타이틀 변경

## Changes
### 사이드바 메뉴명 변경
| 기존 | 변경 |
|------|------|
| 테넌트 생성/조회/수정/삭제 | 테넌트 목록 |
| 요금제 및 라이선스 관리 | 구독 관리 |
| 글로벌 브랜딩/템플릿 기본값 설정 | 브랜딩 설정 |
| 전체 공지사항 등록 및 수정 | 공지사항 |
| 공지사항 배포 관리 | 배포 관리 |
| 전체 사용량 트렌드 및 통계 | 사용량 통계 |

### 설정 페이지 스타일 통일
- `SettingsSecurityPage`: isDark 조건 분기 제거, designTokens 라이트모드로 통일
- `SettingsNotificationsPage`: isDark 조건 분기 제거, designTokens 라이트모드로 통일
- `BillingPage`: 타이틀 "요금제 및 라이선스 관리" → "구독 관리"로 변경

## Related Issue
Closes #333

## Test Plan
- [ ] SA 로그인 후 사이드바 메뉴명이 간소화되었는지 확인
- [ ] `/sa/settings/security` 페이지가 어드민 스타일로 표시되는지 확인
- [ ] `/sa/settings/notifications` 페이지가 어드민 스타일로 표시되는지 확인
- [ ] `/sa/tenants/billing` 페이지 타이틀이 "구독 관리"로 표시되는지 확인
- [ ] 다른 역할(TA, TO, TU) 설정 페이지에도 동일 스타일 적용되는지 확인

## Screenshots
N/A (UI 텍스트 및 스타일 변경)
