### PR TITLE
feat: 학습 플레이어 커리큘럼 UI 개선 (#368)

### DIFF
--- a/src/pages/tu/learning/LearningDetailPage.tsx
+++ b/src/pages/tu/learning/LearningDetailPage.tsx
@@ -67,6 +67,7 @@ interface CurriculumDisplayItem {
   itemName: string; // 표시용 이름 (displayName 또는 itemName)
   itemType: string | null;
   duration: number | null;
+  pageCount: number | null;
   isFolder: boolean;
   seq: number;
   isCompleted: boolean;
@@ -106,7 +107,8 @@ function CurriculumListItem({ item, isDark, onClick }: CurriculumListItemProps) 
   const formatDuration = (seconds: number | null) => {
     if (!seconds) return null;
     const mins = Math.floor(seconds / 60);
-    return `${mins}분`;
+    const secs = Math.floor(seconds % 60);
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
   };
 
   return (
@@ -138,9 +140,10 @@ function CurriculumListItem({ item, isDark, onClick }: CurriculumListItemProps) 
         <h4 className={`font-medium text-sm truncate ${isDark ? 'text-white' : 'text-gray-900'}`}>
           {item.itemName}
         </h4>
-        {item.duration && (
+        {(item.duration || item.pageCount) && (
           <p className={`text-xs mt-0.5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
-            {formatDuration(item.duration)}
+            {item.duration && formatDuration(item.duration)}
+            {item.pageCount && `${item.pageCount}p`}
           </p>
         )}
       </div>
@@ -240,8 +243,9 @@ export function LearningDetailPage() {
           itemName: displayName,
           itemType: item.itemType,
           duration: item.snapshotLearningObject?.duration ?? null,
+          pageCount: item.snapshotLearningObject?.pageCount ?? null,
           isFolder: item.isFolder,
-          seq: seq++,
+          seq: item.isFolder ? 0 : seq++,
           isCompleted: progressMap.get(item.itemId) ?? false,
         });
         if (item.children && item.children.length > 0) {

--- a/src/pages/tu/learning/components/CurriculumSidebar.tsx
+++ b/src/pages/tu/learning/components/CurriculumSidebar.tsx
@@ -261,14 +261,14 @@ export function CurriculumSidebar({
     const flatItems: { seq: number; itemId: number; item: SnapshotItemResponse }[] = [];
     let seq = 1;
 
-    // 재귀적으로 아이템 평탄화
+    // 재귀적으로 아이템 평탄화 (폴더 포함)
     const flattenItems = (itemList: SnapshotItemResponse[]) => {
       itemList.forEach((item) => {
         itemsMap.set(item.itemId, item);
-        // 폴더가 아니고 콘텐츠가 있는 아이템만 추가
-        if (!item.isFolder && item.snapshotLearningObject?.contentId) {
+        // 폴더이거나 콘텐츠가 있는 아이템 추가
+        if (item.isFolder || item.snapshotLearningObject?.contentId) {
           flatItems.push({
-            seq: seq++,
+            seq: item.isFolder ? 0 : seq++, // 폴더는 seq 0
             itemId: item.itemId,
             item: item,
           });

--- a/src/pages/tu/learning/components/ExternalLinkViewer.tsx
+++ b/src/pages/tu/learning/components/ExternalLinkViewer.tsx
@@ -2,11 +2,9 @@
  * ExternalLinkViewer 컴포넌트
  * 외부 링크 콘텐츠를 표시 (YouTube, 외부 사이트 등)
  */
-import { useState, useEffect, useCallback } from 'react';
-import ReactPlayer from 'react-player';
-import { Loader2, AlertCircle, RefreshCw, ExternalLink, Link as LinkIcon } from 'lucide-react';
+import { useCallback } from 'react';
+import { ExternalLink, Link as LinkIcon } from 'lucide-react';
 import { Button } from '@/components/common';
-import { useTranslation } from '@/store/common/languageStore';
 import { useThemeStore } from '@/store/common/themeStore';
 
 interface ExternalLinkViewerProps {
@@ -21,110 +19,15 @@ interface ExternalLinkViewerProps {
 export function ExternalLinkViewer({
   url,
   title,
-  onProgress,
-  onReady,
-  onError,
 }: ExternalLinkViewerProps) {
-  const { t } = useTranslation();
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
 
-  const [isLoading, setIsLoading] = useState(true);
-  const [hasError, setHasError] = useState(false);
-  const [isPlayable, setIsPlayable] = useState(false);
-
-  // URL이 ReactPlayer로 재생 가능한지 확인
-  useEffect(() => {
-    const canPlay = ReactPlayer.canPlay(url);
-    setIsPlayable(canPlay);
-    if (!canPlay) {
-      setIsLoading(false);
-    }
-  }, [url]);
-
-  const handleReady = useCallback(() => {
-    setIsLoading(false);
-    onReady?.();
-  }, [onReady]);
-
-  const handleError = useCallback(() => {
-    setIsLoading(false);
-    setHasError(true);
-    onError?.(new Error('Failed to load external content'));
-  }, [onError]);
-
-  const handleProgress = useCallback(
-    (state: { played: number }) => {
-      onProgress?.({ played: state.played });
-      // 자동 완료 처리 제거 - 사용자가 직접 "학습 완료" 버튼을 클릭해야 함
-    },
-    [onProgress]
-  );
-
-  const handleRetry = useCallback(() => {
-    setHasError(false);
-    setIsLoading(true);
-  }, []);
-
   const handleOpenExternal = useCallback(() => {
     window.open(url, '_blank', 'noopener,noreferrer');
-    // 자동 완료 처리 제거 - 사용자가 직접 "학습 완료" 버튼을 클릭해야 함
   }, [url]);
 
-  // 에러 상태
-  if (hasError) {
-    return (
-      <div
-        className={`relative w-full aspect-video rounded-lg flex flex-col items-center justify-center gap-4 ${
-          isDark ? 'bg-white/5' : 'bg-gray-100'
-        }`}
-      >
-        <AlertCircle className="w-12 h-12 text-red-500" />
-        <span className={isDark ? 'text-white' : 'text-gray-900'}>{t.player.error}</span>
-        <div className="flex gap-2">
-          <Button onClick={handleRetry} variant="outline" className="gap-2">
-            <RefreshCw className="w-4 h-4" />
-            {t.player.retry}
-          </Button>
-          <Button onClick={handleOpenExternal} className="gap-2">
-            <ExternalLink className="w-4 h-4" />
-            Open in New Tab
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
-  // 재생 가능한 URL (YouTube, Vimeo 등)
-  if (isPlayable) {
-    return (
-      <div className={`relative rounded-lg overflow-hidden ${isDark ? 'bg-black' : 'bg-gray-900'}`}>
-        {isLoading && (
-          <div className="absolute inset-0 flex items-center justify-center z-10 bg-black/50">
-            <Loader2 className="w-10 h-10 animate-spin text-white" />
-          </div>
-        )}
-        <div className="aspect-video">
-          <ReactPlayer
-            url={url}
-            width="100%"
-            height="100%"
-            controls
-            onReady={handleReady}
-            onError={handleError}
-            onProgress={handleProgress}
-            config={{
-              youtube: {
-                playerVars: { showinfo: 1 },
-              },
-            }}
-          />
-        </div>
-      </div>
-    );
-  }
-
-  // 일반 외부 링크 (iframe으로 표시하거나 외부 링크로 열기)
+  // 모든 외부 링크를 동일하게 처리
   return (
     <div
       className={`rounded-lg overflow-hidden ${isDark ? 'bg-[#1a1a2e]' : 'bg-white'} border ${
@@ -160,7 +63,7 @@ export function ExternalLinkViewer({
         </Button>
       </div>
 
-      {/* iframe 미리보기 (선택적) */}
+      {/* 링크 열기 안내 */}
       <div
         className={`aspect-video flex items-center justify-center ${
           isDark ? 'bg-white/5' : 'bg-gray-50'


### PR DESCRIPTION
## Summary
- 학습 플레이어 사이드바에 차시(폴더) 표시 추가
- 커리큘럼 아이템에 duration/pageCount 메타데이터 표시
- 외부 링크 뷰어를 일반 링크 방식으로 변경 (ReactPlayer 제거)

## Changes
- `CurriculumSidebar.tsx`: 폴더 포함하여 아이템 평탄화
- `LearningDetailPage.tsx`: pageCount 필드 추가, duration 포맷 변경
- `ExternalLinkViewer.tsx`: ReactPlayer 제거, 일반 외부 링크로 변경

## Test plan
- [x] 학습 플레이어 사이드바에서 차시(폴더) 표시 확인
- [x] duration/pageCount가 올바르게 표시되는지 확인
- [x] 외부 링크 콘텐츠가 새 탭에서 열리는지 확인

## Related
- Closes #368
- Backend: mzc-lp-backend#359