### PR TITLE
Feat:paid mode toggle

### DIFF
--- a/src/components/landing/LandingCourseCard.tsx
+++ b/src/components/landing/LandingCourseCard.tsx
@@ -3,6 +3,7 @@ import { Star, Heart, Loader2, Calendar, Users } from 'lucide-react';
 import { useAuthStore } from '@/store/common/authStore';
 import { useSubdomainPath } from '@/hooks/common';
 import { useCheckWishlistStatus, useToggleWishlist } from '@/hooks/tu';
+import { useTenantFeatures } from '@/contexts/TenantFeaturesContext';
 import { toast } from 'sonner';
 
 interface LandingCourseCardProps {
@@ -51,6 +52,8 @@ export function LandingCourseCard({
   const navigate = useNavigate();
   const { prefixPath } = useSubdomainPath();
   const { isAuthenticated } = useAuthStore();
+  const { isFeatureEnabled } = useTenantFeatures();
+  const paidModeEnabled = isFeatureEnabled('paidModeEnabled');
 
   // 찜 상태 확인 및 토글
   const { data: isWishlisted = false, isLoading: isWishlistChecking } = useCheckWishlistStatus(
@@ -194,7 +197,8 @@ export function LandingCourseCard({
 
         {/* 하단 푸터 (가격 + 참여자 수) */}
         <div className="px-4 pb-4 flex items-center justify-between">
-          {price ? (
+          {/* 유료 모드일 때만 가격 표시 */}
+          {paidModeEnabled && price ? (
             <span className="font-bold text-[#6778ff] text-lg">{price}</span>
           ) : (
             <span />

--- a/src/components/landing/LandingFooter.tsx
+++ b/src/components/landing/LandingFooter.tsx
@@ -11,7 +11,25 @@ export function LandingFooter() {
 
   // 푸터 설정
   const footerSettings = layoutData?.footerSettings;
-  const socialLinks = footerSettings?.socialLinks;
+  const rawSocialLinks = footerSettings?.socialLinks as Record<string, { enabled?: boolean; url?: string } | string> | undefined;
+
+  // socialLinks 구조 통일 (TA에서 { enabled, url } 형식으로 저장)
+  const socialLinks = rawSocialLinks ? {
+    twitter: typeof rawSocialLinks.twitter === 'object' && rawSocialLinks.twitter?.enabled ? rawSocialLinks.twitter.url : (typeof rawSocialLinks.twitter === 'string' ? rawSocialLinks.twitter : undefined),
+    youtube: typeof rawSocialLinks.youtube === 'object' && rawSocialLinks.youtube?.enabled ? rawSocialLinks.youtube.url : (typeof rawSocialLinks.youtube === 'string' ? rawSocialLinks.youtube : undefined),
+    instagram: typeof rawSocialLinks.instagram === 'object' && rawSocialLinks.instagram?.enabled ? rawSocialLinks.instagram.url : (typeof rawSocialLinks.instagram === 'string' ? rawSocialLinks.instagram : undefined),
+    linkedin: typeof rawSocialLinks.linkedin === 'object' && rawSocialLinks.linkedin?.enabled ? rawSocialLinks.linkedin.url : (typeof rawSocialLinks.linkedin === 'string' ? rawSocialLinks.linkedin : undefined),
+    facebook: typeof rawSocialLinks.facebook === 'object' && rawSocialLinks.facebook?.enabled ? rawSocialLinks.facebook.url : (typeof rawSocialLinks.facebook === 'string' ? rawSocialLinks.facebook : undefined),
+  } : undefined;
+
+  // 회사 정보
+  const companyInfo = footerSettings?.companyInfo as { ceo?: string; businessNo?: string; address?: string; phone?: string } | undefined;
+
+  // 법적 링크
+  const legalLinks = footerSettings?.legalLinks as { label: string; url: string }[] | undefined;
+
+  // 저작권 정보
+  const copyright = footerSettings?.copyright as string | undefined;
 
   // 푸터가 비활성화되어 있으면 렌더링하지 않음
   if (footerSettings?.enabled === false) {
@@ -29,10 +47,10 @@ export function LandingFooter() {
                 <span className="text-2xl font-bold gradient-text">{tenantName}</span>
               </div>
               <div className="text-[12px] landing-text-muted leading-relaxed space-y-1">
-                <p>{t.footer.company} | {t.footer.ceo}</p>
-                <p>{t.footer.businessNo}</p>
-                <p>{t.footer.address}</p>
-                <p>{t.footer.phone}</p>
+                <p>{tenantName} | 대표: {companyInfo?.ceo || t.footer.ceo}</p>
+                <p>사업자등록번호: {companyInfo?.businessNo || t.footer.businessNo}</p>
+                <p>{companyInfo?.address || t.footer.address}</p>
+                <p>대표전화: {companyInfo?.phone || t.footer.phone}</p>
               </div>
             </div>
 
@@ -129,19 +147,29 @@ export function LandingFooter() {
         {/* Bottom Section - Legal */}
         <div className="landing-border-top pt-6 flex flex-col md:flex-row justify-between items-center gap-4">
           <div className="flex flex-wrap gap-6 text-[12px] landing-text-muted">
-            <a href="#" className="landing-link-hover transition-colors">
-              {t.footer.privacyPolicy}
-            </a>
-            <a href="#" className="landing-link-hover transition-colors">
-              {t.footer.terms}
-            </a>
-            <a href="#" className="landing-link-hover transition-colors">
-              {t.footer.emailPolicy}
-            </a>
+            {legalLinks && legalLinks.length > 0 ? (
+              legalLinks.map((link, index) => (
+                <a key={index} href={link.url || '#'} className="landing-link-hover transition-colors">
+                  {link.label}
+                </a>
+              ))
+            ) : (
+              <>
+                <a href="/privacy" className="landing-link-hover transition-colors">
+                  {t.footer.privacyPolicy}
+                </a>
+                <a href="/terms" className="landing-link-hover transition-colors">
+                  {t.footer.terms}
+                </a>
+                <a href="/email-policy" className="landing-link-hover transition-colors">
+                  {t.footer.emailPolicy}
+                </a>
+              </>
+            )}
           </div>
           {footerSettings?.showCopyright !== false && (
             <p className="text-[12px] landing-text-muted">
-              &copy; {new Date().getFullYear()} {tenantName}. All rights reserved.
+              {copyright || `© ${new Date().getFullYear()} ${tenantName}. All rights reserved.`}
             </p>
           )}
         </div>

--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -7,6 +7,7 @@ import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation } from '@/store/common/languageStore';
 import { useUnreadNotificationCount, usePublicNavigation, usePublicLayout } from '@/hooks/tu';
 import { useTenantBranding } from '@/contexts/TenantBrandingContext';
+import { useTenantFeatures } from '@/contexts/TenantFeaturesContext';
 import type { NavigationItemResponse } from '@/types/tu/branding.types';
 
 // 기본 네비게이션 메뉴 (fallback)
@@ -32,6 +33,7 @@ export function LandingHeader() {
   const { branding } = useTenantBranding();
   const { data: navigationItems } = usePublicNavigation();
   const { data: layoutData } = usePublicLayout();
+  const { isFeatureEnabled } = useTenantFeatures();
 
   // 네비게이션 메뉴 (TA 설정 또는 기본값)
   // headerSettings.navLinks가 있으면 그것을 사용 (visible 필터링), 없으면 API 데이터 사용
@@ -59,8 +61,16 @@ export function LandingHeader() {
   const showSearch = headerSettings?.showSearch !== false; // 기본값 true
   const showNotifications = headerSettings?.showNotifications !== false; // 기본값 true
   const showThemeToggle = headerSettings?.showThemeToggle !== false; // 기본값 true
-  const showCart = headerSettings?.showCart !== false; // 기본값 true
-  const showWishlist = headerSettings?.showWishlist !== false; // 기본값 true
+  // 유료 모드 확인
+  const paidModeEnabled = isFeatureEnabled('paidModeEnabled');
+  // 장바구니/위시리스트: 레이아웃 설정 + 기능 설정 + 유료모드 모두 확인
+  // 무료 모드(paidModeEnabled=false)면 장바구니 숨김
+  const showCart = (headerSettings?.showCart !== false) && isFeatureEnabled('cartEnabled') && paidModeEnabled;
+  const showWishlist = (headerSettings?.showWishlist !== false) && isFeatureEnabled('wishlistEnabled');
+  // 커뮤니티 기능 확인
+  const communityEnabled = isFeatureEnabled('communityEnabled');
+  // 사용자 강의 생성 기능 확인
+  const userCourseCreationEnabled = isFeatureEnabled('userCourseCreationEnabled');
 
   // API Base URL
   const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api').replace('/api', '');
@@ -133,7 +143,15 @@ export function LandingHeader() {
 
             {/* Desktop Nav Links */}
             <nav className={`hidden md:flex items-center gap-8 font-medium text-[15px] ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
-              {navItems.map((item) => {
+              {navItems
+                .filter((item) => {
+                  // 커뮤니티 링크는 communityEnabled가 false면 숨김
+                  if (item.path.includes('/community') && !communityEnabled) {
+                    return false;
+                  }
+                  return true;
+                })
+                .map((item) => {
                 const isExternal = item.path.startsWith('http');
                 const linkPath = isExternal ? item.path : prefixPath(item.path);
 
@@ -304,18 +322,20 @@ export function LandingHeader() {
                           <BookOpen className="w-4 h-4" />
                           {t.landing.mypage}
                         </Link>
-                        <Link
-                          to={prefixPath('/tu/b2c/mypage/teaching')}
-                          onClick={() => setShowDropdown(false)}
-                          className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors text-sm ${
-                            isDark
-                              ? 'text-gray-300 hover:text-white hover:bg-white/10'
-                              : 'text-gray-700 hover:text-gray-900 hover:bg-gray-100'
-                          }`}
-                        >
-                          <PlusCircle className="w-4 h-4" />
-                          {t.landing.createCourse}
-                        </Link>
+                        {userCourseCreationEnabled && (
+                          <Link
+                            to={prefixPath('/tu/b2c/mypage/teaching')}
+                            onClick={() => setShowDropdown(false)}
+                            className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors text-sm ${
+                              isDark
+                                ? 'text-gray-300 hover:text-white hover:bg-white/10'
+                                : 'text-gray-700 hover:text-gray-900 hover:bg-gray-100'
+                            }`}
+                          >
+                            <PlusCircle className="w-4 h-4" />
+                            {t.landing.createCourse}
+                          </Link>
+                        )}
                       </div>
 
                       {/* 설정 메뉴 */}

--- a/src/components/layout/co/CourseOperatorSidebar/CourseOperatorSidebar.tsx
+++ b/src/components/layout/co/CourseOperatorSidebar/CourseOperatorSidebar.tsx
@@ -1,5 +1,8 @@
+import { useMemo } from 'react';
 import { BaseSidebar } from '../../common/BaseSidebar';
 import { courseOperatorMenuData, roleLabels } from '@/config/sidebar-menus';
+import { usePublicLayout } from '@/hooks/tu';
+import type { MenuItem } from '@/types';
 
 interface CourseOperatorSidebarProps {
   isExpanded: boolean;
@@ -9,11 +12,53 @@ interface CourseOperatorSidebarProps {
   language?: 'ko' | 'en';
 }
 
+// 브랜딩 설정의 visible 속성을 기반으로 메뉴 필터링
+interface BrandingSidebarItem {
+  id: string;
+  label: string;
+  url: string;
+  icon: string;
+  visible: boolean;
+  children?: BrandingSidebarItem[];
+}
+
 export function CourseOperatorSidebar(props: CourseOperatorSidebarProps) {
+  const { data: layoutData } = usePublicLayout();
+  const sidebarSettings = layoutData?.sidebarCOSettings as { enabled?: boolean; items?: BrandingSidebarItem[] } | undefined;
+
+  // 브랜딩 설정을 기반으로 메뉴 필터링
+  const filteredMenuData = useMemo((): MenuItem[] => {
+    if (!sidebarSettings?.items || sidebarSettings.items.length === 0) {
+      return courseOperatorMenuData;
+    }
+
+    // visible: false인 항목 찾기
+    const hiddenIds = new Set<string>();
+    const collectHiddenIds = (items: BrandingSidebarItem[]) => {
+      for (const item of items) {
+        if (!item.visible) {
+          hiddenIds.add(item.id);
+        }
+        if (item.children) {
+          collectHiddenIds(item.children);
+        }
+      }
+    };
+    collectHiddenIds(sidebarSettings.items);
+
+    // 숨겨진 항목 필터링
+    return courseOperatorMenuData
+      .filter((item) => !hiddenIds.has(item.id))
+      .map((item) => ({
+        ...item,
+        subItems: item.subItems?.filter((sub) => !hiddenIds.has(sub.id)),
+      }));
+  }, [sidebarSettings]);
+
   return (
     <BaseSidebar
       {...props}
-      menuData={courseOperatorMenuData}
+      menuData={filteredMenuData}
       roleLabel={roleLabels.courseOperator}
       roleType="co"
     />

--- a/src/components/layout/mypage/MyPageSidebar.tsx
+++ b/src/components/layout/mypage/MyPageSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ChevronDown, ChevronRight, Sun, Moon, Globe, Loader2, BookOpen, GraduationCap } from 'lucide-react';
 import { toast } from 'sonner';
@@ -9,6 +9,8 @@ import { useAuthStore } from '@/store/common/authStore';
 import { userService } from '@/services/common/userService';
 import { authService } from '@/services/common/authService';
 import { useSubdomainPath } from '@/hooks/common';
+import { usePublicLayout } from '@/hooks/tu';
+import { useTenantFeatures } from '@/contexts/TenantFeaturesContext';
 import { cn } from '@/utils/cn';
 import {
   AlertDialog,
@@ -21,6 +23,16 @@ import {
   AlertDialogTitle,
 } from '@/components/common';
 import type { MenuItem } from '@/types';
+
+// 브랜딩 설정의 visible 속성을 기반으로 메뉴 필터링
+interface BrandingSidebarItem {
+  id: string;
+  label: string;
+  url: string;
+  icon: string;
+  visible: boolean;
+  children?: BrandingSidebarItem[];
+}
 
 interface MyPageSidebarProps {
   isExpanded: boolean;
@@ -37,6 +49,54 @@ export function MyPageSidebar({ onMenuItemClick }: MyPageSidebarProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const { prefixPath } = useSubdomainPath();
+
+  // 브랜딩 설정에서 사이드바 설정 가져오기
+  const { data: layoutData } = usePublicLayout();
+  const sidebarSettings = layoutData?.sidebarTUSettings as { enabled?: boolean; items?: BrandingSidebarItem[] } | undefined;
+
+  // 기능 설정 가져오기
+  const { isFeatureEnabled } = useTenantFeatures();
+  const communityEnabled = isFeatureEnabled('communityEnabled');
+  const userCourseCreationEnabled = isFeatureEnabled('userCourseCreationEnabled');
+  const instructorTabEnabled = isFeatureEnabled('instructorTabEnabled');
+
+  // 브랜딩 설정 + 기능 설정을 기반으로 메뉴 필터링
+  const filteredMenuData = useMemo((): MenuItem[] => {
+    // 1. 브랜딩 설정에서 visible: false인 항목 찾기
+    const hiddenIds = new Set<string>();
+    if (sidebarSettings?.items && sidebarSettings.items.length > 0) {
+      const collectHiddenIds = (items: BrandingSidebarItem[]) => {
+        for (const item of items) {
+          if (!item.visible) {
+            hiddenIds.add(item.id);
+          }
+          if (item.children) {
+            collectHiddenIds(item.children);
+          }
+        }
+      };
+      collectHiddenIds(sidebarSettings.items);
+    }
+
+    // 2. 기능 설정에 따라 추가로 숨길 항목
+    // 커뮤니티 비활성화 시 커뮤니티 메뉴 숨김
+    if (!communityEnabled) {
+      hiddenIds.add('my-community');
+    }
+    // 사용자 강의 생성 비활성화 시 강의 디자인 관련 메뉴 숨김
+    if (!userCourseCreationEnabled) {
+      hiddenIds.add('my-teaching');
+      hiddenIds.add('create-course');
+    }
+
+    // 3. 숨겨진 항목 필터링
+    return myPageMenuData
+      .filter((item) => !hiddenIds.has(item.id))
+      .map((item) => ({
+        ...item,
+        subItems: item.subItems?.filter((sub) => !hiddenIds.has(sub.id)),
+      }));
+  }, [sidebarSettings, communityEnabled, userCourseCreationEnabled]);
 
   const { theme, toggleTheme } = useThemeStore();
   const { language, toggleLanguage } = useLanguageStore();
@@ -263,8 +323,8 @@ export function MyPageSidebar({ onMenuItemClick }: MyPageSidebarProps) {
             : 'bg-white border border-gray-200 shadow-sm'
         }`}
       >
-        {/* 모드 스위처 (디자이너 권한이 있는 경우에만 표시) */}
-        {isDesigner && (
+        {/* 모드 스위처 (디자이너 권한 + 강사 탭 기능이 활성화된 경우에만 표시) */}
+        {isDesigner && instructorTabEnabled && (
           <>
             <div
               className="relative rounded-lg p-1 mb-3"
@@ -329,7 +389,7 @@ export function MyPageSidebar({ onMenuItemClick }: MyPageSidebarProps) {
 
         {/* 메뉴 리스트 */}
         <nav className="space-y-1 flex-1">
-          {myPageMenuData.map(renderMenuItem)}
+          {filteredMenuData.map(renderMenuItem)}
         </nav>
 
         {/* 설정 토글 영역 */}

--- a/src/components/layout/tu/TenantUserSidebar/TenantUserSidebar.tsx
+++ b/src/components/layout/tu/TenantUserSidebar/TenantUserSidebar.tsx
@@ -1,5 +1,9 @@
+import { useMemo } from 'react';
 import { BaseSidebar } from '../../common/BaseSidebar';
 import { tenantUserMenuData, roleLabels } from '@/config/sidebar-menus';
+import { usePublicLayout } from '@/hooks/tu';
+import { useTenantFeatures } from '@/contexts/TenantFeaturesContext';
+import type { MenuItem } from '@/types';
 
 interface TenantUserSidebarProps {
   isExpanded: boolean;
@@ -9,13 +13,59 @@ interface TenantUserSidebarProps {
   language?: 'ko' | 'en';
 }
 
+// 브랜딩 설정의 visible 속성을 기반으로 메뉴 필터링
+interface BrandingSidebarItem {
+  id: string;
+  label: string;
+  url: string;
+  icon: string;
+  visible: boolean;
+  children?: BrandingSidebarItem[];
+}
+
 export function TenantUserSidebar(props: TenantUserSidebarProps) {
+  const { data: layoutData } = usePublicLayout();
+  const sidebarSettings = layoutData?.sidebarTUSettings as { enabled?: boolean; items?: BrandingSidebarItem[] } | undefined;
+
+  // 기능 설정 가져오기
+  const { isFeatureEnabled } = useTenantFeatures();
+  const instructorTabEnabled = isFeatureEnabled('instructorTabEnabled');
+
+  // 브랜딩 설정을 기반으로 메뉴 필터링
+  const filteredMenuData = useMemo((): MenuItem[] => {
+    if (!sidebarSettings?.items || sidebarSettings.items.length === 0) {
+      return tenantUserMenuData;
+    }
+
+    // visible: false인 항목 찾기
+    const hiddenIds = new Set<string>();
+    const collectHiddenIds = (items: BrandingSidebarItem[]) => {
+      for (const item of items) {
+        if (!item.visible) {
+          hiddenIds.add(item.id);
+        }
+        if (item.children) {
+          collectHiddenIds(item.children);
+        }
+      }
+    };
+    collectHiddenIds(sidebarSettings.items);
+
+    // 숨겨진 항목 필터링
+    return tenantUserMenuData
+      .filter((item) => !hiddenIds.has(item.id))
+      .map((item) => ({
+        ...item,
+        subItems: item.subItems?.filter((sub) => !hiddenIds.has(sub.id)),
+      }));
+  }, [sidebarSettings]);
+
   return (
     <BaseSidebar
       {...props}
-      menuData={tenantUserMenuData}
+      menuData={filteredMenuData}
       roleLabel={roleLabels.tenantUser}
-      showModeSwitcher={true}
+      showModeSwitcher={instructorTabEnabled}
       currentMode="instructor"
       roleType="tu"
     />

--- a/src/contexts/TenantFeaturesContext.tsx
+++ b/src/contexts/TenantFeaturesContext.tsx
@@ -25,20 +25,6 @@ const DEFAULT_FEATURES: TenantFeaturesResponse = {
 };
 
 /**
- * 인증된 사용자용 기능 설정 조회 Hook
- */
-function useAuthenticatedFeatures(enabled: boolean) {
-  return useQuery({
-    queryKey: ['tenant-features', 'authenticated'],
-    queryFn: () => tenantFeaturesService.getFeatures(),
-    enabled,
-    staleTime: 1000 * 60 * 30, // 30분 캐싱
-    gcTime: 1000 * 60 * 60, // 1시간 가비지 컬렉션
-    retry: false, // 403 에러 시 재시도 안 함
-  });
-}
-
-/**
  * 공개 기능 설정 조회 Hook (비로그인 사용자용)
  */
 function usePublicFeatures(enabled: boolean) {

--- a/src/contexts/TenantFeaturesContext.tsx
+++ b/src/contexts/TenantFeaturesContext.tsx
@@ -21,6 +21,7 @@ const DEFAULT_FEATURES: TenantFeaturesResponse = {
   cartEnabled: true,
   wishlistEnabled: true,
   instructorTabEnabled: true,
+  paidModeEnabled: true, // 기본값: 유료 모드
 };
 
 /**
@@ -57,23 +58,19 @@ export function TenantFeaturesProvider({ children }: { children: ReactNode }) {
   // SA 사용자인지 확인 (tenantId가 없는 인증된 사용자)
   const isSystemAdmin = isAuthenticated && !user?.tenantId;
 
-  // TODO: 백엔드 API가 준비될 때까지 API 호출 비활성화
-  // 현재 백엔드에서 /api/tenant/settings/features 엔드포인트가 403 반환
-  const enableFeatureApi = false;
-
-  // 1. 인증된 사용자(tenantId 있음): tenantId 기반 기능 설정 조회
+  // 1. 인증된 사용자: 공개 API로 기능 설정 조회 (TU용 엔드포인트 사용)
   const {
     data: authFeatures,
     isLoading: authLoading,
     error: authError,
-  } = useAuthenticatedFeatures(enableFeatureApi && isAuthenticated && !!user?.tenantId);
+  } = usePublicFeatures(isAuthenticated && !!user?.tenantId);
 
   // 2. 비로그인 사용자: 공개 API로 기능 설정 조회
   const {
     data: publicFeatures,
     isLoading: publicLoading,
     error: publicError,
-  } = usePublicFeatures(enableFeatureApi && !isAuthenticated);
+  } = usePublicFeatures(!isAuthenticated);
 
   // 기능 설정 결정 로직
   const { features, isLoading, error } = useMemo(() => {

--- a/src/contexts/TenantFeaturesContext.tsx
+++ b/src/contexts/TenantFeaturesContext.tsx
@@ -97,8 +97,8 @@ export function TenantFeaturesProvider({ children }: { children: ReactNode }) {
 
   // 편의 메서드
   const isFeatureEnabled = (feature: keyof TenantFeaturesResponse): boolean => {
-    if (!features) return true; // 로딩 중이거나 에러 시 기본적으로 활성화
-    return features[feature] ?? true;
+    if (!features) return DEFAULT_FEATURES[feature] ?? true; // 로딩 중이거나 에러 시 기본값 사용
+    return features[feature] ?? DEFAULT_FEATURES[feature] ?? true;
   };
 
   return (

--- a/src/pages/ta/branding/BrandingSettingsPage.tsx
+++ b/src/pages/ta/branding/BrandingSettingsPage.tsx
@@ -54,6 +54,12 @@ import {
   CheckCircle,
   Circle,
   Square,
+  Globe,
+  Megaphone,
+  Library,
+  UserCheck,
+  Zap,
+  CreditCard,
   type LucideIcon,
 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
@@ -69,7 +75,9 @@ import {
   useUpdateLayoutSettings,
   useUpdateExtendedBrandingSettings,
 } from '@/hooks/ta/useBrandingQueries';
+import { myPageMenuData, courseOperatorMenuData } from '@/config/sidebar-menus';
 import type { UpdateTenantFeaturesRequest } from '@/services/ta/tenantFeaturesService';
+import type { MenuItem } from '@/types';
 
 // 사용 가능한 아이콘 목록
 const availableIcons = [
@@ -103,6 +111,11 @@ const availableIcons = [
   { value: 'check-circle', label: 'Check Circle' },
   { value: 'circle', label: 'Circle' },
   { value: 'square', label: 'Square' },
+  { value: 'globe', label: 'Globe' },
+  { value: 'megaphone', label: 'Megaphone' },
+  { value: 'library', label: 'Library' },
+  { value: 'user-check', label: 'User Check' },
+  { value: 'zap', label: 'Zap' },
 ];
 
 // 아이콘 문자열 -> 컴포넌트 매핑
@@ -137,6 +150,103 @@ const iconMap: Record<string, LucideIcon> = {
   'check-circle': CheckCircle,
   'circle': Circle,
   'square': Square,
+  'globe': Globe,
+  'megaphone': Megaphone,
+  'library': Library,
+  'user-check': UserCheck,
+  'zap': Zap,
+};
+
+// LucideIcon -> 문자열 역매핑
+const iconToString = (icon: LucideIcon): string => {
+  for (const [key, value] of Object.entries(iconMap)) {
+    if (value === icon) return key;
+  }
+  return 'circle'; // fallback
+};
+
+// MenuItem을 브랜딩 사이드바 아이템으로 변환
+const convertMenuToBrandingItem = (item: MenuItem): {
+  id: string;
+  label: string;
+  url: string;
+  icon: string;
+  visible: boolean;
+  children?: { id: string; label: string; url: string; icon?: string; visible: boolean }[];
+} => ({
+  id: item.id,
+  label: item.label.ko,
+  url: item.path || '',
+  icon: iconToString(item.icon),
+  visible: true,
+  children: item.subItems?.map(sub => ({
+    id: sub.id,
+    label: sub.label.ko,
+    url: sub.path || '',
+    icon: sub.icon ? iconToString(sub.icon) : undefined,
+    visible: true,
+  })),
+});
+
+// 실제 메뉴 데이터로부터 사이드바 기본값 생성
+const generateSidebarTUDefault = () => ({
+  enabled: true,
+  items: myPageMenuData.map(convertMenuToBrandingItem),
+});
+
+const generateSidebarCODefault = () => ({
+  enabled: true,
+  items: courseOperatorMenuData.map(convertMenuToBrandingItem),
+});
+
+// 서버에서 저장된 visible 상태를 실제 메뉴 데이터에 병합
+type SidebarItem = {
+  id: string;
+  label: string;
+  url: string;
+  icon: string;
+  visible: boolean;
+  children?: { id: string; label: string; url: string; icon?: string; visible: boolean }[];
+};
+
+const mergeSidebarSettings = (
+  baseItems: SidebarItem[],
+  savedSettings: { enabled?: boolean; items?: SidebarItem[] } | null | undefined
+): { enabled: boolean; items: SidebarItem[] } => {
+  if (!savedSettings) {
+    return { enabled: true, items: baseItems };
+  }
+
+  // 저장된 visible 상태를 ID로 매핑
+  const savedVisibility = new Map<string, boolean>();
+  const collectVisibility = (items: SidebarItem[]) => {
+    for (const item of items) {
+      savedVisibility.set(item.id, item.visible);
+      if (item.children) {
+        for (const child of item.children) {
+          savedVisibility.set(child.id, child.visible);
+        }
+      }
+    }
+  };
+  if (savedSettings.items) {
+    collectVisibility(savedSettings.items);
+  }
+
+  // 기본 메뉴에 저장된 visible 상태 적용
+  const mergedItems = baseItems.map(item => ({
+    ...item,
+    visible: savedVisibility.has(item.id) ? savedVisibility.get(item.id)! : true,
+    children: item.children?.map(child => ({
+      ...child,
+      visible: savedVisibility.has(child.id) ? savedVisibility.get(child.id)! : true,
+    })),
+  }));
+
+  return {
+    enabled: savedSettings.enabled ?? true,
+    items: mergedItems,
+  };
 };
 
 // 브랜딩 설정 타입
@@ -324,59 +434,13 @@ const defaultBrandingSettings: BrandingSettings = {
       github: { enabled: false, url: '' },
     },
   },
-  sidebarTU: {
-    enabled: true,
-    items: [
-      { id: 'tu-1', label: '마이페이지', url: '/tu/b2c/mypage', icon: 'home', visible: true },
-      {
-        id: 'tu-2',
-        label: '내 수강 강의',
-        url: '',
-        icon: 'book-open',
-        visible: true,
-        children: [
-          { id: 'tu-2-1', label: '수강 중인 강의', url: '/tu/b2c/mypage/learning', visible: true },
-          { id: 'tu-2-2', label: '완료한 강의', url: '/tu/b2c/mypage/completed', visible: true },
-          { id: 'tu-2-3', label: '수료증', url: '/tu/b2c/mypage/certificates', visible: true },
-        ],
-      },
-      {
-        id: 'tu-3',
-        label: '내 강의 관리',
-        url: '',
-        icon: 'pen-tool',
-        visible: true,
-        children: [
-          { id: 'tu-3-1', label: '내 강의', url: '/tu/b2c/mypage/teaching', visible: true },
-          { id: 'tu-3-2', label: '강의 개설하기', url: '/tu/teaching/courses/create', visible: true },
-        ],
-      },
-      { id: 'tu-4', label: '설정', url: '/tu/b2c/mypage/settings', icon: 'settings', visible: true },
-    ],
-  },
-  sidebarCO: {
-    enabled: true,
-    items: [
-      { id: 'co-1', label: '대시보드', url: '/co/dashboard', icon: 'layout-dashboard', visible: true },
-      {
-        id: 'co-2',
-        label: '교육 과정 탐색',
-        url: '',
-        icon: 'search',
-        visible: true,
-        children: [
-          { id: 'co-2-1', label: '과정 검색', url: '/co/courses', visible: true },
-          { id: 'co-2-2', label: '과정 등록/수정', url: '/co/courses/pending', visible: true },
-        ],
-      },
-      { id: 'co-3', label: '사용자 관리', url: '/co/users', icon: 'users', visible: true },
-      { id: 'co-4', label: '설정', url: '/co/settings', icon: 'settings', visible: true },
-    ],
-  },
+  sidebarTU: generateSidebarTUDefault(),
+  sidebarCO: generateSidebarCODefault(),
 };
 
 // 기능 설정 항목
 const FEATURES = [
+  { key: 'paidModeEnabled' as const, label: '유료 모드', description: '비활성화 시 모든 강좌가 무료로 표시됩니다 (가격 숨김)', icon: CreditCard },
   { key: 'communityEnabled' as const, label: '커뮤니티 기능', description: '사용자들이 커뮤니티에서 질문하고 토론할 수 있습니다', icon: MessageCircle },
   { key: 'userCourseCreationEnabled' as const, label: '사용자 강좌 생성', description: '일반 사용자가 직접 강좌를 생성할 수 있습니다', icon: BookOpen },
   { key: 'cartEnabled' as const, label: '장바구니 기능', description: '사용자가 강좌를 장바구니에 담을 수 있습니다', icon: ShoppingCart },
@@ -404,7 +468,17 @@ export function BrandingSettingsPage() {
   const [draggedLegalLinkIndex, setDraggedLegalLinkIndex] = useState<number | null>(null);
   const [draggedLandingCategoryIndex, setDraggedLandingCategoryIndex] = useState<number | null>(null);
   const [draggedCourseSectionIndex, setDraggedCourseSectionIndex] = useState<number | null>(null);
-  const [expandedSidebarItems, setExpandedSidebarItems] = useState<Set<string>>(new Set(['tu-2', 'tu-3', 'co-2']));
+  // 하위 메뉴가 있는 항목들의 ID를 자동으로 수집
+const getExpandableItemIds = () => {
+    const ids: string[] = [];
+    [...myPageMenuData, ...courseOperatorMenuData].forEach(item => {
+      if (item.subItems && item.subItems.length > 0) {
+        ids.push(item.id);
+      }
+    });
+    return ids;
+  };
+  const [expandedSidebarItems, setExpandedSidebarItems] = useState<Set<string>>(new Set(getExpandableItemIds()));
   const [expandedMenuItems, setExpandedMenuItems] = useState<Set<string>>(new Set(['mypage-home']));
 
   // 브랜딩 설정 API 관련
@@ -417,6 +491,7 @@ export function BrandingSettingsPage() {
   const { data: features, isLoading: featuresLoading } = useTenantFeatures();
   const updateFeaturesMutation = useUpdateTenantFeatures();
   const [featureFormData, setFeatureFormData] = useState<UpdateTenantFeaturesRequest>({
+    paidModeEnabled: true,
     communityEnabled: true,
     userCourseCreationEnabled: false,
     cartEnabled: true,
@@ -428,6 +503,7 @@ export function BrandingSettingsPage() {
   useEffect(() => {
     if (features) {
       setFeatureFormData({
+        paidModeEnabled: features.paidModeEnabled,
         communityEnabled: features.communityEnabled,
         userCourseCreationEnabled: features.userCourseCreationEnabled,
         cartEnabled: features.cartEnabled,
@@ -463,12 +539,15 @@ export function BrandingSettingsPage() {
           landingCategory: (tenantSettings.landingPageSettings as { landingCategory?: typeof prev.landingCategory }).landingCategory || prev.landingCategory,
           courseSections: (tenantSettings.landingPageSettings as { courseSections?: typeof prev.courseSections }).courseSections || prev.courseSections,
         }),
-        ...(tenantSettings.sidebarTUSettings && {
-          sidebarTU: tenantSettings.sidebarTUSettings as typeof prev.sidebarTU,
-        }),
-        ...(tenantSettings.sidebarCOSettings && {
-          sidebarCO: tenantSettings.sidebarCOSettings as typeof prev.sidebarCO,
-        }),
+        // 사이드바 설정: 실제 메뉴 데이터를 기준으로 하고 서버의 visible 상태만 병합
+        sidebarTU: mergeSidebarSettings(
+          generateSidebarTUDefault().items,
+          tenantSettings.sidebarTUSettings as { enabled?: boolean; items?: SidebarItem[] } | null
+        ),
+        sidebarCO: mergeSidebarSettings(
+          generateSidebarCODefault().items,
+          tenantSettings.sidebarCOSettings as { enabled?: boolean; items?: SidebarItem[] } | null
+        ),
         // 헤더 설정 로드
         ...(tenantSettings.headerSettings && {
           header: {
@@ -1836,7 +1915,15 @@ export function BrandingSettingsPage() {
                             </div>
                             <Switch
                               checked={isEnabled}
-                              onCheckedChange={(checked) => setFeatureFormData(prev => ({ ...prev, [feature.key]: checked }))}
+                              disabled={feature.key === 'cartEnabled' && !featureFormData.paidModeEnabled}
+                              onCheckedChange={(checked) => {
+                                // 유료 모드 비활성화 시 장바구니도 함께 비활성화
+                                if (feature.key === 'paidModeEnabled' && !checked) {
+                                  setFeatureFormData(prev => ({ ...prev, [feature.key]: checked, cartEnabled: false }));
+                                } else {
+                                  setFeatureFormData(prev => ({ ...prev, [feature.key]: checked }));
+                                }
+                              }}
                             />
                           </div>
                           {index < FEATURES.length - 1 && <hr className="border-gray-100" />}

--- a/src/pages/tu/main/CourseDetailPage.tsx
+++ b/src/pages/tu/main/CourseDetailPage.tsx
@@ -25,6 +25,7 @@ import { LandingFooter } from '@/components/landing/LandingFooter';
 import { CourseCommunitySection } from '@/components/domain/course-community';
 import { CourseReviewSection } from '@/components/domain/course-review';
 import { useCourseTimeDetail, useEnroll, useMyEnrollments, useCheckWishlistStatus, useToggleWishlist, useCheckCartStatus, useToggleCart } from '@/hooks/tu';
+import { useTenantFeatures } from '@/contexts/TenantFeaturesContext';
 import type { CurriculumItemResponse } from '@/types/tu/courseTimeCatalog.types';
 import {
   DELIVERY_TYPE_LABELS,
@@ -200,6 +201,12 @@ export function CourseDetailPage() {
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
 
+  // 기능 설정
+  const { isFeatureEnabled } = useTenantFeatures();
+  const paidModeEnabled = isFeatureEnabled('paidModeEnabled');
+  const cartEnabled = isFeatureEnabled('cartEnabled');
+  const communityEnabled = isFeatureEnabled('communityEnabled');
+
   const toggleSection = (index: number) => {
     if (expandedSections.includes(index)) {
       setExpandedSections(expandedSections.filter((i) => i !== index));
@@ -341,9 +348,9 @@ export function CourseDetailPage() {
     );
   }
 
-  // 가격 정보
+  // 가격 정보 (유료 모드가 비활성화되면 무료로 표시)
   const price = courseTime.isFree ? 0 : parseFloat(courseTime.price);
-  const priceDisplay = courseTime.isFree ? '무료' : `₩${price.toLocaleString()}`;
+  const priceDisplay = !paidModeEnabled || courseTime.isFree ? '무료' : `₩${price.toLocaleString()}`;
 
   // 썸네일
   const thumbnailUrl =
@@ -417,8 +424,8 @@ export function CourseDetailPage() {
                   </span>
                 )}
 
-                {/* 무료 태그 */}
-                {courseTime.isFree && (
+                {/* 무료 태그 (유료 모드일 때만 표시) */}
+                {paidModeEnabled && courseTime.isFree && (
                   <span className="px-3 py-1 rounded-full text-xs font-bold bg-gradient-to-r from-[#ff7867] to-[#ff9a5a] text-white">
                     무료
                   </span>
@@ -538,14 +545,16 @@ export function CourseDetailPage() {
                 }`}
               >
                 <div className="p-6">
-                  {/* Price */}
-                  <div className="flex items-center gap-3 mb-4">
-                    <span
-                      className={`text-3xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}
-                    >
-                      {priceDisplay}
-                    </span>
-                  </div>
+                  {/* Price (유료 모드일 때만 가격 표시, 무료 모드면 숨김) */}
+                  {paidModeEnabled && (
+                    <div className="flex items-center gap-3 mb-4">
+                      <span
+                        className={`text-3xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}
+                      >
+                        {priceDisplay}
+                      </span>
+                    </div>
+                  )}
 
                   {/* 모집 기간 (상시모집이 아닌 경우) */}
                   {!courseTime.isOnDemand && (
@@ -661,24 +670,27 @@ export function CourseDetailPage() {
                             '수강 신청'
                           )}
                         </button>
-                        <button
-                          onClick={handleAddToCart}
-                          disabled={toggleCartMutation.isPending || isCartChecking}
-                          className={`w-full py-4 rounded-xl font-bold text-lg flex items-center justify-center gap-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
-                            isInCart
-                              ? 'bg-green-500 text-white hover:bg-green-600'
-                              : isDark
-                                ? 'bg-white text-gray-900 hover:bg-gray-100'
-                                : 'bg-gray-900 text-white hover:bg-gray-800'
-                          }`}
-                        >
-                          {toggleCartMutation.isPending ? (
-                            <Loader2 className="w-5 h-5 animate-spin" />
-                          ) : (
-                            <ShoppingCart className="w-5 h-5" />
-                          )}
-                          {isInCart ? '장바구니에 담김' : '장바구니 담기'}
-                        </button>
+                        {/* 장바구니 버튼 (유료 모드 + 장바구니 기능 활성화시만 표시) */}
+                        {paidModeEnabled && cartEnabled && (
+                          <button
+                            onClick={handleAddToCart}
+                            disabled={toggleCartMutation.isPending || isCartChecking}
+                            className={`w-full py-4 rounded-xl font-bold text-lg flex items-center justify-center gap-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                              isInCart
+                                ? 'bg-green-500 text-white hover:bg-green-600'
+                                : isDark
+                                  ? 'bg-white text-gray-900 hover:bg-gray-100'
+                                  : 'bg-gray-900 text-white hover:bg-gray-800'
+                            }`}
+                          >
+                            {toggleCartMutation.isPending ? (
+                              <Loader2 className="w-5 h-5 animate-spin" />
+                            ) : (
+                              <ShoppingCart className="w-5 h-5" />
+                            )}
+                            {isInCart ? '장바구니에 담김' : '장바구니 담기'}
+                          </button>
+                        )}
                       </>
                     ) : (
                       <button
@@ -811,27 +823,30 @@ export function CourseDetailPage() {
                 />
               )}
             </button>
-            <button
-              onClick={() => setActiveTab('community')}
-              className={`py-4 font-medium transition-colors relative ${
-                activeTab === 'community'
-                  ? isDark
-                    ? 'text-white'
-                    : 'text-gray-900'
-                  : isDark
-                    ? 'text-gray-400 hover:text-gray-300'
-                    : 'text-gray-500 hover:text-gray-700'
-              }`}
-            >
-              커뮤니티
-              {activeTab === 'community' && (
-                <div
-                  className={`absolute bottom-0 left-0 right-0 h-0.5 ${
-                    isDark ? 'bg-white' : 'bg-gray-900'
-                  }`}
-                />
-              )}
-            </button>
+            {/* 커뮤니티 탭 (communityEnabled일 때만 표시) */}
+            {communityEnabled && (
+              <button
+                onClick={() => setActiveTab('community')}
+                className={`py-4 font-medium transition-colors relative ${
+                  activeTab === 'community'
+                    ? isDark
+                      ? 'text-white'
+                      : 'text-gray-900'
+                    : isDark
+                      ? 'text-gray-400 hover:text-gray-300'
+                      : 'text-gray-500 hover:text-gray-700'
+                }`}
+              >
+                커뮤니티
+                {activeTab === 'community' && (
+                  <div
+                    className={`absolute bottom-0 left-0 right-0 h-0.5 ${
+                      isDark ? 'bg-white' : 'bg-gray-900'
+                    }`}
+                  />
+                )}
+              </button>
+            )}
           </div>
         </div>
       </div>
@@ -980,8 +995,8 @@ export function CourseDetailPage() {
             </section>
           )}
 
-          {/* 커뮤니티 탭 */}
-          {activeTab === 'community' && (
+          {/* 커뮤니티 탭 (communityEnabled일 때만 표시) */}
+          {communityEnabled && activeTab === 'community' && (
             <section className="mb-12">
               <CourseCommunitySection
                 timeId={courseTimeId}

--- a/src/pages/tu/main/LandingPage.tsx
+++ b/src/pages/tu/main/LandingPage.tsx
@@ -11,6 +11,7 @@ import { useThemeStore } from '@/store/common/themeStore';
 import { useTranslation } from '@/store/common/languageStore';
 import { usePopularInstructors, useCourseTimeCatalog, usePublicLayout } from '@/hooks/tu';
 import { useTenantBranding } from '@/contexts/TenantBrandingContext';
+import { useTenantFeatures } from '@/contexts/TenantFeaturesContext';
 import { useBrandingApply } from '@/hooks/tu/useBrandingApply';
 import { useAuth } from '@/hooks/common/auth/useAuth';
 import type { InstructorSummary } from '@/types/tu';
@@ -89,15 +90,17 @@ const CATEGORY_OPTIONS: CategoryOption[] = [
 
 /**
  * CourseTime 데이터를 LandingCourseCard props로 변환
+ * @param courseTime CourseTime 데이터
+ * @param paidModeEnabled 유료 모드 활성화 여부 (false면 가격 숨김)
  */
-function convertCourseTimeToCardProps(courseTime: CourseTimeCatalogResponse) {
+function convertCourseTimeToCardProps(courseTime: CourseTimeCatalogResponse, paidModeEnabled: boolean = true) {
   // 주강사 찾기
   const mainInstructor = courseTime.instructors.find((i) => i.role === 'MAIN');
   const instructorName = mainInstructor?.name || courseTime.instructors[0]?.name || '';
 
-  // 가격 포맷팅 (유료 → 금액, 무료 → 표시 안함)
+  // 가격 포맷팅 (유료 모드 + 유료 강의 → 금액, 그 외 → 표시 안함)
   const price = courseTime.isFree ? 0 : parseFloat(courseTime.price);
-  const priceDisplay = (!courseTime.isFree && price > 0) ? `₩${price.toLocaleString()}` : null;
+  const priceDisplay = (paidModeEnabled && !courseTime.isFree && price > 0) ? `₩${price.toLocaleString()}` : null;
 
   // 태그 생성 (무료 태그 제거)
   const tags: string[] = [];
@@ -145,6 +148,10 @@ export function LandingPage() {
   const isDark = theme === 'dark';
   const { branding } = useTenantBranding();
 
+  // 기능 설정
+  const { isFeatureEnabled } = useTenantFeatures();
+  const paidModeEnabled = isFeatureEnabled('paidModeEnabled');
+
   // 브랜딩 CSS 적용
   useBrandingApply(branding);
 
@@ -177,9 +184,9 @@ export function LandingPage() {
   const { data: instructorsData, isLoading: isInstructorsLoading } = usePopularInstructors(4, USE_INSTRUCTOR_API);
   const popularInstructors = USE_INSTRUCTOR_API ? (instructorsData?.instructors ?? []) : dummyPopularInstructors;
 
-  // CourseTime 데이터를 카드 props로 변환
+  // CourseTime 데이터를 카드 props로 변환 (paidModeEnabled 전달)
   const courseTimes = courseTimeData?.content || [];
-  const courses = courseTimes.map(convertCourseTimeToCardProps);
+  const courses = courseTimes.map((ct) => convertCourseTimeToCardProps(ct, paidModeEnabled));
 
   // 현재 선택된 카테고리 정보 가져오기
   const activeCategory = categoryOptions.find((c) => c.id === activeCategoryId);

--- a/src/pages/tu/main/SearchPage.tsx
+++ b/src/pages/tu/main/SearchPage.tsx
@@ -18,6 +18,7 @@ import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
 import { LandingCourseCard } from '@/components/landing';
 import { useCourseTimeCatalog, useRoadmapExplore, useCommunityPosts } from '@/hooks/tu';
+import { useTenantFeatures } from '@/contexts/TenantFeaturesContext';
 import type { RoadmapExploreItem } from '@/types/tu/roadmapExplore.types';
 import type { CommunityPost } from '@/types/tu/community.types';
 import { ROADMAP_LEVEL_LABELS } from '@/types/tu/roadmapExplore.types';
@@ -873,6 +874,10 @@ export function SearchPage() {
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
 
+  // 기능 설정
+  const { isFeatureEnabled } = useTenantFeatures();
+  const paidModeEnabled = isFeatureEnabled('paidModeEnabled');
+
   // 필터 초기화
   const resetFilters = () => {
     setFilters(DEFAULT_FILTERS);
@@ -1359,7 +1364,7 @@ export function SearchPage() {
                           id={course.id}
                           title={course.title}
                           instructor={course.instructor}
-                          price={course.price}
+                          price={paidModeEnabled ? course.price : null}
                           rating={course.rating}
                           reviewCount={course.reviewCount}
                           studentCount={course.studentCount}

--- a/src/services/ta/tenantFeaturesService.ts
+++ b/src/services/ta/tenantFeaturesService.ts
@@ -14,6 +14,7 @@ export interface TenantFeaturesResponse {
   cartEnabled: boolean;
   wishlistEnabled: boolean;
   instructorTabEnabled: boolean;
+  paidModeEnabled: boolean; // 유료 모드 활성화 (false면 무료 모드 - 가격 숨김)
 }
 
 export interface UpdateTenantFeaturesRequest {
@@ -22,6 +23,7 @@ export interface UpdateTenantFeaturesRequest {
   cartEnabled?: boolean;
   wishlistEnabled?: boolean;
   instructorTabEnabled?: boolean;
+  paidModeEnabled?: boolean;
 }
 
 // ============================================

--- a/src/types/tu/branding.types.ts
+++ b/src/types/tu/branding.types.ts
@@ -58,14 +58,22 @@ export interface FooterSettings {
   showCopyright?: boolean;
   showSocialLinks?: boolean;
   socialLinks?: {
-    facebook?: string;
-    twitter?: string;
-    instagram?: string;
-    youtube?: string;
-    linkedin?: string;
+    facebook?: string | { enabled?: boolean; url?: string };
+    twitter?: string | { enabled?: boolean; url?: string };
+    instagram?: string | { enabled?: boolean; url?: string };
+    youtube?: string | { enabled?: boolean; url?: string };
+    linkedin?: string | { enabled?: boolean; url?: string };
   };
   companyInfoFields?: string[];
   showNewsletter?: boolean;
+  companyInfo?: {
+    ceo?: string;
+    businessNo?: string;
+    address?: string;
+    phone?: string;
+  };
+  legalLinks?: { label: string; url: string }[];
+  copyright?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

테넌트 브랜딩 설정에서 유료/무료 모드 토글 기능을 추가하고, 기능 설정(커뮤니티, 장바구니, 찜 등)이 TU 사이트에 실제로 반영되도록 연동했습니다.

## Related Issue

- 브랜딩 설정 기능 설정 연동
- 유료/무료 모드 토글 기능 추가

## Changes

- **TenantFeaturesContext**: `paidModeEnabled` 기본값 추가, `isFeatureEnabled` 기본값 로직 개선
- **BrandingSettingsPage**: 유료 모드 토글 UI 추가, 유료 모드 비활성화 시 장바구니 자동 비활성화
- **LandingHeader**: 장바구니 아이콘 조건부 표시 (유료 모드 + 장바구니 활성화)
- **LandingCourseCard**: 가격 조건부 표시 (유료 모드 활성화 시에만)
- **LandingPage**: `convertCourseTimeToCardProps`에 `paidModeEnabled` 파라미터 추가
- **SearchPage**: `paidModeEnabled`에 따른 가격 표시 조건 추가
- **CourseDetailPage**: 가격, 장바구니, 커뮤니티 탭 조건부 표시
- **사이드바 컴포넌트들**: 기능 설정에 따른 메뉴 항목 조건부 표시

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 백엔드 PR과 함께 배포되어야 합니다 (backend: feature/paid-mode-toggle)
- 유료 모드 기본값은 `true` (유료 모드)
- 유료 모드 비활성화 시 자동으로 장바구니도 비활성화됨