### PR TITLE
fix: 사이드바 메뉴 활성 상태를 URL 경로와 동기화

### DIFF
--- a/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
+++ b/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState, useEffect, useMemo } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   ChevronDown,
@@ -34,10 +34,43 @@ export function BaseSidebar({
   roleType = 'tu',
 }: BaseSidebarProps & { showModeSwitcher?: boolean; currentMode?: ViewMode; roleType?: RoleType }) {
   const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
   const [activeItem, setActiveItem] = useState<string>('dashboard');
   const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  // 현재 경로에 맞는 메뉴 아이템 찾기
+  const findActiveMenuItem = useMemo(() => {
+    const { pathname } = location;
+
+    for (const item of menuData) {
+      // 2단계 서브메뉴 먼저 확인 (더 구체적인 경로 우선)
+      if (item.subItems) {
+        for (const subItem of item.subItems) {
+          if (subItem.path && pathname.startsWith(subItem.path)) {
+            return { itemId: subItem.id, parentId: item.id };
+          }
+        }
+      }
+
+      // 1단계 메뉴 확인
+      if (item.path && pathname.startsWith(item.path)) {
+        return { itemId: item.id, parentId: null };
+      }
+    }
+
+    return { itemId: 'dashboard', parentId: null };
+  }, [location.pathname, menuData]);
+
+  // URL 변경 시 활성 상태 동기화
+  useEffect(() => {
+    setActiveItem(findActiveMenuItem.itemId);
+
+    if (findActiveMenuItem.parentId && !expandedItems.includes(findActiveMenuItem.parentId)) {
+      setExpandedItems(prev => [...prev, findActiveMenuItem.parentId!]);
+    }
+  }, [findActiveMenuItem]);
 
   // 인증 스토어
   const { refreshToken, logout } = useAuthStore();


### PR DESCRIPTION
## Summary
- 직접 URL 입력 또는 링크 클릭 시 사이드바에서 해당 메뉴가 활성화되지 않던 버그 수정
- `useLocation` 훅으로 현재 경로 감지 후 메뉴 상태 자동 동기화
- 서브메뉴 활성화 시 부모 메뉴 자동 확장

## Changes
- `BaseSidebar.tsx`: URL 경로 기반 메뉴 활성화 로직 추가

## Test plan
- [ ] 직접 URL 입력(`/tu/teaching/courses`)으로 페이지 접근 시 해당 메뉴 활성화 확인
- [ ] 링크 클릭으로 이동 시 메뉴 활성화 확인
- [ ] 서브메뉴 URL 접근 시 부모 메뉴 자동 확장 확인
- [ ] SA/TA/TO/TU 각 역할별 사이드바 정상 동작 확인
- [ ] 사이드바 접힘/펼침 상태에서 모두 정상 동작 확인

Closes #336