### PR TITLE
feat: 강의 발행 버튼 UX 개선

### DIFF
--- a/src/pages/tu/teaching/courses/CourseCreatePage.tsx
+++ b/src/pages/tu/teaching/courses/CourseCreatePage.tsx
@@ -438,7 +438,24 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
                 <ArrowRight size={18} />
               </Button>
             ) : (
-              <Button onClick={handlePublish} disabled={isPublishing}>
+              <Button
+                onClick={handlePublish}
+                disabled={
+                  isPublishing ||
+                  !formData.title ||
+                  !formData.categoryId ||
+                  formData.curriculumItems.length === 0
+                }
+                title={
+                  !formData.title
+                    ? '강의명을 입력해주세요'
+                    : !formData.categoryId
+                      ? '카테고리를 선택해주세요'
+                      : formData.curriculumItems.length === 0
+                        ? '최소 1개의 차시가 필요합니다'
+                        : undefined
+                }
+              >
                 {isPublishing ? (
                   <>
                     <Loader2 size={18} className="animate-spin" />

--- a/src/pages/tu/teaching/courses/components/Step3Review.tsx
+++ b/src/pages/tu/teaching/courses/components/Step3Review.tsx
@@ -174,7 +174,7 @@ export function Step3Review({
 
       {/* 경고 메시지 또는 완료 메시지 */}
       {warnings.length > 0 ? (
-        <Alert variant="destructive">
+        <Alert variant="destructive" style={{ backgroundColor: '#fd9a9a' }}>
           <AlertTriangle size={16} />
           <AlertDescription>
             <strong>{getText('warningTitle')}</strong>


### PR DESCRIPTION
## Summary
- 발행 선행조건 미충족 시 발행하기 버튼 비활성화 처리 (숨기지 않고 disabled)
- 비활성화 시 마우스 호버로 툴팁 사유 표시
- Step3 경고 메시지 배경색 변경으로 시각적 강조

## Changes
- `CourseCreatePage.tsx`: 발행 버튼에 disabled 조건 및 title 속성 추가
- `Step3Review.tsx`: 경고 Alert 배경색 #fd9a9a 적용

## Test plan
- [ ] 강의명 미입력 시 발행 버튼 비활성화 확인
- [ ] 카테고리 미선택 시 발행 버튼 비활성화 확인
- [ ] 차시 0개일 때 발행 버튼 비활성화 확인
- [ ] 모든 조건 충족 시 발행 버튼 활성화 확인
- [ ] Step3 경고 메시지 배경색 확인