### PR TITLE
feat: 콘텐츠 등록 페이지 UI/UX 개선

### DIFF
--- a/src/components/domain/tu/content/ContentPreviewModal.tsx
+++ b/src/components/domain/tu/content/ContentPreviewModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo } from 'react';
-import { Loader2, ExternalLink, Download, AlertCircle, FileText, Lock } from 'lucide-react';
+import { Loader2, ExternalLink, Download, AlertCircle, FileText } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -16,7 +16,6 @@ interface ContentPreviewModalProps {
   contentId: number | null;
   contentType: ContentType | null;
   fileName?: string;
-  downloadable?: boolean;
 }
 
 export function ContentPreviewModal({
@@ -25,7 +24,6 @@ export function ContentPreviewModal({
   contentId,
   contentType,
   fileName,
-  downloadable = true,
 }: Readonly<ContentPreviewModalProps>) {
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
 
@@ -78,22 +76,6 @@ export function ContentPreviewModal({
 
   // 콘텐츠 타입에 따른 렌더링
   const renderContent = useMemo(() => {
-    // 다운로드 비허용 콘텐츠는 미리보기 제한
-    if (!downloadable && contentType !== 'EXTERNAL_LINK') {
-      return (
-        <div className="flex flex-col items-center justify-center py-12 space-y-4">
-          <Lock className="w-16 h-16 text-text-secondary" />
-          <p className="text-text-primary text-lg font-medium">{fileName}</p>
-          <p className="text-text-secondary text-sm text-center">
-            이 콘텐츠는 미리보기가 제한되어 있습니다.
-          </p>
-          <p className="text-text-tertiary text-xs text-center">
-            학습 페이지에서 콘텐츠를 확인하세요.
-          </p>
-        </div>
-      );
-    }
-
     if (contentType === 'EXTERNAL_LINK') {
       return (
         <div className="flex flex-col items-center justify-center py-12 space-y-4">
@@ -183,14 +165,12 @@ export function ContentPreviewModal({
                 title={fileName || 'PDF 미리보기'}
                 className="w-full h-[70vh] border-0 rounded-lg"
               />
-              {downloadable && (
-                <div className="flex justify-end gap-2">
-                  <Button variant="ghost" className="border border-border" onClick={handleDownload}>
-                    <Download size={16} />
-                    다운로드
-                  </Button>
-                </div>
-              )}
+              <div className="flex justify-end gap-2">
+                <Button variant="ghost" className="border border-border" onClick={handleDownload}>
+                  <Download size={16} />
+                  다운로드
+                </Button>
+              </div>
             </div>
           );
         }
@@ -202,12 +182,10 @@ export function ContentPreviewModal({
             <p className="text-text-secondary text-sm">
               이 문서 형식은 미리보기를 지원하지 않습니다.
             </p>
-            {downloadable && (
-              <Button onClick={handleDownload}>
-                <Download size={16} />
-                다운로드
-              </Button>
-            )}
+            <Button onClick={handleDownload}>
+              <Download size={16} />
+              다운로드
+            </Button>
           </div>
         );
 
@@ -219,7 +197,7 @@ export function ContentPreviewModal({
           </div>
         );
     }
-  }, [contentType, isLoading, error, blobUrl, previewData, contentDetail, fileName, downloadable]);
+  }, [contentType, isLoading, error, blobUrl, previewData, contentDetail, fileName]);
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>

--- a/src/components/domain/tu/content/ContentRegistrationWizard.tsx
+++ b/src/components/domain/tu/content/ContentRegistrationWizard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ArrowLeft, ArrowRight, Save, FileText, Upload } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Upload } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button } from '@/components/common';
 import type { LOData } from '@/types';
@@ -15,11 +15,9 @@ interface ContentRegistrationWizardProps {
 
 const t = {
   title: { ko: '콘텐츠 등록', en: 'Create Content' },
-  loadTemplate: { ko: '템플릿 불러오기', en: 'Load Template' },
   close: { ko: '닫기', en: 'Close' },
   previous: { ko: '이전', en: 'Previous' },
   next: { ko: '다음', en: 'Next' },
-  saveDraft: { ko: '임시저장', en: 'Save Draft' },
   submit: { ko: '발행하기', en: 'Publish' },
   step1: { ko: '콘텐츠 정의', en: 'Content Definition' },
   step2: { ko: '파일 업로드', en: 'File Upload' },
@@ -66,15 +64,6 @@ export function ContentRegistrationWizard({
     }
   };
 
-  const handleSaveDraft = () => {
-    console.log('Saving draft:', formData);
-    alert('임시저장되었습니다.');
-  };
-
-  const handleLoadTemplate = () => {
-    alert('템플릿 불러오기 기능은 추후 구현됩니다.');
-  };
-
   const handleSubmit = () => {
     if (!validateCurrentStep()) {
       return;
@@ -89,16 +78,8 @@ export function ContentRegistrationWizard({
         alert('콘텐츠 제목을 입력해주세요.');
         return false;
       }
-      if (!formData.description.trim()) {
-        alert('간략 설명을 입력해주세요.');
-        return false;
-      }
       if (!formData.loType) {
         alert('콘텐츠 유형을 선택해주세요.');
-        return false;
-      }
-      if (!formData.category) {
-        alert('카테고리를 선택해주세요.');
         return false;
       }
     }
@@ -154,10 +135,6 @@ export function ContentRegistrationWizard({
         <div className="max-w-5xl mx-auto flex justify-between items-center">
           <h1 className="text-text-primary m-0">{getText('title')}</h1>
           <div className="flex gap-3 items-center">
-            <Button variant="ghost" onClick={handleLoadTemplate} className="border border-border">
-              <FileText size={16} />
-              {getText('loadTemplate')}
-            </Button>
             <Button variant="ghost" onClick={onBack} className="border border-border">
               {getText('close')}
             </Button>
@@ -210,10 +187,6 @@ export function ContentRegistrationWizard({
                 {getText('previous')}
               </Button>
             )}
-            <Button variant="ghost" onClick={handleSaveDraft} className="border border-border">
-              <Save size={18} />
-              {getText('saveDraft')}
-            </Button>
           </div>
 
           <div>

--- a/src/components/domain/tu/content/Step1ContentDefinition.tsx
+++ b/src/components/domain/tu/content/Step1ContentDefinition.tsx
@@ -111,7 +111,7 @@ export function Step1ContentDefinition({ data, onUpdate }: Readonly<Step1Props>)
           {/* 간략 설명 */}
           <div>
             <label className="block text-sm font-medium text-text-primary mb-1">
-              간략 설명 <span className="text-status-error">*</span>
+              간략 설명
             </label>
             <Textarea
               value={data.description}
@@ -172,7 +172,7 @@ export function Step1ContentDefinition({ data, onUpdate }: Readonly<Step1Props>)
           {/* 카테고리 드롭다운 */}
           <div>
             <label className="block text-sm font-medium text-text-primary mb-1">
-              카테고리 <span className="text-status-error">*</span>
+              카테고리
             </label>
             <NativeSelect
               value={data.category || ''}
@@ -225,53 +225,55 @@ export function Step1ContentDefinition({ data, onUpdate }: Readonly<Step1Props>)
         </div>
       </div>
 
-      {/* 미리보기 이미지 업로드 */}
-      <div>
-        <h2 className="text-text-primary mb-4">미리보기 이미지 (썸네일)</h2>
+      {/* 미리보기 이미지 업로드 - 동영상만 표시 */}
+      {data.loType === 'video' && (
+        <div>
+          <h2 className="text-text-primary mb-4">미리보기 이미지 (썸네일)</h2>
 
-        {!data.thumbnailImage ? (
-          <div
-            onClick={() => thumbnailInputRef.current?.click()}
-            className="border-2 border-dashed border-border rounded-lg p-8 text-center cursor-pointer hover:border-action-primary hover:bg-bg-secondary transition-all"
-          >
-            <div className="flex flex-col items-center">
-              <div className="w-16 h-16 rounded-full bg-bg-secondary flex items-center justify-center mb-3">
-                <ImageIcon className="w-8 h-8 text-text-secondary" />
+          {!data.thumbnailImage ? (
+            <div
+              onClick={() => thumbnailInputRef.current?.click()}
+              className="border-2 border-dashed border-border rounded-lg p-8 text-center cursor-pointer hover:border-action-primary hover:bg-bg-secondary transition-all"
+            >
+              <div className="flex flex-col items-center">
+                <div className="w-16 h-16 rounded-full bg-bg-secondary flex items-center justify-center mb-3">
+                  <ImageIcon className="w-8 h-8 text-text-secondary" />
+                </div>
+                <p className="text-text-primary mb-1">이미지를 선택하세요</p>
+                <p className="text-xs text-text-secondary">권장 크기: 1200x630px | JPG, PNG (최대 5MB)</p>
               </div>
-              <p className="text-text-primary mb-1">이미지를 선택하세요</p>
-              <p className="text-xs text-text-secondary">권장 크기: 1200x630px | JPG, PNG (최대 5MB)</p>
+              <input
+                ref={thumbnailInputRef}
+                type="file"
+                onChange={handleThumbnailUpload}
+                accept="image/jpeg,image/png"
+                className="hidden"
+              />
             </div>
-            <input
-              ref={thumbnailInputRef}
-              type="file"
-              onChange={handleThumbnailUpload}
-              accept="image/jpeg,image/png"
-              className="hidden"
-            />
-          </div>
-        ) : (
-          <div className="border border-border rounded-lg p-4 bg-bg-secondary">
-            <div className="flex items-center gap-4">
-              <div className="w-20 h-20 rounded-lg bg-bg-default border border-border flex items-center justify-center flex-shrink-0 overflow-hidden">
-                <img
-                  src={URL.createObjectURL(data.thumbnailImage)}
-                  alt="Thumbnail"
-                  className="w-full h-full object-cover"
-                />
+          ) : (
+            <div className="border border-border rounded-lg p-4 bg-bg-secondary">
+              <div className="flex items-center gap-4">
+                <div className="w-20 h-20 rounded-lg bg-bg-default border border-border flex items-center justify-center flex-shrink-0 overflow-hidden">
+                  <img
+                    src={URL.createObjectURL(data.thumbnailImage)}
+                    alt="Thumbnail"
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-text-primary mb-1 truncate">{data.thumbnailImage.name}</p>
+                  <p className="text-sm text-text-secondary">
+                    {(data.thumbnailImage.size / 1024 / 1024).toFixed(2)} MB
+                  </p>
+                </div>
+                <Button type="button" variant="ghost" onClick={handleRemoveThumbnail} className="border border-border">
+                  <X className="w-5 h-5" />
+                </Button>
               </div>
-              <div className="flex-1 min-w-0">
-                <p className="text-text-primary mb-1 truncate">{data.thumbnailImage.name}</p>
-                <p className="text-sm text-text-secondary">
-                  {(data.thumbnailImage.size / 1024 / 1024).toFixed(2)} MB
-                </p>
-              </div>
-              <Button type="button" variant="ghost" onClick={handleRemoveThumbnail} className="border border-border">
-                <X className="w-5 h-5" />
-              </Button>
             </div>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/tu/teaching/content/ContentDetailPage.tsx
+++ b/src/pages/tu/teaching/content/ContentDetailPage.tsx
@@ -433,17 +433,15 @@ export function ContentDetailPage({ language = 'ko' }: Readonly<ContentDetailPag
                       <Eye size={16} className="mr-2" />
                       {getText('preview')}
                     </Button>
-                    {content.downloadable !== false && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="text-gray-600 border-gray-200 hover:bg-gray-50"
-                        onClick={handleDownload}
-                      >
-                        <Download size={16} className="mr-2" />
-                        {getText('download')}
-                      </Button>
-                    )}
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="text-gray-600 border-gray-200 hover:bg-gray-50"
+                      onClick={handleDownload}
+                    >
+                      <Download size={16} className="mr-2" />
+                      {getText('download')}
+                    </Button>
                   </>
                 )}
 
@@ -730,7 +728,6 @@ export function ContentDetailPage({ language = 'ko' }: Readonly<ContentDetailPag
         contentId={contentId}
         contentType={content.contentType}
         fileName={content.originalFileName}
-        downloadable={content.downloadable ?? true}
       />
     </div>
   );

--- a/src/pages/tu/teaching/content/MyContentPage.tsx
+++ b/src/pages/tu/teaching/content/MyContentPage.tsx
@@ -22,11 +22,12 @@ import {
   X,
   Folder,
   FolderInput,
+  Download,
 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button, Badge, ViewToggle, DataTable, DataTableColumnHeader, IconStatCard, Checkbox } from '@/components/common';
 import { useMyContents, useDeleteContent, useArchiveContent, useRestoreContent, useContentFolderTree } from '@/hooks/tu';
-import { learningObjectService } from '@/services/tu';
+import { learningObjectService, contentService } from '@/services/tu';
 import {
   ContentCard,
   ContentPreviewModal,
@@ -100,6 +101,7 @@ const t = {
   deselectAll: { ko: '선택 해제', en: 'Deselect All' },
   moveFailed: { ko: '일부 콘텐츠 이동에 실패했습니다.', en: 'Failed to move some contents.' },
   moveSuccess: { ko: '콘텐츠가 이동되었습니다.', en: 'Contents moved successfully.' },
+  download: { ko: '다운로드', en: 'Download' },
 };
 
 export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>) {
@@ -119,8 +121,7 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
     contentId: number | null;
     contentType: ContentType | null;
     fileName: string | null;
-    downloadable: boolean;
-  }>({ isOpen: false, contentId: null, contentType: null, fileName: null, downloadable: true });
+  }>({ isOpen: false, contentId: null, contentType: null, fileName: null });
 
   // 폴더 관리 패널 상태
   const [isFolderPanelOpen, setIsFolderPanelOpen] = useState(false);
@@ -204,12 +205,20 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
       contentId: content.id,
       contentType: content.contentType,
       fileName: content.originalFileName,
-      downloadable: content.downloadable ?? true,
     });
   };
 
+  const handleDownload = async (content: ContentListResponse) => {
+    try {
+      await contentService.downloadFile(content.id, content.originalFileName);
+    } catch (err) {
+      console.error('Download failed:', err);
+      alert(getText('error'));
+    }
+  };
+
   const handleClosePreview = () => {
-    setPreviewModal({ isOpen: false, contentId: null, contentType: null, fileName: null, downloadable: true });
+    setPreviewModal({ isOpen: false, contentId: null, contentType: null, fileName: null });
   };
 
   // 콘텐츠 선택 핸들러
@@ -350,6 +359,14 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
             >
               <Eye size={16} />
             </button>
+            {item.contentType !== 'EXTERNAL_LINK' && (
+              <button
+                onClick={() => handleDownload(item)}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-border rounded-lg text-sm text-text-primary hover:bg-bg-secondary transition-colors"
+              >
+                <Download size={16} />
+              </button>
+            )}
             {item.status === 'ARCHIVED' ? (
               <button
                 onClick={() => handleRestore(item.id)}
@@ -658,7 +675,6 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
         contentId={previewModal.contentId}
         contentType={previewModal.contentType}
         fileName={previewModal.fileName ?? undefined}
-        downloadable={previewModal.downloadable}
       />
 
       {/* 폴더 관리 슬라이드 패널 */}


### PR DESCRIPTION
## Summary
- 콘텐츠 다운로드 버튼에서 `downloadable` 필드 체크 제거
- 콘텐츠 미리보기 모달에서 `downloadable` 필드 체크 제거 (모든 콘텐츠 미리보기/다운로드 가능)
- Step1 콘텐츠 정의 화면에서 간략 설명, 카테고리 필드의 필수 표시(*) 제거

## Changed Files
- `MyContentPage.tsx`: 다운로드 버튼 조건 및 미리보기 모달 state에서 downloadable 제거
- `ContentPreviewModal.tsx`: downloadable prop 및 관련 제한 UI 제거
- `Step1ContentDefinition.tsx`: 비필수 필드 필수 마커 제거

Closes #391