### PR TITLE
fix(ta): 브랜딩 레이아웃 미리보기 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -128,7 +128,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -403,7 +402,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -3655,7 +3653,6 @@
       "resolved": "https://registry.npmjs.org/@svta/cml-xml/-/cml-xml-1.0.1.tgz",
       "integrity": "sha512-11LkJa5kDEcsRMWkVI1ABH3KLCxGoiSVe4kQ293ItVj8ncTTQ7htmCGiJDjS+Cmy35UgF3e/vc0ysJIiWRTx2g==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -3849,7 +3846,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3860,7 +3856,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3916,7 +3911,6 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -4185,7 +4179,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4545,7 +4538,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5175,8 +5167,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5333,7 +5324,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6270,7 +6260,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6950,7 +6939,6 @@
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
       "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7044,7 +7032,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7267,7 +7254,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7298,7 +7284,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7343,8 +7328,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
       "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-player": {
       "version": "3.4.0",
@@ -7374,7 +7358,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7592,8 +7575,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -8240,7 +8222,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8319,7 +8300,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8538,7 +8518,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -8632,7 +8611,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/pages/ta/branding/LayoutSettingsPage.tsx
+++ b/src/pages/ta/branding/LayoutSettingsPage.tsx
@@ -2329,6 +2329,23 @@ export function LayoutSettingsPage() {
             {/* TU 메인 미리보기 */}
             <TabsContent value="tu-main">
               <div className={`border rounded-lg overflow-hidden ${previewTheme === 'dark' ? 'bg-gray-900' : 'bg-white'}`}>
+                {/* 브라우저 탭 시뮬레이션 (파비콘 미리보기) */}
+                <div className={`flex items-center gap-2 px-3 py-2 border-b ${previewTheme === 'dark' ? 'bg-gray-800 border-gray-700' : 'bg-gray-100 border-gray-200'}`}>
+                  <div className="flex items-center gap-1.5">
+                    <div className="w-3 h-3 rounded-full bg-red-400" />
+                    <div className="w-3 h-3 rounded-full bg-yellow-400" />
+                    <div className="w-3 h-3 rounded-full bg-green-400" />
+                  </div>
+                  <div className={`flex items-center gap-2 px-3 py-1 rounded-t-md text-xs ${previewTheme === 'dark' ? 'bg-gray-900 text-gray-300' : 'bg-white text-gray-600'}`}>
+                    {settings.logo.faviconPreview ? (
+                      <img src={settings.logo.faviconPreview} alt="Favicon" className="w-4 h-4 object-contain" />
+                    ) : (
+                      <div className="w-4 h-4 rounded bg-gray-300" />
+                    )}
+                    <span className="truncate max-w-[120px]">{settings.company.name || '사이트 제목'}</span>
+                  </div>
+                </div>
+
                 {/* 상단 알림 배너 */}
                 {settings.colors.enabled && (
                   <div
@@ -2348,9 +2365,18 @@ export function LayoutSettingsPage() {
                   }`}>
                     <div className="flex items-center gap-8">
                       {settings.header.showLogo && (
-                        <span className="font-bold text-xl tracking-tight" style={{ color: settings.colors.primary }}>
-                          {settings.company.name || 'Logo'}
-                        </span>
+                        <div className="flex items-center gap-2">
+                          {(settings.logo.lightPreview || settings.logo.darkPreview) && (
+                            <img
+                              src={(previewTheme === 'dark' ? settings.logo.darkPreview : settings.logo.lightPreview) || settings.logo.lightPreview || settings.logo.darkPreview!}
+                              alt="Logo"
+                              className="h-8 object-contain"
+                            />
+                          )}
+                          <span className="font-bold text-xl tracking-tight" style={{ color: settings.colors.primary }}>
+                            {settings.company.name || 'Logo'}
+                          </span>
+                        </div>
                       )}
                       <div className={`hidden md:flex gap-6 text-sm font-medium ${previewTheme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}>
                         {settings.header.navLinks.filter(l => l.visible).slice(0, 4).map((link, i) => (
@@ -2536,9 +2562,9 @@ export function LayoutSettingsPage() {
                       </div>
                     </div>
                     <div className="flex gap-3">
-                      {settings.footer.socialLinks.facebook.enabled && settings.footer.socialLinks.facebook.url && (
+                      {settings.footer.socialLinks.facebook.enabled && (
                         <a
-                          href={settings.footer.socialLinks.facebook.url}
+                          href={settings.footer.socialLinks.facebook.url || '#'}
                           target="_blank"
                           rel="noopener noreferrer"
                           className={`w-9 h-9 rounded-full flex items-center justify-center transition-all hover:scale-110 cursor-pointer ${previewTheme === 'dark' ? 'bg-gray-800 hover:bg-gray-700' : 'bg-gray-700 hover:bg-gray-600'}`}
@@ -2549,9 +2575,9 @@ export function LayoutSettingsPage() {
                           </svg>
                         </a>
                       )}
-                      {settings.footer.socialLinks.twitter.enabled && settings.footer.socialLinks.twitter.url && (
+                      {settings.footer.socialLinks.twitter.enabled && (
                         <a
-                          href={settings.footer.socialLinks.twitter.url}
+                          href={settings.footer.socialLinks.twitter.url || '#'}
                           target="_blank"
                           rel="noopener noreferrer"
                           className={`w-9 h-9 rounded-full flex items-center justify-center transition-all hover:scale-110 cursor-pointer ${previewTheme === 'dark' ? 'bg-gray-800 hover:bg-gray-700' : 'bg-gray-700 hover:bg-gray-600'}`}
@@ -2562,9 +2588,9 @@ export function LayoutSettingsPage() {
                           </svg>
                         </a>
                       )}
-                      {settings.footer.socialLinks.youtube.enabled && settings.footer.socialLinks.youtube.url && (
+                      {settings.footer.socialLinks.youtube.enabled && (
                         <a
-                          href={settings.footer.socialLinks.youtube.url}
+                          href={settings.footer.socialLinks.youtube.url || '#'}
                           target="_blank"
                           rel="noopener noreferrer"
                           className={`w-9 h-9 rounded-full flex items-center justify-center transition-all hover:scale-110 cursor-pointer ${previewTheme === 'dark' ? 'bg-gray-800 hover:bg-gray-700' : 'bg-gray-700 hover:bg-gray-600'}`}
@@ -2575,9 +2601,9 @@ export function LayoutSettingsPage() {
                           </svg>
                         </a>
                       )}
-                      {settings.footer.socialLinks.instagram.enabled && settings.footer.socialLinks.instagram.url && (
+                      {settings.footer.socialLinks.instagram.enabled && (
                         <a
-                          href={settings.footer.socialLinks.instagram.url}
+                          href={settings.footer.socialLinks.instagram.url || '#'}
                           target="_blank"
                           rel="noopener noreferrer"
                           className={`w-9 h-9 rounded-full flex items-center justify-center transition-all hover:scale-110 cursor-pointer ${previewTheme === 'dark' ? 'bg-gray-800 hover:bg-gray-700' : 'bg-gray-700 hover:bg-gray-600'}`}
@@ -2588,9 +2614,9 @@ export function LayoutSettingsPage() {
                           </svg>
                         </a>
                       )}
-                      {settings.footer.socialLinks.linkedin.enabled && settings.footer.socialLinks.linkedin.url && (
+                      {settings.footer.socialLinks.linkedin.enabled && (
                         <a
-                          href={settings.footer.socialLinks.linkedin.url}
+                          href={settings.footer.socialLinks.linkedin.url || '#'}
                           target="_blank"
                           rel="noopener noreferrer"
                           className={`w-9 h-9 rounded-full flex items-center justify-center transition-all hover:scale-110 cursor-pointer ${previewTheme === 'dark' ? 'bg-gray-800 hover:bg-gray-700' : 'bg-gray-700 hover:bg-gray-600'}`}
@@ -2601,9 +2627,9 @@ export function LayoutSettingsPage() {
                           </svg>
                         </a>
                       )}
-                      {settings.footer.socialLinks.github.enabled && settings.footer.socialLinks.github.url && (
+                      {settings.footer.socialLinks.github.enabled && (
                         <a
-                          href={settings.footer.socialLinks.github.url}
+                          href={settings.footer.socialLinks.github.url || '#'}
                           target="_blank"
                           rel="noopener noreferrer"
                           className={`w-9 h-9 rounded-full flex items-center justify-center transition-all hover:scale-110 cursor-pointer ${previewTheme === 'dark' ? 'bg-gray-800 hover:bg-gray-700' : 'bg-gray-700 hover:bg-gray-600'}`}
@@ -2623,13 +2649,39 @@ export function LayoutSettingsPage() {
             {/* 마이페이지 미리보기 */}
             <TabsContent value="tu-mypage">
               <div className={`border rounded-lg overflow-hidden ${previewTheme === 'dark' ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+                {/* 브라우저 탭 시뮬레이션 (파비콘 미리보기) */}
+                <div className={`flex items-center gap-2 px-3 py-2 border-b ${previewTheme === 'dark' ? 'bg-gray-800 border-gray-700' : 'bg-gray-100 border-gray-200'}`}>
+                  <div className="flex items-center gap-1.5">
+                    <div className="w-3 h-3 rounded-full bg-red-400" />
+                    <div className="w-3 h-3 rounded-full bg-yellow-400" />
+                    <div className="w-3 h-3 rounded-full bg-green-400" />
+                  </div>
+                  <div className={`flex items-center gap-2 px-3 py-1 rounded-t-md text-xs ${previewTheme === 'dark' ? 'bg-gray-900 text-gray-300' : 'bg-white text-gray-600'}`}>
+                    {settings.logo.faviconPreview ? (
+                      <img src={settings.logo.faviconPreview} alt="Favicon" className="w-4 h-4 object-contain" />
+                    ) : (
+                      <div className="w-4 h-4 rounded bg-gray-300" />
+                    )}
+                    <span className="truncate max-w-[120px]">{settings.company.name || '사이트 제목'}</span>
+                  </div>
+                </div>
+
                 {/* 헤더 */}
                 <div className={`h-16 border-b flex items-center px-6 ${
                   previewTheme === 'dark' ? 'bg-[#1e1e1e] border-white/10' : 'bg-white border-gray-200'
                 }`}>
-                  <span className="font-bold text-xl tracking-tight" style={{ color: settings.colors.primary }}>
-                    {settings.company.name || 'Logo'}
-                  </span>
+                  <div className="flex items-center gap-2">
+                    {(settings.logo.lightPreview || settings.logo.darkPreview) && (
+                      <img
+                        src={(previewTheme === 'dark' ? settings.logo.darkPreview : settings.logo.lightPreview) || settings.logo.lightPreview || settings.logo.darkPreview!}
+                        alt="Logo"
+                        className="h-8 object-contain"
+                      />
+                    )}
+                    <span className="font-bold text-xl tracking-tight" style={{ color: settings.colors.primary }}>
+                      {settings.company.name || 'Logo'}
+                    </span>
+                  </div>
                   <div className="ml-auto flex items-center gap-3">
                     <Bell className={`w-5 h-5 ${previewTheme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`} />
                     <div
@@ -2825,13 +2877,39 @@ export function LayoutSettingsPage() {
             {/* TO 미리보기 */}
             <TabsContent value="to">
               <div className={`border rounded-lg overflow-hidden ${previewTheme === 'dark' ? 'bg-gray-950' : 'bg-gray-50'}`}>
+                {/* 브라우저 탭 시뮬레이션 (파비콘 미리보기) */}
+                <div className={`flex items-center gap-2 px-3 py-2 border-b ${previewTheme === 'dark' ? 'bg-gray-800 border-gray-700' : 'bg-gray-100 border-gray-200'}`}>
+                  <div className="flex items-center gap-1.5">
+                    <div className="w-3 h-3 rounded-full bg-red-400" />
+                    <div className="w-3 h-3 rounded-full bg-yellow-400" />
+                    <div className="w-3 h-3 rounded-full bg-green-400" />
+                  </div>
+                  <div className={`flex items-center gap-2 px-3 py-1 rounded-t-md text-xs ${previewTheme === 'dark' ? 'bg-gray-900 text-gray-300' : 'bg-white text-gray-600'}`}>
+                    {settings.logo.faviconPreview ? (
+                      <img src={settings.logo.faviconPreview} alt="Favicon" className="w-4 h-4 object-contain" />
+                    ) : (
+                      <div className="w-4 h-4 rounded bg-gray-300" />
+                    )}
+                    <span className="truncate max-w-[120px]">{settings.company.name || '사이트 제목'}</span>
+                  </div>
+                </div>
+
                 {/* 헤더 */}
                 <div className={`h-16 border-b flex items-center px-6 ${
                   previewTheme === 'dark' ? 'bg-gray-950 border-gray-800' : 'bg-white border-gray-200'
                 }`}>
-                  <span className={`font-bold text-xl ${previewTheme === 'dark' ? 'text-white' : 'text-gray-900'}`}>
-                    {settings.company.name || 'Logo'}
-                  </span>
+                  <div className="flex items-center gap-2">
+                    {(settings.logo.lightPreview || settings.logo.darkPreview) && (
+                      <img
+                        src={(previewTheme === 'dark' ? settings.logo.darkPreview : settings.logo.lightPreview) || settings.logo.lightPreview || settings.logo.darkPreview!}
+                        alt="Logo"
+                        className="h-8 object-contain"
+                      />
+                    )}
+                    <span className={`font-bold text-xl ${previewTheme === 'dark' ? 'text-white' : 'text-gray-900'}`}>
+                      {settings.company.name || 'Logo'}
+                    </span>
+                  </div>
                   <span
                     className="ml-3 text-sm px-2 py-1 rounded-full cursor-pointer transition-all hover:scale-105"
                     style={{


### PR DESCRIPTION
## Summary

- 소셜 미디어: `enabled`만 true이면 미리보기에 아이콘 표시 (URL 없어도 됨)
- 파비콘: 3개 탭(TU 메인, 마이페이지, TO) 모두에 브라우저 탭 시뮬레이션 추가
- 로고: 미리보기 헤더에 로고 이미지 + 회사명 같이 표시되도록 수정

Closes #381

## Test plan

- [ ] 소셜 미디어 ON 설정 시 미리보기 푸터에 아이콘 표시 확인
- [ ] 파비콘 업로드 시 브라우저 탭 시뮬레이션에 표시 확인
- [ ] 로고 업로드 시 미리보기 헤더에 이미지 표시 확인
- [ ] 라이트/다크 모드 전환 시 각 모드 로고 표시 확인
