### PR TITLE
feat: TA/TO/TU 공지함 페이지 구현

### DIFF
--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -1,64 +1,21 @@
 import { useState, useEffect } from 'react';
-import { ChevronLeft, ChevronRight, Sparkles, Rocket, Zap } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useTranslation } from '@/store/common/languageStore';
-import { useDisplayableBanners } from '@/hooks/tu';
+import { useDisplayableBanners, usePublicLayout } from '@/hooks/tu';
 import type { BannerResponse } from '@/types/ta/banner.types';
-
-interface DefaultSlide {
-  type: 'default';
-  id: number;
-  title: string;
-  highlight: string;
-  subtitleKey: 'slide1Subtitle' | 'slide2Subtitle' | 'slide3Subtitle';
-  descKey: 'slide1Desc' | 'slide2Desc' | 'slide3Desc';
-  badge: string;
-  icon: typeof Sparkles;
-  gradientClass: string;
-}
+import type { BannerItem } from '@/types/tu/branding.types';
 
 interface BannerSlide {
   type: 'banner';
   banner: BannerResponse;
 }
 
-type Slide = DefaultSlide | BannerSlide;
+interface BrandingBannerSlide {
+  type: 'branding-banner';
+  bannerItem: BannerItem;
+}
 
-const defaultSlides: DefaultSlide[] = [
-  {
-    type: 'default',
-    id: 1,
-    title: 'Empower Your',
-    highlight: 'Future',
-    subtitleKey: 'slide1Subtitle',
-    descKey: 'slide1Desc',
-    badge: 'MZC LEARN',
-    icon: Sparkles,
-    gradientClass: 'gradient-text',
-  },
-  {
-    type: 'default',
-    id: 2,
-    title: 'Build Your',
-    highlight: 'Career',
-    subtitleKey: 'slide2Subtitle',
-    descKey: 'slide2Desc',
-    badge: 'ROADMAP',
-    icon: Rocket,
-    gradientClass: 'gradient-text-purple',
-  },
-  {
-    type: 'default',
-    id: 3,
-    title: 'Master',
-    highlight: 'Cloud',
-    subtitleKey: 'slide3Subtitle',
-    descKey: 'slide3Desc',
-    badge: 'CLOUD',
-    icon: Zap,
-    gradientClass: 'gradient-text',
-  },
-];
+type Slide = BannerSlide | BrandingBannerSlide;
 
 export function HeroSection() {
   const [currentSlide, setCurrentSlide] = useState(0);
@@ -66,13 +23,23 @@ export function HeroSection() {
   const [direction, setDirection] = useState<'left' | 'right'>('right');
   const { t } = useTranslation();
 
-  // TA 배너 가져오기
+  // TA 배너 가져오기 (기존 배너 API)
   const { data: banners = [] } = useDisplayableBanners('MAIN_TOP');
 
-  // 배너 슬라이드 + 기본 슬라이드 합치기 (배너 먼저)
+  // 브랜딩 설정에서 배너 가져오기 (기본값 포함)
+  const { data: layoutData } = usePublicLayout();
+  const bannerSettings = layoutData?.bannerSettings;
+  const brandingBannerItems = bannerSettings?.enabled !== false ? (bannerSettings?.items || []) : [];
+
+  // 배너 슬라이드 합치기 (브랜딩 배너 먼저, 그다음 기존 배너 API)
   const allSlides: Slide[] = [
+    // 브랜딩 설정 배너 (TA 브랜딩 페이지에서 설정, 기본값 포함)
+    ...brandingBannerItems
+      .filter((item) => item.imageUrl || item.code)
+      .sort((a, b) => a.order - b.order)
+      .map((item): BrandingBannerSlide => ({ type: 'branding-banner', bannerItem: item })),
+    // 기존 배너 API
     ...banners.map((banner): BannerSlide => ({ type: 'banner', banner })),
-    ...defaultSlides,
   ];
 
   const totalSlides = allSlides.length;
@@ -122,10 +89,15 @@ export function HeroSection() {
   };
 
   const currentSlideData = allSlides[currentSlide];
-  const isDefaultSlide = currentSlideData?.type === 'default';
-  const defaultSlide = isDefaultSlide ? currentSlideData : null;
-  const bannerSlide = !isDefaultSlide ? currentSlideData : null;
-  const IconComponent = defaultSlide?.icon ?? Sparkles;
+  const isBannerSlide = currentSlideData?.type === 'banner';
+  const isBrandingBannerSlide = currentSlideData?.type === 'branding-banner';
+  const bannerSlide = isBannerSlide ? currentSlideData : null;
+  const brandingBannerSlide = isBrandingBannerSlide ? currentSlideData : null;
+
+  // 슬라이드가 없으면 렌더링하지 않음
+  if (totalSlides === 0) {
+    return null;
+  }
 
   return (
     <div className="w-full overflow-hidden relative animated-bg py-8 md:py-12">
@@ -137,7 +109,35 @@ export function HeroSection() {
       </div>
 
       <div className="w-full px-4 md:px-8 lg:px-16 h-[400px] md:h-[500px] flex items-center justify-between relative">
-        {/* 배너 슬라이드일 때 - 이미지 표시 */}
+        {/* 브랜딩 배너 슬라이드 (TA 브랜딩 설정에서 추가) */}
+        {brandingBannerSlide && (
+          <div
+            className={`absolute inset-0 z-10 transition-all duration-500 ease-out ${
+              isAnimating
+                ? `opacity-0 ${direction === 'right' ? '-translate-x-8' : 'translate-x-8'}`
+                : 'opacity-100 translate-x-0'
+            }`}
+          >
+            {brandingBannerSlide.bannerItem.type === 'image' && brandingBannerSlide.bannerItem.imageUrl ? (
+              <div className="block w-full h-full">
+                <img
+                  src={brandingBannerSlide.bannerItem.imageUrl}
+                  alt={brandingBannerSlide.bannerItem.title || '배너'}
+                  className="w-full h-full object-contain"
+                />
+                {/* 그라디언트 오버레이 */}
+                <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent pointer-events-none" />
+              </div>
+            ) : brandingBannerSlide.bannerItem.type === 'code' && brandingBannerSlide.bannerItem.code ? (
+              <div
+                className="w-full h-full"
+                dangerouslySetInnerHTML={{ __html: brandingBannerSlide.bannerItem.code }}
+              />
+            ) : null}
+          </div>
+        )}
+
+        {/* 기존 배너 API 슬라이드 */}
         {bannerSlide && (
           <div
             className={`absolute inset-0 z-10 transition-all duration-500 ease-out ${
@@ -163,104 +163,44 @@ export function HeroSection() {
           </div>
         )}
 
-        {/* 기본 슬라이드일 때 - 텍스트 콘텐츠 */}
-        {defaultSlide && (
+        {/* Navigation Arrows */}
+        {totalSlides > 1 && (
           <>
-            <div
-              className={`z-10 max-w-2xl space-y-6 transition-all duration-500 ease-out ${
-                isAnimating
-                  ? `opacity-0 ${direction === 'right' ? '-translate-x-8' : 'translate-x-8'}`
-                  : 'opacity-100 translate-x-0'
-              }`}
+            <button
+              onClick={prevSlide}
+              className="absolute left-4 top-1/2 -translate-y-1/2 p-3 rounded-full glass hover:bg-white/20 transition-all z-20"
+              aria-label={t.hero.prevSlide}
             >
-              <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-xs font-bold bg-white/10 text-white border border-white/20">
-                <IconComponent className="w-4 h-4" />
-                {defaultSlide.badge}
-              </span>
-
-              <div className="space-y-2">
-                <h2 className="text-4xl md:text-6xl lg:text-7xl font-extrabold text-white leading-tight">
-                  {defaultSlide.title}
-                </h2>
-                <h2
-                  className={`text-4xl md:text-6xl lg:text-7xl font-extrabold leading-tight ${defaultSlide.gradientClass}`}
-                >
-                  {defaultSlide.highlight}
-                </h2>
-              </div>
-
-              <p className="text-xl md:text-2xl font-medium text-gray-300 whitespace-pre-line leading-relaxed">
-                {t.hero[defaultSlide.subtitleKey]}
-              </p>
-
-              <p className="text-base md:text-lg text-gray-500">{t.hero[defaultSlide.descKey]}</p>
-
-              <div className="flex gap-4 pt-4">
-                <Link
-                  to="/tu/b2c/courses"
-                  className="landing-btn-primary px-8 py-4 rounded-full text-white font-bold text-base flex items-center gap-2"
-                >
-                  {t.hero.getStarted}
-                  <ChevronRight className="w-5 h-5" />
-                </Link>
-                <Link
-                  to="/tu/b2c/mypage/learning"
-                  className="landing-btn-outline px-8 py-4 rounded-full text-white font-medium text-base"
-                >
-                  {t.hero.explore}
-                </Link>
-              </div>
-            </div>
-
-            {/* Right Side - Abstract Shape (기본 슬라이드에서만) */}
-            <div
-              className={`hidden lg:flex absolute right-8 top-1/2 -translate-y-1/2 items-center justify-center transition-all duration-500 ease-out ${
-                isAnimating ? `opacity-0 scale-95` : 'opacity-100 scale-100'
-              }`}
+              <ChevronLeft className="w-6 h-6 text-white" />
+            </button>
+            <button
+              onClick={nextSlide}
+              className="absolute right-4 top-1/2 -translate-y-1/2 p-3 rounded-full glass hover:bg-white/20 transition-all z-20"
+              aria-label={t.hero.nextSlide}
             >
-              <div className="relative w-80 h-80">
-                <div className="absolute inset-0 bg-gradient-to-br from-[#6778ff]/30 to-[#a855f7]/30 rounded-full blur-2xl animate-pulse"></div>
-                <div className="absolute inset-8 bg-gradient-to-br from-[#70f2a0]/20 to-[#6bc2f0]/20 rounded-full blur-xl"></div>
-                <div className="absolute inset-16 glass rounded-full flex items-center justify-center">
-                  <IconComponent className="w-16 h-16 text-white/80" />
-                </div>
-              </div>
-            </div>
+              <ChevronRight className="w-6 h-6 text-white" />
+            </button>
           </>
         )}
-
-        {/* Navigation Arrows */}
-        <button
-          onClick={prevSlide}
-          className="absolute left-4 top-1/2 -translate-y-1/2 p-3 rounded-full glass hover:bg-white/20 transition-all z-20"
-          aria-label={t.hero.prevSlide}
-        >
-          <ChevronLeft className="w-6 h-6 text-white" />
-        </button>
-        <button
-          onClick={nextSlide}
-          className="absolute right-4 top-1/2 -translate-y-1/2 p-3 rounded-full glass hover:bg-white/20 transition-all z-20"
-          aria-label={t.hero.nextSlide}
-        >
-          <ChevronRight className="w-6 h-6 text-white" />
-        </button>
       </div>
 
       {/* Dots */}
-      <div className="absolute bottom-8 left-1/2 -translate-x-1/2 flex gap-3 z-20">
-        {allSlides.map((_, index) => (
-          <button
-            key={index}
-            onClick={() => goToSlide(index)}
-            aria-label={`${t.hero.goToSlide} ${index + 1}`}
-            className={`h-2 rounded-full transition-all duration-300 ${
-              index === currentSlide
-                ? 'w-8 bg-gradient-to-r from-[#6778ff] to-[#a855f7]'
-                : 'w-2 bg-white/30 hover:bg-white/50'
-            }`}
-          />
-        ))}
-      </div>
+      {totalSlides > 1 && (
+        <div className="absolute bottom-8 left-1/2 -translate-x-1/2 flex gap-3 z-20">
+          {allSlides.map((_, index) => (
+            <button
+              key={index}
+              onClick={() => goToSlide(index)}
+              aria-label={`${t.hero.goToSlide} ${index + 1}`}
+              className={`h-2 rounded-full transition-all duration-300 ${
+                index === currentSlide
+                  ? 'w-8 bg-gradient-to-r from-[#6778ff] to-[#a855f7]'
+                  : 'w-2 bg-white/30 hover:bg-white/50'
+              }`}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/landing/LandingFooter.tsx
+++ b/src/components/landing/LandingFooter.tsx
@@ -2,13 +2,11 @@ import { Youtube, Instagram } from 'lucide-react';
 import { useTranslation } from '@/store/common/languageStore';
 import { useTenantBranding } from '@/contexts/TenantBrandingContext';
 import { usePublicLayout } from '@/hooks/tu';
-import { useAuth } from '@/hooks/common/auth';
 
 export function LandingFooter() {
   const { t } = useTranslation();
   const { branding } = useTenantBranding();
-  const { isAuthenticated } = useAuth();
-  const { data: layoutData } = usePublicLayout(isAuthenticated);
+  const { data: layoutData } = usePublicLayout();
   const tenantName = branding?.tenantName || 'MEGAZONECLOUD';
 
   // 푸터 설정

--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -5,7 +5,7 @@ import { useAuth } from '@/hooks/common/auth';
 import { useMyProfile, useSubdomainPath } from '@/hooks/common';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation } from '@/store/common/languageStore';
-import { useUnreadNotificationCount, usePublicNavigation } from '@/hooks/tu';
+import { useUnreadNotificationCount, usePublicNavigation, usePublicLayout } from '@/hooks/tu';
 import { useTenantBranding } from '@/contexts/TenantBrandingContext';
 import type { NavigationItemResponse } from '@/types/tu/branding.types';
 
@@ -30,10 +30,15 @@ export function LandingHeader() {
   const { data: unreadCountData } = useUnreadNotificationCount(isAuthenticated);
   const unreadCount = unreadCountData?.count || 0;
   const { branding } = useTenantBranding();
-  const { data: navigationItems } = usePublicNavigation(isAuthenticated);
+  const { data: navigationItems } = usePublicNavigation();
+  const { data: layoutData } = usePublicLayout();
 
   // 네비게이션 메뉴 (TA 설정 또는 기본값)
   const navItems = navigationItems && navigationItems.length > 0 ? navigationItems : DEFAULT_NAV_ITEMS;
+
+  // 헤더 설정 (로고 표시 여부 등)
+  const headerSettings = layoutData?.headerSettings;
+  const showLogo = headerSettings?.showLogo !== false; // 기본값 true
 
   // API Base URL
   const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api').replace('/api', '');
@@ -89,17 +94,19 @@ export function LandingHeader() {
         <div className="w-full px-6 md:px-12 lg:px-16 h-16 flex items-center justify-between gap-6">
           {/* Left: Logo & Menu */}
           <div className="flex items-center gap-8 ml-2 md:ml-4">
-            {/* Logo */}
-            <Link to={prefixPath('/tu/b2c')} className={`flex items-center gap-2 font-bold text-xl tracking-tight ${isDark ? '' : 'text-gray-900'}`}>
-              {fullLogoUrl ? (
-                <img src={fullLogoUrl} alt={tenantName} className="h-8 object-contain" />
-              ) : (
-                <>
-                  <span className="text-2xl">M</span>
-                  <span className="gradient-text">{tenantName}</span>
-                </>
-              )}
-            </Link>
+            {/* Logo - showLogo 설정에 따라 표시 */}
+            {showLogo && (
+              <Link to={prefixPath('/tu/b2c')} className={`flex items-center gap-2 font-bold text-xl tracking-tight ${isDark ? '' : 'text-gray-900'}`}>
+                {fullLogoUrl ? (
+                  <img src={fullLogoUrl} alt={tenantName} className="h-8 object-contain" />
+                ) : (
+                  <>
+                    <span className="text-2xl">M</span>
+                    <span className="gradient-text">{tenantName}</span>
+                  </>
+                )}
+              </Link>
+            )}
 
             {/* Desktop Nav Links */}
             <nav className={`hidden md:flex items-center gap-8 font-medium text-[15px] ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>

--- a/src/hooks/sa/index.ts
+++ b/src/hooks/sa/index.ts
@@ -21,6 +21,10 @@ export {
   useArchiveNotice,
   useDistributeNotice,
   useDistributeAllNotice,
+  // 배포 통계
+  useDistributionStats,
+  useDistributionSummary,
+  useDistributionStatsForNotice,
 } from './useNoticeQueries';
 
 export {

--- a/src/hooks/sa/useNoticeQueries.ts
+++ b/src/hooks/sa/useNoticeQueries.ts
@@ -18,6 +18,11 @@ export const noticeKeys = {
   details: () => [...noticeKeys.all, 'detail'] as const,
   detail: (id: number) => [...noticeKeys.details(), id] as const,
   tenants: (id: number) => [...noticeKeys.all, 'tenants', id] as const,
+  // 배포 통계
+  distributions: () => [...noticeKeys.all, 'distributions'] as const,
+  distributionList: (params?: { page?: number; size?: number }) => [...noticeKeys.distributions(), 'list', params] as const,
+  distributionSummary: () => [...noticeKeys.distributions(), 'summary'] as const,
+  distributionDetail: (id: number) => [...noticeKeys.distributions(), 'detail', id] as const,
 };
 
 // ============================================
@@ -141,6 +146,36 @@ export const useDistributeAllNotice = () => {
     onSuccess: (_, id) => {
       queryClient.invalidateQueries({ queryKey: noticeKeys.detail(id) });
       queryClient.invalidateQueries({ queryKey: noticeKeys.tenants(id) });
+      queryClient.invalidateQueries({ queryKey: noticeKeys.distributions() });
     },
+  });
+};
+
+// ============================================
+// 배포 통계 Queries
+// ============================================
+
+/** 배포 통계 목록 조회 */
+export const useDistributionStats = (params?: { page?: number; size?: number }) => {
+  return useQuery({
+    queryKey: noticeKeys.distributionList(params),
+    queryFn: () => noticeService.getDistributionStats(params),
+  });
+};
+
+/** 배포 통계 요약 조회 */
+export const useDistributionSummary = () => {
+  return useQuery({
+    queryKey: noticeKeys.distributionSummary(),
+    queryFn: () => noticeService.getDistributionSummary(),
+  });
+};
+
+/** 특정 공지 배포 상세 조회 */
+export const useDistributionStatsForNotice = (id: number) => {
+  return useQuery({
+    queryKey: noticeKeys.distributionDetail(id),
+    queryFn: () => noticeService.getDistributionStatsForNotice(id),
+    enabled: !!id,
   });
 };

--- a/src/hooks/ta/useBrandingQueries.ts
+++ b/src/hooks/ta/useBrandingQueries.ts
@@ -6,6 +6,7 @@ import {
   brandingService,
   type UpdateDesignSettingsRequest,
   type UpdateLayoutSettingsRequest,
+  type UpdateExtendedBrandingRequest,
   type NavigationItemRequest,
 } from '@/services/ta/brandingService';
 
@@ -51,6 +52,19 @@ export const useUpdateLayoutSettings = () => {
   return useMutation({
     mutationFn: (request: UpdateLayoutSettingsRequest) =>
       brandingService.updateLayoutSettings(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: brandingKeys.settings() });
+    },
+  });
+};
+
+/** 확장 브랜딩 설정 업데이트 (배너, 랜딩페이지, 사이드바 TU/TO) */
+export const useUpdateExtendedBrandingSettings = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: UpdateExtendedBrandingRequest) =>
+      brandingService.updateExtendedBrandingSettings(request),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: brandingKeys.settings() });
     },

--- a/src/hooks/to/index.ts
+++ b/src/hooks/to/index.ts
@@ -6,3 +6,4 @@ export * from './useEnrollmentQueries';
 export * from './useDashboardQueries';
 export * from './useMemberPoolQueries';
 export * from './useAutoEnrollmentRuleQueries';
+export * from './useOperatorNoticeQueries';

--- a/src/hooks/to/useOperatorNoticeQueries.ts
+++ b/src/hooks/to/useOperatorNoticeQueries.ts
@@ -1,0 +1,78 @@
+/**
+ * TO용 공지사항 조회 React Query Hooks (TA가 OPERATOR 대상으로 보낸 공지)
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type { TenantNotice } from '@/types/ta/tenantNotice.types';
+import type { PageResponse } from '@/types/common';
+
+export interface ReceivedNoticeListParams {
+  page?: number;
+  size?: number;
+}
+
+// Query Keys
+export const operatorNoticeKeys = {
+  all: ['operator-notices'] as const,
+  received: () => [...operatorNoticeKeys.all, 'received'] as const,
+  receivedList: (params?: ReceivedNoticeListParams) => [...operatorNoticeKeys.received(), params] as const,
+  receivedDetail: (id: number) => [...operatorNoticeKeys.received(), 'detail', id] as const,
+};
+
+/**
+ * TO가 받은 공지 목록 조회 (TA가 OPERATOR 대상으로 발송한 공지)
+ */
+export const useReceivedNotices = (params?: ReceivedNoticeListParams) => {
+  return useQuery({
+    queryKey: operatorNoticeKeys.receivedList(params),
+    queryFn: async () => {
+      const { data } = await axiosInstance.get<PageResponse<TenantNotice>>(
+        API_ENDPOINTS.TENANT_NOTICES.TU_BASE,
+        {
+          params: {
+            ...params,
+            targetAudience: 'OPERATOR',
+          },
+        }
+      );
+      return data;
+    },
+  });
+};
+
+/**
+ * TO가 받은 공지 상세 조회
+ */
+export const useReceivedNotice = (id: number) => {
+  return useQuery({
+    queryKey: operatorNoticeKeys.receivedDetail(id),
+    queryFn: async () => {
+      const { data } = await axiosInstance.get<TenantNotice>(
+        API_ENDPOINTS.TENANT_NOTICES.TU_BY_ID(id)
+      );
+      return data;
+    },
+    enabled: !!id,
+  });
+};
+
+/**
+ * 공지 읽음 처리 (조회수 증가)
+ */
+export const useMarkNoticeAsViewed = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (noticeId: number) => {
+      // 상세 조회 시 자동으로 조회수 증가
+      const { data } = await axiosInstance.get<TenantNotice>(
+        API_ENDPOINTS.TENANT_NOTICES.TU_BY_ID(noticeId)
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: operatorNoticeKeys.received() });
+    },
+  });
+};

--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -300,3 +300,11 @@ export {
   useUpdateCourseReview,
   useDeleteCourseReview,
 } from './useCourseReviewQueries';
+
+// User Notice Hooks (TU 공지)
+export {
+  userNoticeKeys,
+  useUserNotices,
+  useUserNotice,
+  useUnreadNoticeCount,
+} from './useUserNoticeQueries';

--- a/src/hooks/tu/usePublicLayout.ts
+++ b/src/hooks/tu/usePublicLayout.ts
@@ -5,6 +5,52 @@ import { useQuery } from '@tanstack/react-query';
 import { tenantSettingsService } from '@/services/ta/tenantSettingsService';
 import type { PublicLayoutResponse, NavigationItemResponse } from '@/types/tu/branding.types';
 
+/** 기본 배너 아이템 (HeroSection 기본 슬라이드) */
+const DEFAULT_BANNER_ITEMS = [
+  {
+    id: 'default-1',
+    type: 'code' as const,
+    imageUrl: null,
+    code: `<div class="flex flex-col items-start justify-center h-full px-8 md:px-16">
+      <span class="inline-flex items-center gap-2 px-4 py-2 rounded-full text-xs font-bold bg-white/10 text-white border border-white/20 mb-6">MZC LEARN</span>
+      <h2 class="text-4xl md:text-6xl lg:text-7xl font-extrabold text-white leading-tight">Empower Your</h2>
+      <h2 class="text-4xl md:text-6xl lg:text-7xl font-extrabold leading-tight bg-gradient-to-r from-[#6778ff] to-[#a855f7] bg-clip-text text-transparent">Future</h2>
+      <p class="text-xl md:text-2xl font-medium text-gray-300 mt-6">최신 기술 트렌드를 선도하는<br/>실무 중심의 IT 교육</p>
+      <p class="text-base md:text-lg text-gray-500 mt-2">AWS, AI, 클라우드 전문가가 되는 가장 빠른 길</p>
+    </div>`,
+    title: 'Empower Your Future',
+    order: 0,
+  },
+  {
+    id: 'default-2',
+    type: 'code' as const,
+    imageUrl: null,
+    code: `<div class="flex flex-col items-start justify-center h-full px-8 md:px-16">
+      <span class="inline-flex items-center gap-2 px-4 py-2 rounded-full text-xs font-bold bg-white/10 text-white border border-white/20 mb-6">ROADMAP</span>
+      <h2 class="text-4xl md:text-6xl lg:text-7xl font-extrabold text-white leading-tight">Build Your</h2>
+      <h2 class="text-4xl md:text-6xl lg:text-7xl font-extrabold leading-tight bg-gradient-to-r from-[#a855f7] to-[#ec4899] bg-clip-text text-transparent">Career</h2>
+      <p class="text-xl md:text-2xl font-medium text-gray-300 mt-6">단계별 로드맵으로<br/>체계적인 성장을 경험하세요</p>
+      <p class="text-base md:text-lg text-gray-500 mt-2">입문부터 전문가까지, 맞춤형 학습 경로 제공</p>
+    </div>`,
+    title: 'Build Your Career',
+    order: 1,
+  },
+  {
+    id: 'default-3',
+    type: 'code' as const,
+    imageUrl: null,
+    code: `<div class="flex flex-col items-start justify-center h-full px-8 md:px-16">
+      <span class="inline-flex items-center gap-2 px-4 py-2 rounded-full text-xs font-bold bg-white/10 text-white border border-white/20 mb-6">CLOUD</span>
+      <h2 class="text-4xl md:text-6xl lg:text-7xl font-extrabold text-white leading-tight">Master</h2>
+      <h2 class="text-4xl md:text-6xl lg:text-7xl font-extrabold leading-tight bg-gradient-to-r from-[#6778ff] to-[#6bc2f0] bg-clip-text text-transparent">Cloud</h2>
+      <p class="text-xl md:text-2xl font-medium text-gray-300 mt-6">클라우드 기술의 핵심을<br/>실습과 함께 마스터하세요</p>
+      <p class="text-base md:text-lg text-gray-500 mt-2">AWS, Azure, GCP 공인 자격증 취득 지원</p>
+    </div>`,
+    title: 'Master Cloud',
+    order: 2,
+  },
+];
+
 /** 기본 레이아웃 */
 const DEFAULT_LAYOUT: PublicLayoutResponse = {
   headerSettings: {
@@ -25,6 +71,21 @@ const DEFAULT_LAYOUT: PublicLayoutResponse = {
     padding: 'normal',
   },
   navigationItems: [],
+  // 확장 브랜딩 기본값
+  companyName: null,
+  bannerSettings: {
+    enabled: true,
+    items: DEFAULT_BANNER_ITEMS,
+  },
+  landingPageSettings: null,
+  sidebarTUSettings: null,
+  sidebarTOSettings: null,
+};
+
+/** 기본 배너 설정 */
+const DEFAULT_BANNER_SETTINGS = {
+  enabled: true,
+  items: DEFAULT_BANNER_ITEMS,
 };
 
 /**
@@ -35,7 +96,16 @@ export function usePublicLayout(enabled: boolean = true) {
     queryKey: ['public-layout'],
     queryFn: async () => {
       try {
-        return await tenantSettingsService.getPublicLayout();
+        const response = await tenantSettingsService.getPublicLayout();
+
+        // bannerSettings가 없거나 items가 비어있으면 기본값 사용
+        const bannerSettings = response.bannerSettings;
+        const hasValidBanners = bannerSettings?.items && bannerSettings.items.length > 0;
+
+        return {
+          ...response,
+          bannerSettings: hasValidBanners ? bannerSettings : DEFAULT_BANNER_SETTINGS,
+        };
       } catch {
         return DEFAULT_LAYOUT;
       }

--- a/src/hooks/tu/useUserNoticeQueries.ts
+++ b/src/hooks/tu/useUserNoticeQueries.ts
@@ -1,0 +1,74 @@
+/**
+ * TU용 공지사항 조회 React Query Hooks (TA/TO가 USER 대상으로 보낸 공지)
+ */
+import { useQuery } from '@tanstack/react-query';
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type { TenantNotice } from '@/types/ta/tenantNotice.types';
+import type { PageResponse } from '@/types/common';
+
+export interface UserNoticeListParams {
+  page?: number;
+  size?: number;
+}
+
+// Query Keys
+export const userNoticeKeys = {
+  all: ['user-notices'] as const,
+  lists: () => [...userNoticeKeys.all, 'list'] as const,
+  list: (params?: UserNoticeListParams) => [...userNoticeKeys.lists(), params] as const,
+  detail: (id: number) => [...userNoticeKeys.all, 'detail', id] as const,
+  count: () => [...userNoticeKeys.all, 'count'] as const,
+};
+
+/**
+ * TU가 받은 공지 목록 조회 (TA/TO가 USER 대상으로 발송한 공지)
+ */
+export const useUserNotices = (params?: UserNoticeListParams) => {
+  return useQuery({
+    queryKey: userNoticeKeys.list(params),
+    queryFn: async () => {
+      const { data } = await axiosInstance.get<PageResponse<TenantNotice>>(
+        API_ENDPOINTS.TENANT_NOTICES.TU_BASE,
+        {
+          params: {
+            ...params,
+            targetAudience: 'USER',
+          },
+        }
+      );
+      return data;
+    },
+  });
+};
+
+/**
+ * TU가 받은 공지 상세 조회
+ */
+export const useUserNotice = (id: number) => {
+  return useQuery({
+    queryKey: userNoticeKeys.detail(id),
+    queryFn: async () => {
+      const { data } = await axiosInstance.get<TenantNotice>(
+        API_ENDPOINTS.TENANT_NOTICES.TU_BY_ID(id)
+      );
+      return data;
+    },
+    enabled: !!id,
+  });
+};
+
+/**
+ * TU 읽지 않은 공지 수 조회
+ */
+export const useUnreadNoticeCount = () => {
+  return useQuery({
+    queryKey: userNoticeKeys.count(),
+    queryFn: async () => {
+      const { data } = await axiosInstance.get<{ count: number }>(
+        API_ENDPOINTS.TENANT_NOTICES.TU_COUNT
+      );
+      return data.count;
+    },
+  });
+};

--- a/src/pages/sa/notices/NoticeDistributionPage.tsx
+++ b/src/pages/sa/notices/NoticeDistributionPage.tsx
@@ -3,7 +3,6 @@ import {
   Send,
   Building2,
   CheckCircle,
-  Clock,
   Eye,
   Search,
   ChevronLeft,
@@ -28,7 +27,7 @@ import {
   useDistributionSummary,
   useDistributionStatsForNotice,
 } from '@/hooks/sa';
-import type { NoticeDistributionStats, TenantDistributionInfo } from '@/types/admin';
+import type { TenantDistributionInfo } from '@/types/admin';
 
 const typeConfig: Record<string, { label: string; color: string }> = {
   GENERAL: { label: '일반', color: 'bg-gray-100 text-gray-700' },

--- a/src/pages/sa/notices/NoticeDistributionPage.tsx
+++ b/src/pages/sa/notices/NoticeDistributionPage.tsx
@@ -4,9 +4,11 @@ import {
   Building2,
   CheckCircle,
   Clock,
-  AlertCircle,
   Eye,
   Search,
+  ChevronLeft,
+  ChevronRight,
+  Pin,
 } from 'lucide-react';
 import { AdminPageHeader } from '@/components/domain/admin';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
@@ -14,36 +16,69 @@ import { Button } from '@/components/common/Button';
 import { Input } from '@/components/common/Input';
 import { Badge } from '@/components/common/Badge';
 import { Progress } from '@/components/common/Progress';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/common/Dialog';
+import {
+  useDistributionStats,
+  useDistributionSummary,
+  useDistributionStatsForNotice,
+} from '@/hooks/sa';
+import type { NoticeDistributionStats, TenantDistributionInfo } from '@/types/admin';
 
-// Mock 데이터
-const mockDistributions: {
-  id: number;
-  noticeTitle: string;
-  totalTenants: number;
-  sentCount: number;
-  readCount: number;
-  status: 'COMPLETED' | 'IN_PROGRESS' | 'SCHEDULED' | 'FAILED';
-  distributedAt: string;
-}[] = [
-  { id: 1, noticeTitle: '2025년 1월 시스템 업데이트 안내', totalTenants: 45, sentCount: 45, readCount: 38, status: 'COMPLETED', distributedAt: '2025-12-28 10:00' },
-  { id: 2, noticeTitle: '연말 시스템 점검 안내', totalTenants: 45, sentCount: 45, readCount: 42, status: 'COMPLETED', distributedAt: '2025-12-25 09:00' },
-  { id: 3, noticeTitle: '신규 강좌 오픈 이벤트', totalTenants: 45, sentCount: 30, readCount: 15, status: 'IN_PROGRESS', distributedAt: '2025-12-20 14:00' },
-  { id: 4, noticeTitle: '이용약관 변경 안내', totalTenants: 45, sentCount: 0, readCount: 0, status: 'SCHEDULED', distributedAt: '2026-01-01 00:00' },
-];
-
-const statusConfig = {
-  COMPLETED: { label: '완료', icon: CheckCircle, color: 'bg-green-100 text-green-700' },
-  IN_PROGRESS: { label: '진행중', icon: Clock, color: 'bg-blue-100 text-blue-700' },
-  SCHEDULED: { label: '예약됨', icon: Clock, color: 'bg-yellow-100 text-yellow-700' },
-  FAILED: { label: '실패', icon: AlertCircle, color: 'bg-red-100 text-red-700' },
+const typeConfig: Record<string, { label: string; color: string }> = {
+  GENERAL: { label: '일반', color: 'bg-gray-100 text-gray-700' },
+  UPDATE: { label: '업데이트', color: 'bg-blue-100 text-blue-700' },
+  SYSTEM: { label: '시스템', color: 'bg-yellow-100 text-yellow-700' },
+  EVENT: { label: '이벤트', color: 'bg-purple-100 text-purple-700' },
 };
 
 export function NoticeDistributionPage() {
   const [searchKeyword, setSearchKeyword] = useState('');
+  const [page, setPage] = useState(0);
+  const [selectedNotice, setSelectedNotice] = useState<number | null>(null);
 
-  const filteredDistributions = mockDistributions.filter((dist) =>
+  const { data: statsData, isLoading } = useDistributionStats({ page, size: 10 });
+  const { data: summary } = useDistributionSummary();
+  const { data: noticeDetail } = useDistributionStatsForNotice(selectedNotice || 0);
+
+  const distributions = statsData?.content || [];
+  const totalPages = statsData?.totalPages || 0;
+
+  const filteredDistributions = distributions.filter((dist) =>
     dist.noticeTitle.toLowerCase().includes(searchKeyword.toLowerCase())
   );
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return '-';
+    return new Date(dateString).toLocaleString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+          <div className="grid grid-cols-4 gap-4">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="h-24 bg-gray-200 rounded"></div>
+            ))}
+          </div>
+          <div className="h-64 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="p-6">
@@ -61,7 +96,7 @@ export function NoticeDistributionPage() {
                 <Send className="h-5 w-5 text-brand-primary" />
               </div>
               <div>
-                <p className="text-2xl font-bold">{mockDistributions.length}</p>
+                <p className="text-2xl font-bold">{summary?.totalDistributions || 0}</p>
                 <p className="text-sm text-text-secondary">전체 배포</p>
               </div>
             </div>
@@ -74,8 +109,8 @@ export function NoticeDistributionPage() {
                 <CheckCircle className="h-5 w-5 text-green-600" />
               </div>
               <div>
-                <p className="text-2xl font-bold">{mockDistributions.filter(d => d.status === 'COMPLETED').length}</p>
-                <p className="text-sm text-text-secondary">완료</p>
+                <p className="text-2xl font-bold">{summary?.completedCount || 0}</p>
+                <p className="text-sm text-text-secondary">발행 완료</p>
               </div>
             </div>
           </CardContent>
@@ -84,11 +119,11 @@ export function NoticeDistributionPage() {
           <CardContent className="pt-6">
             <div className="flex items-center gap-3">
               <div className="p-2 bg-blue-100 rounded-lg">
-                <Clock className="h-5 w-5 text-blue-600" />
+                <Eye className="h-5 w-5 text-blue-600" />
               </div>
               <div>
-                <p className="text-2xl font-bold">{mockDistributions.filter(d => d.status === 'IN_PROGRESS').length}</p>
-                <p className="text-sm text-text-secondary">진행중</p>
+                <p className="text-2xl font-bold">{summary?.totalReadCount || 0}</p>
+                <p className="text-sm text-text-secondary">총 열람</p>
               </div>
             </div>
           </CardContent>
@@ -100,13 +135,26 @@ export function NoticeDistributionPage() {
                 <Building2 className="h-5 w-5 text-yellow-600" />
               </div>
               <div>
-                <p className="text-2xl font-bold">45</p>
+                <p className="text-2xl font-bold">{summary?.totalTenants || 0}</p>
                 <p className="text-sm text-text-secondary">대상 테넌트</p>
               </div>
             </div>
           </CardContent>
         </Card>
       </div>
+
+      {/* Average Read Rate */}
+      {summary && summary.averageReadRate > 0 && (
+        <Card className="mb-6">
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm font-medium">평균 열람율</span>
+              <span className="text-sm font-bold">{summary.averageReadRate.toFixed(1)}%</span>
+            </div>
+            <Progress value={summary.averageReadRate} className="h-2" />
+          </CardContent>
+        </Card>
+      )}
 
       {/* Distribution List */}
       <Card>
@@ -128,55 +176,158 @@ export function NoticeDistributionPage() {
           </div>
         </CardHeader>
         <CardContent>
-          <div className="space-y-4">
-            {filteredDistributions.map((dist) => {
-              const config = statusConfig[dist.status];
-              const StatusIcon = config.icon;
-              const sentPercent = (dist.sentCount / dist.totalTenants) * 100;
-              const readPercent = dist.sentCount > 0 ? (dist.readCount / dist.sentCount) * 100 : 0;
+          {filteredDistributions.length === 0 ? (
+            <div className="text-center py-12 text-text-secondary">
+              <Send className="h-12 w-12 mx-auto mb-4 opacity-50" />
+              <p>배포된 공지사항이 없습니다.</p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {filteredDistributions.map((dist) => {
+                const typeConf = typeConfig[dist.noticeType] || typeConfig.GENERAL;
+                const sentPercent = dist.totalTenants > 0 ? (dist.sentCount / dist.totalTenants) * 100 : 0;
+                const readPercent = dist.sentCount > 0 ? (dist.readCount / dist.sentCount) * 100 : 0;
 
-              return (
-                <div key={dist.id} className="p-4 border rounded-lg hover:bg-bg-secondary">
-                  <div className="flex items-center justify-between mb-3">
-                    <div className="flex items-center gap-2">
-                      <h3 className="font-medium">{dist.noticeTitle}</h3>
-                      <Badge className={config.color}>
-                        <StatusIcon className="h-3 w-3 mr-1" />
-                        {config.label}
-                      </Badge>
-                    </div>
-                    <span className="text-sm text-text-secondary">{dist.distributedAt}</span>
-                  </div>
-
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <div className="flex justify-between text-sm mb-1">
-                        <span className="text-text-secondary">발송 현황</span>
-                        <span>{dist.sentCount} / {dist.totalTenants} 테넌트</span>
+                return (
+                  <div key={dist.noticeId} className="p-4 border rounded-lg hover:bg-bg-secondary">
+                    <div className="flex items-center justify-between mb-3">
+                      <div className="flex items-center gap-2">
+                        {dist.isPinned && <Pin className="h-4 w-4 text-yellow-500" />}
+                        <h3 className="font-medium">{dist.noticeTitle}</h3>
+                        <Badge className={typeConf.color}>{typeConf.label}</Badge>
                       </div>
-                      <Progress value={sentPercent} className="h-2" />
+                      <span className="text-sm text-text-secondary">
+                        {formatDate(dist.publishedAt)}
+                      </span>
                     </div>
-                    <div>
-                      <div className="flex justify-between text-sm mb-1">
-                        <span className="text-text-secondary">열람율</span>
-                        <span>{dist.readCount} / {dist.sentCount} ({readPercent.toFixed(0)}%)</span>
-                      </div>
-                      <Progress value={readPercent} className="h-2" />
-                    </div>
-                  </div>
 
-                  <div className="flex justify-end mt-3">
-                    <Button variant="ghost" size="sm">
-                      <Eye className="h-4 w-4 mr-1" />
-                      상세 보기
-                    </Button>
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <div className="flex justify-between text-sm mb-1">
+                          <span className="text-text-secondary">발송 현황</span>
+                          <span>{dist.sentCount} / {dist.totalTenants} 테넌트</span>
+                        </div>
+                        <Progress value={sentPercent} className="h-2" />
+                      </div>
+                      <div>
+                        <div className="flex justify-between text-sm mb-1">
+                          <span className="text-text-secondary">열람율</span>
+                          <span>{dist.readCount} / {dist.sentCount} ({readPercent.toFixed(0)}%)</span>
+                        </div>
+                        <Progress value={readPercent} className="h-2" />
+                      </div>
+                    </div>
+
+                    <div className="flex justify-end mt-3">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setSelectedNotice(dist.noticeId)}
+                      >
+                        <Eye className="h-4 w-4 mr-1" />
+                        상세 보기
+                      </Button>
+                    </div>
                   </div>
-                </div>
-              );
-            })}
-          </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 mt-6">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page === 0}
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <span className="text-sm">
+                {page + 1} / {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages - 1}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
         </CardContent>
       </Card>
+
+      {/* Detail Dialog */}
+      <Dialog open={selectedNotice !== null} onOpenChange={() => setSelectedNotice(null)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>배포 상세 현황</DialogTitle>
+            <DialogDescription>
+              {noticeDetail?.noticeTitle}
+            </DialogDescription>
+          </DialogHeader>
+
+          {noticeDetail && (
+            <div className="space-y-4">
+              {/* Summary */}
+              <div className="grid grid-cols-3 gap-4">
+                <div className="p-3 bg-bg-secondary rounded-lg text-center">
+                  <p className="text-2xl font-bold">{noticeDetail.sentCount}</p>
+                  <p className="text-sm text-text-secondary">배포됨</p>
+                </div>
+                <div className="p-3 bg-bg-secondary rounded-lg text-center">
+                  <p className="text-2xl font-bold">{noticeDetail.readCount}</p>
+                  <p className="text-sm text-text-secondary">열람</p>
+                </div>
+                <div className="p-3 bg-bg-secondary rounded-lg text-center">
+                  <p className="text-2xl font-bold">
+                    {noticeDetail.sentCount > 0
+                      ? ((noticeDetail.readCount / noticeDetail.sentCount) * 100).toFixed(0)
+                      : 0}%
+                  </p>
+                  <p className="text-sm text-text-secondary">열람율</p>
+                </div>
+              </div>
+
+              {/* Tenant List */}
+              <div className="border rounded-lg max-h-80 overflow-y-auto">
+                <table className="w-full">
+                  <thead className="bg-bg-secondary sticky top-0">
+                    <tr>
+                      <th className="px-4 py-2 text-left text-sm font-medium">테넌트</th>
+                      <th className="px-4 py-2 text-left text-sm font-medium">코드</th>
+                      <th className="px-4 py-2 text-center text-sm font-medium">상태</th>
+                      <th className="px-4 py-2 text-left text-sm font-medium">배포일시</th>
+                      <th className="px-4 py-2 text-left text-sm font-medium">열람일시</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {noticeDetail.tenantDistributions.map((tenant: TenantDistributionInfo) => (
+                      <tr key={tenant.tenantId} className="border-t">
+                        <td className="px-4 py-2 text-sm">{tenant.tenantName}</td>
+                        <td className="px-4 py-2 text-sm text-text-secondary">{tenant.tenantCode}</td>
+                        <td className="px-4 py-2 text-center">
+                          {tenant.isRead ? (
+                            <Badge className="bg-green-100 text-green-700">읽음</Badge>
+                          ) : (
+                            <Badge className="bg-gray-100 text-gray-600">미읽음</Badge>
+                          )}
+                        </td>
+                        <td className="px-4 py-2 text-sm">{formatDate(tenant.distributedAt)}</td>
+                        <td className="px-4 py-2 text-sm">{formatDate(tenant.readAt)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/pages/ta/branding/BrandingSettingsPage.tsx
+++ b/src/pages/ta/branding/BrandingSettingsPage.tsx
@@ -452,8 +452,8 @@ export function BrandingSettingsPage() {
           secondary: tenantSettings.secondaryColor || prev.colors.secondary,
         },
         // 확장 브랜딩 설정 (배너 설정이 있고 items가 있으면 사용, 없으면 기본값 유지)
-        ...(tenantSettings.bannerSettings &&
-          (tenantSettings.bannerSettings as { items?: unknown[] }).items?.length > 0 && {
+        ...((tenantSettings.bannerSettings as { items?: unknown[] } | undefined)?.items?.length &&
+          (tenantSettings.bannerSettings as { items?: unknown[] }).items!.length > 0 && {
           banner: tenantSettings.bannerSettings as typeof prev.banner,
         }),
         ...(tenantSettings.landingPageSettings && {
@@ -606,14 +606,14 @@ export function BrandingSettingsPage() {
           showNotifications: settings.header.showNotifications,
           showThemeToggle: settings.header.showThemeToggle,
           navLinks: settings.header.navLinks,
-        },
+        } as unknown as Parameters<typeof updateLayoutMutation.mutateAsync>[0]['headerSettings'],
         footerSettings: {
           enabled: settings.footer.enabled,
           companyInfo: settings.footer.companyInfo,
           copyright: settings.footer.copyright,
           legalLinks: settings.footer.legalLinks,
           socialLinks: settings.footer.socialLinks,
-        },
+        } as unknown as Parameters<typeof updateLayoutMutation.mutateAsync>[0]['footerSettings'],
       });
 
       // 확장 브랜딩 설정 저장
@@ -621,7 +621,14 @@ export function BrandingSettingsPage() {
         companyName: settings.company.name,
         bannerSettings: {
           enabled: settings.banner.enabled,
-          items: settings.banner.items,
+          items: settings.banner.items.map((item, index) => ({
+            id: item.id,
+            type: item.type,
+            imageUrl: item.imagePreview,
+            code: item.code,
+            title: item.title,
+            order: index,
+          })),
         },
         landingPageSettings: {
           landingCategory: settings.landingCategory,

--- a/src/pages/ta/branding/BrandingSettingsPage.tsx
+++ b/src/pages/ta/branding/BrandingSettingsPage.tsx
@@ -62,6 +62,12 @@ import { Switch } from '@/components/common/Switch';
 import { Input } from '@/components/common/Input';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/common/Tabs';
 import { useTenantFeatures, useUpdateTenantFeatures } from '@/hooks/ta';
+import {
+  useTenantSettings,
+  useUpdateDesignSettings,
+  useUpdateLayoutSettings,
+  useUpdateExtendedBrandingSettings,
+} from '@/hooks/ta/useBrandingQueries';
 import type { UpdateTenantFeaturesRequest } from '@/services/ta/tenantFeaturesService';
 
 // 사용 가능한 아이콘 목록
@@ -253,8 +259,45 @@ const defaultBrandingSettings: BrandingSettings = {
   banner: {
     enabled: true,
     items: [
-      { id: '1', type: 'image', imagePreview: null, code: '', title: '메인 배너' },
-      { id: '2', type: 'image', imagePreview: null, code: '', title: '프로모션 배너' },
+      {
+        id: 'default-1',
+        type: 'code',
+        imagePreview: null,
+        code: `<div class="flex flex-col items-start justify-center h-full px-8 md:px-16">
+      <span class="inline-flex items-center gap-2 px-4 py-2 rounded-full text-xs font-bold bg-white/10 text-white border border-white/20 mb-6">MZC LEARN</span>
+      <h2 class="text-4xl md:text-6xl lg:text-7xl font-extrabold text-white leading-tight">Empower Your</h2>
+      <h2 class="text-4xl md:text-6xl lg:text-7xl font-extrabold leading-tight bg-gradient-to-r from-[#6778ff] to-[#a855f7] bg-clip-text text-transparent">Future</h2>
+      <p class="text-xl md:text-2xl font-medium text-gray-300 mt-6">최신 기술 트렌드를 선도하는<br/>실무 중심의 IT 교육</p>
+      <p class="text-base md:text-lg text-gray-500 mt-2">AWS, AI, 클라우드 전문가가 되는 가장 빠른 길</p>
+    </div>`,
+        title: 'Empower Your Future',
+      },
+      {
+        id: 'default-2',
+        type: 'code',
+        imagePreview: null,
+        code: `<div class="flex flex-col items-start justify-center h-full px-8 md:px-16">
+      <span class="inline-flex items-center gap-2 px-4 py-2 rounded-full text-xs font-bold bg-white/10 text-white border border-white/20 mb-6">ROADMAP</span>
+      <h2 class="text-4xl md:text-6xl lg:text-7xl font-extrabold text-white leading-tight">Build Your</h2>
+      <h2 class="text-4xl md:text-6xl lg:text-7xl font-extrabold leading-tight bg-gradient-to-r from-[#a855f7] to-[#ec4899] bg-clip-text text-transparent">Career</h2>
+      <p class="text-xl md:text-2xl font-medium text-gray-300 mt-6">단계별 로드맵으로<br/>체계적인 성장을 경험하세요</p>
+      <p class="text-base md:text-lg text-gray-500 mt-2">입문부터 전문가까지, 맞춤형 학습 경로 제공</p>
+    </div>`,
+        title: 'Build Your Career',
+      },
+      {
+        id: 'default-3',
+        type: 'code',
+        imagePreview: null,
+        code: `<div class="flex flex-col items-start justify-center h-full px-8 md:px-16">
+      <span class="inline-flex items-center gap-2 px-4 py-2 rounded-full text-xs font-bold bg-white/10 text-white border border-white/20 mb-6">CLOUD</span>
+      <h2 class="text-4xl md:text-6xl lg:text-7xl font-extrabold text-white leading-tight">Master</h2>
+      <h2 class="text-4xl md:text-6xl lg:text-7xl font-extrabold leading-tight bg-gradient-to-r from-[#6778ff] to-[#6bc2f0] bg-clip-text text-transparent">Cloud</h2>
+      <p class="text-xl md:text-2xl font-medium text-gray-300 mt-6">클라우드 기술의 핵심을<br/>실습과 함께 마스터하세요</p>
+      <p class="text-base md:text-lg text-gray-500 mt-2">AWS, Azure, GCP 공인 자격증 취득 지원</p>
+    </div>`,
+        title: 'Master Cloud',
+      },
     ],
   },
   footer: {
@@ -361,6 +404,12 @@ export function BrandingSettingsPage() {
   const [expandedSidebarItems, setExpandedSidebarItems] = useState<Set<string>>(new Set(['tu-2', 'tu-3', 'to-2']));
   const [expandedMenuItems, setExpandedMenuItems] = useState<Set<string>>(new Set(['mypage-home']));
 
+  // 브랜딩 설정 API 관련
+  const { data: tenantSettings, isLoading: settingsLoading } = useTenantSettings();
+  const updateDesignMutation = useUpdateDesignSettings();
+  const updateLayoutMutation = useUpdateLayoutSettings();
+  const updateExtendedBrandingMutation = useUpdateExtendedBrandingSettings();
+
   // 기능 설정 관련
   const { data: features, isLoading: featuresLoading } = useTenantFeatures();
   const updateFeaturesMutation = useUpdateTenantFeatures();
@@ -384,6 +433,42 @@ export function BrandingSettingsPage() {
       });
     }
   }, [features]);
+
+  // 서버에서 받아온 브랜딩 설정을 로컬 상태에 초기화
+  useEffect(() => {
+    if (tenantSettings) {
+      setSettings(prev => ({
+        ...prev,
+        company: {
+          name: tenantSettings.companyName || prev.company.name,
+        },
+        logo: {
+          lightPreview: tenantSettings.logoUrl || prev.logo.lightPreview,
+          darkPreview: tenantSettings.darkLogoUrl || prev.logo.darkPreview,
+          faviconPreview: tenantSettings.faviconUrl || prev.logo.faviconPreview,
+        },
+        colors: {
+          primary: tenantSettings.primaryColor || prev.colors.primary,
+          secondary: tenantSettings.secondaryColor || prev.colors.secondary,
+        },
+        // 확장 브랜딩 설정 (배너 설정이 있고 items가 있으면 사용, 없으면 기본값 유지)
+        ...(tenantSettings.bannerSettings &&
+          (tenantSettings.bannerSettings as { items?: unknown[] }).items?.length > 0 && {
+          banner: tenantSettings.bannerSettings as typeof prev.banner,
+        }),
+        ...(tenantSettings.landingPageSettings && {
+          landingCategory: (tenantSettings.landingPageSettings as { landingCategory?: typeof prev.landingCategory }).landingCategory || prev.landingCategory,
+          courseSections: (tenantSettings.landingPageSettings as { courseSections?: typeof prev.courseSections }).courseSections || prev.courseSections,
+        }),
+        ...(tenantSettings.sidebarTUSettings && {
+          sidebarTU: tenantSettings.sidebarTUSettings as typeof prev.sidebarTU,
+        }),
+        ...(tenantSettings.sidebarTOSettings && {
+          sidebarTO: tenantSettings.sidebarTOSettings as typeof prev.sidebarTO,
+        }),
+      }));
+    }
+  }, [tenantSettings]);
 
   // 커뮤니티 관련 항목인지 확인하는 헬퍼 함수
   const isCommunityRelated = (label: string) => {
@@ -503,9 +588,52 @@ export function BrandingSettingsPage() {
   const handleSave = async () => {
     setIsSaving(true);
     try {
-      // TODO: 브랜딩 설정 저장 API 연동
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      // 디자인 설정 저장
+      await updateDesignMutation.mutateAsync({
+        logoUrl: settings.logo.lightPreview,
+        darkLogoUrl: settings.logo.darkPreview,
+        faviconUrl: settings.logo.faviconPreview,
+        primaryColor: settings.colors.primary,
+        secondaryColor: settings.colors.secondary,
+      });
+
+      // 레이아웃 설정 저장
+      await updateLayoutMutation.mutateAsync({
+        headerSettings: {
+          enabled: settings.header.enabled,
+          showLogo: settings.header.showLogo,
+          showSearch: settings.header.showSearch,
+          showNotifications: settings.header.showNotifications,
+          showThemeToggle: settings.header.showThemeToggle,
+          navLinks: settings.header.navLinks,
+        },
+        footerSettings: {
+          enabled: settings.footer.enabled,
+          companyInfo: settings.footer.companyInfo,
+          copyright: settings.footer.copyright,
+          legalLinks: settings.footer.legalLinks,
+          socialLinks: settings.footer.socialLinks,
+        },
+      });
+
+      // 확장 브랜딩 설정 저장
+      await updateExtendedBrandingMutation.mutateAsync({
+        companyName: settings.company.name,
+        bannerSettings: {
+          enabled: settings.banner.enabled,
+          items: settings.banner.items,
+        },
+        landingPageSettings: {
+          landingCategory: settings.landingCategory,
+          courseSections: settings.courseSections,
+        },
+        sidebarTUSettings: settings.sidebarTU,
+        sidebarTOSettings: settings.sidebarTO,
+      });
+
       setHasChanges(false);
+    } catch (error) {
+      console.error('브랜딩 설정 저장 실패:', error);
     } finally {
       setIsSaving(false);
     }
@@ -517,7 +645,7 @@ export function BrandingSettingsPage() {
   };
 
   // 로딩 중
-  if (featuresLoading) {
+  if (featuresLoading || settingsLoading) {
     return (
       <div className="flex items-center justify-center h-screen">
         <Loader2 className="w-8 h-8 animate-spin text-brand-primary" />
@@ -535,7 +663,7 @@ export function BrandingSettingsPage() {
             <p className="text-sm text-text-secondary mt-1">테넌트의 브랜드 아이덴티티와 레이아웃을 설정합니다</p>
           </div>
           <div className="flex gap-2">
-            <Button variant="outline" onClick={handleReset} disabled={!hasChanges}>
+            <Button variant="outline" onClick={handleReset}>
               <RotateCcw className="mr-2 h-4 w-4" />
               초기화
             </Button>

--- a/src/pages/ta/index.ts
+++ b/src/pages/ta/index.ts
@@ -18,4 +18,4 @@ export { TenantSettingsPage, UserManagementSettingsPage } from './settings';
 export { FeatureSettingsPage, TenantCategoryPage } from './features';
 
 // Notices
-export { TenantNoticesPage } from './notices';
+export { TenantNoticesPage, SystemNoticesPage, NoticeInboxPage } from './notices';

--- a/src/pages/ta/notices/NoticeInboxPage.tsx
+++ b/src/pages/ta/notices/NoticeInboxPage.tsx
@@ -316,7 +316,7 @@ export function NoticeInboxPage() {
                               <Badge className={typeConf.color}>{typeConf.label}</Badge>
                             </div>
                             <p className="text-sm text-text-secondary line-clamp-2">
-                              {notice.content.replaceAll(/<[^>]*>/g, '').substring(0, 150)}...
+                              {notice.content.replace(/<[^>]*>/g, '').substring(0, 150)}...
                             </p>
                           </div>
                           <div className="flex flex-col items-end gap-2 ml-4">

--- a/src/pages/ta/notices/NoticeInboxPage.tsx
+++ b/src/pages/ta/notices/NoticeInboxPage.tsx
@@ -1,0 +1,792 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import {
+  Bell,
+  Pin,
+  Eye,
+  CheckCircle,
+  ChevronLeft,
+  ChevronRight,
+  Calendar,
+  AlertCircle,
+  Inbox,
+  Send,
+  Plus,
+  Edit,
+  Trash2,
+  Archive,
+  Users,
+} from 'lucide-react';
+import { AdminPageHeader } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Badge } from '@/components/common/Badge';
+import { Input } from '@/components/common/Input';
+import { Label } from '@/components/common/Label';
+import { Textarea } from '@/components/common/Textarea';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/common/Tabs';
+import { Switch } from '@/components/common/Switch';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/common/Dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/common/Select';
+import {
+  useSystemNotices,
+  useMarkSystemNoticeAsRead,
+} from '@/hooks/ta/useSystemNoticeQueries';
+import {
+  useTenantNotices,
+  useCreateTenantNotice,
+  useUpdateTenantNotice,
+  useDeleteTenantNotice,
+  usePublishTenantNotice,
+  useArchiveTenantNotice,
+} from '@/hooks/ta/useTenantNoticeQueries';
+import type { Notice } from '@/types/admin';
+import type {
+  TenantNotice,
+  TenantNoticeType,
+  TenantNoticeStatus,
+  NoticeTargetAudience,
+  CreateTenantNoticeRequest,
+  UpdateTenantNoticeRequest,
+} from '@/types/ta/tenantNotice.types';
+
+// SA 공지 타입 설정
+const systemTypeConfig: Record<string, { label: string; color: string }> = {
+  GENERAL: { label: '일반', color: 'bg-gray-100 text-gray-700' },
+  UPDATE: { label: '업데이트', color: 'bg-blue-100 text-blue-700' },
+  SYSTEM: { label: '시스템', color: 'bg-yellow-100 text-yellow-700' },
+  EVENT: { label: '이벤트', color: 'bg-purple-100 text-purple-700' },
+};
+
+// TA 공지 타입 설정
+const tenantTypeConfig: Record<TenantNoticeType, { label: string; color: string }> = {
+  GENERAL: { label: '일반', color: 'bg-gray-100 text-gray-700' },
+  IMPORTANT: { label: '중요', color: 'bg-blue-100 text-blue-700' },
+  URGENT: { label: '긴급', color: 'bg-red-100 text-red-700' },
+  EVENT: { label: '이벤트', color: 'bg-purple-100 text-purple-700' },
+};
+
+const statusConfig: Record<TenantNoticeStatus, { label: string; color: string }> = {
+  DRAFT: { label: '초안', color: 'bg-gray-100 text-gray-600' },
+  PUBLISHED: { label: '게시됨', color: 'bg-green-100 text-green-700' },
+  ARCHIVED: { label: '보관됨', color: 'bg-orange-100 text-orange-700' },
+};
+
+const audienceConfig: Record<NoticeTargetAudience, { label: string }> = {
+  OPERATOR: { label: '운영자' },
+  USER: { label: '사용자' },
+};
+
+export function NoticeInboxPage() {
+  const [activeTab, setActiveTab] = useState('inbox');
+
+  // 받은공지 상태
+  const [inboxPage, setInboxPage] = useState(0);
+  const [selectedNotice, setSelectedNotice] = useState<Notice | null>(null);
+
+  // 보낸공지 상태
+  const [statusFilter, setStatusFilter] = useState<TenantNoticeStatus | 'ALL'>('ALL');
+  const [audienceFilter, setAudienceFilter] = useState<NoticeTargetAudience | 'ALL'>('ALL');
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [editingNotice, setEditingNotice] = useState<TenantNotice | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<TenantNotice | null>(null);
+  const [viewingNotice, setViewingNotice] = useState<TenantNotice | null>(null);
+  const [formData, setFormData] = useState<CreateTenantNoticeRequest>({
+    title: '',
+    content: '',
+    type: 'GENERAL',
+    targetAudience: 'USER',
+    isPinned: false,
+  });
+
+  // API Hooks - 받은공지
+  const { data: systemNoticesData, isLoading: isSystemLoading } = useSystemNotices({ page: inboxPage, size: 10 });
+  const markAsReadMutation = useMarkSystemNoticeAsRead();
+
+  // API Hooks - 보낸공지
+  const { data: tenantNoticesData, isLoading: isTenantLoading } = useTenantNotices({
+    status: statusFilter !== 'ALL' ? statusFilter : undefined,
+    targetAudience: audienceFilter !== 'ALL' ? audienceFilter : undefined,
+  });
+  const createMutation = useCreateTenantNotice();
+  const updateMutation = useUpdateTenantNotice();
+  const deleteMutation = useDeleteTenantNotice();
+  const publishMutation = usePublishTenantNotice();
+  const archiveMutation = useArchiveTenantNotice();
+
+  // 받은공지 데이터
+  const systemNotices = systemNoticesData?.content || [];
+  const totalPages = systemNoticesData?.totalPages || 0;
+  const totalSystemElements = systemNoticesData?.totalElements || 0;
+
+  // 보낸공지 데이터
+  const tenantNotices = tenantNoticesData?.content || [];
+  const totalTenantElements = tenantNoticesData?.totalElements || 0;
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return '-';
+    return new Date(dateString).toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  // 받은공지 핸들러
+  const handleViewSystemNotice = (notice: Notice) => {
+    setSelectedNotice(notice);
+    markAsReadMutation.mutate(notice.id);
+  };
+
+  // 보낸공지 핸들러
+  const handleCreateOpen = () => {
+    setFormData({
+      title: '',
+      content: '',
+      type: 'GENERAL',
+      targetAudience: 'USER',
+      isPinned: false,
+    });
+    setIsCreateOpen(true);
+  };
+
+  const handleEditOpen = (notice: TenantNotice) => {
+    setFormData({
+      title: notice.title,
+      content: notice.content,
+      type: notice.type,
+      targetAudience: notice.targetAudience,
+      isPinned: notice.isPinned,
+    });
+    setEditingNotice(notice);
+  };
+
+  const handleCreate = async () => {
+    if (!formData.title.trim() || !formData.content.trim()) return;
+    try {
+      await createMutation.mutateAsync(formData);
+      toast.success('공지사항이 생성되었습니다.');
+      setIsCreateOpen(false);
+    } catch {
+      toast.error('공지사항 생성에 실패했습니다.');
+    }
+  };
+
+  const handleUpdate = async () => {
+    if (!editingNotice || !formData.title.trim() || !formData.content.trim()) return;
+    const request: UpdateTenantNoticeRequest = {
+      title: formData.title,
+      content: formData.content,
+      type: formData.type,
+      targetAudience: formData.targetAudience,
+      isPinned: formData.isPinned,
+    };
+    try {
+      await updateMutation.mutateAsync({ id: editingNotice.id, request });
+      toast.success('공지사항이 수정되었습니다.');
+      setEditingNotice(null);
+    } catch {
+      toast.error('공지사항 수정에 실패했습니다.');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteMutation.mutateAsync(deleteTarget.id);
+      toast.success('공지사항이 삭제되었습니다.');
+      setDeleteTarget(null);
+    } catch {
+      toast.error('공지사항 삭제에 실패했습니다.');
+    }
+  };
+
+  const handlePublish = async (id: number) => {
+    try {
+      await publishMutation.mutateAsync(id);
+      toast.success('공지사항이 발행되었습니다.');
+    } catch {
+      toast.error('공지사항 발행에 실패했습니다.');
+    }
+  };
+
+  const handleArchive = async (id: number) => {
+    try {
+      await archiveMutation.mutateAsync(id);
+      toast.success('공지사항이 보관되었습니다.');
+    } catch {
+      toast.error('공지사항 보관에 실패했습니다.');
+    }
+  };
+
+  const isLoading = isSystemLoading || isTenantLoading;
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+          <div className="h-64 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="공지사항"
+        description="시스템 공지를 확인하고 운영자/사용자에게 공지를 발송합니다"
+      />
+
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+        <TabsList className="mb-4">
+          <TabsTrigger value="inbox" className="flex items-center gap-2">
+            <Inbox className="h-4 w-4" />
+            받은 공지
+            {totalSystemElements > 0 && (
+              <Badge variant="secondary" className="ml-1">{totalSystemElements}</Badge>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="outbox" className="flex items-center gap-2">
+            <Send className="h-4 w-4" />
+            보낸 공지
+            {totalTenantElements > 0 && (
+              <Badge variant="secondary" className="ml-1">{totalTenantElements}</Badge>
+            )}
+          </TabsTrigger>
+        </TabsList>
+
+        {/* 받은 공지 탭 */}
+        <TabsContent value="inbox">
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Bell className="h-5 w-5 text-brand-primary" />
+                <div>
+                  <CardTitle>시스템 공지사항</CardTitle>
+                  <CardDescription>시스템 관리자로부터 받은 공지사항입니다</CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {systemNotices.length === 0 ? (
+                <div className="text-center py-12 text-text-secondary">
+                  <Inbox className="h-12 w-12 mx-auto mb-4 opacity-50" />
+                  <p>받은 공지사항이 없습니다.</p>
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {systemNotices.map((notice) => {
+                    const typeConf = systemTypeConfig[notice.type] || systemTypeConfig.GENERAL;
+
+                    return (
+                      <div
+                        key={notice.id}
+                        role="button"
+                        tabIndex={0}
+                        className="p-4 border rounded-lg hover:bg-bg-secondary cursor-pointer transition-colors"
+                        onClick={() => handleViewSystemNotice(notice)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            handleViewSystemNotice(notice);
+                          }
+                        }}
+                      >
+                        <div className="flex items-start justify-between">
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2 mb-1">
+                              {notice.isPinned && (
+                                <Pin className="h-4 w-4 text-yellow-500 flex-shrink-0" />
+                              )}
+                              <h3 className="font-medium">{notice.title}</h3>
+                              <Badge className={typeConf.color}>{typeConf.label}</Badge>
+                            </div>
+                            <p className="text-sm text-text-secondary line-clamp-2">
+                              {notice.content.replaceAll(/<[^>]*>/g, '').substring(0, 150)}...
+                            </p>
+                          </div>
+                          <div className="flex flex-col items-end gap-2 ml-4">
+                            <span className="text-xs text-text-secondary flex items-center gap-1">
+                              <Calendar className="h-3 w-3" />
+                              {formatDate(notice.publishedAt)}
+                            </span>
+                            <Button variant="ghost" size="sm">
+                              <Eye className="h-4 w-4 mr-1" />
+                              보기
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
+              {/* Pagination */}
+              {totalPages > 1 && (
+                <div className="flex items-center justify-center gap-2 mt-6">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={inboxPage === 0}
+                    onClick={() => setInboxPage((p) => Math.max(0, p - 1))}
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                  </Button>
+                  <span className="text-sm">
+                    {inboxPage + 1} / {totalPages}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={inboxPage >= totalPages - 1}
+                    onClick={() => setInboxPage((p) => p + 1)}
+                  >
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* 보낸 공지 탭 */}
+        <TabsContent value="outbox">
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Send className="h-5 w-5 text-brand-primary" />
+                  <div>
+                    <CardTitle>발송한 공지사항</CardTitle>
+                    <CardDescription>운영자와 사용자에게 발송한 공지사항입니다</CardDescription>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Select
+                    value={audienceFilter}
+                    onValueChange={(v) => setAudienceFilter(v as NoticeTargetAudience | 'ALL')}
+                  >
+                    <SelectTrigger className="w-32">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="ALL">전체 대상</SelectItem>
+                      <SelectItem value="OPERATOR">운영자</SelectItem>
+                      <SelectItem value="USER">사용자</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <Select
+                    value={statusFilter}
+                    onValueChange={(v) => setStatusFilter(v as TenantNoticeStatus | 'ALL')}
+                  >
+                    <SelectTrigger className="w-32">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="ALL">전체 상태</SelectItem>
+                      <SelectItem value="DRAFT">초안</SelectItem>
+                      <SelectItem value="PUBLISHED">게시됨</SelectItem>
+                      <SelectItem value="ARCHIVED">보관됨</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <Button onClick={handleCreateOpen}>
+                    <Plus className="mr-2 h-4 w-4" />
+                    공지 작성
+                  </Button>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                {tenantNotices.length === 0 ? (
+                  <div className="text-center py-8 text-text-secondary">
+                    <Send className="h-12 w-12 mx-auto mb-4 opacity-50" />
+                    <p>발송한 공지사항이 없습니다</p>
+                  </div>
+                ) : (
+                  tenantNotices.map((notice) => (
+                    <div
+                      key={notice.id}
+                      className="flex items-center justify-between p-4 border rounded-lg hover:bg-bg-secondary"
+                    >
+                      <div className="flex items-start gap-3 flex-1 min-w-0">
+                        {notice.isPinned && <Pin className="h-4 w-4 text-brand-primary mt-1 flex-shrink-0" />}
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <h3 className="font-medium truncate">{notice.title}</h3>
+                            <Badge className={tenantTypeConfig[notice.type].color}>
+                              {tenantTypeConfig[notice.type].label}
+                            </Badge>
+                            <Badge className={statusConfig[notice.status].color}>
+                              {statusConfig[notice.status].label}
+                            </Badge>
+                            <Badge variant="outline">
+                              <Users className="h-3 w-3 mr-1" />
+                              {audienceConfig[notice.targetAudience].label}
+                            </Badge>
+                          </div>
+                          <div className="flex items-center gap-4 mt-1 text-sm text-text-secondary">
+                            <span className="flex items-center gap-1">
+                              <Calendar className="h-3 w-3" />
+                              {new Date(notice.createdAt).toLocaleDateString()}
+                            </span>
+                            {notice.status === 'PUBLISHED' && (
+                              <span className="flex items-center gap-1">
+                                <Eye className="h-3 w-3" />
+                                조회 {notice.viewCount}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-1 flex-shrink-0">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setViewingNotice(notice)}
+                          title="미리보기"
+                        >
+                          <Eye className="h-4 w-4" />
+                        </Button>
+                        {notice.status === 'DRAFT' && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handlePublish(notice.id)}
+                            disabled={publishMutation.isPending}
+                            title="발행"
+                          >
+                            <Send className="h-4 w-4 text-green-600" />
+                          </Button>
+                        )}
+                        {notice.status === 'PUBLISHED' && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleArchive(notice.id)}
+                            disabled={archiveMutation.isPending}
+                            title="보관"
+                          >
+                            <Archive className="h-4 w-4 text-orange-600" />
+                          </Button>
+                        )}
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleEditOpen(notice)}
+                        >
+                          <Edit className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-red-500"
+                          onClick={() => setDeleteTarget(notice)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+
+      {/* 받은공지 상세 Dialog */}
+      <Dialog open={selectedNotice !== null} onOpenChange={() => setSelectedNotice(null)}>
+        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <div className="flex items-center gap-2">
+              {selectedNotice?.isPinned && <Pin className="h-4 w-4 text-yellow-500" />}
+              <DialogTitle>{selectedNotice?.title}</DialogTitle>
+            </div>
+            <DialogDescription className="flex items-center gap-3">
+              {selectedNotice && (
+                <>
+                  <Badge className={systemTypeConfig[selectedNotice.type]?.color || systemTypeConfig.GENERAL.color}>
+                    {systemTypeConfig[selectedNotice.type]?.label || '일반'}
+                  </Badge>
+                  <span className="text-xs">
+                    {formatDate(selectedNotice.publishedAt)}
+                  </span>
+                </>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+
+          {selectedNotice && (
+            <div className="mt-4">
+              {selectedNotice.expiredAt && new Date(selectedNotice.expiredAt) < new Date() && (
+                <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg flex items-center gap-2 text-yellow-700">
+                  <AlertCircle className="h-4 w-4" />
+                  <span className="text-sm">이 공지사항은 만료되었습니다.</span>
+                </div>
+              )}
+
+              <div
+                className="prose prose-sm max-w-none"
+                dangerouslySetInnerHTML={{ __html: selectedNotice.content }}
+              />
+
+              <div className="mt-6 pt-4 border-t flex items-center justify-between text-sm text-text-secondary">
+                <div className="flex items-center gap-1">
+                  <CheckCircle className="h-4 w-4 text-green-500" />
+                  읽음
+                </div>
+                {selectedNotice.expiredAt && (
+                  <span>만료일: {formatDate(selectedNotice.expiredAt)}</span>
+                )}
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* 보낸공지 작성 Dialog */}
+      <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>새 공지사항 작성</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label>제목 *</Label>
+              <Input
+                value={formData.title}
+                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                placeholder="공지사항 제목을 입력하세요"
+              />
+            </div>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <Label>유형</Label>
+                <Select
+                  value={formData.type}
+                  onValueChange={(v) => setFormData({ ...formData, type: v as TenantNoticeType })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="GENERAL">일반</SelectItem>
+                    <SelectItem value="IMPORTANT">중요</SelectItem>
+                    <SelectItem value="URGENT">긴급</SelectItem>
+                    <SelectItem value="EVENT">이벤트</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>대상</Label>
+                <Select
+                  value={formData.targetAudience}
+                  onValueChange={(v) => setFormData({ ...formData, targetAudience: v as NoticeTargetAudience })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="USER">사용자</SelectItem>
+                    <SelectItem value="OPERATOR">운영자</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-center gap-2 pt-6">
+                <Switch
+                  id="isPinned"
+                  checked={formData.isPinned}
+                  onCheckedChange={(v) => setFormData({ ...formData, isPinned: v })}
+                />
+                <Label htmlFor="isPinned">상단 고정</Label>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>내용 *</Label>
+              <Textarea
+                value={formData.content}
+                onChange={(e) => setFormData({ ...formData, content: e.target.value })}
+                placeholder="공지사항 내용을 입력하세요"
+                rows={8}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsCreateOpen(false)}>
+              취소
+            </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={!formData.title.trim() || !formData.content.trim() || createMutation.isPending}
+            >
+              {createMutation.isPending ? '생성 중...' : '생성'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* 보낸공지 수정 Dialog */}
+      <Dialog open={!!editingNotice} onOpenChange={() => setEditingNotice(null)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>공지사항 수정</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label>제목 *</Label>
+              <Input
+                value={formData.title}
+                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                placeholder="공지사항 제목을 입력하세요"
+              />
+            </div>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <Label>유형</Label>
+                <Select
+                  value={formData.type}
+                  onValueChange={(v) => setFormData({ ...formData, type: v as TenantNoticeType })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="GENERAL">일반</SelectItem>
+                    <SelectItem value="IMPORTANT">중요</SelectItem>
+                    <SelectItem value="URGENT">긴급</SelectItem>
+                    <SelectItem value="EVENT">이벤트</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>대상</Label>
+                <Select
+                  value={formData.targetAudience}
+                  onValueChange={(v) => setFormData({ ...formData, targetAudience: v as NoticeTargetAudience })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="USER">사용자</SelectItem>
+                    <SelectItem value="OPERATOR">운영자</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-center gap-2 pt-6">
+                <Switch
+                  id="isPinnedEdit"
+                  checked={formData.isPinned}
+                  onCheckedChange={(v) => setFormData({ ...formData, isPinned: v })}
+                />
+                <Label htmlFor="isPinnedEdit">상단 고정</Label>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>내용 *</Label>
+              <Textarea
+                value={formData.content}
+                onChange={(e) => setFormData({ ...formData, content: e.target.value })}
+                placeholder="공지사항 내용을 입력하세요"
+                rows={8}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditingNotice(null)}>
+              취소
+            </Button>
+            <Button
+              onClick={handleUpdate}
+              disabled={!formData.title.trim() || !formData.content.trim() || updateMutation.isPending}
+            >
+              {updateMutation.isPending ? '저장 중...' : '저장'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* 보낸공지 삭제 확인 Dialog */}
+      <Dialog open={!!deleteTarget} onOpenChange={() => setDeleteTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>공지사항 삭제</DialogTitle>
+          </DialogHeader>
+          <p className="py-4">
+            "{deleteTarget?.title}" 공지사항을 삭제하시겠습니까?
+            <br />
+            <span className="text-sm text-text-secondary">
+              이 작업은 되돌릴 수 없습니다.
+            </span>
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)}>
+              취소
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? '삭제 중...' : '삭제'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* 보낸공지 미리보기 Dialog */}
+      <Dialog open={!!viewingNotice} onOpenChange={() => setViewingNotice(null)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              {viewingNotice?.isPinned && <Pin className="h-4 w-4 text-brand-primary" />}
+              {viewingNotice?.title}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="py-4">
+            <div className="flex items-center gap-2 mb-4">
+              {viewingNotice && (
+                <>
+                  <Badge className={tenantTypeConfig[viewingNotice.type].color}>
+                    {tenantTypeConfig[viewingNotice.type].label}
+                  </Badge>
+                  <Badge variant="outline">
+                    <Users className="h-3 w-3 mr-1" />
+                    {audienceConfig[viewingNotice.targetAudience].label}
+                  </Badge>
+                  <span className="text-sm text-text-secondary">
+                    {new Date(viewingNotice.createdAt).toLocaleDateString()}
+                  </span>
+                </>
+              )}
+            </div>
+            <div className="prose prose-sm max-w-none whitespace-pre-wrap">
+              {viewingNotice?.content}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setViewingNotice(null)}>
+              닫기
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/ta/notices/SystemNoticesPage.tsx
+++ b/src/pages/ta/notices/SystemNoticesPage.tsx
@@ -1,0 +1,222 @@
+import { useState } from 'react';
+import {
+  Bell,
+  Pin,
+  Eye,
+  CheckCircle,
+  ChevronLeft,
+  ChevronRight,
+  Calendar,
+  AlertCircle,
+} from 'lucide-react';
+import { AdminPageHeader } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Badge } from '@/components/common/Badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/common/Dialog';
+import {
+  useSystemNotices,
+  useSystemNotice,
+  useMarkSystemNoticeAsRead,
+} from '@/hooks/ta/useSystemNoticeQueries';
+import type { Notice } from '@/types/admin';
+
+const typeConfig: Record<string, { label: string; color: string }> = {
+  GENERAL: { label: '일반', color: 'bg-gray-100 text-gray-700' },
+  UPDATE: { label: '업데이트', color: 'bg-blue-100 text-blue-700' },
+  SYSTEM: { label: '시스템', color: 'bg-yellow-100 text-yellow-700' },
+  EVENT: { label: '이벤트', color: 'bg-purple-100 text-purple-700' },
+};
+
+export function SystemNoticesPage() {
+  const [page, setPage] = useState(0);
+  const [selectedNoticeId, setSelectedNoticeId] = useState<number | null>(null);
+
+  const { data: noticesData, isLoading } = useSystemNotices({ page, size: 10 });
+  const { data: selectedNotice } = useSystemNotice(selectedNoticeId || 0);
+  const markAsReadMutation = useMarkSystemNoticeAsRead();
+
+  const notices = noticesData?.content || [];
+  const totalPages = noticesData?.totalPages || 0;
+  const totalElements = noticesData?.totalElements || 0;
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return '-';
+    return new Date(dateString).toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  const handleViewNotice = (notice: Notice) => {
+    setSelectedNoticeId(notice.id);
+    // 읽음 처리
+    markAsReadMutation.mutate(notice.id);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+          <div className="h-64 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="시스템 공지사항"
+        description="시스템 관리자가 배포한 공지사항입니다"
+      />
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Bell className="h-5 w-5 text-brand-primary" />
+              <div>
+                <CardTitle>공지사항 목록</CardTitle>
+                <CardDescription>전체 {totalElements}개의 공지사항</CardDescription>
+              </div>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {notices.length === 0 ? (
+            <div className="text-center py-12 text-text-secondary">
+              <Bell className="h-12 w-12 mx-auto mb-4 opacity-50" />
+              <p>배포된 시스템 공지사항이 없습니다.</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {notices.map((notice) => {
+                const typeConf = typeConfig[notice.type] || typeConfig.GENERAL;
+
+                return (
+                  <div
+                    key={notice.id}
+                    className="p-4 border rounded-lg hover:bg-bg-secondary cursor-pointer transition-colors"
+                    onClick={() => handleViewNotice(notice)}
+                  >
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2 mb-1">
+                          {notice.isPinned && (
+                            <Pin className="h-4 w-4 text-yellow-500 flex-shrink-0" />
+                          )}
+                          <h3 className="font-medium">{notice.title}</h3>
+                          <Badge className={typeConf.color}>{typeConf.label}</Badge>
+                        </div>
+                        <p className="text-sm text-text-secondary line-clamp-2">
+                          {notice.content.replace(/<[^>]*>/g, '').substring(0, 150)}...
+                        </p>
+                      </div>
+                      <div className="flex flex-col items-end gap-2 ml-4">
+                        <span className="text-xs text-text-secondary flex items-center gap-1">
+                          <Calendar className="h-3 w-3" />
+                          {formatDate(notice.publishedAt)}
+                        </span>
+                        <Button variant="ghost" size="sm">
+                          <Eye className="h-4 w-4 mr-1" />
+                          보기
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 mt-6">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page === 0}
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <span className="text-sm">
+                {page + 1} / {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages - 1}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Detail Dialog */}
+      <Dialog open={selectedNoticeId !== null} onOpenChange={() => setSelectedNoticeId(null)}>
+        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <div className="flex items-center gap-2">
+              {selectedNotice?.isPinned && <Pin className="h-4 w-4 text-yellow-500" />}
+              <DialogTitle>{selectedNotice?.title}</DialogTitle>
+            </div>
+            <DialogDescription className="flex items-center gap-3">
+              {selectedNotice && (
+                <>
+                  <Badge className={typeConfig[selectedNotice.type]?.color || typeConfig.GENERAL.color}>
+                    {typeConfig[selectedNotice.type]?.label || '일반'}
+                  </Badge>
+                  <span className="text-xs">
+                    {formatDate(selectedNotice.publishedAt)}
+                  </span>
+                </>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+
+          {selectedNotice && (
+            <div className="mt-4">
+              {/* Expiry Warning */}
+              {selectedNotice.expiredAt && new Date(selectedNotice.expiredAt) < new Date() && (
+                <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg flex items-center gap-2 text-yellow-700">
+                  <AlertCircle className="h-4 w-4" />
+                  <span className="text-sm">이 공지사항은 만료되었습니다.</span>
+                </div>
+              )}
+
+              {/* Content */}
+              <div
+                className="prose prose-sm max-w-none"
+                dangerouslySetInnerHTML={{ __html: selectedNotice.content }}
+              />
+
+              {/* Footer */}
+              <div className="mt-6 pt-4 border-t flex items-center justify-between text-sm text-text-secondary">
+                <div className="flex items-center gap-1">
+                  <CheckCircle className="h-4 w-4 text-green-500" />
+                  읽음
+                </div>
+                {selectedNotice.expiredAt && (
+                  <span>만료일: {formatDate(selectedNotice.expiredAt)}</span>
+                )}
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/ta/notices/index.ts
+++ b/src/pages/ta/notices/index.ts
@@ -1,1 +1,3 @@
 export { TenantNoticesPage } from './TenantNoticesPage';
+export { SystemNoticesPage } from './SystemNoticesPage';
+export { NoticeInboxPage } from './NoticeInboxPage';

--- a/src/pages/to/notices/OperatorNoticeInboxPage.tsx
+++ b/src/pages/to/notices/OperatorNoticeInboxPage.tsx
@@ -1,0 +1,705 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import {
+  Bell,
+  Pin,
+  Eye,
+  ChevronLeft,
+  ChevronRight,
+  Calendar,
+  Inbox,
+  Send,
+  Plus,
+  Edit,
+  Trash2,
+  Archive,
+} from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Badge } from '@/components/common/Badge';
+import { Input } from '@/components/common/Input';
+import { Label } from '@/components/common/Label';
+import { Textarea } from '@/components/common/Textarea';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/common/Tabs';
+import { Switch } from '@/components/common/Switch';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/common/Dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/common/Select';
+import { useReceivedNotices, useMarkNoticeAsViewed } from '@/hooks/to/useOperatorNoticeQueries';
+import {
+  useTenantNotices,
+  useCreateTenantNotice,
+  useUpdateTenantNotice,
+  useDeleteTenantNotice,
+  usePublishTenantNotice,
+  useArchiveTenantNotice,
+} from '@/hooks/ta/useTenantNoticeQueries';
+import type {
+  TenantNotice,
+  TenantNoticeType,
+  TenantNoticeStatus,
+  CreateTenantNoticeRequest,
+  UpdateTenantNoticeRequest,
+} from '@/types/ta/tenantNotice.types';
+
+// 공지 타입 설정
+const typeConfig: Record<TenantNoticeType, { label: string; color: string }> = {
+  GENERAL: { label: '일반', color: 'bg-gray-100 text-gray-700' },
+  IMPORTANT: { label: '중요', color: 'bg-blue-100 text-blue-700' },
+  URGENT: { label: '긴급', color: 'bg-red-100 text-red-700' },
+  EVENT: { label: '이벤트', color: 'bg-purple-100 text-purple-700' },
+};
+
+const statusConfig: Record<TenantNoticeStatus, { label: string; color: string }> = {
+  DRAFT: { label: '초안', color: 'bg-gray-100 text-gray-600' },
+  PUBLISHED: { label: '게시됨', color: 'bg-green-100 text-green-700' },
+  ARCHIVED: { label: '보관됨', color: 'bg-orange-100 text-orange-700' },
+};
+
+export function OperatorNoticeInboxPage() {
+  const [activeTab, setActiveTab] = useState('inbox');
+
+  // 받은공지 상태
+  const [inboxPage, setInboxPage] = useState(0);
+  const [selectedNotice, setSelectedNotice] = useState<TenantNotice | null>(null);
+
+  // 보낸공지 상태
+  const [statusFilter, setStatusFilter] = useState<TenantNoticeStatus | 'ALL'>('ALL');
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [editingNotice, setEditingNotice] = useState<TenantNotice | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<TenantNotice | null>(null);
+  const [viewingNotice, setViewingNotice] = useState<TenantNotice | null>(null);
+  const [formData, setFormData] = useState<CreateTenantNoticeRequest>({
+    title: '',
+    content: '',
+    type: 'GENERAL',
+    targetAudience: 'USER',
+    isPinned: false,
+  });
+
+  // API Hooks - 받은공지 (TA가 OPERATOR 대상으로 보낸 공지)
+  const { data: receivedNoticesData, isLoading: isReceivedLoading } = useReceivedNotices({
+    page: inboxPage,
+    size: 10,
+  });
+  const markAsViewedMutation = useMarkNoticeAsViewed();
+
+  // API Hooks - 보낸공지 (USER 대상)
+  const { data: sentNoticesData, isLoading: isSentLoading } = useTenantNotices({
+    status: statusFilter !== 'ALL' ? statusFilter : undefined,
+    targetAudience: 'USER',
+  });
+  const createMutation = useCreateTenantNotice();
+  const updateMutation = useUpdateTenantNotice();
+  const deleteMutation = useDeleteTenantNotice();
+  const publishMutation = usePublishTenantNotice();
+  const archiveMutation = useArchiveTenantNotice();
+
+  // 받은공지 데이터
+  const receivedNotices = receivedNoticesData?.content || [];
+  const totalPages = receivedNoticesData?.totalPages || 0;
+  const totalReceivedElements = receivedNoticesData?.totalElements || 0;
+
+  // 보낸공지 데이터
+  const sentNotices = sentNoticesData?.content || [];
+  const totalSentElements = sentNoticesData?.totalElements || 0;
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return '-';
+    return new Date(dateString).toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  // 받은공지 핸들러
+  const handleViewReceivedNotice = (notice: TenantNotice) => {
+    setSelectedNotice(notice);
+    markAsViewedMutation.mutate(notice.id);
+  };
+
+  // 보낸공지 핸들러
+  const handleCreateOpen = () => {
+    setFormData({
+      title: '',
+      content: '',
+      type: 'GENERAL',
+      targetAudience: 'USER',
+      isPinned: false,
+    });
+    setIsCreateOpen(true);
+  };
+
+  const handleEditOpen = (notice: TenantNotice) => {
+    setFormData({
+      title: notice.title,
+      content: notice.content,
+      type: notice.type,
+      targetAudience: 'USER',
+      isPinned: notice.isPinned,
+    });
+    setEditingNotice(notice);
+  };
+
+  const handleCreate = async () => {
+    if (!formData.title.trim() || !formData.content.trim()) return;
+    try {
+      await createMutation.mutateAsync({
+        ...formData,
+        targetAudience: 'USER',
+      });
+      toast.success('공지사항이 생성되었습니다.');
+      setIsCreateOpen(false);
+    } catch {
+      toast.error('공지사항 생성에 실패했습니다.');
+    }
+  };
+
+  const handleUpdate = async () => {
+    if (!editingNotice || !formData.title.trim() || !formData.content.trim()) return;
+    const request: UpdateTenantNoticeRequest = {
+      title: formData.title,
+      content: formData.content,
+      type: formData.type,
+      targetAudience: 'USER',
+      isPinned: formData.isPinned,
+    };
+    try {
+      await updateMutation.mutateAsync({ id: editingNotice.id, request });
+      toast.success('공지사항이 수정되었습니다.');
+      setEditingNotice(null);
+    } catch {
+      toast.error('공지사항 수정에 실패했습니다.');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteMutation.mutateAsync(deleteTarget.id);
+      toast.success('공지사항이 삭제되었습니다.');
+      setDeleteTarget(null);
+    } catch {
+      toast.error('공지사항 삭제에 실패했습니다.');
+    }
+  };
+
+  const handlePublish = async (id: number) => {
+    try {
+      await publishMutation.mutateAsync(id);
+      toast.success('공지사항이 발행되었습니다.');
+    } catch {
+      toast.error('공지사항 발행에 실패했습니다.');
+    }
+  };
+
+  const handleArchive = async (id: number) => {
+    try {
+      await archiveMutation.mutateAsync(id);
+      toast.success('공지사항이 보관되었습니다.');
+    } catch {
+      toast.error('공지사항 보관에 실패했습니다.');
+    }
+  };
+
+  const isLoading = isReceivedLoading || isSentLoading;
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+          <div className="h-64 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      {/* Header */}
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold text-text-primary">공지사항</h1>
+        <p className="text-sm text-text-secondary mt-1">
+          관리자 공지를 확인하고 학습자에게 공지를 발송합니다
+        </p>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+        <TabsList className="mb-4">
+          <TabsTrigger value="inbox" className="flex items-center gap-2">
+            <Inbox className="h-4 w-4" />
+            받은 공지
+            {totalReceivedElements > 0 && (
+              <Badge variant="secondary" className="ml-1">{totalReceivedElements}</Badge>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="outbox" className="flex items-center gap-2">
+            <Send className="h-4 w-4" />
+            보낸 공지
+            {totalSentElements > 0 && (
+              <Badge variant="secondary" className="ml-1">{totalSentElements}</Badge>
+            )}
+          </TabsTrigger>
+        </TabsList>
+
+        {/* 받은 공지 탭 */}
+        <TabsContent value="inbox">
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Bell className="h-5 w-5 text-brand-primary" />
+                <div>
+                  <CardTitle>관리자 공지사항</CardTitle>
+                  <CardDescription>테넌트 관리자로부터 받은 공지사항입니다</CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {receivedNotices.length === 0 ? (
+                <div className="text-center py-12 text-text-secondary">
+                  <Inbox className="h-12 w-12 mx-auto mb-4 opacity-50" />
+                  <p>받은 공지사항이 없습니다.</p>
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {receivedNotices.map((notice) => {
+                    const typeConf = typeConfig[notice.type] || typeConfig.GENERAL;
+
+                    return (
+                      <div
+                        key={notice.id}
+                        role="button"
+                        tabIndex={0}
+                        className="p-4 border rounded-lg hover:bg-bg-secondary cursor-pointer transition-colors"
+                        onClick={() => handleViewReceivedNotice(notice)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            handleViewReceivedNotice(notice);
+                          }
+                        }}
+                      >
+                        <div className="flex items-start justify-between">
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2 mb-1">
+                              {notice.isPinned && (
+                                <Pin className="h-4 w-4 text-yellow-500 flex-shrink-0" />
+                              )}
+                              <h3 className="font-medium">{notice.title}</h3>
+                              <Badge className={typeConf.color}>{typeConf.label}</Badge>
+                            </div>
+                            <p className="text-sm text-text-secondary line-clamp-2">
+                              {notice.content.replaceAll(/<[^>]*>/g, '').substring(0, 150)}...
+                            </p>
+                          </div>
+                          <div className="flex flex-col items-end gap-2 ml-4">
+                            <span className="text-xs text-text-secondary flex items-center gap-1">
+                              <Calendar className="h-3 w-3" />
+                              {formatDate(notice.publishedAt || notice.createdAt)}
+                            </span>
+                            <Button variant="ghost" size="sm">
+                              <Eye className="h-4 w-4 mr-1" />
+                              보기
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
+              {/* Pagination */}
+              {totalPages > 1 && (
+                <div className="flex items-center justify-center gap-2 mt-6">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={inboxPage === 0}
+                    onClick={() => setInboxPage((p) => Math.max(0, p - 1))}
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                  </Button>
+                  <span className="text-sm">
+                    {inboxPage + 1} / {totalPages}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={inboxPage >= totalPages - 1}
+                    onClick={() => setInboxPage((p) => p + 1)}
+                  >
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* 보낸 공지 탭 */}
+        <TabsContent value="outbox">
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Send className="h-5 w-5 text-brand-primary" />
+                  <div>
+                    <CardTitle>학습자 공지사항</CardTitle>
+                    <CardDescription>학습자에게 발송한 공지사항입니다</CardDescription>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Select
+                    value={statusFilter}
+                    onValueChange={(v) => setStatusFilter(v as TenantNoticeStatus | 'ALL')}
+                  >
+                    <SelectTrigger className="w-32">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="ALL">전체 상태</SelectItem>
+                      <SelectItem value="DRAFT">초안</SelectItem>
+                      <SelectItem value="PUBLISHED">게시됨</SelectItem>
+                      <SelectItem value="ARCHIVED">보관됨</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <Button onClick={handleCreateOpen}>
+                    <Plus className="mr-2 h-4 w-4" />
+                    공지 작성
+                  </Button>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                {sentNotices.length === 0 ? (
+                  <div className="text-center py-8 text-text-secondary">
+                    <Send className="h-12 w-12 mx-auto mb-4 opacity-50" />
+                    <p>발송한 공지사항이 없습니다</p>
+                  </div>
+                ) : (
+                  sentNotices.map((notice) => (
+                    <div
+                      key={notice.id}
+                      className="flex items-center justify-between p-4 border rounded-lg hover:bg-bg-secondary"
+                    >
+                      <div className="flex items-start gap-3 flex-1 min-w-0">
+                        {notice.isPinned && <Pin className="h-4 w-4 text-brand-primary mt-1 flex-shrink-0" />}
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <h3 className="font-medium truncate">{notice.title}</h3>
+                            <Badge className={typeConfig[notice.type].color}>
+                              {typeConfig[notice.type].label}
+                            </Badge>
+                            <Badge className={statusConfig[notice.status].color}>
+                              {statusConfig[notice.status].label}
+                            </Badge>
+                          </div>
+                          <div className="flex items-center gap-4 mt-1 text-sm text-text-secondary">
+                            <span className="flex items-center gap-1">
+                              <Calendar className="h-3 w-3" />
+                              {new Date(notice.createdAt).toLocaleDateString()}
+                            </span>
+                            {notice.status === 'PUBLISHED' && (
+                              <span className="flex items-center gap-1">
+                                <Eye className="h-3 w-3" />
+                                조회 {notice.viewCount}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-1 flex-shrink-0">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setViewingNotice(notice)}
+                          title="미리보기"
+                        >
+                          <Eye className="h-4 w-4" />
+                        </Button>
+                        {notice.status === 'DRAFT' && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handlePublish(notice.id)}
+                            disabled={publishMutation.isPending}
+                            title="발행"
+                          >
+                            <Send className="h-4 w-4 text-green-600" />
+                          </Button>
+                        )}
+                        {notice.status === 'PUBLISHED' && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleArchive(notice.id)}
+                            disabled={archiveMutation.isPending}
+                            title="보관"
+                          >
+                            <Archive className="h-4 w-4 text-orange-600" />
+                          </Button>
+                        )}
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleEditOpen(notice)}
+                        >
+                          <Edit className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-red-500"
+                          onClick={() => setDeleteTarget(notice)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+
+      {/* 받은공지 상세 Dialog */}
+      <Dialog open={selectedNotice !== null} onOpenChange={() => setSelectedNotice(null)}>
+        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <div className="flex items-center gap-2">
+              {selectedNotice?.isPinned && <Pin className="h-4 w-4 text-yellow-500" />}
+              <DialogTitle>{selectedNotice?.title}</DialogTitle>
+            </div>
+          </DialogHeader>
+
+          {selectedNotice && (
+            <div className="mt-4">
+              <div className="flex items-center gap-3 mb-4">
+                <Badge className={typeConfig[selectedNotice.type]?.color || typeConfig.GENERAL.color}>
+                  {typeConfig[selectedNotice.type]?.label || '일반'}
+                </Badge>
+                <span className="text-sm text-text-secondary">
+                  {formatDate(selectedNotice.publishedAt || selectedNotice.createdAt)}
+                </span>
+              </div>
+
+              <div className="prose prose-sm max-w-none whitespace-pre-wrap">
+                {selectedNotice.content}
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* 보낸공지 작성 Dialog */}
+      <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>새 공지사항 작성</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label>제목 *</Label>
+              <Input
+                value={formData.title}
+                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                placeholder="공지사항 제목을 입력하세요"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>유형</Label>
+                <Select
+                  value={formData.type}
+                  onValueChange={(v) => setFormData({ ...formData, type: v as TenantNoticeType })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="GENERAL">일반</SelectItem>
+                    <SelectItem value="IMPORTANT">중요</SelectItem>
+                    <SelectItem value="URGENT">긴급</SelectItem>
+                    <SelectItem value="EVENT">이벤트</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-center gap-2 pt-6">
+                <Switch
+                  id="isPinned"
+                  checked={formData.isPinned}
+                  onCheckedChange={(v) => setFormData({ ...formData, isPinned: v })}
+                />
+                <Label htmlFor="isPinned">상단 고정</Label>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>내용 *</Label>
+              <Textarea
+                value={formData.content}
+                onChange={(e) => setFormData({ ...formData, content: e.target.value })}
+                placeholder="공지사항 내용을 입력하세요"
+                rows={8}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsCreateOpen(false)}>
+              취소
+            </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={!formData.title.trim() || !formData.content.trim() || createMutation.isPending}
+            >
+              {createMutation.isPending ? '생성 중...' : '생성'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* 보낸공지 수정 Dialog */}
+      <Dialog open={!!editingNotice} onOpenChange={() => setEditingNotice(null)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>공지사항 수정</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label>제목 *</Label>
+              <Input
+                value={formData.title}
+                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                placeholder="공지사항 제목을 입력하세요"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>유형</Label>
+                <Select
+                  value={formData.type}
+                  onValueChange={(v) => setFormData({ ...formData, type: v as TenantNoticeType })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="GENERAL">일반</SelectItem>
+                    <SelectItem value="IMPORTANT">중요</SelectItem>
+                    <SelectItem value="URGENT">긴급</SelectItem>
+                    <SelectItem value="EVENT">이벤트</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-center gap-2 pt-6">
+                <Switch
+                  id="isPinnedEdit"
+                  checked={formData.isPinned}
+                  onCheckedChange={(v) => setFormData({ ...formData, isPinned: v })}
+                />
+                <Label htmlFor="isPinnedEdit">상단 고정</Label>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>내용 *</Label>
+              <Textarea
+                value={formData.content}
+                onChange={(e) => setFormData({ ...formData, content: e.target.value })}
+                placeholder="공지사항 내용을 입력하세요"
+                rows={8}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditingNotice(null)}>
+              취소
+            </Button>
+            <Button
+              onClick={handleUpdate}
+              disabled={!formData.title.trim() || !formData.content.trim() || updateMutation.isPending}
+            >
+              {updateMutation.isPending ? '저장 중...' : '저장'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* 보낸공지 삭제 확인 Dialog */}
+      <Dialog open={!!deleteTarget} onOpenChange={() => setDeleteTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>공지사항 삭제</DialogTitle>
+          </DialogHeader>
+          <p className="py-4">
+            "{deleteTarget?.title}" 공지사항을 삭제하시겠습니까?
+            <br />
+            <span className="text-sm text-text-secondary">
+              이 작업은 되돌릴 수 없습니다.
+            </span>
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)}>
+              취소
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? '삭제 중...' : '삭제'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* 보낸공지 미리보기 Dialog */}
+      <Dialog open={!!viewingNotice} onOpenChange={() => setViewingNotice(null)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              {viewingNotice?.isPinned && <Pin className="h-4 w-4 text-brand-primary" />}
+              {viewingNotice?.title}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="py-4">
+            <div className="flex items-center gap-2 mb-4">
+              {viewingNotice && (
+                <>
+                  <Badge className={typeConfig[viewingNotice.type].color}>
+                    {typeConfig[viewingNotice.type].label}
+                  </Badge>
+                  <span className="text-sm text-text-secondary">
+                    {new Date(viewingNotice.createdAt).toLocaleDateString()}
+                  </span>
+                </>
+              )}
+            </div>
+            <div className="prose prose-sm max-w-none whitespace-pre-wrap">
+              {viewingNotice?.content}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setViewingNotice(null)}>
+              닫기
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/to/notices/OperatorNoticeInboxPage.tsx
+++ b/src/pages/to/notices/OperatorNoticeInboxPage.tsx
@@ -301,7 +301,7 @@ export function OperatorNoticeInboxPage() {
                               <Badge className={typeConf.color}>{typeConf.label}</Badge>
                             </div>
                             <p className="text-sm text-text-secondary line-clamp-2">
-                              {notice.content.replaceAll(/<[^>]*>/g, '').substring(0, 150)}...
+                              {notice.content.replace(/<[^>]*>/g, '').substring(0, 150)}...
                             </p>
                           </div>
                           <div className="flex flex-col items-end gap-2 ml-4">

--- a/src/pages/to/notices/index.ts
+++ b/src/pages/to/notices/index.ts
@@ -1,1 +1,2 @@
 export { OperatorNoticesPage } from './OperatorNoticesPage';
+export { OperatorNoticeInboxPage } from './OperatorNoticeInboxPage';

--- a/src/pages/tu/index.ts
+++ b/src/pages/tu/index.ts
@@ -21,4 +21,4 @@ export { SettingsLanguagePage } from './settings';
 export { LandingPage, CoursesExplorePage, RoadmapExplorePage, RoadmapDetailPage, CommunityPage, CommunityDetailPage, CartPage, WishlistPage, NotificationsPage, NotificationDetailPage, CourseDetailPage, InstructorProfilePage, SearchPage } from './main';
 export { CatalogPage, CatalogDetailPage } from './catalog';
 export { MyLearningPage, LearningDetailPage, LearningPlayerPage } from './learning';
-export { MyPage, MyPageHome, ProfilePage, MyTeachingPage, TeachingStatsPage, CompletedCoursesPage, CertificationsPage, MyPostsPage, MyCommentsPage } from './mypage';
+export { MyPage, MyPageHome, ProfilePage, MyTeachingPage, TeachingStatsPage, CompletedCoursesPage, CertificationsPage, MyPostsPage, MyCommentsPage, UserNoticesPage } from './mypage';

--- a/src/pages/tu/main/LandingPage.tsx
+++ b/src/pages/tu/main/LandingPage.tsx
@@ -9,10 +9,10 @@ import {
 } from '@/components/landing';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation } from '@/store/common/languageStore';
-import { usePopularInstructors, useCourseTimeCatalog } from '@/hooks/tu';
+import { usePopularInstructors, useCourseTimeCatalog, usePublicLayout } from '@/hooks/tu';
 import { useTenantBranding } from '@/contexts/TenantBrandingContext';
-import { useAuthStore } from '@/store/common/authStore';
 import { useBrandingApply } from '@/hooks/tu/useBrandingApply';
+import { useAuth } from '@/hooks/common/auth/useAuth';
 import type { InstructorSummary } from '@/types/tu';
 import type { CourseTimeCatalogResponse } from '@/types/tu/courseTimeCatalog.types';
 import { DELIVERY_TYPE_LABELS, PROGRAM_LEVEL_LABELS } from '@/types/tu/courseTimeCatalog.types';
@@ -141,12 +141,29 @@ export function LandingPage() {
   const [activeCategoryId, setActiveCategoryId] = useState<number | null>(null);
   const { theme } = useThemeStore();
   const { t } = useTranslation();
+  const { isAuthenticated } = useAuth();
   const isDark = theme === 'dark';
   const { branding } = useTenantBranding();
 
-  const { isAuthenticated } = useAuthStore();
   // 브랜딩 CSS 적용
   useBrandingApply(branding);
+
+  // 레이아웃 설정 (카테고리 등) - 항상 호출 (공개 API, X-Subdomain 헤더로 테넌트 식별)
+  const { data: layoutData } = usePublicLayout();
+  const landingPageSettings = layoutData?.landingPageSettings;
+  const landingCategory = landingPageSettings?.landingCategory;
+
+  // TA에서 설정한 카테고리가 있으면 사용, 없으면 기본 카테고리 사용
+  const categoryOptions: CategoryOption[] = landingCategory?.enabled && landingCategory?.items?.length > 0
+    ? [
+        { id: null, name: '전체', code: 'all' },
+        ...landingCategory.items.map((name, index) => ({
+          id: index + 1,
+          name,
+          code: name.toLowerCase().replace(/\s+/g, '-'),
+        })),
+      ]
+    : CATEGORY_OPTIONS;
 
   // CourseTime API로 강의 데이터 로드 (모집중/진행중, 카테고리 필터 적용)
   const { data: courseTimeData, isLoading: isCoursesLoading } = useCourseTimeCatalog({
@@ -165,7 +182,7 @@ export function LandingPage() {
   const courses = courseTimes.map(convertCourseTimeToCardProps);
 
   // 현재 선택된 카테고리 정보 가져오기
-  const activeCategory = CATEGORY_OPTIONS.find((c) => c.id === activeCategoryId);
+  const activeCategory = categoryOptions.find((c) => c.id === activeCategoryId);
 
   // API에서 이미 categoryId로 필터링됨, 추가 클라이언트 필터링 불필요
   const filteredCourses = courses;
@@ -191,7 +208,7 @@ export function LandingPage() {
         <div className="w-full px-4 md:px-8 lg:px-16 py-12">
           {/* Quick Category Chips */}
           <div className="flex flex-wrap items-center gap-3">
-            {CATEGORY_OPTIONS.map((cat) => (
+            {categoryOptions.map((cat) => (
               <button
                 key={cat.code}
                 onClick={() => setActiveCategoryId(cat.id)}

--- a/src/pages/tu/mypage/UserNoticesPage.tsx
+++ b/src/pages/tu/mypage/UserNoticesPage.tsx
@@ -118,7 +118,7 @@ export function UserNoticesPage() {
                           <Badge className={typeConf.color}>{typeConf.label}</Badge>
                         </div>
                         <p className="text-sm text-text-secondary line-clamp-2">
-                          {notice.content.replaceAll(/<[^>]*>/g, '').substring(0, 150)}...
+                          {notice.content.replace(/<[^>]*>/g, '').substring(0, 150)}...
                         </p>
                       </div>
                       <div className="flex flex-col items-end gap-2 ml-4">

--- a/src/pages/tu/mypage/UserNoticesPage.tsx
+++ b/src/pages/tu/mypage/UserNoticesPage.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react';
+import {
+  Bell,
+  Pin,
+  Eye,
+  ChevronLeft,
+  ChevronRight,
+  Calendar,
+  Inbox,
+} from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Badge } from '@/components/common/Badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/common/Dialog';
+import { useUserNotices, useUserNotice } from '@/hooks/tu/useUserNoticeQueries';
+import type { TenantNotice, TenantNoticeType } from '@/types/ta/tenantNotice.types';
+
+// 공지 타입 설정
+const typeConfig: Record<TenantNoticeType, { label: string; color: string }> = {
+  GENERAL: { label: '일반', color: 'bg-gray-100 text-gray-700' },
+  IMPORTANT: { label: '중요', color: 'bg-blue-100 text-blue-700' },
+  URGENT: { label: '긴급', color: 'bg-red-100 text-red-700' },
+  EVENT: { label: '이벤트', color: 'bg-purple-100 text-purple-700' },
+};
+
+export function UserNoticesPage() {
+  const [page, setPage] = useState(0);
+  const [selectedNoticeId, setSelectedNoticeId] = useState<number | null>(null);
+
+  // API Hooks
+  const { data: noticesData, isLoading } = useUserNotices({ page, size: 10 });
+  const { data: selectedNotice } = useUserNotice(selectedNoticeId || 0);
+
+  const notices = noticesData?.content || [];
+  const totalPages = noticesData?.totalPages || 0;
+  const totalElements = noticesData?.totalElements || 0;
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return '-';
+    return new Date(dateString).toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  const handleViewNotice = (notice: TenantNotice) => {
+    setSelectedNoticeId(notice.id);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+          <div className="h-64 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      {/* Header */}
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold text-text-primary">공지사항</h1>
+        <p className="text-sm text-text-secondary mt-1">
+          관리자가 발송한 공지사항을 확인합니다
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Bell className="h-5 w-5 text-brand-primary" />
+            <div>
+              <CardTitle>공지사항</CardTitle>
+              <CardDescription>전체 {totalElements}개의 공지사항</CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {notices.length === 0 ? (
+            <div className="text-center py-12 text-text-secondary">
+              <Inbox className="h-12 w-12 mx-auto mb-4 opacity-50" />
+              <p>공지사항이 없습니다.</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {notices.map((notice) => {
+                const typeConf = typeConfig[notice.type] || typeConfig.GENERAL;
+
+                return (
+                  <div
+                    key={notice.id}
+                    role="button"
+                    tabIndex={0}
+                    className="p-4 border rounded-lg hover:bg-bg-secondary cursor-pointer transition-colors"
+                    onClick={() => handleViewNotice(notice)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        handleViewNotice(notice);
+                      }
+                    }}
+                  >
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2 mb-1">
+                          {notice.isPinned && (
+                            <Pin className="h-4 w-4 text-yellow-500 flex-shrink-0" />
+                          )}
+                          <h3 className="font-medium">{notice.title}</h3>
+                          <Badge className={typeConf.color}>{typeConf.label}</Badge>
+                        </div>
+                        <p className="text-sm text-text-secondary line-clamp-2">
+                          {notice.content.replaceAll(/<[^>]*>/g, '').substring(0, 150)}...
+                        </p>
+                      </div>
+                      <div className="flex flex-col items-end gap-2 ml-4">
+                        <span className="text-xs text-text-secondary flex items-center gap-1">
+                          <Calendar className="h-3 w-3" />
+                          {formatDate(notice.publishedAt || notice.createdAt)}
+                        </span>
+                        <Button variant="ghost" size="sm">
+                          <Eye className="h-4 w-4 mr-1" />
+                          보기
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 mt-6">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page === 0}
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <span className="text-sm">
+                {page + 1} / {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages - 1}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 상세 Dialog */}
+      <Dialog open={selectedNoticeId !== null} onOpenChange={() => setSelectedNoticeId(null)}>
+        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <div className="flex items-center gap-2">
+              {selectedNotice?.isPinned && <Pin className="h-4 w-4 text-yellow-500" />}
+              <DialogTitle>{selectedNotice?.title}</DialogTitle>
+            </div>
+          </DialogHeader>
+
+          {selectedNotice && (
+            <div className="mt-4">
+              <div className="flex items-center gap-3 mb-4">
+                <Badge className={typeConfig[selectedNotice.type]?.color || typeConfig.GENERAL.color}>
+                  {typeConfig[selectedNotice.type]?.label || '일반'}
+                </Badge>
+                <span className="text-sm text-text-secondary">
+                  {formatDate(selectedNotice.publishedAt || selectedNotice.createdAt)}
+                </span>
+              </div>
+
+              <div className="prose prose-sm max-w-none whitespace-pre-wrap">
+                {selectedNotice.content}
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/tu/mypage/index.ts
+++ b/src/pages/tu/mypage/index.ts
@@ -7,3 +7,4 @@ export { CompletedCoursesPage } from './CompletedCoursesPage';
 export { CertificationsPage } from './CertificationsPage';
 export { MyPostsPage } from './MyPostsPage';
 export { MyCommentsPage } from './MyCommentsPage';
+export { UserNoticesPage } from './UserNoticesPage';

--- a/src/routes/ta.routes.tsx
+++ b/src/routes/ta.routes.tsx
@@ -21,6 +21,8 @@ import {
   TenantSettingsPage,
   UserManagementSettingsPage,
   TenantNoticesPage,
+  SystemNoticesPage,
+  NoticeInboxPage,
 } from '@/pages/ta';
 import { EmployeeListPage } from '@/pages/ta/users/EmployeeListPage';
 import { AutoEnrollmentRulesPage } from '@/pages/ta/automation/AutoEnrollmentRulesPage';
@@ -61,7 +63,9 @@ const taChildRoutes = (
     <Route path="analytics/export" element={<ExportPage />} />
     <Route path="analytics/logs" element={<LogsPage />} />
     {/* 공지사항 관리 */}
-    <Route path="notices" element={<TenantNoticesPage />} />
+    <Route path="notices" element={<NoticeInboxPage />} />
+    <Route path="notices/manage" element={<TenantNoticesPage />} />
+    <Route path="notices/system" element={<SystemNoticesPage />} />
     {/* 설정 */}
     <Route path="settings" element={<SettingsPage />} />
     <Route path="settings/security" element={<SettingsSecurityPage />} />

--- a/src/routes/to.routes.tsx
+++ b/src/routes/to.routes.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/pages/to/program';
 import { InstructorAssignmentsPage } from '@/pages/to/instructor';
 import { UserManagementPage } from '@/pages/to/user';
-import { OperatorNoticesPage } from '@/pages/to/notices';
+import { OperatorNoticesPage, OperatorNoticeInboxPage } from '@/pages/to/notices';
 import { DashboardPage } from '@/pages/to';
 import MemberPoolListPage from '@/pages/to/member-pool/MemberPoolListPage';
 import AutoEnrollmentRulesPage from '@/pages/to/auto-enrollment/AutoEnrollmentRulesPage';
@@ -60,7 +60,8 @@ export const toRoutes = (
     {/* 자동 입과 규칙 관리 */}
     <Route path="auto-enrollment-rules" element={<AutoEnrollmentRulesPage />} />
     {/* 공지사항 관리 */}
-    <Route path="notices" element={<OperatorNoticesPage />} />
+    <Route path="notices" element={<OperatorNoticeInboxPage />} />
+    <Route path="notices/manage" element={<OperatorNoticesPage />} />
     {/* 설정 */}
     <Route path="settings" element={<SettingsPage />} />
     <Route path="settings/security" element={<SettingsSecurityPage />} />

--- a/src/routes/tu.mypage.routes.tsx
+++ b/src/routes/tu.mypage.routes.tsx
@@ -15,6 +15,7 @@ import {
   CertificationsPage,
   MyPostsPage,
   MyCommentsPage,
+  UserNoticesPage,
 } from '@/pages/tu';
 import {
   SettingsPage,
@@ -78,6 +79,7 @@ export const tuMyPageRoutes = (
     <Route path="teaching/stats" element={<TeachingStatsPage />} />
     <Route path="posts" element={<MyPostsPage />} />
     <Route path="comments" element={<MyCommentsPage />} />
+    <Route path="notices" element={<UserNoticesPage />} />
     <Route path="settings" element={<SettingsPage />} />
     <Route path="settings/security" element={<SettingsSecurityPage />} />
     <Route path="settings/notifications" element={<SettingsNotificationsPage />} />
@@ -103,6 +105,9 @@ export const tuMyPageRoutes = (
     {/* 커뮤니티 */}
     <Route path="posts" element={<MyPostsPage />} />
     <Route path="comments" element={<MyCommentsPage />} />
+
+    {/* 공지사항 */}
+    <Route path="notices" element={<UserNoticesPage />} />
 
     {/* 설정 */}
     <Route path="settings" element={<SettingsPage />} />

--- a/src/services/common/api/axiosInstance.ts
+++ b/src/services/common/api/axiosInstance.ts
@@ -1,6 +1,7 @@
 import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios';
 import { useAuthStore } from '@/store/common/authStore';
 import { API_ENDPOINTS } from './endpoints';
+import { extractTenantIdentifier } from '@/utils/tenantUtils';
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
@@ -29,12 +30,18 @@ const processQueue = (error: AxiosError | null, token: string | null = null) => 
   failedQueue = [];
 };
 
-// Request interceptor: 토큰 헤더 추가
+// Request interceptor: 토큰 및 서브도메인 헤더 추가
 axiosInstance.interceptors.request.use(
   (config) => {
     const accessToken = useAuthStore.getState().accessToken;
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+
+    // 서브도메인 헤더 추가 (테넌트 식별용)
+    const tenantIdentifier = extractTenantIdentifier();
+    if (tenantIdentifier?.type === 'subdomain') {
+      config.headers['X-Subdomain'] = tenantIdentifier.identifier;
     }
 
     // FormData인 경우 Content-Type을 제거하여 브라우저가 자동으로 multipart/form-data로 설정하도록 함

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -63,6 +63,7 @@ export const API_ENDPOINTS = {
     DESIGN: '/tenant/settings/design',
     LAYOUT: '/tenant/settings/layout',
     BRANDING: '/tenant/settings/branding',
+    BRANDING_EXTENDED: '/tenant/settings/branding/extended',
     USER_MANAGEMENT: '/tenant/settings/user-management',
     // Navigation
     NAVIGATION: '/tenant/settings/navigation',

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -91,6 +91,17 @@ export const API_ENDPOINTS = {
     DISTRIBUTE: (id: number) => `/sa/notices/${id}/distribute`,
     DISTRIBUTE_ALL: (id: number) => `/sa/notices/${id}/distribute-all`,
     TENANTS: (id: number) => `/sa/notices/${id}/tenants`,
+    // 배포 통계
+    DISTRIBUTIONS: '/sa/notices/distributions',
+    DISTRIBUTIONS_SUMMARY: '/sa/notices/distributions/summary',
+    DISTRIBUTION_BY_ID: (id: number) => `/sa/notices/${id}/distributions`,
+  },
+
+  // System Notices for TA (TA가 받은 SA 공지)
+  SYSTEM_NOTICES_FOR_TA: {
+    BASE: '/ta/notices',
+    BY_ID: (id: number) => `/ta/notices/${id}`,
+    MARK_READ: (id: number) => `/ta/notices/${id}/read`,
   },
 
   // Categories (TO)

--- a/src/services/sa/noticeService.ts
+++ b/src/services/sa/noticeService.ts
@@ -10,6 +10,9 @@ import type {
   CreateNoticeRequest,
   UpdateNoticeRequest,
   DistributeNoticeRequest,
+  NoticeDistributionStatsResponse,
+  NoticeDistributionSummary,
+  NoticeDistributionStats,
 } from '@/types/admin';
 
 export const noticeService = {
@@ -83,6 +86,35 @@ export const noticeService = {
   async getDistributedTenants(id: number): Promise<number[]> {
     const { data } = await axiosInstance.get<number[]>(
       API_ENDPOINTS.NOTICES.TENANTS(id)
+    );
+    return data;
+  },
+
+  // ============================================
+  // 배포 통계 API
+  // ============================================
+
+  /** 배포 통계 목록 조회 */
+  async getDistributionStats(params?: { page?: number; size?: number }): Promise<NoticeDistributionStatsResponse> {
+    const { data } = await axiosInstance.get<NoticeDistributionStatsResponse>(
+      API_ENDPOINTS.NOTICES.DISTRIBUTIONS,
+      { params }
+    );
+    return data;
+  },
+
+  /** 배포 통계 요약 조회 */
+  async getDistributionSummary(): Promise<NoticeDistributionSummary> {
+    const { data } = await axiosInstance.get<NoticeDistributionSummary>(
+      API_ENDPOINTS.NOTICES.DISTRIBUTIONS_SUMMARY
+    );
+    return data;
+  },
+
+  /** 특정 공지 배포 상세 조회 */
+  async getDistributionStatsForNotice(id: number): Promise<NoticeDistributionStats> {
+    const { data } = await axiosInstance.get<NoticeDistributionStats>(
+      API_ENDPOINTS.NOTICES.DISTRIBUTION_BY_ID(id)
     );
     return data;
   },

--- a/src/services/ta/brandingService.ts
+++ b/src/services/ta/brandingService.ts
@@ -15,6 +15,7 @@ import type {
   ResponsiveSettings,
   UpdateDesignSettingsRequest,
   UpdateLayoutSettingsRequest,
+  UpdateExtendedBrandingRequest,
 } from '@/types/admin';
 
 // Re-export types for consumers
@@ -30,6 +31,7 @@ export type {
   ResponsiveSettings,
   UpdateDesignSettingsRequest,
   UpdateLayoutSettingsRequest,
+  UpdateExtendedBrandingRequest,
 };
 
 // ============================================
@@ -54,6 +56,12 @@ export interface TenantSettingsResponse {
   sidebarSettings: SidebarSettings;
   footerSettings: FooterSettings;
   contentSettings: ContentSettings;
+  // 확장 브랜딩 설정
+  companyName: string | null;
+  bannerSettings: Record<string, unknown> | null;
+  landingPageSettings: Record<string, unknown> | null;
+  sidebarTUSettings: Record<string, unknown> | null;
+  sidebarTOSettings: Record<string, unknown> | null;
   // 확장 UI 설정
   typographySettings: TypographySettings | null;
   colorModeSettings: ColorModeSettings | null;
@@ -132,6 +140,15 @@ export const brandingService = {
   async updateLayoutSettings(request: UpdateLayoutSettingsRequest): Promise<TenantSettingsResponse> {
     const { data } = await axiosInstance.put<TenantSettingsResponse>(
       API_ENDPOINTS.TENANT_SETTINGS.LAYOUT,
+      request
+    );
+    return data;
+  },
+
+  /** 확장 브랜딩 설정 업데이트 (배너, 랜딩페이지, 사이드바 TU/TO) */
+  async updateExtendedBrandingSettings(request: UpdateExtendedBrandingRequest): Promise<TenantSettingsResponse> {
+    const { data } = await axiosInstance.put<TenantSettingsResponse>(
+      API_ENDPOINTS.TENANT_SETTINGS.BRANDING_EXTENDED,
       request
     );
     return data;

--- a/src/types/admin/notice.types.ts
+++ b/src/types/admin/notice.types.ts
@@ -55,3 +55,47 @@ export interface UpdateNoticeRequest {
 export interface DistributeNoticeRequest {
   tenantIds: number[];
 }
+
+// ============================================
+// 배포 통계 타입
+// ============================================
+
+export interface TenantDistributionInfo {
+  tenantId: number;
+  tenantName: string;
+  tenantCode: string;
+  isRead: boolean;
+  distributedAt: string;
+  readAt: string | null;
+}
+
+export interface NoticeDistributionStats {
+  noticeId: number;
+  noticeTitle: string;
+  noticeType: NoticeType;
+  noticeStatus: NoticeStatus;
+  isPinned: boolean;
+  totalTenants: number;
+  sentCount: number;
+  readCount: number;
+  publishedAt: string | null;
+  createdAt: string;
+  tenantDistributions: TenantDistributionInfo[];
+}
+
+export interface NoticeDistributionStatsResponse {
+  content: NoticeDistributionStats[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+}
+
+export interface NoticeDistributionSummary {
+  totalDistributions: number;
+  completedCount: number;
+  inProgressCount: number;
+  totalTenants: number;
+  totalReadCount: number;
+  averageReadRate: number;
+}

--- a/src/types/admin/tenantSettings.types.ts
+++ b/src/types/admin/tenantSettings.types.ts
@@ -129,6 +129,13 @@ export interface TenantSettingsDetail {
   footerSettings: FooterSettings | null;
   contentSettings: ContentSettings | null;
 
+  // Extended Branding Settings
+  companyName: string | null;
+  bannerSettings: Record<string, unknown> | null;
+  landingPageSettings: Record<string, unknown> | null;
+  sidebarTUSettings: Record<string, unknown> | null;
+  sidebarTOSettings: Record<string, unknown> | null;
+
   // Extended UI Settings
   typographySettings: TypographySettings | null;
   colorModeSettings: ColorModeSettings | null;
@@ -248,4 +255,80 @@ export interface NavigationItemRequest {
   enabled?: boolean;
   displayOrder?: number;
   target?: string;
+}
+
+// ============================================
+// 확장 브랜딩 설정 타입
+// ============================================
+
+// 배너 아이템
+export interface BannerItem {
+  id: string;
+  type: 'image' | 'code';
+  imageUrl: string | null;
+  code: string;
+  title: string;
+  order: number;
+}
+
+// 배너 설정
+export interface BannerSettings {
+  enabled: boolean;
+  items: BannerItem[];
+}
+
+// 랜딩 페이지 카테고리 설정
+export interface LandingCategorySettings {
+  enabled: boolean;
+  items: string[];
+  sectionTitle: string;
+}
+
+// 강좌 섹션 아이템
+export interface CourseSectionItem {
+  id: string;
+  title: string;
+}
+
+// 강좌 섹션 설정
+export interface CourseSectionsSettings {
+  enabled: boolean;
+  items: CourseSectionItem[];
+}
+
+// 랜딩 페이지 설정
+export interface LandingPageSettings {
+  landingCategory: LandingCategorySettings;
+  courseSections: CourseSectionsSettings;
+}
+
+// 사이드바 메뉴 아이템
+export interface SidebarMenuItem {
+  id: string;
+  label: string;
+  url: string;
+  icon: string;
+  visible: boolean;
+  children?: {
+    id: string;
+    label: string;
+    url: string;
+    icon?: string;
+    visible: boolean;
+  }[];
+}
+
+// TU/TO 사이드바 설정
+export interface SidebarRoleSettings {
+  enabled: boolean;
+  items: SidebarMenuItem[];
+}
+
+// 확장 브랜딩 설정 요청 타입
+export interface UpdateExtendedBrandingRequest {
+  companyName?: string;
+  bannerSettings?: BannerSettings;
+  landingPageSettings?: LandingPageSettings;
+  sidebarTUSettings?: SidebarRoleSettings;
+  sidebarTOSettings?: SidebarRoleSettings;
 }

--- a/src/types/tu/branding.types.ts
+++ b/src/types/tu/branding.types.ts
@@ -83,4 +83,89 @@ export interface PublicLayoutResponse {
   footerSettings: FooterSettings | null;
   contentSettings: ContentSettings | null;
   navigationItems: NavigationItemResponse[];
+  // 확장 브랜딩 설정
+  companyName: string | null;
+  bannerSettings: BannerSettings | null;
+  landingPageSettings: LandingPageSettings | null;
+  sidebarTUSettings: SidebarRoleSettings | null;
+  sidebarTOSettings: SidebarRoleSettings | null;
+}
+
+/**
+ * 배너 아이템 타입
+ */
+export interface BannerItem {
+  id: string;
+  type: 'image' | 'code';
+  imageUrl: string | null;
+  code: string;
+  title: string;
+  order: number;
+}
+
+/**
+ * 배너 설정 타입
+ */
+export interface BannerSettings {
+  enabled: boolean;
+  items: BannerItem[];
+}
+
+/**
+ * 랜딩 카테고리 설정 타입
+ */
+export interface LandingCategorySettings {
+  enabled: boolean;
+  items: string[];
+  sectionTitle: string;
+}
+
+/**
+ * 강좌 섹션 아이템 타입
+ */
+export interface CourseSectionItem {
+  id: string;
+  title: string;
+}
+
+/**
+ * 강좌 섹션 설정 타입
+ */
+export interface CourseSectionsSettings {
+  enabled: boolean;
+  items: CourseSectionItem[];
+}
+
+/**
+ * 랜딩 페이지 설정 타입
+ */
+export interface LandingPageSettings {
+  landingCategory: LandingCategorySettings;
+  courseSections: CourseSectionsSettings;
+}
+
+/**
+ * 사이드바 메뉴 아이템 타입
+ */
+export interface SidebarMenuItem {
+  id: string;
+  label: string;
+  url: string;
+  icon: string;
+  visible: boolean;
+  children?: {
+    id: string;
+    label: string;
+    url: string;
+    icon?: string;
+    visible: boolean;
+  }[];
+}
+
+/**
+ * TU/TO 사이드바 설정 타입
+ */
+export interface SidebarRoleSettings {
+  enabled: boolean;
+  items: SidebarMenuItem[];
 }


### PR DESCRIPTION
## Summary

TA 브랜딩 설정과 TU/TO 페이지 연동 기능을 구현했습니다. TA에서 설정한 배너, 카테고리, 푸터 등의 브랜딩이 해당 서브도메인의 TU 랜딩 페이지에 적용됩니다.

## Related Issue

- Closes #

## Changes

- X-Subdomain 헤더를 통한 테넌트 식별 추가 (axiosInstance)
- 확장 브랜딩 설정 API 연동 (배너, 랜딩페이지, 사이드바)
- HeroSection에서 브랜딩 배너 표시 지원 (이미지/코드 타입)
- 기본 배너 3개 설정 (Empower Your Future, Build Your Career, Master Cloud)
- LandingHeader, LandingFooter에 브랜딩 설정 적용
- 브랜딩 설정 페이지 초기화 버튼 항상 활성화
- PublicLayout API에서 배너 설정 기본값 적용

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)



## Additional Notes

- 서브도메인별로 브랜딩이 격리되어 적용됩니다
- 백엔드 PR과 함께 머지되어야 합니다
