### PR TITLE
Fix/frontend bugs

### DIFF
--- a/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
+++ b/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
@@ -17,6 +17,7 @@ import { useTenantBranding } from '@/contexts/TenantBrandingContext';
 import { ModeSwitcher, type ViewMode } from '../ModeSwitcher';
 import { useAuthStore } from '@/store/common/authStore';
 import { authService } from '@/services/common/authService';
+import { useSubdomainPath } from '@/hooks/common';
 
 // 역할 타입
 type RoleType = 'sa' | 'ta' | 'to' | 'tu';
@@ -36,6 +37,7 @@ export function BaseSidebar({
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();
+  const { prefixPath } = useSubdomainPath();
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
   const [activeItem, setActiveItem] = useState<string>('dashboard');
   const [isLoggingOut, setIsLoggingOut] = useState(false);
@@ -116,9 +118,9 @@ export function BaseSidebar({
 
   const handleModeChange = (mode: ViewMode) => {
     if (mode === 'learner') {
-      navigate('/tu/b2c/mypage');
+      navigate(prefixPath('/tu/b2c/mypage'));
     } else {
-      navigate('/tu/dashboard');
+      navigate(prefixPath('/tu/dashboard'));
     }
   };
 

--- a/src/components/layout/mypage/MyPageLayout.tsx
+++ b/src/components/layout/mypage/MyPageLayout.tsx
@@ -54,6 +54,7 @@ export function MyPageLayout({ children }: MyPageLayoutProps) {
           onMenuItemClick={handleMenuItemClick}
           isDarkMode={isDarkMode}
           language={language}
+          subdomain={subdomain}
         />
 
         <main className="flex-1 overflow-auto">{children}</main>

--- a/src/components/layout/mypage/MyPageSidebar.tsx
+++ b/src/components/layout/mypage/MyPageSidebar.tsx
@@ -8,6 +8,7 @@ import { useLanguageStore, useTranslation } from '@/store/common/languageStore';
 import { useAuthStore } from '@/store/common/authStore';
 import { userService } from '@/services/common/userService';
 import { authService } from '@/services/common/authService';
+import { useSubdomainPath } from '@/hooks/common';
 import { cn } from '@/utils/cn';
 import {
   AlertDialog,
@@ -27,13 +28,25 @@ interface MyPageSidebarProps {
   onMenuItemClick?: (itemId: string) => void;
   isDarkMode?: boolean;
   language?: 'ko' | 'en';
+  subdomain?: string;
 }
 
 type ViewMode = 'instructor' | 'learner';
 
-export function MyPageSidebar({ onMenuItemClick }: MyPageSidebarProps) {
+export function MyPageSidebar({ onMenuItemClick, subdomain: subdomainProp }: MyPageSidebarProps) {
   const location = useLocation();
   const navigate = useNavigate();
+  const { subdomain: subdomainFromParams } = useSubdomainPath();
+
+  // props로 전달된 subdomain을 우선 사용, 없으면 훅에서 가져온 값 사용
+  const subdomain = subdomainProp || subdomainFromParams;
+  const prefixPath = (path: string) => {
+    if (subdomain) {
+      return `/${subdomain}${path}`;
+    }
+    return path;
+  };
+
   const { theme, toggleTheme } = useThemeStore();
   const { language, toggleLanguage } = useLanguageStore();
   const { t } = useTranslation();
@@ -269,7 +282,7 @@ export function MyPageSidebar({ onMenuItemClick }: MyPageSidebarProps) {
                 <button
                   onClick={() => {
                     setCurrentMode('instructor');
-                    navigate('/tu/dashboard');
+                    navigate(prefixPath('/tu/dashboard'));
                   }}
                   className={cn(
                     'flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-md',
@@ -288,7 +301,10 @@ export function MyPageSidebar({ onMenuItemClick }: MyPageSidebarProps) {
                   <span>{language === 'ko' ? '강사' : 'Instructor'}</span>
                 </button>
                 <button
-                  onClick={() => setCurrentMode('learner')}
+                  onClick={() => {
+                    setCurrentMode('learner');
+                    navigate(prefixPath('/tu/b2c/mypage'));
+                  }}
                   className={cn(
                     'flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-md',
                     'transition-all duration-200 text-sm font-medium whitespace-nowrap'

--- a/src/hooks/common/useAuthQueries.ts
+++ b/src/hooks/common/useAuthQueries.ts
@@ -68,7 +68,7 @@ export const useLogin = () => {
       const subdomainPrefix = (!isDefaultSubdomain && user.role !== 'SYSTEM_ADMIN') ? `/${subdomain}` : '';
 
       // 관리자 역할은 프로필 체크 스킵
-      const adminRoles = ['SYSTEM_ADMIN', 'TENANT_ADMIN', 'TENANT_OPERATOR'];
+      const adminRoles = ['SYSTEM_ADMIN', 'TENANT_ADMIN', 'OPERATOR'];
       const isAdminRole = adminRoles.includes(user.role);
 
       // 프로필 미완성 시 프로필 수정 페이지로 리다이렉트 (단체 계정 생성 사용자 - 관리자 제외)
@@ -82,7 +82,7 @@ export const useLogin = () => {
       const roleBasePath: Record<string, string> = {
         SYSTEM_ADMIN: '/sa',
         TENANT_ADMIN: '/ta',
-        TENANT_OPERATOR: '/to',
+        OPERATOR: '/to',
         DESIGNER: '/tu/teaching',
         USER: '/tu/b2c',
       };

--- a/src/hooks/sa/useDashboardQueries.ts
+++ b/src/hooks/sa/useDashboardQueries.ts
@@ -2,18 +2,18 @@
  * SA Dashboard React Query Hooks (SYSTEM_ADMIN)
  */
 import { useQuery } from '@tanstack/react-query';
-import { saDashboardService } from '@/services/sa';
+import { saDashboardService, type DashboardPeriod } from '@/services/sa';
 
 // Query Keys
 export const saDashboardKeys = {
   all: ['sa-dashboard'] as const,
-  dashboard: () => [...saDashboardKeys.all, 'stats'] as const,
+  dashboard: (period?: DashboardPeriod) => [...saDashboardKeys.all, 'stats', period ?? 'all'] as const,
 };
 
 /** SA 대시보드 통계 조회 */
-export const useSaDashboard = () => {
+export const useSaDashboard = (period?: DashboardPeriod) => {
   return useQuery({
-    queryKey: saDashboardKeys.dashboard(),
-    queryFn: () => saDashboardService.getDashboard(),
+    queryKey: saDashboardKeys.dashboard(period),
+    queryFn: () => saDashboardService.getDashboard(period),
   });
 };

--- a/src/hooks/ta/useDashboardQueries.ts
+++ b/src/hooks/ta/useDashboardQueries.ts
@@ -2,18 +2,18 @@
  * TA Dashboard React Query Hooks (TENANT_ADMIN)
  */
 import { useQuery } from '@tanstack/react-query';
-import { taDashboardService } from '@/services/ta';
+import { taDashboardService, type DashboardPeriod } from '@/services/ta';
 
 // Query Keys
 export const taDashboardKeys = {
   all: ['ta-dashboard'] as const,
-  kpi: () => [...taDashboardKeys.all, 'kpi'] as const,
+  kpi: (period?: DashboardPeriod) => [...taDashboardKeys.all, 'kpi', period ?? 'all'] as const,
 };
 
 /** TA KPI 대시보드 통계 조회 */
-export const useTaKpiDashboard = () => {
+export const useTaKpiDashboard = (period?: DashboardPeriod) => {
   return useQuery({
-    queryKey: taDashboardKeys.kpi(),
-    queryFn: () => taDashboardService.getKpiDashboard(),
+    queryKey: taDashboardKeys.kpi(period),
+    queryFn: () => taDashboardService.getKpiDashboard(period),
   });
 };

--- a/src/hooks/to/useDashboardQueries.ts
+++ b/src/hooks/to/useDashboardQueries.ts
@@ -2,18 +2,18 @@
  * TO Dashboard React Query Hooks (OPERATOR)
  */
 import { useQuery } from '@tanstack/react-query';
-import { toDashboardService } from '@/services/to';
+import { toDashboardService, type DashboardPeriod } from '@/services/to';
 
 // Query Keys
 export const toDashboardKeys = {
   all: ['to-dashboard'] as const,
-  tasks: () => [...toDashboardKeys.all, 'tasks'] as const,
+  tasks: (period?: DashboardPeriod) => [...toDashboardKeys.all, 'tasks', period ?? 'all'] as const,
 };
 
 /** TO 운영 대시보드 통계 조회 */
-export const useToDashboard = () => {
+export const useToDashboard = (period?: DashboardPeriod) => {
   return useQuery({
-    queryKey: toDashboardKeys.tasks(),
-    queryFn: () => toDashboardService.getDashboard(),
+    queryKey: toDashboardKeys.tasks(period),
+    queryFn: () => toDashboardService.getDashboard(period),
   });
 };

--- a/src/pages/sa/dashboard/DashboardPage.tsx
+++ b/src/pages/sa/dashboard/DashboardPage.tsx
@@ -13,8 +13,9 @@ import { Skeleton } from '@/components/common/Skeleton';
 import { NoDataEmpty } from '@/components/common/EmptyState';
 import { useSaDashboard } from '@/hooks/sa';
 import type { TenantStatus, PlanType } from '@/types/admin';
+import type { DashboardPeriod } from '@/services/sa';
 
-type DateRange = '7d' | '30d' | 'all';
+type DateRange = DashboardPeriod;
 
 const DATE_RANGE_OPTIONS: { value: DateRange; label: string }[] = [
   { value: 'all', label: '전체' },
@@ -23,8 +24,8 @@ const DATE_RANGE_OPTIONS: { value: DateRange; label: string }[] = [
 ];
 
 export function DashboardPage() {
-  const { data, isLoading, error } = useSaDashboard();
   const [dateRange, setDateRange] = useState<DateRange>('all');
+  const { data, isLoading, error } = useSaDashboard(dateRange);
 
   // 선택된 기간 라벨 가져오기
   const selectedRangeLabel = DATE_RANGE_OPTIONS.find((opt) => opt.value === dateRange)?.label ?? '';

--- a/src/pages/ta/dashboard/DashboardPage.tsx
+++ b/src/pages/ta/dashboard/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { Users, BookOpen, TrendingUp, GraduationCap, AlertCircle, UserPlus, FileText, CheckCircle } from 'lucide-react';
 import {
   AreaChart,
@@ -20,8 +20,9 @@ import { Progress } from '@/components/common/Progress';
 import { Skeleton } from '@/components/common/Skeleton';
 import { NoDataEmpty } from '@/components/common/EmptyState';
 import { useTaKpiDashboard } from '@/hooks/ta';
+import type { DashboardPeriod } from '@/services/ta';
 
-type DateRange = '7d' | '30d' | 'all';
+type DateRange = DashboardPeriod;
 
 const DATE_RANGE_OPTIONS: { value: DateRange; label: string }[] = [
   { value: 'all', label: '전체' },
@@ -30,8 +31,8 @@ const DATE_RANGE_OPTIONS: { value: DateRange; label: string }[] = [
 ];
 
 export function DashboardPage() {
-  const { data, isLoading, error } = useTaKpiDashboard();
   const [dateRange, setDateRange] = useState<DateRange>('all');
+  const { data, isLoading, error } = useTaKpiDashboard(dateRange);
 
   // 선택된 기간 라벨 가져오기
   const selectedRangeLabel = DATE_RANGE_OPTIONS.find((opt) => opt.value === dateRange)?.label ?? '';
@@ -56,99 +57,14 @@ export function DashboardPage() {
     );
   }
 
-  const userStats = data?.userStats ?? { total: 0, active: 0, inactive: 0, suspended: 0, withdrawn: 0, newThisMonth: 0 };
-  const programStats = data?.programStats ?? { total: 0, draft: 0, pending: 0, approved: 0, rejected: 0, closed: 0 };
-  const enrollmentStats = data?.enrollmentStats ?? { totalEnrollments: 0, byStatus: { enrolled: 0, completed: 0, dropped: 0, failed: 0 }, completionRate: 0 };
-  const monthlyTrend = data?.monthlyTrend ?? [];
+  const defaultUserStats = { total: 0, active: 0, inactive: 0, suspended: 0, withdrawn: 0, newThisMonth: 0 };
+  const defaultProgramStats = { total: 0, draft: 0, pending: 0, approved: 0, rejected: 0, closed: 0 };
+  const defaultEnrollmentStats = { totalEnrollments: 0, byStatus: { enrolled: 0, completed: 0, dropped: 0, failed: 0 }, completionRate: 0 };
 
-  // 1~12월 전체 X축 데이터 생성 (미래 데이터는 null로 처리)
-  const fullYearChartData = useMemo(() => {
-    const currentDate = new Date();
-    const currentYear = currentDate.getFullYear();
-    const currentMonth = currentDate.getMonth() + 1; // 1-12
-
-    // 1~12월 기본 데이터 생성
-    const fullYearData = Array.from({ length: 12 }, (_, i) => {
-      const month = i + 1;
-      const monthKey = `${currentYear}-${String(month).padStart(2, '0')}`;
-
-      // 기존 데이터에서 해당 월 찾기
-      const existingData = monthlyTrend.find((item) => item.month === monthKey);
-
-      // 미래 데이터는 null, 과거/현재는 데이터 또는 0
-      if (month > currentMonth) {
-        return {
-          month: monthKey,
-          enrollments: null,
-          completions: null,
-        };
-      }
-
-      return {
-        month: monthKey,
-        enrollments: existingData?.enrollments ?? 0,
-        completions: existingData?.completions ?? 0,
-      };
-    });
-
-    return fullYearData;
-  }, [monthlyTrend]);
-
-  // 선택한 기간에 따라 월별 트렌드 필터링 + 가짜 시작점 추가
-  const filteredMonthlyTrend = useMemo(() => {
-    let baseData: typeof fullYearChartData;
-
-    if (dateRange === 'all') {
-      baseData = fullYearChartData;
-    } else {
-      const currentDate = new Date();
-      const currentMonth = currentDate.getMonth(); // 0-11
-
-      if (dateRange === '7d') {
-        // 이번 달만
-        baseData = fullYearChartData.slice(currentMonth, currentMonth + 1);
-      } else {
-        // 30d: 최근 6개월
-        const startMonth = Math.max(0, currentMonth - 5);
-        baseData = fullYearChartData.slice(startMonth, currentMonth + 1);
-      }
-    }
-
-    // 실제 데이터가 있는 포인트 개수 확인 (null이 아닌 데이터)
-    const validDataPoints = baseData.filter(
-      (item) => item.enrollments !== null || item.completions !== null
-    ).length;
-
-    // 데이터 포인트가 1개일 때: 가짜 시작점 추가 (바닥에서 올라가는 삼각형 효과)
-    if (validDataPoints === 1 && baseData.length > 0) {
-      const firstDataIndex = baseData.findIndex(
-        (item) => item.enrollments !== null || item.completions !== null
-      );
-
-      if (firstDataIndex > 0) {
-        // 앞에 데이터가 있으면 이전 월을 0으로 설정
-        const newData = [...baseData];
-        const prevMonth = newData[firstDataIndex - 1];
-        newData[firstDataIndex - 1] = {
-          ...prevMonth,
-          enrollments: 0,
-          completions: 0,
-        };
-        return newData;
-      } else {
-        // 첫 번째 월이 데이터 포인트면 앞에 가짜 시작점 추가
-        const currentYear = new Date().getFullYear();
-        const dummyStart = {
-          month: `${currentYear}-00`, // 가상의 0월 (표시 안 됨)
-          enrollments: 0,
-          completions: 0,
-        };
-        return [dummyStart, ...baseData];
-      }
-    }
-
-    return baseData;
-  }, [fullYearChartData, dateRange]);
+  const userStats = { ...defaultUserStats, ...data?.userStats };
+  const programStats = { ...defaultProgramStats, ...data?.programStats };
+  const enrollmentStats = { ...defaultEnrollmentStats, ...data?.enrollmentStats, byStatus: { ...defaultEnrollmentStats.byStatus, ...data?.enrollmentStats?.byStatus } };
+  const dailyTrend = data?.dailyTrend ?? [];
 
   return (
     <div className="p-6">
@@ -376,15 +292,15 @@ export function DashboardPage() {
           </CardContent>
         </Card>
 
-        {/* 월별 수강 추이 차트 */}
+        {/* 일별 수강 추이 차트 */}
         <Card>
           <CardHeader>
-            <CardTitle>월별 수강 추이</CardTitle>
+            <CardTitle>일별 수강 추이</CardTitle>
           </CardHeader>
           <CardContent>
             {isLoading ? (
               <Skeleton className="h-64" />
-            ) : filteredMonthlyTrend.length === 0 ? (
+            ) : dailyTrend.length === 0 ? (
               <NoDataEmpty
                 title="데이터가 없습니다"
                 description="선택한 기간에 수강 데이터가 없습니다."
@@ -394,7 +310,7 @@ export function DashboardPage() {
               <div className="w-full" style={{ minHeight: 256 }}>
                 <ResponsiveContainer width="100%" height={256}>
                   <AreaChart
-                    data={filteredMonthlyTrend}
+                    data={dailyTrend}
                     margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
                   >
                     <defs>
@@ -411,14 +327,11 @@ export function DashboardPage() {
                     </defs>
                     <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
                     <XAxis
-                      dataKey="month"
+                      dataKey="date"
                       tick={{ fontSize: 12, fill: 'var(--muted-foreground)' }}
-                      tickFormatter={(value) => {
-                        const [, month] = value.split('-');
-                        const monthNum = parseInt(month);
-                        // 가짜 0월은 표시하지 않음
-                        if (monthNum === 0) return '';
-                        return `${monthNum}월`;
+                      tickFormatter={(value: string) => {
+                        const [, month, day] = value.split('-');
+                        return `${parseInt(month)}/${parseInt(day)}`;
                       }}
                     />
                     <YAxis
@@ -431,16 +344,9 @@ export function DashboardPage() {
                         border: '1px solid var(--border)',
                         borderRadius: '8px',
                       }}
-                      labelFormatter={(value) => {
-                        const [year, month] = value.split('-');
-                        const monthNum = parseInt(month);
-                        // 가짜 0월은 "시작점"으로 표시
-                        if (monthNum === 0) return '시작점';
-                        return `${year}년 ${monthNum}월`;
-                      }}
-                      formatter={(value, name) => {
-                        if (value === null) return ['데이터 없음', name];
-                        return [value, name];
+                      labelFormatter={(value: string) => {
+                        const [year, month, day] = value.split('-');
+                        return `${year}년 ${parseInt(month)}월 ${parseInt(day)}일`;
                       }}
                     />
                     <Legend />
@@ -450,11 +356,10 @@ export function DashboardPage() {
                       dataKey="enrollments"
                       name="수강 신청"
                       stroke="#4C2D9A"
-                      strokeWidth={3}
+                      strokeWidth={2}
                       fill="url(#enrollmentGradient)"
-                      connectNulls={false}
-                      dot={{ fill: '#4C2D9A', strokeWidth: 2, r: 4 }}
-                      activeDot={{ r: 6, strokeWidth: 2 }}
+                      dot={false}
+                      activeDot={{ r: 4, strokeWidth: 2 }}
                     />
                     {/* 수료를 나중에 그려서 앞에 배치 */}
                     <Area
@@ -462,11 +367,10 @@ export function DashboardPage() {
                       dataKey="completions"
                       name="수료"
                       stroke="#3D7A4A"
-                      strokeWidth={3}
+                      strokeWidth={2}
                       fill="url(#completionGradient)"
-                      connectNulls={false}
-                      dot={{ fill: '#3D7A4A', strokeWidth: 2, r: 4 }}
-                      activeDot={{ r: 6, strokeWidth: 2 }}
+                      dot={false}
+                      activeDot={{ r: 4, strokeWidth: 2 }}
                     />
                   </AreaChart>
                 </ResponsiveContainer>

--- a/src/pages/to/dashboard/DashboardPage.tsx
+++ b/src/pages/to/dashboard/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import {
   Clock,
   Users,
@@ -30,8 +30,9 @@ import { Progress } from '@/components/common/Progress';
 import { Skeleton } from '@/components/common/Skeleton';
 import { NoDataEmpty } from '@/components/common/EmptyState';
 import { useToDashboard } from '@/hooks/to';
+import type { DashboardPeriod } from '@/services/to';
 
-type DateRange = '7d' | '30d' | 'all';
+type DateRange = DashboardPeriod;
 
 const DATE_RANGE_OPTIONS: { value: DateRange; label: string }[] = [
   { value: 'all', label: '전체' },
@@ -40,8 +41,8 @@ const DATE_RANGE_OPTIONS: { value: DateRange; label: string }[] = [
 ];
 
 export function DashboardPage() {
-  const { data, isLoading, error } = useToDashboard();
   const [dateRange, setDateRange] = useState<DateRange>('all');
+  const { data, isLoading, error } = useToDashboard(dateRange);
 
   if (error) {
     return (
@@ -78,21 +79,6 @@ export function DashboardPage() {
     averageCapacityUtilization: 0,
   };
   const dailyTrend = data?.dailyTrend ?? [];
-
-  // 선택한 기간에 따라 데이터 필터링
-  const filteredDailyTrend = useMemo(() => {
-    if (dailyTrend.length === 0) return [];
-    if (dateRange === 'all') return dailyTrend;
-
-    const days = dateRange === '7d' ? 7 : 30;
-    const cutoffDate = new Date();
-    cutoffDate.setDate(cutoffDate.getDate() - days);
-
-    return dailyTrend.filter((item) => {
-      const itemDate = new Date(item.date);
-      return itemDate >= cutoffDate;
-    });
-  }, [dailyTrend, dateRange]);
 
   // 선택된 기간 라벨 가져오기
   const selectedRangeLabel = DATE_RANGE_OPTIONS.find((opt) => opt.value === dateRange)?.label ?? '';
@@ -359,7 +345,7 @@ export function DashboardPage() {
           <CardContent>
             {isLoading ? (
               <Skeleton className="h-64" />
-            ) : filteredDailyTrend.length === 0 ? (
+            ) : dailyTrend.length === 0 ? (
               <NoDataEmpty
                 title="데이터가 없습니다"
                 description="선택한 기간에 수강 신청 데이터가 없습니다."
@@ -368,10 +354,10 @@ export function DashboardPage() {
             ) : (
               <div className="h-64">
                 <ResponsiveContainer width="100%" height="100%">
-                  {filteredDailyTrend.length >= 7 ? (
+                  {dailyTrend.length >= 7 ? (
                     // 7일 이상: AreaChart로 트렌드 시각화
                     <AreaChart
-                      data={filteredDailyTrend}
+                      data={dailyTrend}
                       margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
                     >
                       <defs>
@@ -413,7 +399,7 @@ export function DashboardPage() {
                   ) : (
                     // 7일 미만: BarChart (막대 너비 제한 + 호버 효과 + 그라데이션)
                     <BarChart
-                      data={filteredDailyTrend}
+                      data={dailyTrend}
                       margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
                     >
                       <defs>

--- a/src/pages/to/enrollment/EnrollmentManagementPage.tsx
+++ b/src/pages/to/enrollment/EnrollmentManagementPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { useSubdomainPath } from '@/hooks/common';
 import type { ColumnDef } from '@tanstack/react-table';
 import {
   Search,
@@ -150,6 +151,7 @@ function StatCard({
 export function EnrollmentManagementPage({ language = 'ko' }: Readonly<EnrollmentManagementPageProps>) {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
   const courseTimeId = Number(id);
 
   const [searchQuery, setSearchQuery] = useState('');
@@ -475,7 +477,7 @@ export function EnrollmentManagementPage({ language = 'ko' }: Readonly<Enrollmen
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => navigate('/to/times')}
+              onClick={() => navigate(prefixPath('/to/times'))}
               className="border border-border"
             >
               <ArrowLeft size={16} />

--- a/src/pages/to/instructor/InstructorAssignmentsPage.tsx
+++ b/src/pages/to/instructor/InstructorAssignmentsPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSubdomainPath } from '@/hooks/common';
 import type { ColumnDef } from '@tanstack/react-table';
 import {
   Search,
@@ -165,6 +166,7 @@ function StatCard({
 
 export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<InstructorAssignmentsPageProps>) {
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
   const [searchQuery, setSearchQuery] = useState('');
   const [roleFilter, setRoleFilter] = useState<InstructorRole | 'all'>('all');
   const [statusFilter, setStatusFilter] = useState<AssignmentStatus | 'all'>('all');
@@ -408,7 +410,7 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-40">
           <DropdownMenuItem
-            onClick={() => item.courseTime?.id && navigate(`/to/times/${item.courseTime.id}`)}
+            onClick={() => item.courseTime?.id && navigate(prefixPath(`/to/times/${item.courseTime.id}`))}
             disabled={!item.courseTime?.id}
           >
             <Eye size={14} />
@@ -850,7 +852,7 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
                 <button
                   onClick={() => {
                     if (selectedAssignment.courseTime?.id) {
-                      navigate(`/to/times/${selectedAssignment.courseTime.id}`);
+                      navigate(prefixPath(`/to/times/${selectedAssignment.courseTime.id}`));
                     }
                   }}
                   disabled={!selectedAssignment.courseTime?.id}

--- a/src/pages/to/member-pool/MemberPoolListPage.tsx
+++ b/src/pages/to/member-pool/MemberPoolListPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSubdomainPath } from '@/hooks/common';
 import {
   Plus,
   Search,
@@ -119,6 +120,7 @@ const initialFormData: MemberPoolFormData = {
  */
 export default function MemberPoolListPage() {
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
 
   // 검색 및 필터 상태
   const [searchTerm, setSearchTerm] = useState('');
@@ -623,7 +625,7 @@ export default function MemberPoolListPage() {
                             backgroundColor: designTokens.button.brand_default,
                             color: designTokens.button.brand_text,
                           }}
-                          onClick={() => navigate(`/to/enrollments/batch?poolId=${selectedPool.id}`)}
+                          onClick={() => navigate(prefixPath(`/to/enrollments/batch?poolId=${selectedPool.id}`))}
                         >
                           <GraduationCap className="w-3 h-3" />
                           일괄 입과

--- a/src/pages/to/program/ProgramDetailPage.tsx
+++ b/src/pages/to/program/ProgramDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { useSubdomainPath } from '@/hooks/common';
 import {
   CheckCircle,
   XCircle,
@@ -90,6 +91,7 @@ const statusBadgeVariant: Record<ProgramStatus, 'default' | 'secondary' | 'succe
 export function ProgramDetailPage({ language = 'ko' }: Readonly<ProgramDetailPageProps>) {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
   const programId = Number(id);
 
   const [showRejectModal, setShowRejectModal] = useState(false);
@@ -170,7 +172,7 @@ export function ProgramDetailPage({ language = 'ko' }: Readonly<ProgramDetailPag
           <FileText size={48} className="mx-auto mb-3 text-text-placeholder" />
           <p className="text-text-secondary">{error ? getText('error') : getText('notFound')}</p>
           <BackButton
-            onClick={() => navigate('/to/courses')}
+            onClick={() => navigate(prefixPath('/to/courses'))}
             label={getText('back')}
             className="mt-4"
           />
@@ -185,7 +187,7 @@ export function ProgramDetailPage({ language = 'ko' }: Readonly<ProgramDetailPag
         {/* 뒤로가기 버튼 */}
         <div className="mb-4">
           <BackButton
-            onClick={() => navigate('/to/courses')}
+            onClick={() => navigate(prefixPath('/to/courses'))}
             label={getText('back')}
           />
         </div>

--- a/src/pages/to/program/ProgramListPage.tsx
+++ b/src/pages/to/program/ProgramListPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSubdomainPath } from '@/hooks/common';
 import type { ColumnDef } from '@tanstack/react-table';
 import {
   Search,
@@ -143,6 +144,7 @@ function StatCard({
 
 export function ProgramListPage({ language = 'ko' }: Readonly<ProgramListPageProps>) {
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<ProgramStatus | 'all'>('all');
   const [showFilters, setShowFilters] = useState(false);
@@ -312,7 +314,7 @@ export function ProgramListPage({ language = 'ko' }: Readonly<ProgramListPagePro
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-40">
           {/* 상세보기 - 모든 상태 */}
-          <DropdownMenuItem onClick={() => navigate(`/to/courses/${item.id}`)}>
+          <DropdownMenuItem onClick={() => navigate(prefixPath(`/to/courses/${item.id}`))}>
             <Eye size={14} />
             {getText('view')}
           </DropdownMenuItem>
@@ -587,7 +589,7 @@ export function ProgramListPage({ language = 'ko' }: Readonly<ProgramListPagePro
               pageIndex={page}
               pageSize={10}
               onPageChange={setPage}
-              onRowClick={(item) => navigate(`/to/courses/${item.id}`)}
+              onRowClick={(item) => navigate(prefixPath(`/to/courses/${item.id}`))}
               labels={{
                 noResults: getText('noResults'),
                 rowsPerPage: language === 'ko' ? '페이지당 행 수' : 'Rows per page',

--- a/src/pages/to/program/ProgramPendingPage.tsx
+++ b/src/pages/to/program/ProgramPendingPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSubdomainPath } from '@/hooks/common';
 import type { ColumnDef } from '@tanstack/react-table';
 import {
   Search,
@@ -112,6 +113,7 @@ function StatCard({
 
 export function ProgramPendingPage({ language = 'ko' }: Readonly<ProgramPendingPageProps>) {
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
   const [searchQuery, setSearchQuery] = useState('');
   const [page, setPage] = useState(0);
 
@@ -226,7 +228,7 @@ export function ProgramPendingPage({ language = 'ko' }: Readonly<ProgramPendingP
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-40">
-          <DropdownMenuItem onClick={() => navigate(`/to/courses/${item.id}`)}>
+          <DropdownMenuItem onClick={() => navigate(prefixPath(`/to/courses/${item.id}`))}>
             <Eye size={14} />
             {getText('view')}
           </DropdownMenuItem>
@@ -439,7 +441,7 @@ export function ProgramPendingPage({ language = 'ko' }: Readonly<ProgramPendingP
               pageIndex={page}
               pageSize={10}
               onPageChange={setPage}
-              onRowClick={(item) => navigate(`/to/courses/${item.id}`)}
+              onRowClick={(item) => navigate(prefixPath(`/to/courses/${item.id}`))}
               labels={{
                 noResults: getText('noResults'),
                 rowsPerPage: language === 'ko' ? '페이지당 행 수' : 'Rows per page',

--- a/src/pages/to/time/CourseTimeCreatePage.tsx
+++ b/src/pages/to/time/CourseTimeCreatePage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSubdomainPath } from '@/hooks/common';
 import { toast } from 'sonner';
 import { ArrowLeft, ArrowRight, Save, Loader2, Calendar, Clock, BookOpen, Info, UserPlus, X, Users } from 'lucide-react';
 import { cn } from '@/utils/cn';
@@ -127,6 +128,7 @@ interface InstructorAssignment {
 
 export function CourseTimeCreatePage({ language = 'ko' }: Readonly<CourseTimeCreatePageProps>) {
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
   const createTime = useCreateTime();
   const { data: approvedProgramsData, isLoading: isLoadingPrograms } = useApprovedPrograms();
   const { data: usersData, isLoading: isLoadingUsers } = useUsers({ role: 'DESIGNER', size: 100 });
@@ -321,13 +323,13 @@ export function CourseTimeCreatePage({ language = 'ko' }: Readonly<CourseTimeCre
               ? '차수가 생성되었으나 일부 강사 배정에 실패했습니다.'
               : 'Course time created but some instructor assignments failed.'
           );
-          navigate('/to/times');
+          navigate(prefixPath('/to/times'));
           return;
         }
       }
 
       toast.success(getText('createSuccess'));
-      navigate('/to/times');
+      navigate(prefixPath('/to/times'));
     } catch (err: unknown) {
       console.error('Create failed:', err);
 
@@ -446,7 +448,7 @@ export function CourseTimeCreatePage({ language = 'ko' }: Readonly<CourseTimeCre
       <div className="bg-bg-default border-b border-border px-6 py-4">
         <div className="max-w-5xl mx-auto flex justify-between items-center">
           <h1 className="text-text-primary m-0">{getText('title')}</h1>
-          <Button variant="ghost" onClick={() => navigate('/to/times')} className="border border-border">
+          <Button variant="ghost" onClick={() => navigate(prefixPath('/to/times'))} className="border border-border">
             {getText('close')}
           </Button>
         </div>

--- a/src/pages/to/time/CourseTimeCreatePage.tsx
+++ b/src/pages/to/time/CourseTimeCreatePage.tsx
@@ -59,6 +59,8 @@ const t = {
   owner: { ko: '담당 강사', en: 'Owner' },
   noOwner: { ko: '미배정', en: 'Not assigned' },
   noThumbnail: { ko: '썸네일 없음', en: 'No thumbnail' },
+  recommendedPeriod: { ko: '권장 운영기간', en: 'Recommended Period' },
+  noRecommendedPeriod: { ko: '설정 안됨', en: 'Not set' },
   timeTitle: { ko: '차수명', en: 'Title' },
   timeTitlePlaceholder: { ko: '예: 2025년 1차', en: 'e.g., 2025 Session 1' },
   description: { ko: '설명', en: 'Description' },
@@ -591,6 +593,17 @@ export function CourseTimeCreatePage({ language = 'ko' }: Readonly<CourseTimeCre
                           </span>
                         </div>
                       </div>
+                      {/* 권장 운영기간 */}
+                      {(selectedProgram.courseStartDate || selectedProgram.courseEndDate) && (
+                        <div className="mt-3 pt-3 border-t border-border">
+                          <span className="text-text-secondary">{getText('recommendedPeriod')}: </span>
+                          <span className="text-text-primary font-medium">
+                            {selectedProgram.courseStartDate && selectedProgram.courseEndDate
+                              ? `${selectedProgram.courseStartDate} ~ ${selectedProgram.courseEndDate}`
+                              : selectedProgram.courseStartDate || selectedProgram.courseEndDate || getText('noRecommendedPeriod')}
+                          </span>
+                        </div>
+                      )}
                       {selectedProgram.description && (
                         <p className="mt-2 text-sm text-text-secondary line-clamp-2">
                           {selectedProgram.description}

--- a/src/pages/to/time/CourseTimeDetailPage.tsx
+++ b/src/pages/to/time/CourseTimeDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { useSubdomainPath } from '@/hooks/common';
 import { toast } from 'sonner';
 import {
   Edit,
@@ -138,6 +139,7 @@ const statusBadgeVariant: Record<CourseTimeStatus, 'default' | 'secondary' | 'su
 export function CourseTimeDetailPage({ language = 'ko' }: Readonly<CourseTimeDetailPageProps>) {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
   const timeId = parseInt(id || '0');
 
   const [isEditing, setIsEditing] = useState(false);
@@ -221,7 +223,7 @@ export function CourseTimeDetailPage({ language = 'ko' }: Readonly<CourseTimeDet
     try {
       await deleteTime.mutateAsync(timeId);
       toast.success(getText('deleteSuccess'));
-      navigate('/to/times');
+      navigate(prefixPath('/to/times'));
     } catch (err) {
       console.error('Delete failed:', err);
       toast.error(getText('statusChangeError'));
@@ -309,7 +311,7 @@ export function CourseTimeDetailPage({ language = 'ko' }: Readonly<CourseTimeDet
           <Calendar size={48} className="mx-auto mb-3 text-text-placeholder" />
           <p className="text-text-secondary">{error ? getText('error') : getText('notFound')}</p>
           <BackButton
-            onClick={() => navigate('/to/times')}
+            onClick={() => navigate(prefixPath('/to/times'))}
             label={getText('back')}
             className="mt-4"
           />
@@ -326,7 +328,7 @@ export function CourseTimeDetailPage({ language = 'ko' }: Readonly<CourseTimeDet
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
               <BackButton
-                onClick={() => navigate('/to/times')}
+                onClick={() => navigate(prefixPath('/to/times'))}
                 label={getText('back')}
               />
               <div>
@@ -363,7 +365,7 @@ export function CourseTimeDetailPage({ language = 'ko' }: Readonly<CourseTimeDet
                       <span>{getText('edit')}</span>
                     </Button>
                   )}
-                  <Button variant="ghost" onClick={() => navigate(`/to/times/${timeId}/clone`)}>
+                  <Button variant="ghost" onClick={() => navigate(prefixPath(`/to/times/${timeId}/clone`))}>
                     <Copy size={20} />
                     <span>{getText('clone')}</span>
                   </Button>

--- a/src/pages/to/time/CourseTimeDetailPage.tsx
+++ b/src/pages/to/time/CourseTimeDetailPage.tsx
@@ -24,7 +24,7 @@ import {
   DollarSign,
 } from 'lucide-react';
 import { cn } from '@/utils/cn';
-import { Button, Badge, Input, Label, NativeSelect, Card, Textarea, BackButton } from '@/components/common';
+import { Button, Badge, Input, Label, NativeSelect, Card, BackButton } from '@/components/common';
 import { EnrollmentTab } from '@/pages/to/enrollment';
 import {
   useTime,
@@ -191,10 +191,9 @@ export function CourseTimeDetailPage({ language = 'ko' }: Readonly<CourseTimeDet
     if (courseTime) {
       setEditData({
         title: courseTime.title,
-        description: courseTime.description || '',
         deliveryType: courseTime.deliveryType,
         enrollmentMethod: courseTime.enrollmentMethod,
-        location: courseTime.location || '',
+        location: courseTime.locationInfo || '',
         capacity: courseTime.capacity,
         price: courseTime.price ? parseFloat(courseTime.price) : null,
       });
@@ -429,78 +428,217 @@ export function CourseTimeDetailPage({ language = 'ko' }: Readonly<CourseTimeDet
         {/* 기본 정보 탭 */}
         {activeTab === 'info' && (
           <div className="p-6 px-8 max-w-6xl">
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              {/* 기본 정보 */}
-            <Card className="p-6">
-              <h2 className="text-lg font-semibold text-text-primary mb-4 flex items-center gap-2">
-                <FileText size={18} className="text-text-secondary" />
-                {getText('basicInfo')}
-              </h2>
-              <div className="space-y-4">
-                <div>
-                  <Label className="text-text-secondary">{getText('timeTitle')}</Label>
-                  {isEditing ? (
-                    <Input
-                      value={editData.title || ''}
-                      onChange={(e) => setEditData({ ...editData, title: e.target.value })}
-                    />
-                  ) : (
-                    <p className="text-text-primary font-medium">{courseTime.title}</p>
-                  )}
+            {/* Bento Grid 레이아웃 */}
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+              {/* 기본 정보 + 프로그램 정보 (통합, 2열 차지) */}
+              <Card className="p-6 lg:col-span-2">
+                <h2 className="text-lg font-semibold text-text-primary mb-4 flex items-center gap-2">
+                  <FileText size={18} className="text-text-secondary" />
+                  {getText('basicInfo')}
+                </h2>
+                <div className="space-y-4">
+                  <div>
+                    <Label className="text-text-secondary">{getText('timeTitle')}</Label>
+                    {isEditing ? (
+                      <Input
+                        value={editData.title || ''}
+                        onChange={(e) => setEditData({ ...editData, title: e.target.value })}
+                      />
+                    ) : (
+                      <p className="text-text-primary font-medium text-lg">{courseTime.title}</p>
+                    )}
+                  </div>
+
+                  {/* 프로그램 정보 섹션 */}
+                  <div className="pt-4 border-t border-border">
+                    <div className="flex items-center gap-2 mb-3">
+                      <BookOpen size={16} className="text-text-secondary" />
+                      <span className="text-sm font-medium text-text-secondary">{getText('programInfo')}</span>
+                    </div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      <div>
+                        <Label className="text-text-secondary">{getText('programTitle')}</Label>
+                        <p className="text-text-primary font-medium">{courseTime.programTitle || '-'}</p>
+                      </div>
+                      {courseTime.programDescription && (
+                        <div className="md:col-span-2">
+                          <Label className="text-text-secondary">{getText('description')}</Label>
+                          <p className="text-text-primary whitespace-pre-wrap text-sm">{courseTime.programDescription}</p>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="pt-2 border-t border-border">
+                    <Label className="text-text-secondary">{getText('createdAt')}</Label>
+                    <p className="text-text-primary text-sm">{formatDateTime(courseTime.createdAt)}</p>
+                  </div>
                 </div>
-                <div>
-                  <Label className="text-text-secondary">{getText('description')}</Label>
-                  {isEditing ? (
-                    <Textarea
-                      value={editData.description || ''}
-                      onChange={(e) => setEditData({ ...editData, description: e.target.value })}
-                      rows={3}
-                    />
-                  ) : (
-                    <p className="text-text-primary whitespace-pre-wrap">
-                      {courseTime.description || getText('noDescription')}
+              </Card>
+
+              {/* 정원 현황 (Progress Bar 포함) */}
+              <Card className="p-6">
+                <h2 className="text-lg font-semibold text-text-primary mb-4 flex items-center gap-2">
+                  <Users size={18} className="text-text-secondary" />
+                  {getText('capacityInfo')}
+                </h2>
+                <div className="space-y-4">
+                  {/* Progress Bar */}
+                  <div>
+                    <div className="flex justify-between items-center mb-2">
+                      <Label className="text-text-secondary">{getText('currentEnrollment')}</Label>
+                      <span className="text-text-primary font-semibold">
+                        {courseTime.currentEnrollment}
+                        <span className="text-text-secondary font-normal">
+                          {' / '}{courseTime.capacity || getText('unlimited')}
+                        </span>
+                      </span>
+                    </div>
+                    {courseTime.capacity ? (
+                      <div className="w-full bg-bg-secondary rounded-full h-3 overflow-hidden">
+                        <div
+                          className={cn(
+                            'h-full rounded-full transition-all duration-500',
+                            (courseTime.currentEnrollment / courseTime.capacity) >= 0.9
+                              ? 'bg-status-error'
+                              : (courseTime.currentEnrollment / courseTime.capacity) >= 0.7
+                              ? 'bg-status-warning'
+                              : 'bg-status-success'
+                          )}
+                          style={{ width: `${Math.min(100, (courseTime.currentEnrollment / courseTime.capacity) * 100)}%` }}
+                        />
+                      </div>
+                    ) : (
+                      <div className="w-full bg-bg-secondary rounded-full h-3">
+                        <div className="h-full rounded-full bg-status-info w-1/4" />
+                      </div>
+                    )}
+                    {courseTime.capacity && (
+                      <p className="text-xs text-text-secondary mt-1">
+                        {Math.round((courseTime.currentEnrollment / courseTime.capacity) * 100)}% {language === 'ko' ? '모집 완료' : 'filled'}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-3 pt-2">
+                    <div className="bg-bg-secondary p-3 rounded-lg">
+                      <Label className="text-text-secondary text-xs">{getText('availableSeats')}</Label>
+                      <p className="text-text-primary text-xl font-bold">
+                        {courseTime.availableSeats ?? '∞'}
+                      </p>
+                    </div>
+                    <div className="bg-bg-secondary p-3 rounded-lg">
+                      <Label className="text-text-secondary text-xs flex items-center gap-1">
+                        <DollarSign size={12} />
+                        {getText('price')}
+                      </Label>
+                      {isEditing ? (
+                        <Input
+                          type="number"
+                          value={editData.price ?? ''}
+                          onChange={(e) =>
+                            setEditData({
+                              ...editData,
+                              price: e.target.value ? parseInt(e.target.value) : null,
+                            })
+                          }
+                          placeholder="0 = 무료"
+                          className="mt-1"
+                        />
+                      ) : (
+                        <p className="text-text-primary text-xl font-bold">
+                          {formatPrice(courseTime.price, courseTime.isFree)}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </Card>
+
+              {/* 기간 정보 (D-Day 배지 포함) */}
+              <Card className="p-6 lg:col-span-2">
+                <h2 className="text-lg font-semibold text-text-primary mb-4 flex items-center gap-2">
+                  <Calendar size={18} className="text-text-secondary" />
+                  {getText('periodInfo')}
+                </h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  {/* 모집 기간 */}
+                  <div className="bg-bg-secondary p-4 rounded-lg">
+                    <div className="flex items-center justify-between mb-2">
+                      <Label className="text-text-secondary">{getText('enrollmentPeriod')}</Label>
+                      {(() => {
+                        const today = new Date();
+                        const enrollStart = new Date(courseTime.enrollStartDate);
+                        const enrollEnd = new Date(courseTime.enrollEndDate);
+                        const isAlwaysOpen = courseTime.enrollEndDate === '9999-12-31';
+
+                        if (isAlwaysOpen) {
+                          return <Badge variant="success">{getText('alwaysOpen')}</Badge>;
+                        } else if (today < enrollStart) {
+                          const daysUntil = Math.ceil((enrollStart.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+                          return <Badge variant="secondary">D-{daysUntil}</Badge>;
+                        } else if (today <= enrollEnd) {
+                          const daysLeft = Math.ceil((enrollEnd.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+                          return <Badge variant="success">{language === 'ko' ? `모집 중 (D-${daysLeft})` : `Open (D-${daysLeft})`}</Badge>;
+                        } else {
+                          return <Badge variant="destructive">{language === 'ko' ? '모집 종료' : 'Closed'}</Badge>;
+                        }
+                      })()}
+                    </div>
+                    <p className="text-text-primary font-medium">
+                      {formatDate(courseTime.enrollStartDate)} ~ {formatDate(courseTime.enrollEndDate)}
                     </p>
+                  </div>
+
+                  {/* 학습 기간 */}
+                  <div className="bg-bg-secondary p-4 rounded-lg">
+                    <div className="flex items-center justify-between mb-2">
+                      <Label className="text-text-secondary">{getText('learningPeriod')}</Label>
+                      {(() => {
+                        const today = new Date();
+                        const classStart = new Date(courseTime.classStartDate);
+                        const classEnd = new Date(courseTime.classEndDate);
+
+                        if (today < classStart) {
+                          const daysUntil = Math.ceil((classStart.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+                          return <Badge variant="secondary">D-{daysUntil}</Badge>;
+                        } else if (today <= classEnd) {
+                          const daysLeft = Math.ceil((classEnd.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+                          return <Badge variant="default">{language === 'ko' ? `진행 중 (D-${daysLeft})` : `Ongoing (D-${daysLeft})`}</Badge>;
+                        } else {
+                          return <Badge variant="destructive">{language === 'ko' ? '종료' : 'Ended'}</Badge>;
+                        }
+                      })()}
+                    </div>
+                    <p className="text-text-primary font-medium">
+                      {formatDate(courseTime.classStartDate)} ~ {formatDate(courseTime.classEndDate)}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-4 mt-4 pt-4 border-t border-border">
+                  <div className="flex items-center gap-2">
+                    <Label className="text-text-secondary">{getText('allowLateEnrollment')}</Label>
+                    <Badge variant={courseTime.allowLateEnrollment ? 'success' : 'secondary'}>
+                      {courseTime.allowLateEnrollment ? getText('allowLateEnrollmentYes') : getText('allowLateEnrollmentNo')}
+                    </Badge>
+                  </div>
+                  {courseTime.minProgressForCompletion && (
+                    <div className="flex items-center gap-2">
+                      <Label className="text-text-secondary">{getText('minProgressForCompletion')}</Label>
+                      <Badge variant="default">{courseTime.minProgressForCompletion}%</Badge>
+                    </div>
                   )}
                 </div>
-                <div className="pt-2 border-t border-border">
-                  <Label className="text-text-secondary">{getText('createdAt')}</Label>
-                  <p className="text-text-primary text-sm">{formatDateTime(courseTime.createdAt)}</p>
-                </div>
-              </div>
-            </Card>
+              </Card>
 
-            {/* 프로그램 정보 */}
-            <Card className="p-6">
-              <h2 className="text-lg font-semibold text-text-primary mb-4 flex items-center gap-2">
-                <BookOpen size={18} className="text-text-secondary" />
-                {getText('programInfo')}
-              </h2>
-              <div className="space-y-4">
-                <div>
-                  <Label className="text-text-secondary">{getText('programTitle')}</Label>
-                  <p className="text-text-primary font-medium">{courseTime.programTitle || '-'}</p>
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <Label className="text-text-secondary">{getText('courseId')}</Label>
-                    <p className="text-text-primary">{courseTime.cmCourseId || '-'}</p>
-                  </div>
-                  <div>
-                    <Label className="text-text-secondary">{getText('courseTitle')}</Label>
-                    <p className="text-text-primary">{courseTime.cmCourseTitle || '-'}</p>
-                  </div>
-                </div>
-              </div>
-            </Card>
-
-            {/* 진행 정보 */}
-            <Card className="p-6">
-              <h2 className="text-lg font-semibold text-text-primary mb-4 flex items-center gap-2">
-                <Play size={18} className="text-text-secondary" />
-                {getText('deliveryInfo')}
-              </h2>
-              <div className="space-y-4">
-                <div className="grid grid-cols-2 gap-4">
+              {/* 진행 정보 */}
+              <Card className="p-6">
+                <h2 className="text-lg font-semibold text-text-primary mb-4 flex items-center gap-2">
+                  <Play size={18} className="text-text-secondary" />
+                  {getText('deliveryInfo')}
+                </h2>
+                <div className="space-y-4">
                   <div>
                     <Label className="text-text-secondary">{getText('deliveryType')}</Label>
                     {isEditing ? (
@@ -515,7 +653,7 @@ export function CourseTimeDetailPage({ language = 'ko' }: Readonly<CourseTimeDet
                         }))}
                       />
                     ) : (
-                      <p className="text-text-primary">
+                      <p className="text-text-primary font-medium">
                         {DELIVERY_TYPE_LABELS[courseTime.deliveryType]}
                       </p>
                     )}
@@ -537,161 +675,65 @@ export function CourseTimeDetailPage({ language = 'ko' }: Readonly<CourseTimeDet
                         }))}
                       />
                     ) : (
-                      <p className="text-text-primary">
+                      <p className="text-text-primary font-medium">
                         {ENROLLMENT_METHOD_LABELS[courseTime.enrollmentMethod]}
                       </p>
                     )}
                   </div>
+                  <div>
+                    <Label className="text-text-secondary flex items-center gap-1">
+                      <MapPin size={14} />
+                      {getText('location')}
+                    </Label>
+                    {isEditing ? (
+                      <Input
+                        value={editData.location || ''}
+                        onChange={(e) => setEditData({ ...editData, location: e.target.value })}
+                      />
+                    ) : (
+                      <p className="text-text-primary">
+                        {courseTime.locationInfo || getText('noLocation')}
+                      </p>
+                    )}
+                  </div>
                 </div>
-                <div>
-                  <Label className="text-text-secondary flex items-center gap-1">
-                    <MapPin size={14} />
-                    {getText('location')}
-                  </Label>
-                  {isEditing ? (
-                    <Input
-                      value={editData.location || ''}
-                      onChange={(e) => setEditData({ ...editData, location: e.target.value })}
-                    />
-                  ) : (
-                    <p className="text-text-primary">
-                      {courseTime.location || getText('noLocation')}
-                    </p>
+              </Card>
+
+              {/* 강사 정보 (전체 너비) */}
+              <Card className="p-6 lg:col-span-3">
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="text-lg font-semibold text-text-primary flex items-center gap-2">
+                    <User size={18} className="text-text-secondary" />
+                    {getText('instructors')}
+                  </h2>
+                  {courseTime.status === 'DRAFT' && (
+                    <Button variant="ghost" size="sm">
+                      <UserPlus size={16} />
+                      <span>{getText('addInstructor')}</span>
+                    </Button>
                   )}
                 </div>
-              </div>
-            </Card>
-
-            {/* 기간 정보 */}
-            <Card className="p-6">
-              <h2 className="text-lg font-semibold text-text-primary mb-4 flex items-center gap-2">
-                <Calendar size={18} className="text-text-secondary" />
-                {getText('periodInfo')}
-              </h2>
-              <div className="space-y-4">
-                <div>
-                  <Label className="text-text-secondary">{getText('enrollmentPeriod')}</Label>
-                  <p className="text-text-primary">
-                    {formatDate(courseTime.enrollStartDate)} ~ {formatDate(courseTime.enrollEndDate)}
-                  </p>
-                </div>
-                <div>
-                  <Label className="text-text-secondary">{getText('learningPeriod')}</Label>
-                  <p className="text-text-primary">
-                    {formatDate(courseTime.classStartDate)} ~ {formatDate(courseTime.classEndDate)}
-                  </p>
-                </div>
-                <div className="pt-2 border-t border-border">
-                  <Label className="text-text-secondary">{getText('allowLateEnrollment')}</Label>
-                  <p className="text-text-primary">
-                    <Badge variant={courseTime.allowLateEnrollment ? 'success' : 'secondary'}>
-                      {courseTime.allowLateEnrollment ? getText('allowLateEnrollmentYes') : getText('allowLateEnrollmentNo')}
-                    </Badge>
-                  </p>
-                </div>
-              </div>
-            </Card>
-
-            {/* 정원 및 수강 */}
-            <Card className="p-6">
-              <h2 className="text-lg font-semibold text-text-primary mb-4 flex items-center gap-2">
-                <Users size={18} className="text-text-secondary" />
-                {getText('capacityInfo')}
-              </h2>
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <Label className="text-text-secondary">{getText('capacity')}</Label>
-                  {isEditing ? (
-                    <Input
-                      type="number"
-                      value={editData.capacity ?? ''}
-                      onChange={(e) =>
-                        setEditData({
-                          ...editData,
-                          capacity: e.target.value ? parseInt(e.target.value) : null,
-                        })
-                      }
-                      placeholder="0 = 무제한"
-                    />
-                  ) : (
-                    <p className="text-text-primary text-xl font-semibold">
-                      {courseTime.capacity || getText('unlimited')}
-                    </p>
-                  )}
-                </div>
-                <div>
-                  <Label className="text-text-secondary">{getText('currentEnrollment')}</Label>
-                  <p className="text-text-primary text-xl font-semibold">
-                    {courseTime.currentEnrollment}
-                  </p>
-                </div>
-                <div>
-                  <Label className="text-text-secondary">{getText('availableSeats')}</Label>
-                  <p className="text-text-primary text-xl font-semibold">
-                    {courseTime.availableSeats ?? getText('unlimited')}
-                  </p>
-                </div>
-                <div>
-                  <Label className="text-text-secondary flex items-center gap-1">
-                    <DollarSign size={14} />
-                    {getText('price')}
-                  </Label>
-                  {isEditing ? (
-                    <Input
-                      type="number"
-                      value={editData.price ?? ''}
-                      onChange={(e) =>
-                        setEditData({
-                          ...editData,
-                          price: e.target.value ? parseInt(e.target.value) : null,
-                        })
-                      }
-                      placeholder="0 = 무료"
-                    />
-                  ) : (
-                    <p className="text-text-primary text-xl font-semibold">
-                      {formatPrice(courseTime.price, courseTime.isFree)}
-                    </p>
-                  )}
-                </div>
-              </div>
-            </Card>
-
-            {/* 강사 정보 */}
-            <Card className="p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-lg font-semibold text-text-primary flex items-center gap-2">
-                  <User size={18} className="text-text-secondary" />
-                  {getText('instructors')}
-                </h2>
-                {courseTime.status === 'DRAFT' && (
-                  <Button variant="ghost" size="sm">
-                    <UserPlus size={16} />
-                    <span>{getText('addInstructor')}</span>
-                  </Button>
-                )}
-              </div>
-              {courseTime.instructors && courseTime.instructors.length > 0 ? (
-                <div className="space-y-3">
-                  {courseTime.instructors.map((instructor) => (
-                    <div
-                      key={instructor.id}
-                      className="flex items-center justify-between p-3 bg-bg-secondary rounded-lg"
-                    >
-                      <div>
-                        <p className="text-text-primary font-medium">{instructor.userName}</p>
-                        <p className="text-text-secondary text-sm">{instructor.userEmail}</p>
+                {courseTime.instructors && courseTime.instructors.length > 0 ? (
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                    {courseTime.instructors.map((instructor) => (
+                      <div
+                        key={instructor.id}
+                        className="flex items-center justify-between p-3 bg-bg-secondary rounded-lg"
+                      >
+                        <div>
+                          <p className="text-text-primary font-medium">{instructor.userName}</p>
+                          <p className="text-text-secondary text-sm">{instructor.userEmail}</p>
+                        </div>
+                        <Badge variant={instructor.role === 'MAIN' ? 'default' : 'secondary'}>
+                          {getText(instructor.role)}
+                        </Badge>
                       </div>
-                      <Badge variant={instructor.role === 'MAIN' ? 'default' : 'secondary'}>
-                        {getText(instructor.role)}
-                      </Badge>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <p className="text-text-secondary text-center py-4">{getText('noInstructors')}</p>
-              )}
-            </Card>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-text-secondary text-center py-4">{getText('noInstructors')}</p>
+                )}
+              </Card>
             </div>
           </div>
         )}

--- a/src/pages/to/time/CourseTimesPage.tsx
+++ b/src/pages/to/time/CourseTimesPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSubdomainPath } from '@/hooks/common';
 import { toast } from 'sonner';
 import type { ColumnDef } from '@tanstack/react-table';
 import {
@@ -147,6 +148,7 @@ function StatCard({
 
 export function CourseTimesPage({ language = 'ko' }: Readonly<CourseTimesPageProps>) {
   const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<CourseTimeStatus | 'all'>('all');
   const [showFilters, setShowFilters] = useState(false);
@@ -259,11 +261,11 @@ export function CourseTimesPage({ language = 'ko' }: Readonly<CourseTimesPagePro
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-40">
-          <DropdownMenuItem onClick={() => navigate(`/to/times/${item.id}`)}>
+          <DropdownMenuItem onClick={() => navigate(prefixPath(`/to/times/${item.id}`))}>
             <Eye size={14} />
             {getText('view')}
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => navigate(`/to/times/${item.id}/clone`)}>
+          <DropdownMenuItem onClick={() => navigate(prefixPath(`/to/times/${item.id}/clone`))}>
             <Copy size={14} />
             {getText('clone')}
           </DropdownMenuItem>
@@ -419,7 +421,7 @@ export function CourseTimesPage({ language = 'ko' }: Readonly<CourseTimesPagePro
               <h1 className="text-text-primary mb-1">{getText('title')}</h1>
               <p className="text-text-secondary text-sm m-0">{getText('subtitle')}</p>
             </div>
-            <Button onClick={() => navigate('/to/times/create')}>
+            <Button onClick={() => navigate(prefixPath('/to/times/create'))}>
               <Plus size={20} />
               <span>{getText('createTime')}</span>
             </Button>
@@ -562,7 +564,7 @@ export function CourseTimesPage({ language = 'ko' }: Readonly<CourseTimesPagePro
               pageIndex={page}
               pageSize={10}
               onPageChange={setPage}
-              onRowClick={(item) => navigate(`/to/times/${item.id}`)}
+              onRowClick={(item) => navigate(prefixPath(`/to/times/${item.id}`))}
               labels={{
                 noResults: getText('noResults'),
                 rowsPerPage: language === 'ko' ? '페이지당 행 수' : 'Rows per page',

--- a/src/services/sa/dashboardService.ts
+++ b/src/services/sa/dashboardService.ts
@@ -6,11 +6,16 @@ import axiosInstance from '@/services/common/api/axiosInstance';
 import { API_ENDPOINTS } from '@/services/common/api/endpoints';
 import type { SaDashboardResponse } from '@/types/admin';
 
+export type DashboardPeriod = '7d' | '30d' | 'all';
+
 export const saDashboardService = {
   /** SA 대시보드 통계 조회 */
-  async getDashboard(): Promise<SaDashboardResponse> {
+  async getDashboard(period?: DashboardPeriod): Promise<SaDashboardResponse> {
     const { data } = await axiosInstance.get<SaDashboardResponse>(
-      API_ENDPOINTS.SA_DASHBOARD.BASE
+      API_ENDPOINTS.SA_DASHBOARD.BASE,
+      {
+        params: period && period !== 'all' ? { period } : undefined,
+      }
     );
     return data;
   },

--- a/src/services/sa/index.ts
+++ b/src/services/sa/index.ts
@@ -2,7 +2,7 @@ export { tenantService } from './tenantService';
 export type { TenantFilterParams } from './tenantService';
 export { noticeService } from './noticeService';
 export { saAnalyticsService } from './analyticsService';
-export { saDashboardService } from './dashboardService';
+export { saDashboardService, type DashboardPeriod } from './dashboardService';
 export { systemSettingsService } from './systemSettingsService';
 export type {
   SystemSettingsResponse,

--- a/src/services/ta/dashboardService.ts
+++ b/src/services/ta/dashboardService.ts
@@ -6,11 +6,16 @@ import axiosInstance from '@/services/common/api/axiosInstance';
 import { API_ENDPOINTS } from '@/services/common/api/endpoints';
 import type { TaKpiDashboardResponse } from '@/types/admin';
 
+export type DashboardPeriod = '7d' | '30d' | 'all';
+
 export const taDashboardService = {
   /** TA KPI 대시보드 통계 조회 */
-  async getKpiDashboard(): Promise<TaKpiDashboardResponse> {
+  async getKpiDashboard(period?: DashboardPeriod): Promise<TaKpiDashboardResponse> {
     const { data } = await axiosInstance.get<TaKpiDashboardResponse>(
-      API_ENDPOINTS.TA_DASHBOARD.KPI
+      API_ENDPOINTS.TA_DASHBOARD.KPI,
+      {
+        params: period && period !== 'all' ? { period } : undefined,
+      }
     );
     return data;
   },

--- a/src/services/ta/index.ts
+++ b/src/services/ta/index.ts
@@ -1,7 +1,7 @@
 export { userService } from './userService';
 export { groupService } from './groupService';
 export { tenantSettingsService } from './tenantSettingsService';
-export { taDashboardService } from './dashboardService';
+export { taDashboardService, type DashboardPeriod } from './dashboardService';
 export { analyticsService } from './analyticsService';
 export { bannerService } from './bannerService';
 export { tenantFeaturesService } from './tenantFeaturesService';

--- a/src/services/to/dashboardService.ts
+++ b/src/services/to/dashboardService.ts
@@ -6,11 +6,16 @@ import axiosInstance from '@/services/common/api/axiosInstance';
 import { API_ENDPOINTS } from '@/services/common/api/endpoints';
 import type { ToOperatorDashboardResponse } from '@/types/to';
 
+export type DashboardPeriod = '7d' | '30d' | 'all';
+
 export const toDashboardService = {
   /** TO 운영 대시보드 통계 조회 */
-  async getDashboard(): Promise<ToOperatorDashboardResponse> {
+  async getDashboard(period?: DashboardPeriod): Promise<ToOperatorDashboardResponse> {
     const { data } = await axiosInstance.get<ToOperatorDashboardResponse>(
-      API_ENDPOINTS.TO_DASHBOARD.TASKS
+      API_ENDPOINTS.TO_DASHBOARD.TASKS,
+      {
+        params: period && period !== 'all' ? { period } : undefined,
+      }
     );
     return data;
   },

--- a/src/services/tu/courseTimeCatalogService.ts
+++ b/src/services/tu/courseTimeCatalogService.ts
@@ -11,11 +11,34 @@ import type {
 } from '@/types/tu/courseTimeCatalog.types';
 import type { ApiResponse, PageResponse } from '@/types/common';
 
+/**
+ * URL에서 서브도메인 추출
+ * 예: /mzc/tu/b2c/courses → 'mzc'
+ */
+function getSubdomainFromUrl(): string | null {
+  const pathname = window.location.pathname;
+  // 패턴: /:subdomain/tu/... 또는 /:subdomain/ta/... 등
+  const match = pathname.match(/^\/([^/]+)\/(?:tu|ta|to|sa)\//);
+  if (match) {
+    return match[1];
+  }
+  return null;
+}
+
 // Public API용 axios 인스턴스 (인증 토큰 불필요)
 // VITE_API_BASE_URL이 이미 /api를 포함하므로 BASE_URL에서 /api 제거
 const publicAxios = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api',
   timeout: 10000,
+});
+
+// 요청 인터셉터: X-Subdomain 헤더 추가
+publicAxios.interceptors.request.use((config) => {
+  const subdomain = getSubdomainFromUrl();
+  if (subdomain) {
+    config.headers['X-Subdomain'] = subdomain;
+  }
+  return config;
 });
 
 const BASE_URL = '/public/course-times';

--- a/src/types/admin/dashboard.types.ts
+++ b/src/types/admin/dashboard.types.ts
@@ -52,7 +52,7 @@ export interface TaKpiDashboardResponse {
   userStats: TaUserStats;
   programStats: TaProgramStats;
   enrollmentStats: TaEnrollmentStats;
-  monthlyTrend: TaMonthlyTrend[];
+  dailyTrend: TaDailyTrend[];
 }
 
 /** TA 대시보드 - 사용자 통계 */
@@ -90,9 +90,9 @@ export interface TaEnrollmentByStatus {
   failed: number;
 }
 
-/** TA 대시보드 - 월별 추이 */
-export interface TaMonthlyTrend {
-  month: string;
+/** TA 대시보드 - 일별 추이 */
+export interface TaDailyTrend {
+  date: string;
   enrollments: number;
   completions: number;
 }

--- a/src/types/common/program.types.ts
+++ b/src/types/common/program.types.ts
@@ -47,6 +47,9 @@ export interface ProgramResponse {
   ownerName: string | null;
   ownerEmail: string | null;
   snapshotId: number | null;
+  // Course 권장 운영 기간 (차수 생성 시 참고용)
+  courseStartDate: string | null;
+  courseEndDate: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/types/to/time.types.ts
+++ b/src/types/to/time.types.ts
@@ -66,12 +66,16 @@ export interface CourseTimeInstructor {
   status: 'ACTIVE' | 'REPLACED' | 'CANCELLED';
 }
 
-/** 차수 상세 조회 응답 */
+/** 차수 상세 조회 응답 (백엔드 CourseTimeDetailResponse 매칭) */
 export interface CourseTimeDetailResponse extends CourseTimeResponse {
-  description: string | null;
-  location: string | null;
+  programId: number | null;
   programTitle: string | null;
-  cmCourseTitle: string | null;
+  programDescription: string | null;
+  maxWaitingCount: number | null;
+  minProgressForCompletion: number | null;
+  locationInfo: string | null;
+  createdBy: number | null;
+  updatedAt: string;
   instructors: CourseTimeInstructor[];
 }
 


### PR DESCRIPTION
## Summary
- 강사/학습자 모드 전환 시 서브도메인이 URL에서 빠지는 버그 수정
- (백엔드) NavigationItem 중복 삽입 동시성 버그 수정

## Changes

### Frontend
- `BaseSidebar.tsx`: `handleModeChange` 함수에서 `useSubdomainPath` 훅의 `prefixPath`를 사용하여 서브도메인 유지
  - 기존: `navigate('/tu/b2c/mypage')` → 서브도메인 누락
  - 수정: `navigate(prefixPath('/tu/b2c/mypage'))` → 서브도메인 유지

### Backend
- `TenantSettingsServiceImpl.java`: `existsByTenantId` 체크 방식에서 실제 조회 후 isEmpty 체크로 변경하여 race condition 방지

## Test plan
- [ ] `/{subdomain}/tu/dashboard`에서 학습자 전환 클릭 → `/{subdomain}/tu/b2c/mypage`로 이동 확인
- [ ] `/{subdomain}/tu/b2c/mypage`에서 강사 전환 클릭 → `/{subdomain}/tu/dashboard`로 이동 확인
- [ ] 반복 전환 시에도 서브도메인이 유지되는지 확인