### PR TITLE
feat: 강의 커뮤니티 비밀글 기능 추가

### DIFF
--- a/src/components/domain/course-community/CourseCommunityPostCard.tsx
+++ b/src/components/domain/course-community/CourseCommunityPostCard.tsx
@@ -2,7 +2,8 @@
  * 코스 커뮤니티 게시글 카드 컴포넌트
  */
 
-import { MessageCircle, Heart, Eye, Clock, CheckCircle } from 'lucide-react';
+import { MessageCircle, Heart, Eye, Clock, CheckCircle, Lock } from 'lucide-react';
+import { toast } from 'sonner';
 import type { CourseCommunityPost } from '@/types/tu/courseCommunity.types';
 import { POST_TYPE_LABELS } from '@/types/tu/courseCommunity.types';
 import { formatDistanceToNow } from 'date-fns';
@@ -12,6 +13,8 @@ interface CourseCommunityPostCardProps {
   post: CourseCommunityPost;
   isDark: boolean;
   onClick: () => void;
+  currentUserId?: number;
+  instructorIds?: number[];
 }
 
 const TYPE_COLORS: Record<string, { bg: string; text: string }> = {
@@ -26,6 +29,8 @@ export function CourseCommunityPostCard({
   post,
   isDark,
   onClick,
+  currentUserId,
+  instructorIds,
 }: CourseCommunityPostCardProps) {
   const typeColor = TYPE_COLORS[post.type] || TYPE_COLORS.discussion;
   const timeAgo = formatDistanceToNow(new Date(post.createdAt), {
@@ -33,9 +38,30 @@ export function CourseCommunityPostCard({
     locale: ko,
   });
 
+  // 비밀글 열람 권한 확인
+  const canViewPrivatePost = (): boolean => {
+    if (!post.isPrivate) return true;
+    if (!currentUserId) return false;
+    if (post.author.id === currentUserId) return true;
+    if (instructorIds?.includes(currentUserId)) return true;
+    return false;
+  };
+
+  const hasAccess = canViewPrivatePost();
+
+  const handleClick = () => {
+    if (post.isPrivate && !hasAccess) {
+      toast.error('비밀글입니다', {
+        description: '작성자와 강사만 열람할 수 있습니다.',
+      });
+      return;
+    }
+    onClick();
+  };
+
   return (
     <div
-      onClick={onClick}
+      onClick={handleClick}
       className={`p-4 rounded-xl cursor-pointer transition-all hover:shadow-md ${
         isDark
           ? 'bg-white/5 hover:bg-white/10 border border-white/10'
@@ -61,6 +87,12 @@ export function CourseCommunityPostCard({
               해결됨
             </span>
           )}
+          {post.isPrivate && (
+            <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-gray-500/10 text-gray-500">
+              <Lock className="w-3 h-3" />
+              비밀글
+            </span>
+          )}
         </div>
       </div>
 
@@ -68,13 +100,13 @@ export function CourseCommunityPostCard({
       <h3
         className={`font-semibold mb-2 line-clamp-2 ${
           isDark ? 'text-white' : 'text-gray-900'
-        }`}
+        } ${!hasAccess && post.isPrivate ? 'italic' : ''}`}
       >
-        {post.title}
+        {hasAccess ? post.title : '비밀글입니다'}
       </h3>
 
       {/* Excerpt */}
-      {post.excerpt && (
+      {hasAccess && post.excerpt && (
         <p
           className={`text-sm mb-3 line-clamp-2 ${
             isDark ? 'text-gray-400' : 'text-gray-600'
@@ -83,9 +115,18 @@ export function CourseCommunityPostCard({
           {post.excerpt}
         </p>
       )}
+      {!hasAccess && post.isPrivate && (
+        <p
+          className={`text-sm mb-3 ${
+            isDark ? 'text-gray-500' : 'text-gray-400'
+          }`}
+        >
+          작성자와 강사만 열람할 수 있습니다.
+        </p>
+      )}
 
       {/* Tags */}
-      {post.tags && post.tags.length > 0 && (
+      {hasAccess && post.tags && post.tags.length > 0 && (
         <div className="flex flex-wrap gap-1 mb-3">
           {post.tags.slice(0, 3).map((tag) => (
             <span

--- a/src/components/domain/course-community/CourseCommunityPostDetail.tsx
+++ b/src/components/domain/course-community/CourseCommunityPostDetail.tsx
@@ -14,6 +14,7 @@ import {
   Loader2,
   Send,
   CornerDownRight,
+  Lock,
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { ko } from 'date-fns/locale';
@@ -38,6 +39,7 @@ interface CourseCommunityPostDetailProps {
   onClose: () => void;
   onEdit: () => void;
   onDelete: () => void;
+  instructorIds?: number[];
 }
 
 const TYPE_COLORS: Record<string, { bg: string; text: string }> = {
@@ -55,6 +57,7 @@ export function CourseCommunityPostDetail({
   onClose,
   onEdit,
   onDelete,
+  instructorIds,
 }: CourseCommunityPostDetailProps) {
   const { user } = useAuthStore();
   const [commentContent, setCommentContent] = useState('');
@@ -120,6 +123,17 @@ export function CourseCommunityPostDetail({
 
   const isAuthor = user?.id === post?.author.id;
   const comments = commentsData?.comments || [];
+
+  // 비밀글 열람 권한 확인
+  const canViewPrivatePost = (): boolean => {
+    if (!post?.isPrivate) return true;
+    if (!user?.id) return false;
+    if (post.author.id === user.id) return true;
+    if (instructorIds?.includes(user.id)) return true;
+    return false;
+  };
+
+  const hasAccess = canViewPrivatePost();
 
   const renderComment = (comment: Comment, depth = 0) => {
     const isCommentAuthor = user?.id === comment.author.id;
@@ -291,6 +305,36 @@ export function CourseCommunityPostDetail({
         {isPostLoading ? (
           <div className="flex items-center justify-center py-20">
             <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
+          </div>
+        ) : post && !hasAccess ? (
+          <div className="flex flex-col items-center justify-center py-20 px-6">
+            <div
+              className={`w-20 h-20 rounded-full flex items-center justify-center mb-6 ${
+                isDark ? 'bg-white/10' : 'bg-gray-100'
+              }`}
+            >
+              <Lock className={`w-10 h-10 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+            </div>
+            <h3
+              className={`text-xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}
+            >
+              비밀글입니다
+            </h3>
+            <p
+              className={`text-center mb-6 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}
+            >
+              작성자와 강사만 열람할 수 있습니다.
+            </p>
+            <button
+              onClick={onClose}
+              className={`px-6 py-2 rounded-lg font-medium transition-colors ${
+                isDark
+                  ? 'bg-white/10 text-white hover:bg-white/20'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              }`}
+            >
+              돌아가기
+            </button>
           </div>
         ) : post ? (
           <div className="p-6">

--- a/src/components/domain/course-community/CourseCommunitySection.tsx
+++ b/src/components/domain/course-community/CourseCommunitySection.tsx
@@ -11,6 +11,7 @@ import {
   useUpdateCourseCommunityPost,
   useDeleteCourseCommunityPost,
 } from '@/hooks/tu/useCourseCommunityQueries';
+import { useAuthStore } from '@/store/common/authStore';
 import type {
   CourseCommunityFilter,
   PostType,
@@ -26,6 +27,7 @@ interface CourseCommunitySectionProps {
   timeId: number;
   isDark: boolean;
   canWrite?: boolean;
+  instructorIds?: number[];
 }
 
 const POST_TYPE_FILTERS: { value: PostType | 'all'; label: string }[] = [
@@ -40,7 +42,9 @@ export function CourseCommunitySection({
   timeId,
   isDark,
   canWrite = true,
+  instructorIds,
 }: CourseCommunitySectionProps) {
+  const { user } = useAuthStore();
   const [filter, setFilter] = useState<CourseCommunityFilter>({
     type: 'all',
     sortBy: 'latest',
@@ -273,6 +277,8 @@ export function CourseCommunitySection({
                 post={post}
                 isDark={isDark}
                 onClick={() => setSelectedPost(post)}
+                currentUserId={user?.id}
+                instructorIds={instructorIds}
               />
             ))}
 
@@ -340,6 +346,7 @@ export function CourseCommunitySection({
           onClose={() => setSelectedPost(null)}
           onEdit={() => handleEditClick(selectedPost)}
           onDelete={() => handleDeletePost(selectedPost.id)}
+          instructorIds={instructorIds}
         />
       )}
     </div>

--- a/src/components/domain/course-community/CourseCommunityWritePostModal.tsx
+++ b/src/components/domain/course-community/CourseCommunityWritePostModal.tsx
@@ -3,7 +3,7 @@
  */
 
 import { useState, useRef, useEffect } from 'react';
-import { X, Tag, Loader2, ImagePlus, Trash2 } from 'lucide-react';
+import { X, Tag, Loader2, ImagePlus, Trash2, Lock } from 'lucide-react';
 import type {
   PostType,
   CreateCourseCommunityPostRequest,
@@ -46,6 +46,7 @@ export function CourseCommunityWritePostModal({
   const [images, setImages] = useState<
     { file: File; preview: string; uploading: boolean; url?: string }[]
   >([]);
+  const [isPrivate, setIsPrivate] = useState(false);
   const [errors, setErrors] = useState<{
     title?: string;
     content?: string;
@@ -60,6 +61,7 @@ export function CourseCommunityWritePostModal({
       setTitle(editPost.title);
       setContent(editPost.content);
       setTags(editPost.tags || []);
+      setIsPrivate(editPost.isPrivate || false);
     } else {
       setPostType('question');
       setTitle('');
@@ -67,6 +69,7 @@ export function CourseCommunityWritePostModal({
       setTags([]);
       setTagInput('');
       setImages([]);
+      setIsPrivate(false);
       setErrors({});
     }
   }, [editPost, isOpen]);
@@ -203,6 +206,7 @@ export function CourseCommunityWritePostModal({
       content: content.trim(),
       category: categoryMap[postType] || '일반',
       tags: tags.length > 0 ? tags : undefined,
+      isPrivate: isPrivate || undefined,
     };
 
     await onSubmit(data);
@@ -510,6 +514,41 @@ export function CourseCommunityWritePostModal({
                 ))}
               </div>
             )}
+          </div>
+
+          {/* Private Post Option */}
+          <div
+            className={`flex items-center gap-3 p-4 rounded-xl border ${
+              isDark ? 'bg-white/5 border-white/10' : 'bg-gray-50 border-gray-200'
+            }`}
+          >
+            <input
+              type="checkbox"
+              id="isPrivate"
+              checked={isPrivate}
+              onChange={(e) => setIsPrivate(e.target.checked)}
+              className="w-4 h-4 rounded border-gray-300 text-[#6778ff] focus:ring-[#6778ff] cursor-pointer"
+            />
+            <Lock
+              className={`w-4 h-4 ${
+                isPrivate
+                  ? 'text-[#6778ff]'
+                  : isDark
+                    ? 'text-gray-500'
+                    : 'text-gray-400'
+              }`}
+            />
+            <label
+              htmlFor="isPrivate"
+              className={`flex-1 cursor-pointer ${isDark ? 'text-white' : 'text-gray-900'}`}
+            >
+              <span className="font-medium">비밀글로 작성</span>
+              <span
+                className={`text-xs ml-2 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}
+              >
+                작성자와 강사만 열람 가능
+              </span>
+            </label>
           </div>
 
           {/* Submit Button */}

--- a/src/pages/tu/main/CourseDetailPage.tsx
+++ b/src/pages/tu/main/CourseDetailPage.tsx
@@ -987,6 +987,7 @@ export function CourseDetailPage() {
                 timeId={courseTimeId}
                 isDark={isDark}
                 canWrite={isAlreadyEnrolled}
+                instructorIds={courseTime?.instructors?.map((i) => i.id)}
               />
             </section>
           )}

--- a/src/types/tu/courseCommunity.types.ts
+++ b/src/types/tu/courseCommunity.types.ts
@@ -43,6 +43,7 @@ export interface CourseCommunityPost {
   isLiked?: boolean;
   isPinned?: boolean;
   isSolved?: boolean;
+  isPrivate?: boolean;
   createdAt: string;
   updatedAt?: string;
 }
@@ -77,6 +78,7 @@ export interface CreateCourseCommunityPostRequest {
   content: string;
   category: string;
   tags?: string[];
+  isPrivate?: boolean;
 }
 
 // 코스 커뮤니티 게시글 수정 요청
@@ -84,6 +86,7 @@ export interface UpdateCourseCommunityPostRequest {
   title?: string;
   content?: string;
   tags?: string[];
+  isPrivate?: boolean;
 }
 
 // 코스 커뮤니티 댓글 작성 요청


### PR DESCRIPTION
## Summary

강의 커뮤니티에 비밀글 기능을 추가했습니다. 모든 게시글 타입(질문, 팁, 후기, 토론)에서 비밀글 옵션을 사용할 수 있으며, 작성자와 해당 강의의 강사만 내용을 열람할 수 있습니다.

## Related Issue

- Closes #

## Changes

- `CourseCommunityPost`, `CreateCourseCommunityPostRequest`, `UpdateCourseCommunityPostRequest` 타입에 `isPrivate` 필드 추가
- 글쓰기/수정 모달에 비밀글 체크박스 UI 추가
- 게시글 카드에 비밀글 뱃지(🔒) 표시 및 권한 없는 사용자에게 내용 숨김 처리
- 권한 없는 사용자가 비밀글 클릭 시 토스트 메시지로 안내
- 게시글 상세 모달에서 권한 없는 사용자 접근 시 차단 UI 표시
- `CourseDetailPage`에서 강사 ID 배열을 `CourseCommunitySection`에 전달

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- **백엔드 미구현**: 현재 프론트엔드만 선 구현된 상태입니다. 백엔드 API 연동 시 서버에서도 접근 권한 검증이 필요합니다.
- **열람 권한**: 작성자 본인 + `courseTime.instructors` 배열에 포함된 모든 강사(주강사, 보조강사, 조교 등)
- **UX**: 비밀글도 목록에 표시되지만, 권한 없는 사용자에게는 제목과 내용이 숨겨지고 클릭 시 토스트 메시지로 안내됩니다.