### PR TITLE
fix: 수강평 빈 상태 메시지를 수강 신청 여부에 따라 분기 처리

### DIFF
--- a/src/components/domain/course-review/CourseReviewSection.tsx
+++ b/src/components/domain/course-review/CourseReviewSection.tsx
@@ -277,7 +277,9 @@ export function CourseReviewSection({ timeId, isDark = false, canWrite = false }
             아직 수강평이 없습니다
           </p>
           <p className={`text-sm ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
-            첫 번째 수강평을 작성해보세요!
+            {canWrite
+              ? '첫 번째 수강평을 작성해보세요!'
+              : '수강 신청 후 수강평을 작성할 수 있습니다.'}
           </p>
         </div>
       )}


### PR DESCRIPTION
## Summary

수강평 빈 상태 메시지를 수강 신청 여부에 따라 분기 처리

## Related Issue

- Closes #

## Changes

- 수강 신청한 사용자: "첫 번째 수강평을 작성해보세요!"
- 미수강 사용자: "수강 신청 후 수강평을 작성할 수 있습니다."

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)



## Additional Notes

`canWrite` prop에 따라 빈 상태 메시지만 분기 처리. 리뷰 목록/통계 조회는 모든 사용자에게 호출됨.