### PR TITLE
feat: Course status 필드 프론트엔드 대응

### DIFF
--- a/src/pages/tu/teaching/courses/CourseCreatePage.tsx
+++ b/src/pages/tu/teaching/courses/CourseCreatePage.tsx
@@ -9,7 +9,7 @@
  */
 import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { ArrowLeft, ArrowRight, Save, FileText, Upload, Loader2 } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Save, FileText, Loader2, Send } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button } from '@/components/common';
 import { courseService, categoryService } from '@/services/common';
@@ -79,9 +79,9 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
 
   const [currentStep, setCurrentStep] = useState(1);
   const [categories, setCategories] = useState<CategoryResponse[]>([]);
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [isPublishing, setIsPublishing] = useState(false);
   const [courseId, setCourseId] = useState<number | null>(
     courseIdParam ? Number(courseIdParam) : null
   );
@@ -241,13 +241,15 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
     }
   };
 
-  const handleSubmit = async () => {
+  const handlePublish = async () => {
     if (!formData.title) {
       alert('강의명을 입력해주세요.');
       return;
     }
 
-    setIsSubmitting(true);
+    if (!confirm(getText('publishConfirm'))) return;
+
+    setIsPublishing(true);
     try {
       const request: CreateCourseRequest = {
         title: formData.title,
@@ -266,29 +268,33 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
       if (courseId) {
         // 기존 강의 수정
         await courseService.update(courseId, request);
+
+        // 커리큘럼 저장
+        if (formData.curriculumItems.length > 0) {
+          await deleteAllCurriculumItems(courseId);
+          await createCurriculumItemsRecursively(courseId, formData.curriculumItems, null);
+        }
       } else {
         // 새 강의 생성
-        const courseResponse = await courseService.create(request);
-        targetCourseId = courseResponse.courseId;
+        const response = await courseService.create(request);
+        targetCourseId = response.courseId;
+
+        // 커리큘럼 생성
+        if (formData.curriculumItems.length > 0) {
+          await createCurriculumItemsRecursively(response.courseId, formData.curriculumItems, null);
+        }
       }
 
-      // 커리큘럼 항목 생성 (트리 구조 재귀 처리)
-      // 참고: 기존 강의 수정 시에는 이미 저장된 커리큘럼이 있을 수 있음
-      if (targetCourseId && formData.curriculumItems.length > 0) {
-        await createCurriculumItemsRecursively(
-          targetCourseId,
-          formData.curriculumItems,
-          null
-        );
-      }
+      // 발행 API 호출
+      await courseService.publish(targetCourseId!);
 
-      alert('강의가 등록되었습니다!');
+      alert(getText('publishSuccess'));
       navigate('/tu/teaching/courses');
     } catch (error) {
-      console.error('강의 등록 실패:', error);
-      alert('강의 등록에 실패했습니다. 다시 시도해주세요.');
+      console.error('강의 발행 실패:', error);
+      alert(getText('publishError'));
     } finally {
-      setIsSubmitting(false);
+      setIsPublishing(false);
     }
   };
 
@@ -432,9 +438,18 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
                 <ArrowRight size={18} />
               </Button>
             ) : (
-              <Button onClick={handleSubmit} disabled={isSubmitting}>
-                <Upload size={18} />
-                {isSubmitting ? '등록 중...' : getText('submit')}
+              <Button onClick={handlePublish} disabled={isPublishing}>
+                {isPublishing ? (
+                  <>
+                    <Loader2 size={18} className="animate-spin" />
+                    {getText('publishing')}
+                  </>
+                ) : (
+                  <>
+                    <Send size={18} />
+                    {getText('publish')}
+                  </>
+                )}
               </Button>
             )}
           </div>

--- a/src/pages/tu/teaching/courses/MyCoursesPage.tsx
+++ b/src/pages/tu/teaching/courses/MyCoursesPage.tsx
@@ -5,11 +5,11 @@ import { cn } from '@/utils/cn';
 import { Button, IconStatCard } from '@/components/common';
 import { CourseCard } from '@/components/domain/tu/course';
 import { useMyCourses, useApplyProgramsBulk, toCourseForApplication } from '@/hooks/tu';
-import type { Course, CourseStatus } from '@/types';
-import type { CourseResponse } from '@/types/common/course.types';
+import type { Course } from '@/types';
+import type { CourseResponse, CoursePublishStatus } from '@/types/common/course.types';
 
-/** 완성 상태 필터 타입 */
-type CompletionFilter = 'all' | 'complete' | 'incomplete';
+/** 발행 상태 필터 타입 */
+type StatusFilter = 'all' | 'draft' | 'published';
 
 interface MyCoursesPageProps {
   language?: 'ko' | 'en';
@@ -18,7 +18,7 @@ interface MyCoursesPageProps {
 const DEFAULT_THUMBNAIL = 'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=400&h=250&fit=crop';
 
 /** CourseResponse를 UI용 Course 타입으로 변환 */
-function mapCourseResponseToCourse(response: CourseResponse): Course & { isComplete: boolean } {
+function mapCourseResponseToCourse(response: CourseResponse): Course & { isComplete: boolean; courseStatus: CoursePublishStatus } {
   return {
     id: String(response.courseId),
     title: response.title,
@@ -30,8 +30,9 @@ function mapCourseResponseToCourse(response: CourseResponse): Course & { isCompl
     category: response.tags?.[0] || '미분류',
     students: 0,
     lastAccessed: new Date(response.updatedAt).toLocaleDateString('ko-KR'),
-    status: response.isComplete ? 'active' as CourseStatus : 'draft' as CourseStatus,
+    status: response.status === 'PUBLISHED' ? 'active' : 'draft',
     isComplete: response.isComplete,
+    courseStatus: response.status,
   };
 }
 
@@ -40,8 +41,8 @@ const t = {
   subtitle: { ko: '개설한 강의를 관리하고 수강생을 확인하세요', en: 'Manage your courses and track student progress' },
   createCourse: { ko: '강의 생성', en: 'Create Course' },
   all: { ko: '전체', en: 'All' },
-  complete: { ko: '작성완료', en: 'Complete' },
-  incomplete: { ko: '작성중', en: 'In Progress' },
+  draft: { ko: '임시저장', en: 'Draft' },
+  published: { ko: '발행됨', en: 'Published' },
   sortBy: { ko: '정렬', en: 'Sort By' },
   recent: { ko: '최신순', en: 'Recent' },
   studentCount: { ko: '수강생 순', en: 'Students' },
@@ -71,7 +72,7 @@ const t = {
 
 export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>) {
   const navigate = useNavigate();
-  const [filterStatus, setFilterStatus] = useState<CompletionFilter>('all');
+  const [filterStatus, setFilterStatus] = useState<StatusFilter>('all');
   const [sortBy, setSortBy] = useState<'recent' | 'students' | 'title'>('recent');
   const [selectedCourseIds, setSelectedCourseIds] = useState<Set<string>>(new Set());
 
@@ -176,8 +177,8 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
 
   const filteredCourses = courses.filter((course) => {
     if (filterStatus === 'all') return true;
-    if (filterStatus === 'complete') return course.isComplete;
-    if (filterStatus === 'incomplete') return !course.isComplete;
+    if (filterStatus === 'draft') return course.courseStatus === 'DRAFT';
+    if (filterStatus === 'published') return course.courseStatus === 'PUBLISHED';
     return true;
   });
 
@@ -220,7 +221,7 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
         <div className="flex gap-2 items-center">
           <Filter size={18} className="text-text-secondary" />
           <div className="flex gap-1 bg-bg-secondary p-1 rounded-lg">
-            {(['all', 'complete', 'incomplete'] as const).map((status) => (
+            {(['all', 'draft', 'published'] as const).map((status) => (
               <button
                 key={status}
                 onClick={() => setFilterStatus(status)}
@@ -297,10 +298,10 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
           return (
             <div key={course.id} className="relative">
               {/* Status Badge - 썸네일 우측 하단 */}
-              {!course.isComplete && (
+              {course.courseStatus === 'DRAFT' && (
                 <div className="absolute top-[10rem] left-3 z-10 px-2 py-1 rounded-md bg-status-warning text-white text-xs font-medium flex items-center gap-1 shadow-sm">
                   <AlertTriangle size={12} />
-                  {getText('incomplete')}
+                  {getText('draft')}
                 </div>
               )}
 
@@ -331,7 +332,7 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
                     manageCourse: getText('manageCourse'),
                   }}
                   renderActions={
-                    course.isComplete ? (
+                    course.courseStatus === 'PUBLISHED' ? (
                       <>
                         <Button
                           size="sm"

--- a/src/pages/tu/teaching/courses/components/Step3Review.tsx
+++ b/src/pages/tu/teaching/courses/components/Step3Review.tsx
@@ -189,8 +189,8 @@ export function Step3Review({
         <Alert variant="info">
           <CheckCircle2 size={16} />
           <AlertDescription>
-            <strong>{getText('readyToSubmit')}</strong>
-            <p className="mt-1 mb-0">{getText('readyToSubmitDesc')}</p>
+            <strong>{getText('readyToPublish')}</strong>
+            <p className="mt-1 mb-0">{getText('readyToPublishDesc')}</p>
           </AlertDescription>
         </Alert>
       )}

--- a/src/pages/tu/teaching/courses/components/courseCreate.constants.ts
+++ b/src/pages/tu/teaching/courses/components/courseCreate.constants.ts
@@ -113,6 +113,14 @@ export const translations = {
   // 공통
   cancel: { ko: '취소', en: 'Cancel' },
   processing: { ko: '처리 중...', en: 'Processing...' },
+  // 발행
+  publish: { ko: '발행하기', en: 'Publish' },
+  publishing: { ko: '발행 중...', en: 'Publishing...' },
+  publishSuccess: { ko: '강의가 발행되었습니다.', en: 'Course has been published.' },
+  publishError: { ko: '발행에 실패했습니다. 다시 시도해주세요.', en: 'Failed to publish. Please try again.' },
+  publishConfirm: { ko: '강의를 발행하시겠습니까? 발행 후에는 프로그램에 신청할 수 있습니다.', en: 'Do you want to publish this course? After publishing, you can apply for programs.' },
+  readyToPublish: { ko: '발행 준비 완료', en: 'Ready to Publish' },
+  readyToPublishDesc: { ko: '모든 필수 정보가 입력되었습니다. 발행하기 버튼을 눌러 강의를 발행하세요.', en: 'All required information has been entered. Click Publish to publish your course.' },
   // 페이지네이션
   prev: { ko: '이전', en: 'Prev' },
   pageInfo: { ko: '{current} / {total} 페이지', en: 'Page {current} of {total}' },

--- a/src/services/common/courseService.ts
+++ b/src/services/common/courseService.ts
@@ -97,6 +97,22 @@ export const courseService = {
     await axiosInstance.delete(API_ENDPOINTS.COURSES.BY_ID(id));
   },
 
+  /** 강의 발행 */
+  async publish(id: number): Promise<CourseResponse> {
+    const { data } = await axiosInstance.post<CourseResponse>(
+      `${API_ENDPOINTS.COURSES.BY_ID(id)}/publish`
+    );
+    return data;
+  },
+
+  /** 강의 발행 취소 */
+  async unpublish(id: number): Promise<CourseResponse> {
+    const { data } = await axiosInstance.post<CourseResponse>(
+      `${API_ENDPOINTS.COURSES.BY_ID(id)}/unpublish`
+    );
+    return data;
+  },
+
   // ============================================
   // Course Items (차시)
   // ============================================

--- a/src/types/common/course.types.ts
+++ b/src/types/common/course.types.ts
@@ -13,6 +13,9 @@ export type CourseLevel = 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED';
 /** 강의 유형 */
 export type CourseType = 'ONLINE' | 'OFFLINE' | 'BLENDED';
 
+/** 강의 발행 상태 (API용, UI용 CourseStatus와 구분) */
+export type CoursePublishStatus = 'DRAFT' | 'PUBLISHED';
+
 // ============================================
 // Response Types
 // ============================================
@@ -25,6 +28,8 @@ export interface CourseResponse {
   thumbnailUrl: string | null;
   level: CourseLevel | null;
   type: CourseType | null;
+  /** 발행 상태 (DRAFT: 임시저장, PUBLISHED: 발행됨) */
+  status: CoursePublishStatus;
   estimatedHours: number | null;
   categoryId: number | null;
   startDate: string | null;
@@ -72,6 +77,8 @@ export interface CourseDetailResponse {
   thumbnailUrl: string | null;
   level: CourseLevel | null;
   type: CourseType | null;
+  /** 발행 상태 (DRAFT: 임시저장, PUBLISHED: 발행됨) */
+  status: CoursePublishStatus;
   estimatedHours: number | null;
   categoryId: number | null;
   startDate: string | null;
@@ -115,6 +122,7 @@ export interface UpdateCourseRequest {
   startDate?: string;
   endDate?: string;
   tags?: string[];
+  status?: CoursePublishStatus;
 }
 
 // ============================================
@@ -175,4 +183,10 @@ export const COURSE_TYPE_LABELS: Record<CourseType, string> = {
   ONLINE: '온라인',
   OFFLINE: '오프라인',
   BLENDED: '블렌디드',
+};
+
+/** CoursePublishStatus 라벨 맵 */
+export const COURSE_PUBLISH_STATUS_LABELS: Record<CoursePublishStatus, string> = {
+  DRAFT: '임시저장',
+  PUBLISHED: '발행됨',
 };


### PR DESCRIPTION
## Summary
- 백엔드 이슈 #333 (Course status 필드 추가)에 대응하는 프론트엔드 변경
- 강의 발행 상태(DRAFT/PUBLISHED)를 UI에서 관리할 수 있도록 구현

## Changes
- `CoursePublishStatus` 타입 추가 (`DRAFT` | `PUBLISHED`)
- `courseService`에 `publish()`, `unpublish()` API 메서드 추가
- `MyCoursesPage`: isComplete 기반 → status 기반 필터링으로 변경
- `CourseCreatePage`: Step3 하단에 "발행하기" 버튼 추가
- `Step3Review`: "발행 준비 완료" 메시지로 변경

## Test plan
- [ ] 강의 생성 후 발행하기 버튼 클릭 → 발행 성공 확인
- [ ] MyCoursesPage에서 임시저장/발행됨 필터 동작 확인
- [ ] 발행된 강의 카드에 "과정 관리", "프로그램 신청" 버튼 표시
- [ ] 임시저장 강의 카드에 "이어서 작성" 버튼 표시