### PR TITLE
feat: 프로필 페이지에 부서/직급 입력 필드 추가

### DIFF
--- a/src/pages/tu/mypage/ProfilePage.tsx
+++ b/src/pages/tu/mypage/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import { User, Camera, Save, Loader2, Lock, Mail, Calendar, AlertTriangle, CheckCircle, Shield, Info } from 'lucide-react';
+import { User, Camera, Save, Loader2, Lock, Mail, Calendar, AlertTriangle, CheckCircle, Shield, Info, Building2, Briefcase } from 'lucide-react';
 import { toast } from 'sonner';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation, useLanguageStore } from '@/store/common/languageStore';
@@ -53,7 +53,7 @@ export function ProfilePage() {
   const withdrawMutation = useWithdraw();
 
   // Local State
-  const [profileData, setProfileData] = useState({ name: '' });
+  const [profileData, setProfileData] = useState({ name: '', department: '', position: '' });
   const [passwordData, setPasswordData] = useState({
     currentPassword: '',
     newPassword: '',
@@ -70,7 +70,11 @@ export function ProfilePage() {
   // Sync profile data from API
   useEffect(() => {
     if (profile) {
-      setProfileData({ name: profile.name });
+      setProfileData({
+        name: profile.name,
+        department: profile.department || '',
+        position: profile.position || '',
+      });
       if (profile.profileImageUrl) {
         const imageUrl = profile.profileImageUrl.startsWith('http')
           ? profile.profileImageUrl
@@ -141,7 +145,11 @@ export function ProfilePage() {
     }
 
     try {
-      await updateProfileMutation.mutateAsync({ name: profileData.name });
+      await updateProfileMutation.mutateAsync({
+        name: profileData.name,
+        department: profileData.department || undefined,
+        position: profileData.position || undefined,
+      });
       toast.success('프로필 정보가 저장되었습니다.');
     } catch {
       toast.error('프로필 저장에 실패했습니다.');
@@ -330,6 +338,34 @@ export function ProfilePage() {
                 onChange={(e) => setProfileData((prev) => ({ ...prev, name: e.target.value }))}
                 className={inputClass}
               />
+            </div>
+
+            {/* Department & Position */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-5">
+              <div>
+                <Label className={`flex items-center gap-2 mb-2 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  <Building2 className="w-4 h-4" />
+                  부서
+                </Label>
+                <Input
+                  value={profileData.department}
+                  onChange={(e) => setProfileData((prev) => ({ ...prev, department: e.target.value }))}
+                  placeholder="예: 개발팀, 회계팀"
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <Label className={`flex items-center gap-2 mb-2 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  <Briefcase className="w-4 h-4" />
+                  직급
+                </Label>
+                <Input
+                  value={profileData.position}
+                  onChange={(e) => setProfileData((prev) => ({ ...prev, position: e.target.value }))}
+                  placeholder="예: 대리, 과장, 팀장"
+                  className={inputClass}
+                />
+              </div>
             </div>
 
             {/* Email (Read-only) */}

--- a/src/types/common/auth.types.ts
+++ b/src/types/common/auth.types.ts
@@ -35,6 +35,8 @@ export interface UpdateProfileRequest {
   name?: string;
   phone?: string;
   profileImageUrl?: string;
+  department?: string;  // 부서 (개발팀, 회계팀 등)
+  position?: string;    // 직급 (인턴, 신입, 대리, 과장, 차장, 팀장 등)
 }
 
 // --- Response DTOs ---
@@ -62,6 +64,8 @@ export interface UserDetailResponse {
   role: TenantRole;
   status: UserStatus;
   profileImageUrl?: string;
+  department?: string;    // 부서 (개발팀, 회계팀 등)
+  position?: string;      // 직급 (인턴, 신입, 대리, 과장, 차장, 팀장 등)
   tenantId?: number;
   tenantName?: string;
   tenantSubdomain?: string;


### PR DESCRIPTION
## Summary

테넌트 기능 설정 UI 및 프로필 페이지 부서/직급 입력 기능 추가

## Related Issue

- Closes #323
- Closes #321

## Changes

- 테넌트 기능 On/Off 설정 페이지 구현
- 프로필 미완성 사용자 리다이렉트 처리 (단체 계정 생성 시)
- ProfilePage에 부서(department), 직급(position) 입력 필드 추가
- auth.types.ts에 department, position 필드 타입 추가

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)
