### PR TITLE
feat: 콘텐츠 설정 UI 개선 및 버그 수정 (#363)

### DIFF
--- a/src/components/common/RadioOptionCard/RadioOptionCard.tsx
+++ b/src/components/common/RadioOptionCard/RadioOptionCard.tsx
@@ -58,6 +58,10 @@ interface RadioOptionCardProps {
   variant?: 'card' | 'simple';
   /** HTML id (simple 스타일에서 label 연결용) */
   id?: string;
+  /** 비활성화 여부 */
+  disabled?: boolean;
+  /** 비활성화 안내 문구 */
+  disabledMessage?: string;
 }
 
 export function RadioOptionCard({
@@ -73,6 +77,8 @@ export function RadioOptionCard({
   className,
   variant = 'card',
   id,
+  disabled = false,
+  disabledMessage,
 }: Readonly<RadioOptionCardProps>) {
   // Simple 스타일: 기본 라디오 버튼 (RadioGroup 대체)
   if (variant === 'simple') {
@@ -114,12 +120,13 @@ export function RadioOptionCard({
   return (
     <label
       className={cn(
-        'flex items-center gap-3 p-4 rounded-lg cursor-pointer transition-all',
+        'flex items-center gap-3 p-4 rounded-lg transition-all',
+        disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
         className
       )}
       style={{
-        border: `1px solid ${isSelected ? designTokens.action.primary_default : designTokens.bg.border}`,
-        backgroundColor: isSelected ? designTokens.bg.secondary : 'transparent',
+        border: `1px solid ${isSelected && !disabled ? designTokens.action.primary_default : designTokens.bg.border}`,
+        backgroundColor: isSelected && !disabled ? designTokens.bg.secondary : 'transparent',
       }}
     >
       <input
@@ -127,17 +134,18 @@ export function RadioOptionCard({
         name={name}
         value={value}
         checked={isSelected}
-        onChange={() => onChange(value)}
+        onChange={() => !disabled && onChange(value)}
+        disabled={disabled}
         className="hidden"
       />
       {/* 좌측 라디오 마커 */}
       <div
         className="w-5 h-5 rounded-full border-2 flex items-center justify-center flex-shrink-0"
         style={{
-          borderColor: isSelected ? designTokens.action.primary_default : designTokens.bg.border,
+          borderColor: isSelected && !disabled ? designTokens.action.primary_default : designTokens.bg.border,
         }}
       >
-        {isSelected && (
+        {isSelected && !disabled && (
           <div
             className="w-2.5 h-2.5 rounded-full"
             style={{ backgroundColor: designTokens.action.primary_default }}
@@ -153,8 +161,13 @@ export function RadioOptionCard({
         </div>
       )}
       <div className="flex-1">
-        <div style={{ color: designTokens.text.primary, fontSize: '14px', marginBottom: description ? '4px' : 0 }}>
+        <div style={{ color: designTokens.text.primary, fontSize: '14px', marginBottom: (description || disabledMessage) ? '4px' : 0 }}>
           {label}
+          {disabled && disabledMessage && (
+            <span className="ml-2 text-xs text-yellow-600 bg-yellow-50 px-2 py-0.5 rounded">
+              {disabledMessage}
+            </span>
+          )}
         </div>
         {description && (
           <div style={{ color: designTokens.text.secondary, fontSize: '12px' }}>

--- a/src/components/domain/tu/content/Step3Settings.tsx
+++ b/src/components/domain/tu/content/Step3Settings.tsx
@@ -9,7 +9,7 @@ interface Step3Props {
   isExternalLink?: boolean;
 }
 
-const completionOptions: { value: CompletionCriteria; label: string; description: string }[] = [
+const completionOptions: { value: CompletionCriteria; label: string; description: string; disabled?: boolean; disabledMessage?: string }[] = [
   {
     value: 'button-click',
     label: '완료 버튼 클릭',
@@ -19,20 +19,26 @@ const completionOptions: { value: CompletionCriteria; label: string; description
     value: '90-percent',
     label: '90% 시청 완료',
     description: '콘텐츠의 90% 이상을 시청하면 자동으로 완료 처리됩니다',
+    disabled: true,
+    disabledMessage: '추후 개발 예정',
   },
   {
     value: '100-percent',
     label: '100% 시청 완료',
     description: '콘텐츠를 끝까지 시청해야 완료 처리됩니다',
+    disabled: true,
+    disabledMessage: '추후 개발 예정',
   },
 ];
 
-const accessOptions: { value: AccessControl; icon: typeof Globe; label: string; description: string }[] = [
+const accessOptions: { value: AccessControl; icon: typeof Globe; label: string; description: string; disabled?: boolean; disabledMessage?: string }[] = [
   {
     value: 'public',
     icon: Globe,
     label: '전체 공개',
     description: '모든 테넌트와 사용자가 접근할 수 있습니다',
+    disabled: true,
+    disabledMessage: '추후 개발 예정',
   },
   {
     value: 'private',
@@ -128,6 +134,8 @@ export function Step3Settings({ data, onUpdate, isExternalLink = false }: Readon
                 description={option.description}
                 isSelected={data.completionCriteria === option.value}
                 onChange={(value) => onUpdate({ completionCriteria: value as CompletionCriteria })}
+                disabled={option.disabled}
+                disabledMessage={option.disabledMessage}
               />
             ))}
           </div>
@@ -155,6 +163,8 @@ export function Step3Settings({ data, onUpdate, isExternalLink = false }: Readon
               icon={option.icon}
               isSelected={data.accessControl === option.value}
               onChange={(value) => onUpdate({ accessControl: value as AccessControl })}
+              disabled={option.disabled}
+              disabledMessage={option.disabledMessage}
             />
           ))}
         </div>

--- a/src/pages/tu/learning/MyLearningPage.tsx
+++ b/src/pages/tu/learning/MyLearningPage.tsx
@@ -165,11 +165,12 @@ export function MyLearningPage() {
   const [showFilters, setShowFilters] = useState(false);
   const [page, setPage] = useState(0);
 
-  // API 파라미터
+  // API 파라미터 - "수강 중인 강의" 페이지이므로 APPROVED 상태만 조회
+  // 필터에서 다른 상태를 선택하면 해당 상태로 조회
   const params: EnrollmentFilterParams = {
     page,
     size: 12,
-    status: statusFilter !== 'all' ? statusFilter : undefined,
+    status: statusFilter !== 'all' ? statusFilter : 'APPROVED',
   };
 
   const { data, isLoading, isError } = useMyEnrollments(params);

--- a/src/pages/tu/teaching/content/MyContentPage.tsx
+++ b/src/pages/tu/teaching/content/MyContentPage.tsx
@@ -131,10 +131,10 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
 
   const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
 
-  // API 파라미터 구성
+  // API 파라미터 구성 - 카드뷰는 3x3=9개, 리스트뷰는 10개
   const params: ContentFilterParams = {
     page,
-    size: 10,
+    size: viewMode === 'grid' ? 9 : 10,
     ...(typeFilter !== 'all' && { contentType: typeFilter }),
     ...(statusFilter !== 'all' && { status: statusFilter }),
     ...(searchQuery && { keyword: searchQuery }),

--- a/src/pages/tu/teaching/courses/components/ExistingContentModal.tsx
+++ b/src/pages/tu/teaching/courses/components/ExistingContentModal.tsx
@@ -126,15 +126,15 @@ export function ExistingContentModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-      <DialogContent className="max-w-2xl sm:max-w-2xl max-h-[80vh] bg-bg-default">
-        <DialogHeader>
+      <DialogContent className="max-w-2xl sm:max-w-2xl max-h-[80vh] flex flex-col bg-bg-default">
+        <DialogHeader className="shrink-0">
           <DialogTitle className="flex items-center gap-2 text-text-primary">
             <FileText size={20} />
             {getText('existingContentModalTitle')}
           </DialogTitle>
         </DialogHeader>
 
-        <div className="flex flex-col gap-4 py-4 flex-1 min-h-0 overflow-hidden">
+        <div className="flex flex-col gap-4 py-4 flex-1 min-h-0">
           {/* 검색 및 필터 */}
           <div className="flex gap-3 shrink-0">
             <div className="relative flex-1">
@@ -164,7 +164,7 @@ export function ExistingContentModal({
           </div>
 
           {/* 콘텐츠 목록 */}
-          <div className="border border-border rounded-lg overflow-y-auto flex-1 min-h-0">
+          <div className="border border-border rounded-lg overflow-y-auto flex-1 min-h-0 max-h-[400px]">
               {isLoading ? (
                 <div className="p-8 text-center text-text-secondary">
                   {getText('processing')}

--- a/src/services/tu/contentFolderService.ts
+++ b/src/services/tu/contentFolderService.ts
@@ -29,53 +29,53 @@ function transformToTreeNode(folder: ContentFolderResponse): ContentFolderTreeNo
 export const contentFolderService = {
   // 폴더 생성
   async create(request: CreateContentFolderRequest): Promise<ContentFolderTreeNode> {
-    const { data } = await axiosInstance.post<{ data: ContentFolderResponse }>(
+    const { data } = await axiosInstance.post<ContentFolderResponse>(
       API_ENDPOINTS.CONTENT_FOLDERS.BASE,
       request
     );
-    return transformToTreeNode(data.data);
+    return transformToTreeNode(data);
   },
 
   // 전체 폴더 트리 조회
   async getFolderTree(): Promise<ContentFolderTreeNode[]> {
-    const { data } = await axiosInstance.get<{ data: ContentFolderResponse[] }>(
+    const { data } = await axiosInstance.get<ContentFolderResponse[]>(
       API_ENDPOINTS.CONTENT_FOLDERS.TREE
     );
-    return (data.data ?? []).map(transformToTreeNode);
+    return (data ?? []).map(transformToTreeNode);
   },
 
   // 폴더 상세 조회
   async getFolder(id: number): Promise<ContentFolderTreeNode> {
-    const { data } = await axiosInstance.get<{ data: ContentFolderResponse }>(
+    const { data } = await axiosInstance.get<ContentFolderResponse>(
       API_ENDPOINTS.CONTENT_FOLDERS.BY_ID(id)
     );
-    return transformToTreeNode(data.data);
+    return transformToTreeNode(data);
   },
 
   // 하위 폴더 목록 조회
   async getChildren(id: number): Promise<ContentFolderTreeNode[]> {
-    const { data } = await axiosInstance.get<{ data: ContentFolderResponse[] }>(
+    const { data } = await axiosInstance.get<ContentFolderResponse[]>(
       API_ENDPOINTS.CONTENT_FOLDERS.CHILDREN(id)
     );
-    return (data.data ?? []).map(transformToTreeNode);
+    return (data ?? []).map(transformToTreeNode);
   },
 
   // 폴더명 수정
   async update(id: number, request: UpdateContentFolderRequest): Promise<ContentFolderTreeNode> {
-    const { data } = await axiosInstance.put<{ data: ContentFolderResponse }>(
+    const { data } = await axiosInstance.put<ContentFolderResponse>(
       API_ENDPOINTS.CONTENT_FOLDERS.BY_ID(id),
       request
     );
-    return transformToTreeNode(data.data);
+    return transformToTreeNode(data);
   },
 
   // 폴더 이동
   async move(id: number, request: MoveContentFolderRequest): Promise<ContentFolderTreeNode> {
-    const { data } = await axiosInstance.put<{ data: ContentFolderResponse }>(
+    const { data } = await axiosInstance.put<ContentFolderResponse>(
       API_ENDPOINTS.CONTENT_FOLDERS.MOVE(id),
       request
     );
-    return transformToTreeNode(data.data);
+    return transformToTreeNode(data);
   },
 
   // 폴더 삭제

--- a/src/services/tu/enrollmentService.ts
+++ b/src/services/tu/enrollmentService.ts
@@ -94,6 +94,20 @@ const mapEnrollmentStatus = (status: string): EnrollmentStatus => {
 };
 
 /**
+ * 프론트엔드 상태를 백엔드 상태로 매핑 (API 요청용)
+ */
+const mapStatusToBackend = (status: EnrollmentStatus): string | undefined => {
+  const statusMap: Record<EnrollmentStatus, string> = {
+    APPROVED: 'ENROLLED',
+    COMPLETED: 'COMPLETED',
+    CANCELLED: 'DROPPED',
+    PENDING: 'ENROLLED', // PENDING은 백엔드에 없으므로 ENROLLED로
+    REJECTED: 'DROPPED', // REJECTED도 백엔드에 없으므로 DROPPED로
+  };
+  return statusMap[status];
+};
+
+/**
  * 백엔드 응답을 프론트엔드 Enrollment로 변환
  */
 const transformEnrollment = (
@@ -161,10 +175,14 @@ export const enrollmentService = {
    * - 차수(courseTime) 정보를 추가로 조회하여 programTitle, courseTimeName 등 보완
    */
   getMyEnrollments: async (params?: EnrollmentFilterParams): Promise<PageResponse<Enrollment>> => {
-    // 1. 수강 목록 조회
+    // 1. 수강 목록 조회 (status를 백엔드 형식으로 변환)
+    const backendParams = {
+      ...params,
+      status: params?.status ? mapStatusToBackend(params.status) : undefined,
+    };
     const response = await axiosInstance.get<PageResponse<BackendEnrollmentResponse>>(
       API_ENDPOINTS.ENROLLMENTS.MY,
-      { params }
+      { params: backendParams }
     );
     const pageData = response.data;
 


### PR DESCRIPTION
## Summary
- 콘텐츠 설정 UI 개선 (RadioOptionCard disabled 상태 추가)
- 내 콘텐츠 페이지 카드뷰 페이지당 9개로 조정 (3x3 그리드)
- 기존 콘텐츠 불러오기 모달 스크롤 수정
- 수강 목록 상태 필터링 버그 수정 (APPROVED → ENROLLED 매핑)
- contentFolderService data.data 버그 수정

## Changes
- `RadioOptionCard`: disabled, disabledMessage props 추가
- `Step3Settings`: 미구현 옵션에 "추후 개발 예정" 메시지 표시
- `MyContentPage`: 카드뷰 9개, 리스트뷰 10개 페이지네이션
- `ExistingContentModal`: flex 레이아웃으로 스크롤 문제 해결
- `enrollmentService`: 프론트엔드-백엔드 상태 매핑 함수 추가
- `MyLearningPage`: 기본 필터를 APPROVED(수강중)로 변경
- `contentFolderService`: data.data 중복 접근 버그 수정

## Test Plan
- [x] 강의 생성 시 콘텐츠 설정 단계에서 disabled 옵션 확인
- [x] 내 콘텐츠 페이지에서 카드뷰 3x3 그리드 확인
- [x] 기존 콘텐츠 불러오기 모달에서 스크롤 동작 확인
- [x] 수강중인 강의 페이지에서 상태 필터링 동작 확인

Closes #363