### PR TITLE
fix: 수강평 API 응답 구조 변경 대응

### DIFF
--- a/src/components/domain/course-review/CourseReviewSection.tsx
+++ b/src/components/domain/course-review/CourseReviewSection.tsx
@@ -62,7 +62,7 @@ export function CourseReviewSection({ timeId, isDark = false, canWrite = false }
   const deleteMutation = useDeleteCourseReview();
 
   const reviews = reviewsData?.content || [];
-  const hasMyReview = !!myReview;
+  const hasMyReview = !!myReview?.id;
 
   const handleOpenModal = (review?: CourseReview) => {
     if (review) {
@@ -169,9 +169,10 @@ export function CourseReviewSection({ timeId, isDark = false, canWrite = false }
             </div>
 
             {/* 별점 분포 */}
+            {stats.ratingDistribution && (
             <div className="flex-1 space-y-2">
               {[5, 4, 3, 2, 1].map((star) => {
-                const count = stats.ratingDistribution[star as keyof typeof stats.ratingDistribution] || 0;
+                const count = stats.ratingDistribution?.[star as keyof typeof stats.ratingDistribution] || 0;
                 const percentage = stats.totalReviews > 0 ? (count / stats.totalReviews) * 100 : 0;
                 return (
                   <div key={star} className="flex items-center gap-2">
@@ -191,6 +192,7 @@ export function CourseReviewSection({ timeId, isDark = false, canWrite = false }
                 );
               })}
             </div>
+            )}
           </div>
         </div>
       ) : null}

--- a/src/types/tu/courseReview.types.ts
+++ b/src/types/tu/courseReview.types.ts
@@ -39,7 +39,7 @@ export interface CourseReviewListResponse {
 export interface CourseReviewStats {
   averageRating: number;
   totalReviews: number;
-  ratingDistribution: {
+  ratingDistribution?: {
     1: number;
     2: number;
     3: number;


### PR DESCRIPTION
## Summary

수강평 기능의 백엔드 API 응답 구조 변경에 따른 프론트엔드 버그 수정

## Related Issue

- Closes #

## Changes

- `CourseReviewStats.ratingDistribution`을 optional 필드로 변경
- 별점 분포 섹션 조건부 렌더링 추가 (ratingDistribution 없을 때 에러 방지)
- `hasMyReview` 판단 로직 수정 (`!!myReview` → `!!myReview?.id`)

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes

백엔드에서 `ratingDistribution` 필드가 없는 경우와 내 리뷰가 없을 때 빈 객체를 반환하는 경우를 처리했습니다.