### PR TITLE
fix: 수강평 API 응답 구조 매핑 추가

### DIFF
--- a/src/services/tu/courseReviewService.ts
+++ b/src/services/tu/courseReviewService.ts
@@ -7,6 +7,8 @@ import axiosInstance from '@/services/common/api/axiosInstance';
 import type {
   CourseReview,
   CourseReviewListResponse,
+  CourseReviewListApiResponse,
+  CourseReviewApiResponse,
   CourseReviewStats,
   CreateReviewRequest,
   UpdateReviewRequest,
@@ -14,6 +16,32 @@ import type {
 } from '@/types/tu/courseReview.types';
 
 const getBaseUrl = (timeId: number) => `/times/${timeId}/reviews`;
+
+/** 백엔드 리뷰를 프론트엔드 형식으로 변환 */
+const mapReview = (review: CourseReviewApiResponse): CourseReview => ({
+  id: review.reviewId,
+  courseTimeId: review.courseTimeId,
+  author: {
+    id: review.userId,
+    name: review.userName,
+    profileImageUrl: review.userProfileImageUrl || null,
+  },
+  rating: review.rating,
+  content: review.content,
+  completionRate: review.completionRate || 0,
+  createdAt: review.createdAt,
+  updatedAt: review.updatedAt,
+  isMyReview: review.isMyReview || false,
+});
+
+/** 백엔드 리뷰 목록을 프론트엔드 형식으로 변환 */
+const mapReviewList = (response: CourseReviewListApiResponse): CourseReviewListResponse => ({
+  content: response.reviews.map(mapReview),
+  totalElements: response.totalElements,
+  totalPages: response.totalPages,
+  page: response.currentPage,
+  size: response.pageSize,
+});
 
 export const courseReviewService = {
   /**
@@ -37,8 +65,9 @@ export const courseReviewService = {
 
     const query = queryParams.toString();
     const url = query ? `${getBaseUrl(timeId)}?${query}` : getBaseUrl(timeId);
-    const response = await axiosInstance.get<CourseReviewListResponse>(url);
-    return response.data;
+    const response = await axiosInstance.get<CourseReviewListApiResponse>(url);
+    console.log('📝 Reviews API Response:', response.data);
+    return mapReviewList(response.data);
   },
 
   /**
@@ -56,10 +85,14 @@ export const courseReviewService = {
    */
   getMyReview: async (timeId: number): Promise<CourseReview | null> => {
     try {
-      const response = await axiosInstance.get<CourseReview>(
+      const response = await axiosInstance.get<CourseReviewApiResponse>(
         `${getBaseUrl(timeId)}/my`
       );
-      return response.data;
+      // 빈 객체나 reviewId가 없으면 null 반환
+      if (!response.data || !response.data.reviewId) {
+        return null;
+      }
+      return mapReview(response.data);
     } catch {
       // 리뷰가 없는 경우 null 반환
       return null;
@@ -73,11 +106,11 @@ export const courseReviewService = {
     timeId: number,
     data: CreateReviewRequest
   ): Promise<CourseReview> => {
-    const response = await axiosInstance.post<CourseReview>(
+    const response = await axiosInstance.post<CourseReviewApiResponse>(
       getBaseUrl(timeId),
       data
     );
-    return response.data;
+    return mapReview(response.data);
   },
 
   /**
@@ -88,11 +121,11 @@ export const courseReviewService = {
     reviewId: number,
     data: UpdateReviewRequest
   ): Promise<CourseReview> => {
-    const response = await axiosInstance.patch<CourseReview>(
+    const response = await axiosInstance.patch<CourseReviewApiResponse>(
       `${getBaseUrl(timeId)}/${reviewId}`,
       data
     );
-    return response.data;
+    return mapReview(response.data);
   },
 
   /**

--- a/src/types/tu/courseReview.types.ts
+++ b/src/types/tu/courseReview.types.ts
@@ -13,7 +13,7 @@ export interface ReviewAuthor {
   profileImageUrl: string | null;
 }
 
-/** 코스 리뷰 응답 */
+/** 코스 리뷰 응답 (프론트엔드용) */
 export interface CourseReview {
   id: number;
   courseTimeId: number;
@@ -26,13 +26,39 @@ export interface CourseReview {
   isMyReview: boolean;
 }
 
-/** 리뷰 목록 응답 */
+/** 백엔드 리뷰 응답 (API 원본) */
+export interface CourseReviewApiResponse {
+  reviewId: number;
+  courseTimeId: number;
+  userId: number;
+  userName: string;
+  userProfileImageUrl?: string | null;
+  rating: number;
+  content: string;
+  completionRate?: number;
+  createdAt: string;
+  updatedAt: string;
+  isMyReview?: boolean;
+}
+
+/** 리뷰 목록 응답 (프론트엔드용) */
 export interface CourseReviewListResponse {
   content: CourseReview[];
   totalElements: number;
   totalPages: number;
   page: number;
   size: number;
+}
+
+/** 백엔드 리뷰 목록 응답 (API 원본) */
+export interface CourseReviewListApiResponse {
+  reviews: CourseReviewApiResponse[];
+  totalElements: number;
+  totalPages: number;
+  currentPage: number;
+  pageSize: number;
+  averageRating?: number;
+  reviewCount?: number;
 }
 
 /** 리뷰 통계 응답 */


### PR DESCRIPTION
## Summary

수강평 API 응답 구조가 프론트엔드 타입과 달라서 리뷰 목록이 표시되지 않는 문제를 수정했습니다.

## Related Issue

- Closes #

## Changes

- 백엔드 API 응답 타입 추가 (`CourseReviewApiResponse`, `CourseReviewListApiResponse`)
- 응답 매핑 함수 추가 (`mapReview`, `mapReviewList`)
  - `reviews` → `content`
  - `reviewId` → `id`
  - `userId`, `userName` → `author` 객체
  - `currentPage` → `page`
  - `pageSize` → `size`
- `ratingDistribution` optional 처리로 에러 방지
- `hasMyReview` 판단 로직 수정 (`!!myReview` → `!!myReview?.id`)

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes

백엔드 API 응답 구조와 프론트엔드 타입 사이의 불일치를 매핑 레이어로 해결했습니다.