### PR TITLE
fix: 설정 페이지 subdomain 지원 추가

### DIFF
--- a/src/pages/common/settings/SettingsPage.tsx
+++ b/src/pages/common/settings/SettingsPage.tsx
@@ -52,19 +52,32 @@ const getSettingCards = (userRole: UserRole): SettingCardData[] => {
   ];
 };
 
-// URL 경로에서 역할 추출
+// URL 경로에서 역할 추출 (subdomain 지원: /sa, /ta, /to 또는 /:subdomain/ta, /:subdomain/to)
 const getRoleFromPath = (pathname: string): UserRole => {
-  if (pathname.startsWith('/sa')) return 'SYSTEM_ADMIN';
-  if (pathname.startsWith('/ta')) return 'TENANT_ADMIN';
-  if (pathname.startsWith('/to')) return 'OPERATOR';
+  if (pathname.includes('/sa')) return 'SYSTEM_ADMIN';
+  if (pathname.includes('/ta')) return 'TENANT_ADMIN';
+  if (pathname.includes('/to')) return 'OPERATOR';
   return 'USER';
 };
 
-// 역할별 base path
+// 역할별 base path (subdomain 지원)
 const getBasePath = (pathname: string): string => {
-  if (pathname.startsWith('/sa')) return '/sa';
-  if (pathname.startsWith('/ta')) return '/ta';
-  if (pathname.startsWith('/to')) return '/to';
+  // /sa 또는 /:subdomain/sa
+  const saMatch = pathname.match(/^(\/[^/]+)?\/sa/);
+  if (saMatch) return saMatch[0];
+
+  // /ta 또는 /:subdomain/ta
+  const taMatch = pathname.match(/^(\/[^/]+)?\/ta/);
+  if (taMatch) return taMatch[0];
+
+  // /to 또는 /:subdomain/to
+  const toMatch = pathname.match(/^(\/[^/]+)?\/to/);
+  if (toMatch) return toMatch[0];
+
+  // /tu 또는 /:subdomain/tu
+  const tuMatch = pathname.match(/^(\/[^/]+)?\/tu/);
+  if (tuMatch) return tuMatch[0];
+
   return '/tu';
 };
 


### PR DESCRIPTION
## Summary
설정 페이지(SettingsPage)에서 subdomain이 포함된 URL 경로를 인식하지 못하는 문제를 수정했습니다. 기존에는 `/lg/ta/settings` 같은 경로에서 USER로 인식되어 "언어 및 지역" 카드만 표시되었습니다.

## Related Issue
- N/A

## Changes
- `getRoleFromPath`: `startsWith()` → `includes()`로 변경하여 `/lg/ta`, `/lg/to` 등 subdomain 경로 인식
- `getBasePath`: 정규식을 사용하여 subdomain 포함 경로(`/lg/ta`, `/lg/to`) 정확히 추출

## Type of Change
- [x] Fix: 버그 수정

## Checklist
- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 로컬에서 테스트가 통과합니다

## Screenshots (Optional)
**수정 전**: `/lg/ta/settings`에서 "언어 및 지역" 카드만 표시
**수정 후**: "계정 및 보안", "알림", "외관" 카드 정상 표시

## Additional Notes
- SA(`/sa`), TA(`/ta`, `/:subdomain/ta`), TO(`/:subdomain/to`) 모든 경로에서 정상 동작 확인
