### PR TITLE
feat: 테넌트 공지사항 UI 구현

### DIFF
--- a/src/components/layout/tu/TenantUserLayout.tsx
+++ b/src/components/layout/tu/TenantUserLayout.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { TenantUserSidebar } from './TenantUserSidebar';
+import { TenantNoticePopup } from '@/components/tu/TenantNoticePopup';
 import { designTokens } from '@/styles/admin-design-tokens';
 import { tenantUserMenuData } from '@/config/sidebar-menus';
 import { useUIStore, useIsDarkMode } from '@/store/common/uiStore';
@@ -55,6 +56,9 @@ export function TenantUserLayout({ children }: TenantUserLayoutProps) {
       />
 
       <main className="flex-1 overflow-auto">{children}</main>
+
+      {/* 공지사항 팝업 */}
+      <TenantNoticePopup />
     </div>
   );
 }

--- a/src/components/tu/TenantNoticePopup/TenantNoticePopup.tsx
+++ b/src/components/tu/TenantNoticePopup/TenantNoticePopup.tsx
@@ -1,0 +1,224 @@
+/**
+ * TU 공지사항 팝업 컴포넌트
+ * 로그인 후 사용자에게 최신 공지사항을 팝업으로 표시
+ */
+import { useState, useEffect, useCallback } from 'react';
+import { ChevronLeft, ChevronRight, Pin, Bell } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/common/Dialog';
+import { Button } from '@/components/common/Button';
+import { Badge } from '@/components/common/Badge';
+import { Checkbox } from '@/components/common/Checkbox';
+import { Label } from '@/components/common/Label';
+import { useVisibleTenantNotices } from '@/hooks/ta/useTenantNoticeQueries';
+import type { TenantNotice, TenantNoticeType } from '@/types/ta/tenantNotice.types';
+
+const STORAGE_KEY = 'tenant-notice-dismissed';
+const DISMISS_DURATION = 24 * 60 * 60 * 1000; // 24시간
+
+const typeConfig: Record<TenantNoticeType, { label: string; color: string }> = {
+  GENERAL: { label: '일반', color: 'bg-gray-100 text-gray-700' },
+  IMPORTANT: { label: '중요', color: 'bg-blue-100 text-blue-700' },
+  URGENT: { label: '긴급', color: 'bg-red-100 text-red-700' },
+  EVENT: { label: '이벤트', color: 'bg-purple-100 text-purple-700' },
+};
+
+interface DismissedData {
+  noticeIds: number[];
+  dismissedUntil: number | null; // null means dismissed forever for those IDs
+}
+
+function getDismissedData(): DismissedData {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const data = JSON.parse(stored) as DismissedData;
+      // 만료 시간 체크
+      if (data.dismissedUntil && data.dismissedUntil < Date.now()) {
+        // 시간 기반 dismiss가 만료됨
+        return { noticeIds: [], dismissedUntil: null };
+      }
+      return data;
+    }
+  } catch {
+    // 파싱 실패 시 초기값 반환
+  }
+  return { noticeIds: [], dismissedUntil: null };
+}
+
+function setDismissedData(data: DismissedData): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+export function TenantNoticePopup() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [dontShowToday, setDontShowToday] = useState(false);
+  const [visibleNotices, setVisibleNotices] = useState<TenantNotice[]>([]);
+
+  const { data: noticesData, isLoading } = useVisibleTenantNotices({ size: 10 });
+
+  // 공지사항 필터링 및 정렬
+  useEffect(() => {
+    if (!noticesData?.content || isLoading) return;
+
+    const dismissedData = getDismissedData();
+
+    // 사용자에게 보여줄 공지 필터링 (USER 대상만, 이미 본 공지 제외)
+    const userNotices = noticesData.content
+      .filter((notice) => notice.targetAudience === 'USER')
+      .filter((notice) => !dismissedData.noticeIds.includes(notice.id));
+
+    // 고정된 공지 먼저, 그 다음 최신순
+    const sortedNotices = userNotices.sort((a, b) => {
+      if (a.isPinned && !b.isPinned) return -1;
+      if (!a.isPinned && b.isPinned) return 1;
+      return new Date(b.publishedAt || b.createdAt).getTime() -
+             new Date(a.publishedAt || a.createdAt).getTime();
+    });
+
+    setVisibleNotices(sortedNotices);
+
+    // 보여줄 공지가 있으면 팝업 열기
+    if (sortedNotices.length > 0) {
+      setIsOpen(true);
+    }
+  }, [noticesData, isLoading]);
+
+  const currentNotice = visibleNotices[currentIndex];
+  const totalNotices = visibleNotices.length;
+
+  const handlePrev = useCallback(() => {
+    setCurrentIndex((prev) => (prev > 0 ? prev - 1 : prev));
+  }, []);
+
+  const handleNext = useCallback(() => {
+    setCurrentIndex((prev) => (prev < totalNotices - 1 ? prev + 1 : prev));
+  }, [totalNotices]);
+
+  const handleClose = useCallback(() => {
+    const dismissedData = getDismissedData();
+    const currentNoticeIds = visibleNotices.map((n) => n.id);
+
+    if (dontShowToday) {
+      // 오늘 하루 보지 않기 - 24시간 동안 모든 현재 공지 숨김
+      setDismissedData({
+        noticeIds: [...new Set([...dismissedData.noticeIds, ...currentNoticeIds])],
+        dismissedUntil: Date.now() + DISMISS_DURATION,
+      });
+    } else {
+      // 현재 보고 있는 공지만 dismissed 처리
+      if (currentNotice) {
+        setDismissedData({
+          ...dismissedData,
+          noticeIds: [...new Set([...dismissedData.noticeIds, currentNotice.id])],
+        });
+      }
+    }
+
+    setIsOpen(false);
+  }, [dontShowToday, visibleNotices, currentNotice]);
+
+  if (isLoading || !currentNotice) {
+    return null;
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <div className="flex items-center justify-between pr-8">
+            <DialogTitle className="flex items-center gap-2">
+              <Bell className="h-5 w-5 text-brand-primary" />
+              공지사항
+            </DialogTitle>
+            {totalNotices > 1 && (
+              <span className="text-sm text-text-secondary">
+                {currentIndex + 1} / {totalNotices}
+              </span>
+            )}
+          </div>
+        </DialogHeader>
+
+        <div className="py-4">
+          {/* 공지 헤더 */}
+          <div className="flex items-center gap-2 mb-3">
+            {currentNotice.isPinned && (
+              <Pin className="h-4 w-4 text-brand-primary" />
+            )}
+            <Badge className={typeConfig[currentNotice.type].color}>
+              {typeConfig[currentNotice.type].label}
+            </Badge>
+            <span className="text-xs text-text-secondary">
+              {new Date(currentNotice.publishedAt || currentNotice.createdAt).toLocaleDateString()}
+            </span>
+          </div>
+
+          {/* 공지 제목 */}
+          <h3 className="text-lg font-semibold mb-3">{currentNotice.title}</h3>
+
+          {/* 공지 내용 */}
+          <div className="prose prose-sm max-w-none text-text-secondary whitespace-pre-wrap max-h-60 overflow-y-auto">
+            {currentNotice.content}
+          </div>
+
+          {/* 페이지 네비게이션 (공지가 여러 개일 때) */}
+          {totalNotices > 1 && (
+            <div className="flex items-center justify-center gap-2 mt-4 pt-4 border-t">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handlePrev}
+                disabled={currentIndex === 0}
+              >
+                <ChevronLeft className="h-4 w-4" />
+                이전
+              </Button>
+              <div className="flex gap-1">
+                {visibleNotices.map((_, idx) => (
+                  <button
+                    key={idx}
+                    onClick={() => setCurrentIndex(idx)}
+                    className={`w-2 h-2 rounded-full transition-colors ${
+                      idx === currentIndex
+                        ? 'bg-brand-primary'
+                        : 'bg-gray-300 hover:bg-gray-400'
+                    }`}
+                  />
+                ))}
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleNext}
+                disabled={currentIndex === totalNotices - 1}
+              >
+                다음
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="flex-col sm:flex-row gap-4">
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="dontShowToday"
+              checked={dontShowToday}
+              onCheckedChange={(checked) => setDontShowToday(checked === true)}
+            />
+            <Label htmlFor="dontShowToday" className="text-sm text-text-secondary cursor-pointer">
+              오늘 하루 보지 않기
+            </Label>
+          </div>
+          <Button onClick={handleClose}>확인</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/tu/TenantNoticePopup/index.ts
+++ b/src/components/tu/TenantNoticePopup/index.ts
@@ -1,0 +1,1 @@
+export { TenantNoticePopup } from './TenantNoticePopup';

--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -183,6 +183,12 @@ export const tenantAdminMenuData: MenuItem[] = [
     ],
   },
   {
+    id: 'notice-management',
+    label: { ko: '공지사항 관리', en: 'Notice Management' },
+    icon: Megaphone,
+    path: '/ta/notices',
+  },
+  {
     id: 'settings',
     label: { ko: '설정', en: 'Settings' },
     icon: Settings,

--- a/src/hooks/ta/index.ts
+++ b/src/hooks/ta/index.ts
@@ -118,3 +118,18 @@ export {
   useActivateAutoEnrollmentRule,
   useDeactivateAutoEnrollmentRule,
 } from './useAutoEnrollmentRuleQueries';
+
+export {
+  tenantNoticeKeys,
+  useTenantNotices,
+  useSearchTenantNotices,
+  useTenantNotice,
+  useCreateTenantNotice,
+  useUpdateTenantNotice,
+  useDeleteTenantNotice,
+  usePublishTenantNotice,
+  useArchiveTenantNotice,
+  useVisibleTenantNotices,
+  useVisibleTenantNotice,
+  useVisibleTenantNoticeCount,
+} from './useTenantNoticeQueries';

--- a/src/hooks/ta/useTenantNoticeQueries.ts
+++ b/src/hooks/ta/useTenantNoticeQueries.ts
@@ -1,0 +1,178 @@
+/**
+ * TA 테넌트 공지사항 관련 React Query 훅
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { tenantNoticeService } from '@/services/ta/tenantNoticeService';
+import type {
+  CreateTenantNoticeRequest,
+  UpdateTenantNoticeRequest,
+  TenantNoticeListParams,
+  TenantNoticeSearchParams,
+} from '@/types/ta/tenantNotice.types';
+
+// ============================================
+// Query Keys
+// ============================================
+
+export const tenantNoticeKeys = {
+  all: ['tenant-notices'] as const,
+  lists: () => [...tenantNoticeKeys.all, 'list'] as const,
+  list: (params?: TenantNoticeListParams) => [...tenantNoticeKeys.lists(), params] as const,
+  search: (params: TenantNoticeSearchParams) => [...tenantNoticeKeys.all, 'search', params] as const,
+  details: () => [...tenantNoticeKeys.all, 'detail'] as const,
+  detail: (id: number) => [...tenantNoticeKeys.details(), id] as const,
+  // TU/TO 조회용
+  visible: () => [...tenantNoticeKeys.all, 'visible'] as const,
+  visibleList: (params?: { page?: number; size?: number }) => [...tenantNoticeKeys.visible(), 'list', params] as const,
+  visibleDetail: (id: number) => [...tenantNoticeKeys.visible(), 'detail', id] as const,
+  visibleCount: () => [...tenantNoticeKeys.visible(), 'count'] as const,
+};
+
+// ============================================
+// TA/TO 관리용 훅
+// ============================================
+
+/**
+ * 공지사항 목록 조회
+ */
+export const useTenantNotices = (params?: TenantNoticeListParams) => {
+  return useQuery({
+    queryKey: tenantNoticeKeys.list(params),
+    queryFn: () => tenantNoticeService.getNotices(params),
+  });
+};
+
+/**
+ * 공지사항 검색
+ */
+export const useSearchTenantNotices = (params: TenantNoticeSearchParams) => {
+  return useQuery({
+    queryKey: tenantNoticeKeys.search(params),
+    queryFn: () => tenantNoticeService.searchNotices(params),
+    enabled: !!params.keyword,
+  });
+};
+
+/**
+ * 공지사항 상세 조회
+ */
+export const useTenantNotice = (id: number) => {
+  return useQuery({
+    queryKey: tenantNoticeKeys.detail(id),
+    queryFn: () => tenantNoticeService.getNotice(id),
+    enabled: !!id,
+  });
+};
+
+/**
+ * 공지사항 생성
+ */
+export const useCreateTenantNotice = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateTenantNoticeRequest) => tenantNoticeService.createNotice(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantNoticeKeys.lists() });
+    },
+  });
+};
+
+/**
+ * 공지사항 수정
+ */
+export const useUpdateTenantNotice = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: { id: number; request: UpdateTenantNoticeRequest }) =>
+      tenantNoticeService.updateNotice(id, request),
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries({ queryKey: tenantNoticeKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: tenantNoticeKeys.detail(id) });
+    },
+  });
+};
+
+/**
+ * 공지사항 삭제
+ */
+export const useDeleteTenantNotice = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => tenantNoticeService.deleteNotice(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantNoticeKeys.lists() });
+    },
+  });
+};
+
+/**
+ * 공지사항 발행
+ */
+export const usePublishTenantNotice = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => tenantNoticeService.publishNotice(id),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: tenantNoticeKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: tenantNoticeKeys.detail(id) });
+      // TU/TO 조회용 캐시도 무효화
+      queryClient.invalidateQueries({ queryKey: tenantNoticeKeys.visible() });
+    },
+  });
+};
+
+/**
+ * 공지사항 보관
+ */
+export const useArchiveTenantNotice = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => tenantNoticeService.archiveNotice(id),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: tenantNoticeKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: tenantNoticeKeys.detail(id) });
+      // TU/TO 조회용 캐시도 무효화
+      queryClient.invalidateQueries({ queryKey: tenantNoticeKeys.visible() });
+    },
+  });
+};
+
+// ============================================
+// TU/TO 조회용 훅
+// ============================================
+
+/**
+ * 발행된 공지사항 목록 조회 (TU/TO용)
+ */
+export const useVisibleTenantNotices = (params?: { page?: number; size?: number }) => {
+  return useQuery({
+    queryKey: tenantNoticeKeys.visibleList(params),
+    queryFn: () => tenantNoticeService.getVisibleNotices(params),
+  });
+};
+
+/**
+ * 발행된 공지사항 상세 조회 (TU/TO용, 조회수 증가)
+ */
+export const useVisibleTenantNotice = (id: number) => {
+  return useQuery({
+    queryKey: tenantNoticeKeys.visibleDetail(id),
+    queryFn: () => tenantNoticeService.getVisibleNotice(id),
+    enabled: !!id,
+  });
+};
+
+/**
+ * 발행된 공지사항 수 조회 (TU/TO용)
+ */
+export const useVisibleTenantNoticeCount = () => {
+  return useQuery({
+    queryKey: tenantNoticeKeys.visibleCount(),
+    queryFn: () => tenantNoticeService.countVisibleNotices(),
+  });
+};

--- a/src/pages/ta/index.ts
+++ b/src/pages/ta/index.ts
@@ -16,3 +16,6 @@ export { TenantSettingsPage, UserManagementSettingsPage } from './settings';
 
 // Features
 export { FeatureSettingsPage, TenantCategoryPage } from './features';
+
+// Notices
+export { TenantNoticesPage } from './notices';

--- a/src/pages/ta/notices/TenantNoticesPage.tsx
+++ b/src/pages/ta/notices/TenantNoticesPage.tsx
@@ -1,0 +1,545 @@
+import { useState } from 'react';
+import {
+  Plus,
+  Edit,
+  Trash2,
+  Pin,
+  Calendar,
+  Send,
+  Archive,
+  Users,
+  Eye,
+} from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Badge } from '@/components/common/Badge';
+import { Label } from '@/components/common/Label';
+import { Textarea } from '@/components/common/Textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/common/Dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/common/Select';
+import { Switch } from '@/components/common/Switch';
+import {
+  useTenantNotices,
+  useCreateTenantNotice,
+  useUpdateTenantNotice,
+  useDeleteTenantNotice,
+  usePublishTenantNotice,
+  useArchiveTenantNotice,
+} from '@/hooks/ta/useTenantNoticeQueries';
+import type {
+  TenantNotice,
+  TenantNoticeType,
+  TenantNoticeStatus,
+  NoticeTargetAudience,
+  CreateTenantNoticeRequest,
+  UpdateTenantNoticeRequest,
+} from '@/types/ta/tenantNotice.types';
+
+const typeConfig: Record<TenantNoticeType, { label: string; color: string }> = {
+  GENERAL: { label: '일반', color: 'bg-gray-100 text-gray-700' },
+  IMPORTANT: { label: '중요', color: 'bg-blue-100 text-blue-700' },
+  URGENT: { label: '긴급', color: 'bg-red-100 text-red-700' },
+  EVENT: { label: '이벤트', color: 'bg-purple-100 text-purple-700' },
+};
+
+const statusConfig: Record<TenantNoticeStatus, { label: string; color: string }> = {
+  DRAFT: { label: '초안', color: 'bg-gray-100 text-gray-600' },
+  PUBLISHED: { label: '게시됨', color: 'bg-green-100 text-green-700' },
+  ARCHIVED: { label: '보관됨', color: 'bg-orange-100 text-orange-700' },
+};
+
+const audienceConfig: Record<NoticeTargetAudience, { label: string; icon: typeof Users }> = {
+  OPERATOR: { label: '운영자', icon: Users },
+  USER: { label: '사용자', icon: Users },
+};
+
+export function TenantNoticesPage() {
+  const [statusFilter, setStatusFilter] = useState<TenantNoticeStatus | 'ALL'>('ALL');
+  const [audienceFilter, setAudienceFilter] = useState<NoticeTargetAudience | 'ALL'>('ALL');
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [editingNotice, setEditingNotice] = useState<TenantNotice | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<TenantNotice | null>(null);
+  const [viewingNotice, setViewingNotice] = useState<TenantNotice | null>(null);
+
+  // Form state
+  const [formData, setFormData] = useState<CreateTenantNoticeRequest>({
+    title: '',
+    content: '',
+    type: 'GENERAL',
+    targetAudience: 'USER',
+    isPinned: false,
+  });
+
+  // API Hooks
+  const { data: noticesData, isLoading } = useTenantNotices({
+    status: statusFilter !== 'ALL' ? statusFilter : undefined,
+    targetAudience: audienceFilter !== 'ALL' ? audienceFilter : undefined,
+  });
+  const createMutation = useCreateTenantNotice();
+  const updateMutation = useUpdateTenantNotice();
+  const deleteMutation = useDeleteTenantNotice();
+  const publishMutation = usePublishTenantNotice();
+  const archiveMutation = useArchiveTenantNotice();
+
+  const notices = noticesData?.content || [];
+  const totalNotices = noticesData?.totalElements || 0;
+
+  const handleCreateOpen = () => {
+    setFormData({
+      title: '',
+      content: '',
+      type: 'GENERAL',
+      targetAudience: 'USER',
+      isPinned: false,
+    });
+    setIsCreateOpen(true);
+  };
+
+  const handleEditOpen = (notice: TenantNotice) => {
+    setFormData({
+      title: notice.title,
+      content: notice.content,
+      type: notice.type,
+      targetAudience: notice.targetAudience,
+      isPinned: notice.isPinned,
+    });
+    setEditingNotice(notice);
+  };
+
+  const handleCreate = async () => {
+    if (!formData.title.trim() || !formData.content.trim()) return;
+    await createMutation.mutateAsync(formData);
+    setIsCreateOpen(false);
+  };
+
+  const handleUpdate = async () => {
+    if (!editingNotice || !formData.title.trim() || !formData.content.trim()) return;
+    const request: UpdateTenantNoticeRequest = {
+      title: formData.title,
+      content: formData.content,
+      type: formData.type,
+      targetAudience: formData.targetAudience,
+      isPinned: formData.isPinned,
+    };
+    await updateMutation.mutateAsync({ id: editingNotice.id, request });
+    setEditingNotice(null);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    await deleteMutation.mutateAsync(deleteTarget.id);
+    setDeleteTarget(null);
+  };
+
+  const handlePublish = async (id: number) => {
+    await publishMutation.mutateAsync(id);
+  };
+
+  const handleArchive = async (id: number) => {
+    await archiveMutation.mutateAsync(id);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+          <div className="h-64 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-semibold text-text-primary">공지사항 관리</h1>
+          <p className="text-sm text-text-secondary mt-1">
+            운영자와 사용자에게 공지사항을 관리합니다
+          </p>
+        </div>
+        <Button onClick={handleCreateOpen}>
+          <Plus className="mr-2 h-4 w-4" />
+          공지 작성
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>공지사항 목록</CardTitle>
+              <CardDescription>전체 {totalNotices}개의 공지사항</CardDescription>
+            </div>
+            <div className="flex items-center gap-3">
+              <Select
+                value={audienceFilter}
+                onValueChange={(v) => setAudienceFilter(v as NoticeTargetAudience | 'ALL')}
+              >
+                <SelectTrigger className="w-32">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ALL">전체 대상</SelectItem>
+                  <SelectItem value="OPERATOR">운영자</SelectItem>
+                  <SelectItem value="USER">사용자</SelectItem>
+                </SelectContent>
+              </Select>
+              <Select
+                value={statusFilter}
+                onValueChange={(v) => setStatusFilter(v as TenantNoticeStatus | 'ALL')}
+              >
+                <SelectTrigger className="w-32">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ALL">전체 상태</SelectItem>
+                  <SelectItem value="DRAFT">초안</SelectItem>
+                  <SelectItem value="PUBLISHED">게시됨</SelectItem>
+                  <SelectItem value="ARCHIVED">보관됨</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {notices.length === 0 ? (
+              <div className="text-center py-8 text-text-secondary">
+                등록된 공지사항이 없습니다
+              </div>
+            ) : (
+              notices.map((notice) => (
+                <div
+                  key={notice.id}
+                  className="flex items-center justify-between p-4 border rounded-lg hover:bg-bg-secondary"
+                >
+                  <div className="flex items-start gap-3 flex-1 min-w-0">
+                    {notice.isPinned && <Pin className="h-4 w-4 text-brand-primary mt-1 flex-shrink-0" />}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <h3 className="font-medium truncate">{notice.title}</h3>
+                        <Badge className={typeConfig[notice.type].color}>
+                          {typeConfig[notice.type].label}
+                        </Badge>
+                        <Badge className={statusConfig[notice.status].color}>
+                          {statusConfig[notice.status].label}
+                        </Badge>
+                        <Badge variant="outline">
+                          <Users className="h-3 w-3 mr-1" />
+                          {audienceConfig[notice.targetAudience].label}
+                        </Badge>
+                      </div>
+                      <div className="flex items-center gap-4 mt-1 text-sm text-text-secondary">
+                        <span className="flex items-center gap-1">
+                          <Calendar className="h-3 w-3" />
+                          {new Date(notice.createdAt).toLocaleDateString()}
+                        </span>
+                        {notice.status === 'PUBLISHED' && (
+                          <span className="flex items-center gap-1">
+                            <Eye className="h-3 w-3" />
+                            조회 {notice.viewCount}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1 flex-shrink-0">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setViewingNotice(notice)}
+                      title="미리보기"
+                    >
+                      <Eye className="h-4 w-4" />
+                    </Button>
+                    {notice.status === 'DRAFT' && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handlePublish(notice.id)}
+                        disabled={publishMutation.isPending}
+                        title="발행"
+                      >
+                        <Send className="h-4 w-4 text-green-600" />
+                      </Button>
+                    )}
+                    {notice.status === 'PUBLISHED' && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleArchive(notice.id)}
+                        disabled={archiveMutation.isPending}
+                        title="보관"
+                      >
+                        <Archive className="h-4 w-4 text-orange-600" />
+                      </Button>
+                    )}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleEditOpen(notice)}
+                    >
+                      <Edit className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-red-500"
+                      onClick={() => setDeleteTarget(notice)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Create Dialog */}
+      <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>새 공지사항 작성</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label>제목 *</Label>
+              <Input
+                value={formData.title}
+                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                placeholder="공지사항 제목을 입력하세요"
+              />
+            </div>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <Label>유형</Label>
+                <Select
+                  value={formData.type}
+                  onValueChange={(v) => setFormData({ ...formData, type: v as TenantNoticeType })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="GENERAL">일반</SelectItem>
+                    <SelectItem value="IMPORTANT">중요</SelectItem>
+                    <SelectItem value="URGENT">긴급</SelectItem>
+                    <SelectItem value="EVENT">이벤트</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>대상</Label>
+                <Select
+                  value={formData.targetAudience}
+                  onValueChange={(v) => setFormData({ ...formData, targetAudience: v as NoticeTargetAudience })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="USER">사용자</SelectItem>
+                    <SelectItem value="OPERATOR">운영자</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-center gap-2 pt-6">
+                <Switch
+                  id="isPinned"
+                  checked={formData.isPinned}
+                  onCheckedChange={(v) => setFormData({ ...formData, isPinned: v })}
+                />
+                <Label htmlFor="isPinned">상단 고정</Label>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>내용 *</Label>
+              <Textarea
+                value={formData.content}
+                onChange={(e) => setFormData({ ...formData, content: e.target.value })}
+                placeholder="공지사항 내용을 입력하세요"
+                rows={8}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsCreateOpen(false)}>
+              취소
+            </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={!formData.title.trim() || !formData.content.trim() || createMutation.isPending}
+            >
+              {createMutation.isPending ? '생성 중...' : '생성'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Dialog */}
+      <Dialog open={!!editingNotice} onOpenChange={() => setEditingNotice(null)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>공지사항 수정</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label>제목 *</Label>
+              <Input
+                value={formData.title}
+                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                placeholder="공지사항 제목을 입력하세요"
+              />
+            </div>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <Label>유형</Label>
+                <Select
+                  value={formData.type}
+                  onValueChange={(v) => setFormData({ ...formData, type: v as TenantNoticeType })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="GENERAL">일반</SelectItem>
+                    <SelectItem value="IMPORTANT">중요</SelectItem>
+                    <SelectItem value="URGENT">긴급</SelectItem>
+                    <SelectItem value="EVENT">이벤트</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>대상</Label>
+                <Select
+                  value={formData.targetAudience}
+                  onValueChange={(v) => setFormData({ ...formData, targetAudience: v as NoticeTargetAudience })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="USER">사용자</SelectItem>
+                    <SelectItem value="OPERATOR">운영자</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-center gap-2 pt-6">
+                <Switch
+                  id="isPinnedEdit"
+                  checked={formData.isPinned}
+                  onCheckedChange={(v) => setFormData({ ...formData, isPinned: v })}
+                />
+                <Label htmlFor="isPinnedEdit">상단 고정</Label>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>내용 *</Label>
+              <Textarea
+                value={formData.content}
+                onChange={(e) => setFormData({ ...formData, content: e.target.value })}
+                placeholder="공지사항 내용을 입력하세요"
+                rows={8}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditingNotice(null)}>
+              취소
+            </Button>
+            <Button
+              onClick={handleUpdate}
+              disabled={!formData.title.trim() || !formData.content.trim() || updateMutation.isPending}
+            >
+              {updateMutation.isPending ? '저장 중...' : '저장'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirm Dialog */}
+      <Dialog open={!!deleteTarget} onOpenChange={() => setDeleteTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>공지사항 삭제</DialogTitle>
+          </DialogHeader>
+          <p className="py-4">
+            "{deleteTarget?.title}" 공지사항을 삭제하시겠습니까?
+            <br />
+            <span className="text-sm text-text-secondary">
+              이 작업은 되돌릴 수 없습니다.
+            </span>
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)}>
+              취소
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? '삭제 중...' : '삭제'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Preview Dialog */}
+      <Dialog open={!!viewingNotice} onOpenChange={() => setViewingNotice(null)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              {viewingNotice?.isPinned && <Pin className="h-4 w-4 text-brand-primary" />}
+              {viewingNotice?.title}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="py-4">
+            <div className="flex items-center gap-2 mb-4">
+              {viewingNotice && (
+                <>
+                  <Badge className={typeConfig[viewingNotice.type].color}>
+                    {typeConfig[viewingNotice.type].label}
+                  </Badge>
+                  <Badge variant="outline">
+                    <Users className="h-3 w-3 mr-1" />
+                    {audienceConfig[viewingNotice.targetAudience].label}
+                  </Badge>
+                  <span className="text-sm text-text-secondary">
+                    {new Date(viewingNotice.createdAt).toLocaleDateString()}
+                  </span>
+                </>
+              )}
+            </div>
+            <div className="prose prose-sm max-w-none whitespace-pre-wrap">
+              {viewingNotice?.content}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setViewingNotice(null)}>
+              닫기
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/ta/notices/index.ts
+++ b/src/pages/ta/notices/index.ts
@@ -1,0 +1,1 @@
+export { TenantNoticesPage } from './TenantNoticesPage';

--- a/src/routes/ta.routes.tsx
+++ b/src/routes/ta.routes.tsx
@@ -25,6 +25,7 @@ import {
   UserManagementSettingsPage,
   FeatureSettingsPage,
   TenantCategoryPage,
+  TenantNoticesPage,
 } from '@/pages/ta';
 import { BannerManagementPage } from '@/pages/ta/branding/BannerManagementPage';
 import { EmployeeListPage } from '@/pages/ta/users/EmployeeListPage';
@@ -72,6 +73,8 @@ const taChildRoutes = (
     {/* 기능 설정 */}
     <Route path="features" element={<FeatureSettingsPage />} />
     <Route path="features/categories" element={<TenantCategoryPage />} />
+    {/* 공지사항 관리 */}
+    <Route path="notices" element={<TenantNoticesPage />} />
     {/* 설정 */}
     <Route path="settings" element={<SettingsPage />} />
     <Route path="settings/security" element={<SettingsSecurityPage />} />

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -370,4 +370,17 @@ export const API_ENDPOINTS = {
     ACTIVATE: (id: number) => `/auto-enrollment-rules/${id}/activate`,
     DEACTIVATE: (id: number) => `/auto-enrollment-rules/${id}/deactivate`,
   },
+
+  // Tenant Notices (테넌트 공지) - TA/TO 관리, TU/TO 조회
+  TENANT_NOTICES: {
+    BASE: '/tenant/notices',
+    SEARCH: '/tenant/notices/search',
+    BY_ID: (id: number) => `/tenant/notices/${id}`,
+    PUBLISH: (id: number) => `/tenant/notices/${id}/publish`,
+    ARCHIVE: (id: number) => `/tenant/notices/${id}/archive`,
+    // TU/TO 조회용
+    TU_BASE: '/tu/notices',
+    TU_BY_ID: (id: number) => `/tu/notices/${id}`,
+    TU_COUNT: '/tu/notices/count',
+  },
 } as const;

--- a/src/services/ta/index.ts
+++ b/src/services/ta/index.ts
@@ -9,3 +9,4 @@ export { tenantCategoryService } from './tenantCategoryService';
 export { employeeService } from './employeeService';
 export { departmentService } from './departmentService';
 export { autoEnrollmentRuleService } from './autoEnrollmentRuleService';
+export { tenantNoticeService } from './tenantNoticeService';

--- a/src/services/ta/tenantNoticeService.ts
+++ b/src/services/ta/tenantNoticeService.ts
@@ -1,0 +1,152 @@
+/**
+ * TA 테넌트 공지사항 관리 API 서비스
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type {
+  TenantNotice,
+  TenantNoticeListResponse,
+  TenantNoticeListParams,
+  TenantNoticeSearchParams,
+  CreateTenantNoticeRequest,
+  UpdateTenantNoticeRequest,
+} from '@/types/ta/tenantNotice.types';
+
+/**
+ * 요청 객체에서 undefined 값만 제거 (null은 유지)
+ */
+function cleanRequest<T extends object>(obj: T): Partial<T> {
+  const cleaned: Partial<T> = {};
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const value = obj[key];
+      if (value === undefined) continue;
+      cleaned[key as keyof T] = value;
+    }
+  }
+  return cleaned;
+}
+
+export const tenantNoticeService = {
+  // ============================================
+  // TA/TO 관리용 API
+  // ============================================
+
+  /**
+   * 공지사항 목록 조회
+   */
+  async getNotices(params?: TenantNoticeListParams): Promise<TenantNoticeListResponse> {
+    const { data } = await axiosInstance.get<TenantNoticeListResponse>(
+      API_ENDPOINTS.TENANT_NOTICES.BASE,
+      { params }
+    );
+    return data;
+  },
+
+  /**
+   * 공지사항 검색
+   */
+  async searchNotices(params: TenantNoticeSearchParams): Promise<TenantNoticeListResponse> {
+    const { data } = await axiosInstance.get<TenantNoticeListResponse>(
+      API_ENDPOINTS.TENANT_NOTICES.SEARCH,
+      { params }
+    );
+    return data;
+  },
+
+  /**
+   * 공지사항 상세 조회
+   */
+  async getNotice(id: number): Promise<TenantNotice> {
+    const { data } = await axiosInstance.get<TenantNotice>(
+      API_ENDPOINTS.TENANT_NOTICES.BY_ID(id)
+    );
+    return data;
+  },
+
+  /**
+   * 공지사항 생성
+   */
+  async createNotice(request: CreateTenantNoticeRequest): Promise<TenantNotice> {
+    const cleanedRequest = cleanRequest(request);
+    const { data } = await axiosInstance.post<TenantNotice>(
+      API_ENDPOINTS.TENANT_NOTICES.BASE,
+      cleanedRequest
+    );
+    return data;
+  },
+
+  /**
+   * 공지사항 수정
+   */
+  async updateNotice(id: number, request: UpdateTenantNoticeRequest): Promise<TenantNotice> {
+    const cleanedRequest = cleanRequest(request);
+    const { data } = await axiosInstance.put<TenantNotice>(
+      API_ENDPOINTS.TENANT_NOTICES.BY_ID(id),
+      cleanedRequest
+    );
+    return data;
+  },
+
+  /**
+   * 공지사항 삭제
+   */
+  async deleteNotice(id: number): Promise<void> {
+    await axiosInstance.delete(API_ENDPOINTS.TENANT_NOTICES.BY_ID(id));
+  },
+
+  /**
+   * 공지사항 발행
+   */
+  async publishNotice(id: number): Promise<TenantNotice> {
+    const { data } = await axiosInstance.post<TenantNotice>(
+      API_ENDPOINTS.TENANT_NOTICES.PUBLISH(id)
+    );
+    return data;
+  },
+
+  /**
+   * 공지사항 보관
+   */
+  async archiveNotice(id: number): Promise<TenantNotice> {
+    const { data } = await axiosInstance.post<TenantNotice>(
+      API_ENDPOINTS.TENANT_NOTICES.ARCHIVE(id)
+    );
+    return data;
+  },
+
+  // ============================================
+  // TU/TO 조회용 API
+  // ============================================
+
+  /**
+   * 발행된 공지사항 목록 조회 (TU/TO용)
+   */
+  async getVisibleNotices(params?: { page?: number; size?: number }): Promise<TenantNoticeListResponse> {
+    const { data } = await axiosInstance.get<TenantNoticeListResponse>(
+      API_ENDPOINTS.TENANT_NOTICES.TU_BASE,
+      { params }
+    );
+    return data;
+  },
+
+  /**
+   * 발행된 공지사항 상세 조회 (TU/TO용, 조회수 증가)
+   */
+  async getVisibleNotice(id: number): Promise<TenantNotice> {
+    const { data } = await axiosInstance.get<TenantNotice>(
+      API_ENDPOINTS.TENANT_NOTICES.TU_BY_ID(id)
+    );
+    return data;
+  },
+
+  /**
+   * 발행된 공지사항 수 조회 (TU/TO용)
+   */
+  async countVisibleNotices(): Promise<number> {
+    const { data } = await axiosInstance.get<number>(
+      API_ENDPOINTS.TENANT_NOTICES.TU_COUNT
+    );
+    return data;
+  },
+};

--- a/src/types/ta/index.ts
+++ b/src/types/ta/index.ts
@@ -2,3 +2,4 @@ export * from './banner.types';
 export * from './employee.types';
 export * from './department.types';
 export * from './autoEnrollmentRule.types';
+export * from './tenantNotice.types';

--- a/src/types/ta/tenantNotice.types.ts
+++ b/src/types/ta/tenantNotice.types.ts
@@ -1,0 +1,65 @@
+/**
+ * Tenant Notice 타입 정의 (TA)
+ * 테넌트 관리자/운영자가 TO/TU에게 보내는 공지
+ */
+
+export type TenantNoticeType = 'GENERAL' | 'IMPORTANT' | 'URGENT' | 'EVENT';
+export type TenantNoticeStatus = 'DRAFT' | 'PUBLISHED' | 'ARCHIVED';
+export type NoticeTargetAudience = 'OPERATOR' | 'USER';
+
+export interface TenantNotice {
+  id: number;
+  tenantId: number;
+  title: string;
+  content: string;
+  type: TenantNoticeType;
+  status: TenantNoticeStatus;
+  targetAudience: NoticeTargetAudience;
+  creatorRole: string;
+  isPinned: boolean;
+  publishedAt: string | null;
+  expiredAt: string | null;
+  createdBy: number;
+  viewCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TenantNoticeListResponse {
+  content: TenantNotice[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+}
+
+export interface TenantNoticeListParams {
+  status?: TenantNoticeStatus;
+  targetAudience?: NoticeTargetAudience;
+  page?: number;
+  size?: number;
+}
+
+export interface TenantNoticeSearchParams {
+  keyword: string;
+  page?: number;
+  size?: number;
+}
+
+export interface CreateTenantNoticeRequest {
+  title: string;
+  content: string;
+  type: TenantNoticeType;
+  targetAudience: NoticeTargetAudience;
+  isPinned?: boolean;
+  expiredAt?: string;
+}
+
+export interface UpdateTenantNoticeRequest {
+  title?: string;
+  content?: string;
+  type?: TenantNoticeType;
+  targetAudience?: NoticeTargetAudience;
+  isPinned?: boolean;
+  expiredAt?: string;
+}


### PR DESCRIPTION
## Summary

테넌트 공지사항 UI 기능을 구현했습니다. TA가 공지를 관리하고, TU가 팝업으로 공지를 확인할 수 있습니다.

## Related Issue

- Closes #345

## Changes

- TA 공지사항 관리 페이지 추가 (`/ta/notices`)
  - 공지사항 CRUD (생성/수정/삭제)
  - 상태별 필터링 (초안/게시됨/보관됨)
  - 대상별 필터링 (운영자/사용자)
  - 발행 및 보관 기능
- TU 공지사항 팝업 컴포넌트 추가
  - 로그인 후 자동 팝업 표시
  - 여러 공지 탐색 (이전/다음)
  - "오늘 하루 보지 않기" 기능
  - 고정 공지 우선 표시
- TA 사이드바에 "공지사항 관리" 메뉴 추가
- TA 라우트 추가 (`/ta/notices`)

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 백엔드 PR #344와 함께 사용됩니다
- 기존 `useTenantNoticeQueries` 훅을 활용합니다