### PR TITLE
feat: 콘텐츠 일괄 등록 기능 (#402)

### DIFF
--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -16,7 +16,6 @@ export {
   useRestoreVersion,
   useContentPreview,
   useBulkUploadContent,
-  useBulkUploadFromZip,
 } from './useContentQueries';
 
 // Learning Object (LO) Hooks

--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -15,6 +15,8 @@ export {
   useRestoreContent,
   useRestoreVersion,
   useContentPreview,
+  useBulkUploadContent,
+  useBulkUploadFromZip,
 } from './useContentQueries';
 
 // Learning Object (LO) Hooks

--- a/src/hooks/tu/useContentQueries.ts
+++ b/src/hooks/tu/useContentQueries.ts
@@ -219,3 +219,39 @@ export const useContentPreview = (id: number | null) => {
     enabled: !!id,
   });
 };
+
+// 일괄 업로드 파라미터
+interface BulkUploadParams {
+  files: File[];
+  folderId?: number;
+  completionCriteria?: 'BUTTON_CLICK' | 'PERCENT_90' | 'PERCENT_100';
+  downloadable?: boolean;
+}
+
+// 다중 파일 일괄 업로드
+export const useBulkUploadContent = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ files, folderId, completionCriteria, downloadable }: BulkUploadParams) =>
+      contentService.bulkUploadFiles(files, { folderId, completionCriteria, downloadable }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: contentKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: contentKeys.myLists() });
+    },
+  });
+};
+
+// ZIP 파일 일괄 업로드
+export const useBulkUploadFromZip = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ file, folderId, completionCriteria, downloadable }: { file: File } & Omit<BulkUploadParams, 'files'>) =>
+      contentService.bulkUploadFromZip(file, { folderId, completionCriteria, downloadable }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: contentKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: contentKeys.myLists() });
+    },
+  });
+};

--- a/src/hooks/tu/useContentQueries.ts
+++ b/src/hooks/tu/useContentQueries.ts
@@ -241,17 +241,3 @@ export const useBulkUploadContent = () => {
     },
   });
 };
-
-// ZIP 파일 일괄 업로드
-export const useBulkUploadFromZip = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: ({ file, folderId, completionCriteria, downloadable }: { file: File } & Omit<BulkUploadParams, 'files'>) =>
-      contentService.bulkUploadFromZip(file, { folderId, completionCriteria, downloadable }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: contentKeys.lists() });
-      queryClient.invalidateQueries({ queryKey: contentKeys.myLists() });
-    },
-  });
-};

--- a/src/pages/tu/index.ts
+++ b/src/pages/tu/index.ts
@@ -7,6 +7,7 @@ export {
   CourseApplyPage,
   TuContentCreatePage,
   ContentDetailPage,
+  ContentBulkUploadPage,
   MyAssignmentsPage,
   AssignmentDetailPage,
   MyProgramsPage,

--- a/src/pages/tu/teaching/content/ContentBulkUploadPage.tsx
+++ b/src/pages/tu/teaching/content/ContentBulkUploadPage.tsx
@@ -4,7 +4,6 @@ import {
   Upload,
   X,
   File,
-  FileArchive,
   CheckCircle,
   AlertCircle,
   Loader2,
@@ -13,14 +12,14 @@ import {
 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button } from '@/components/common';
-import { useBulkUploadContent, useBulkUploadFromZip } from '@/hooks/tu';
+import { useBulkUploadContent } from '@/hooks/tu';
 import { useSubdomainPath } from '@/hooks/common/useSubdomainPath';
 
 interface ContentBulkUploadPageProps {
   language?: 'ko' | 'en';
 }
 
-type UploadMode = 'files' | 'zip' | 'folder';
+type UploadMode = 'files' | 'folder';
 
 interface FileItem {
   file: File;
@@ -35,13 +34,10 @@ const t = {
   uploadMode: { ko: '업로드 방식', en: 'Upload Mode' },
   multipleFiles: { ko: '파일 선택', en: 'Select Files' },
   multipleFilesDesc: { ko: '여러 개의 파일을 직접 선택', en: 'Select multiple files directly' },
-  zipFile: { ko: 'ZIP 파일', en: 'ZIP File' },
-  zipFileDesc: { ko: 'ZIP 압축 파일을 업로드', en: 'Upload a ZIP archive' },
   folderUpload: { ko: '폴더 업로드', en: 'Folder Upload' },
   folderUploadDesc: { ko: '폴더 전체를 업로드', en: 'Upload an entire folder' },
   dragAndDrop: { ko: '파일을 드래그하여 업로드하거나', en: 'Drag and drop files here or' },
   selectFiles: { ko: '파일 선택', en: 'Select Files' },
-  selectZip: { ko: 'ZIP 파일 선택', en: 'Select ZIP File' },
   selectFolder: { ko: '폴더 선택', en: 'Select Folder' },
   supportedFormats: { ko: '지원 형식: MP4, MOV, JPG, PNG, PDF, DOC, DOCX, PPT, PPTX', en: 'Supported: MP4, MOV, JPG, PNG, PDF, DOC, DOCX, PPT, PPTX' },
   maxFiles: { ko: '최대 10개, 총 2GB까지', en: 'Max 10 files, up to 2GB total' },
@@ -84,11 +80,9 @@ export function ContentBulkUploadPage({ language = 'ko' }: Readonly<ContentBulkU
   } | null>(null);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const zipInputRef = useRef<HTMLInputElement>(null);
   const folderInputRef = useRef<HTMLInputElement>(null);
 
   const bulkUpload = useBulkUploadContent();
-  const zipUpload = useBulkUploadFromZip();
 
   const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
 
@@ -119,15 +113,6 @@ export function ContentBulkUploadPage({ language = 'ko' }: Readonly<ContentBulkU
   }, []);
 
   const addFiles = (newFiles: File[]) => {
-    // ZIP 모드인 경우 첫 번째 ZIP 파일만 추가
-    if (uploadMode === 'zip') {
-      const zipFile = newFiles.find(f => f.name.toLowerCase().endsWith('.zip'));
-      if (zipFile) {
-        setFiles([{ file: zipFile, status: 'pending' }]);
-      }
-      return;
-    }
-
     // 최대 10개 제한
     const currentCount = files.length;
     const allowedCount = 10 - currentCount;
@@ -180,33 +165,18 @@ export function ContentBulkUploadPage({ language = 'ko' }: Readonly<ContentBulkU
     setUploadResult(null);
 
     try {
-      if (uploadMode === 'zip' && files.length === 1) {
-        // ZIP 파일 업로드
-        const result = await zipUpload.mutateAsync({
-          file: files[0].file,
-          completionCriteria: 'BUTTON_CLICK',
-          downloadable: false,
-        });
-        setUploadResult({
-          success: result.successCount,
-          failed: result.failCount,
-          total: result.totalCount,
-          failedItems: result.failedItems,
-        });
-      } else {
-        // 다중 파일 업로드
-        const result = await bulkUpload.mutateAsync({
-          files: files.map(f => f.file),
-          completionCriteria: 'BUTTON_CLICK',
-          downloadable: false,
-        });
-        setUploadResult({
-          success: result.successCount,
-          failed: result.failCount,
-          total: result.totalCount,
-          failedItems: result.failedItems,
-        });
-      }
+      // 다중 파일 업로드
+      const result = await bulkUpload.mutateAsync({
+        files: files.map(f => f.file),
+        completionCriteria: 'BUTTON_CLICK',
+        downloadable: false,
+      });
+      setUploadResult({
+        success: result.successCount,
+        failed: result.failCount,
+        total: result.totalCount,
+        failedItems: result.failedItems,
+      });
     } catch (error) {
       console.error('Bulk upload failed:', error);
       setUploadResult({
@@ -298,10 +268,9 @@ export function ContentBulkUploadPage({ language = 'ko' }: Readonly<ContentBulkU
           <>
             <div className="bg-bg-default rounded-xl p-6 border border-border mb-6">
               <h2 className="text-text-primary mb-4">{getText('uploadMode')}</h2>
-              <div className="grid grid-cols-3 gap-4">
+              <div className="grid grid-cols-2 gap-4">
                 {([
                   { mode: 'files' as const, icon: File, title: getText('multipleFiles'), desc: getText('multipleFilesDesc') },
-                  { mode: 'zip' as const, icon: FileArchive, title: getText('zipFile'), desc: getText('zipFileDesc') },
                   { mode: 'folder' as const, icon: FolderUp, title: getText('folderUpload'), desc: getText('folderUploadDesc') },
                 ]).map(({ mode, icon: Icon, title, desc }) => (
                   <button
@@ -342,9 +311,7 @@ export function ContentBulkUploadPage({ language = 'ko' }: Readonly<ContentBulkU
                     : 'border-border hover:border-action-primary hover:bg-bg-secondary/50'
                 )}
                 onClick={() => {
-                  if (uploadMode === 'zip') {
-                    zipInputRef.current?.click();
-                  } else if (uploadMode === 'folder') {
+                  if (uploadMode === 'folder') {
                     folderInputRef.current?.click();
                   } else {
                     fileInputRef.current?.click();
@@ -357,9 +324,7 @@ export function ContentBulkUploadPage({ language = 'ko' }: Readonly<ContentBulkU
                   </div>
                   <p className="text-text-primary mb-2">{getText('dragAndDrop')}</p>
                   <Button type="button">
-                    {uploadMode === 'zip' ? getText('selectZip') :
-                     uploadMode === 'folder' ? getText('selectFolder') :
-                     getText('selectFiles')}
+                    {uploadMode === 'folder' ? getText('selectFolder') : getText('selectFiles')}
                   </Button>
                   <p className="text-xs text-text-secondary mt-4">{getText('supportedFormats')}</p>
                   <p className="text-xs text-text-secondary">{getText('maxFiles')}</p>
@@ -373,13 +338,6 @@ export function ContentBulkUploadPage({ language = 'ko' }: Readonly<ContentBulkU
                   onChange={handleFileSelect}
                   className="hidden"
                   accept=".mp4,.mov,.avi,.mkv,.jpg,.jpeg,.png,.gif,.webp,.pdf,.txt,.doc,.docx,.ppt,.pptx"
-                />
-                <input
-                  ref={zipInputRef}
-                  type="file"
-                  onChange={handleFileSelect}
-                  className="hidden"
-                  accept=".zip"
                 />
                 <input
                   ref={folderInputRef}

--- a/src/pages/tu/teaching/content/ContentBulkUploadPage.tsx
+++ b/src/pages/tu/teaching/content/ContentBulkUploadPage.tsx
@@ -297,100 +297,132 @@ export function ContentBulkUploadPage({ language = 'ko' }: Readonly<ContentBulkU
               </div>
             </div>
 
-            {/* 파일 드롭존 */}
+            {/* 파일 드롭존 - 파일이 없을 때만 크게 표시 */}
             <div className="bg-bg-default rounded-xl p-6 border border-border mb-6">
-              <div
-                onDragEnter={handleDragEnter}
-                onDragOver={handleDragOver}
-                onDragLeave={handleDragLeave}
-                onDrop={handleDrop}
-                className={cn(
-                  'border-2 border-dashed rounded-lg p-12 text-center transition-all cursor-pointer',
-                  isDragging
-                    ? 'border-action-primary bg-action-primary/5'
-                    : 'border-border hover:border-action-primary hover:bg-bg-secondary/50'
-                )}
-                onClick={() => {
-                  if (uploadMode === 'folder') {
-                    folderInputRef.current?.click();
-                  } else {
-                    fileInputRef.current?.click();
-                  }
-                }}
-              >
-                <div className="flex flex-col items-center">
-                  <div className="w-20 h-20 mb-4 rounded-full bg-bg-secondary flex items-center justify-center">
-                    <Upload className="w-10 h-10 text-action-primary" />
-                  </div>
-                  <p className="text-text-primary mb-2">{getText('dragAndDrop')}</p>
-                  <Button type="button">
-                    {uploadMode === 'folder' ? getText('selectFolder') : getText('selectFiles')}
-                  </Button>
-                  <p className="text-xs text-text-secondary mt-4">{getText('supportedFormats')}</p>
-                  <p className="text-xs text-text-secondary">{getText('maxFiles')}</p>
-                </div>
-
-                {/* Hidden file inputs */}
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  multiple
-                  onChange={handleFileSelect}
-                  className="hidden"
-                  accept=".mp4,.mov,.avi,.mkv,.jpg,.jpeg,.png,.gif,.webp,.pdf,.txt,.doc,.docx,.ppt,.pptx"
-                />
-                <input
-                  ref={folderInputRef}
-                  type="file"
-                  multiple
-                  onChange={handleFileSelect}
-                  className="hidden"
-                  {...{ webkitdirectory: '', directory: '' } as React.InputHTMLAttributes<HTMLInputElement>}
-                />
-              </div>
-            </div>
-
-            {/* 선택된 파일 목록 */}
-            {files.length > 0 && (
-              <div className="bg-bg-default rounded-xl p-6 border border-border mb-6">
-                <div className="flex items-center justify-between mb-4">
-                  <h2 className="text-text-primary">
-                    {getText('selectedFiles')} ({files.length}/10)
-                  </h2>
-                  <Button variant="ghost" size="sm" onClick={handleClearAll}>
-                    {getText('clearAll')}
-                  </Button>
-                </div>
-                <div className="space-y-2 max-h-80 overflow-y-auto">
-                  {files.map((item, index) => (
-                    <div
-                      key={index}
-                      className="flex items-center gap-3 p-3 bg-bg-secondary rounded-lg"
-                    >
-                      <File className="w-5 h-5 text-action-primary flex-shrink-0" />
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm text-text-primary truncate">{item.file.name}</p>
-                        <p className="text-xs text-text-secondary">{formatFileSize(item.file.size)}</p>
-                      </div>
-                      {item.status === 'success' && (
-                        <CheckCircle className="w-5 h-5 text-status-success flex-shrink-0" />
-                      )}
-                      {item.status === 'error' && (
-                        <AlertCircle className="w-5 h-5 text-status-error flex-shrink-0" />
-                      )}
-                      {item.status === 'pending' && (
-                        <button
-                          onClick={() => handleRemoveFile(index)}
-                          className="p-1 hover:bg-bg-default rounded transition-colors"
-                        >
-                          <X className="w-4 h-4 text-text-secondary" />
-                        </button>
-                      )}
+              {files.length === 0 ? (
+                /* 파일 없을 때: 큰 드롭존 */
+                <div
+                  onDragEnter={handleDragEnter}
+                  onDragOver={handleDragOver}
+                  onDragLeave={handleDragLeave}
+                  onDrop={handleDrop}
+                  className={cn(
+                    'border-2 border-dashed rounded-lg p-12 text-center transition-all cursor-pointer',
+                    isDragging
+                      ? 'border-action-primary bg-action-primary/5'
+                      : 'border-border hover:border-action-primary hover:bg-bg-secondary/50'
+                  )}
+                  onClick={() => {
+                    if (uploadMode === 'folder') {
+                      folderInputRef.current?.click();
+                    } else {
+                      fileInputRef.current?.click();
+                    }
+                  }}
+                >
+                  <div className="flex flex-col items-center">
+                    <div className="w-20 h-20 mb-4 rounded-full bg-bg-secondary flex items-center justify-center">
+                      <Upload className="w-10 h-10 text-action-primary" />
                     </div>
-                  ))}
+                    <p className="text-text-primary mb-2">{getText('dragAndDrop')}</p>
+                    <Button type="button">
+                      {uploadMode === 'folder' ? getText('selectFolder') : getText('selectFiles')}
+                    </Button>
+                    <p className="text-xs text-text-secondary mt-4">{getText('supportedFormats')}</p>
+                    <p className="text-xs text-text-secondary">{getText('maxFiles')}</p>
+                  </div>
                 </div>
-              </div>
-            )}
+              ) : (
+                /* 파일 있을 때: 파일 목록 + 작은 추가 버튼 */
+                <>
+                  <div className="flex items-center justify-between mb-4">
+                    <h2 className="text-text-primary">
+                      {getText('selectedFiles')} ({files.length}/10)
+                    </h2>
+                    <div className="flex items-center gap-2">
+                      <Button variant="ghost" size="sm" onClick={handleClearAll}>
+                        {getText('clearAll')}
+                      </Button>
+                    </div>
+                  </div>
+                  <div className="space-y-2 max-h-80 overflow-y-auto mb-4">
+                    {files.map((item, index) => (
+                      <div
+                        key={index}
+                        className="flex items-center gap-3 p-3 bg-bg-secondary rounded-lg"
+                      >
+                        <File className="w-5 h-5 text-action-primary flex-shrink-0" />
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm text-text-primary truncate">{item.file.name}</p>
+                          <p className="text-xs text-text-secondary">{formatFileSize(item.file.size)}</p>
+                        </div>
+                        {item.status === 'success' && (
+                          <CheckCircle className="w-5 h-5 text-status-success flex-shrink-0" />
+                        )}
+                        {item.status === 'error' && (
+                          <AlertCircle className="w-5 h-5 text-status-error flex-shrink-0" />
+                        )}
+                        {item.status === 'pending' && (
+                          <button
+                            onClick={() => handleRemoveFile(index)}
+                            className="p-1 hover:bg-bg-default rounded transition-colors"
+                          >
+                            <X className="w-4 h-4 text-text-secondary" />
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                  {/* 파일 추가 영역 (작은 드롭존) */}
+                  {files.length < 10 && (
+                    <div
+                      onDragEnter={handleDragEnter}
+                      onDragOver={handleDragOver}
+                      onDragLeave={handleDragLeave}
+                      onDrop={handleDrop}
+                      className={cn(
+                        'border-2 border-dashed rounded-lg p-4 text-center transition-all cursor-pointer',
+                        isDragging
+                          ? 'border-action-primary bg-action-primary/5'
+                          : 'border-border hover:border-action-primary hover:bg-bg-secondary/50'
+                      )}
+                      onClick={() => {
+                        if (uploadMode === 'folder') {
+                          folderInputRef.current?.click();
+                        } else {
+                          fileInputRef.current?.click();
+                        }
+                      }}
+                    >
+                      <div className="flex items-center justify-center gap-2 text-text-secondary">
+                        <Upload className="w-5 h-5" />
+                        <span className="text-sm">
+                          {language === 'ko' ? '파일 추가 (드래그 또는 클릭)' : 'Add files (drag or click)'}
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
+
+              {/* Hidden file inputs */}
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                onChange={handleFileSelect}
+                className="hidden"
+                accept=".mp4,.mov,.avi,.mkv,.jpg,.jpeg,.png,.gif,.webp,.pdf,.txt,.doc,.docx,.ppt,.pptx"
+              />
+              <input
+                ref={folderInputRef}
+                type="file"
+                multiple
+                onChange={handleFileSelect}
+                className="hidden"
+                {...{ webkitdirectory: '', directory: '' } as React.InputHTMLAttributes<HTMLInputElement>}
+              />
+            </div>
 
             {/* 업로드 버튼 */}
             <div className="flex justify-end">

--- a/src/pages/tu/teaching/content/ContentBulkUploadPage.tsx
+++ b/src/pages/tu/teaching/content/ContentBulkUploadPage.tsx
@@ -1,0 +1,462 @@
+import { useState, useRef, DragEvent, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Upload,
+  X,
+  File,
+  FileArchive,
+  CheckCircle,
+  AlertCircle,
+  Loader2,
+  ArrowLeft,
+  FolderUp,
+} from 'lucide-react';
+import { cn } from '@/utils/cn';
+import { Button } from '@/components/common';
+import { useBulkUploadContent, useBulkUploadFromZip } from '@/hooks/tu';
+import { useSubdomainPath } from '@/hooks/common/useSubdomainPath';
+
+interface ContentBulkUploadPageProps {
+  language?: 'ko' | 'en';
+}
+
+type UploadMode = 'files' | 'zip' | 'folder';
+
+interface FileItem {
+  file: File;
+  status: 'pending' | 'uploading' | 'success' | 'error';
+  errorMessage?: string;
+}
+
+const t = {
+  title: { ko: '콘텐츠 일괄 등록', en: 'Bulk Content Upload' },
+  subtitle: { ko: '여러 파일을 한번에 업로드하세요. 최대 10개까지 가능합니다.', en: 'Upload multiple files at once. Maximum 10 files allowed.' },
+  back: { ko: '돌아가기', en: 'Back' },
+  uploadMode: { ko: '업로드 방식', en: 'Upload Mode' },
+  multipleFiles: { ko: '파일 선택', en: 'Select Files' },
+  multipleFilesDesc: { ko: '여러 개의 파일을 직접 선택', en: 'Select multiple files directly' },
+  zipFile: { ko: 'ZIP 파일', en: 'ZIP File' },
+  zipFileDesc: { ko: 'ZIP 압축 파일을 업로드', en: 'Upload a ZIP archive' },
+  folderUpload: { ko: '폴더 업로드', en: 'Folder Upload' },
+  folderUploadDesc: { ko: '폴더 전체를 업로드', en: 'Upload an entire folder' },
+  dragAndDrop: { ko: '파일을 드래그하여 업로드하거나', en: 'Drag and drop files here or' },
+  selectFiles: { ko: '파일 선택', en: 'Select Files' },
+  selectZip: { ko: 'ZIP 파일 선택', en: 'Select ZIP File' },
+  selectFolder: { ko: '폴더 선택', en: 'Select Folder' },
+  supportedFormats: { ko: '지원 형식: MP4, MOV, JPG, PNG, PDF, DOC, DOCX, PPT, PPTX', en: 'Supported: MP4, MOV, JPG, PNG, PDF, DOC, DOCX, PPT, PPTX' },
+  maxFiles: { ko: '최대 10개, 총 2GB까지', en: 'Max 10 files, up to 2GB total' },
+  selectedFiles: { ko: '선택된 파일', en: 'Selected Files' },
+  removeFile: { ko: '파일 삭제', en: 'Remove File' },
+  clearAll: { ko: '전체 삭제', en: 'Clear All' },
+  upload: { ko: '업로드', en: 'Upload' },
+  uploading: { ko: '업로드 중...', en: 'Uploading...' },
+  uploadComplete: { ko: '업로드 완료', en: 'Upload Complete' },
+  uploadResult: { ko: '업로드 결과', en: 'Upload Result' },
+  success: { ko: '성공', en: 'Success' },
+  failed: { ko: '실패', en: 'Failed' },
+  total: { ko: '전체', en: 'Total' },
+  goToList: { ko: '목록으로', en: 'Go to List' },
+  uploadMore: { ko: '추가 업로드', en: 'Upload More' },
+  tooManyFiles: { ko: '최대 10개까지 선택할 수 있습니다.', en: 'You can select up to 10 files.' },
+  noFilesSelected: { ko: '파일을 선택해주세요.', en: 'Please select files.' },
+};
+
+const formatFileSize = (bytes: number) => {
+  if (bytes === 0) return '0 Bytes';
+  const k = 1024;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + ' ' + sizes[i];
+};
+
+export function ContentBulkUploadPage({ language = 'ko' }: Readonly<ContentBulkUploadPageProps>) {
+  const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
+  const [uploadMode, setUploadMode] = useState<UploadMode>('files');
+  const [files, setFiles] = useState<FileItem[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadResult, setUploadResult] = useState<{
+    success: number;
+    failed: number;
+    total: number;
+    failedItems: { fileName: string; errorMessage: string }[];
+  } | null>(null);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const zipInputRef = useRef<HTMLInputElement>(null);
+  const folderInputRef = useRef<HTMLInputElement>(null);
+
+  const bulkUpload = useBulkUploadContent();
+  const zipUpload = useBulkUploadFromZip();
+
+  const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
+
+  const handleDragEnter = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+  };
+
+  const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  const handleDrop = useCallback((e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+
+    const droppedFiles = Array.from(e.dataTransfer.files);
+    addFiles(droppedFiles);
+  }, []);
+
+  const addFiles = (newFiles: File[]) => {
+    // ZIP 모드인 경우 첫 번째 ZIP 파일만 추가
+    if (uploadMode === 'zip') {
+      const zipFile = newFiles.find(f => f.name.toLowerCase().endsWith('.zip'));
+      if (zipFile) {
+        setFiles([{ file: zipFile, status: 'pending' }]);
+      }
+      return;
+    }
+
+    // 최대 10개 제한
+    const currentCount = files.length;
+    const allowedCount = 10 - currentCount;
+
+    if (allowedCount <= 0) {
+      alert(getText('tooManyFiles'));
+      return;
+    }
+
+    const filesToAdd = newFiles.slice(0, allowedCount);
+    const newFileItems: FileItem[] = filesToAdd.map(f => ({
+      file: f,
+      status: 'pending' as const,
+    }));
+
+    setFiles(prev => [...prev, ...newFileItems]);
+
+    if (newFiles.length > allowedCount) {
+      alert(getText('tooManyFiles'));
+    }
+  };
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFiles = e.target.files;
+    if (selectedFiles) {
+      addFiles(Array.from(selectedFiles));
+    }
+    // Reset input
+    if (e.target) {
+      e.target.value = '';
+    }
+  };
+
+  const handleRemoveFile = (index: number) => {
+    setFiles(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const handleClearAll = () => {
+    setFiles([]);
+    setUploadResult(null);
+  };
+
+  const handleUpload = async () => {
+    if (files.length === 0) {
+      alert(getText('noFilesSelected'));
+      return;
+    }
+
+    setIsUploading(true);
+    setUploadResult(null);
+
+    try {
+      if (uploadMode === 'zip' && files.length === 1) {
+        // ZIP 파일 업로드
+        const result = await zipUpload.mutateAsync({
+          file: files[0].file,
+          completionCriteria: 'BUTTON_CLICK',
+          downloadable: false,
+        });
+        setUploadResult({
+          success: result.successCount,
+          failed: result.failCount,
+          total: result.totalCount,
+          failedItems: result.failedItems,
+        });
+      } else {
+        // 다중 파일 업로드
+        const result = await bulkUpload.mutateAsync({
+          files: files.map(f => f.file),
+          completionCriteria: 'BUTTON_CLICK',
+          downloadable: false,
+        });
+        setUploadResult({
+          success: result.successCount,
+          failed: result.failCount,
+          total: result.totalCount,
+          failedItems: result.failedItems,
+        });
+      }
+    } catch (error) {
+      console.error('Bulk upload failed:', error);
+      setUploadResult({
+        success: 0,
+        failed: files.length,
+        total: files.length,
+        failedItems: files.map(f => ({
+          fileName: f.file.name,
+          errorMessage: 'Upload failed',
+        })),
+      });
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleGoToList = () => {
+    navigate(prefixPath('/tu/teaching/content'));
+  };
+
+  const handleUploadMore = () => {
+    setFiles([]);
+    setUploadResult(null);
+  };
+
+  return (
+    <div className="min-h-screen bg-bg-app">
+      {/* Header */}
+      <div className="bg-bg-app border-b border-border px-6 py-4">
+        <div className="max-w-4xl mx-auto">
+          <div className="flex items-center gap-4 mb-2">
+            <Button variant="ghost" size="sm" onClick={() => navigate(-1)}>
+              <ArrowLeft size={20} />
+              {getText('back')}
+            </Button>
+          </div>
+          <h1 className="text-text-primary m-0">{getText('title')}</h1>
+          <p className="text-text-secondary text-sm m-0 mt-1">{getText('subtitle')}</p>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="max-w-4xl mx-auto p-6">
+        {/* 업로드 결과 표시 */}
+        {uploadResult && (
+          <div className="bg-bg-default rounded-xl p-6 border border-border mb-6">
+            <h2 className="text-text-primary mb-4">{getText('uploadResult')}</h2>
+            <div className="flex gap-4 mb-4">
+              <div className="flex-1 bg-status-success/10 rounded-lg p-4 text-center">
+                <CheckCircle className="w-8 h-8 text-status-success mx-auto mb-2" />
+                <p className="text-2xl font-bold text-status-success">{uploadResult.success}</p>
+                <p className="text-sm text-text-secondary">{getText('success')}</p>
+              </div>
+              <div className="flex-1 bg-status-error/10 rounded-lg p-4 text-center">
+                <AlertCircle className="w-8 h-8 text-status-error mx-auto mb-2" />
+                <p className="text-2xl font-bold text-status-error">{uploadResult.failed}</p>
+                <p className="text-sm text-text-secondary">{getText('failed')}</p>
+              </div>
+            </div>
+
+            {uploadResult.failedItems.length > 0 && (
+              <div className="bg-status-error/5 rounded-lg p-4 mb-4">
+                <p className="text-sm font-medium text-status-error mb-2">
+                  {getText('failed')} ({uploadResult.failedItems.length})
+                </p>
+                <ul className="text-sm text-text-secondary space-y-1">
+                  {uploadResult.failedItems.map((item, i) => (
+                    <li key={i}>
+                      <span className="font-medium">{item.fileName}</span>: {item.errorMessage}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            <div className="flex gap-3 justify-end">
+              <Button variant="ghost" className="border border-border" onClick={handleUploadMore}>
+                {getText('uploadMore')}
+              </Button>
+              <Button onClick={handleGoToList}>
+                {getText('goToList')}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* 업로드 모드 선택 */}
+        {!uploadResult && (
+          <>
+            <div className="bg-bg-default rounded-xl p-6 border border-border mb-6">
+              <h2 className="text-text-primary mb-4">{getText('uploadMode')}</h2>
+              <div className="grid grid-cols-3 gap-4">
+                {([
+                  { mode: 'files' as const, icon: File, title: getText('multipleFiles'), desc: getText('multipleFilesDesc') },
+                  { mode: 'zip' as const, icon: FileArchive, title: getText('zipFile'), desc: getText('zipFileDesc') },
+                  { mode: 'folder' as const, icon: FolderUp, title: getText('folderUpload'), desc: getText('folderUploadDesc') },
+                ]).map(({ mode, icon: Icon, title, desc }) => (
+                  <button
+                    key={mode}
+                    onClick={() => {
+                      setUploadMode(mode);
+                      setFiles([]);
+                    }}
+                    className={cn(
+                      'p-4 rounded-xl border-2 text-left transition-all',
+                      uploadMode === mode
+                        ? 'border-action-primary bg-action-primary/5'
+                        : 'border-border hover:border-action-primary/50'
+                    )}
+                  >
+                    <Icon className={cn(
+                      'w-8 h-8 mb-2',
+                      uploadMode === mode ? 'text-action-primary' : 'text-text-secondary'
+                    )} />
+                    <p className="font-medium text-text-primary">{title}</p>
+                    <p className="text-xs text-text-secondary mt-1">{desc}</p>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* 파일 드롭존 */}
+            <div className="bg-bg-default rounded-xl p-6 border border-border mb-6">
+              <div
+                onDragEnter={handleDragEnter}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                className={cn(
+                  'border-2 border-dashed rounded-lg p-12 text-center transition-all cursor-pointer',
+                  isDragging
+                    ? 'border-action-primary bg-action-primary/5'
+                    : 'border-border hover:border-action-primary hover:bg-bg-secondary/50'
+                )}
+                onClick={() => {
+                  if (uploadMode === 'zip') {
+                    zipInputRef.current?.click();
+                  } else if (uploadMode === 'folder') {
+                    folderInputRef.current?.click();
+                  } else {
+                    fileInputRef.current?.click();
+                  }
+                }}
+              >
+                <div className="flex flex-col items-center">
+                  <div className="w-20 h-20 mb-4 rounded-full bg-bg-secondary flex items-center justify-center">
+                    <Upload className="w-10 h-10 text-action-primary" />
+                  </div>
+                  <p className="text-text-primary mb-2">{getText('dragAndDrop')}</p>
+                  <Button type="button">
+                    {uploadMode === 'zip' ? getText('selectZip') :
+                     uploadMode === 'folder' ? getText('selectFolder') :
+                     getText('selectFiles')}
+                  </Button>
+                  <p className="text-xs text-text-secondary mt-4">{getText('supportedFormats')}</p>
+                  <p className="text-xs text-text-secondary">{getText('maxFiles')}</p>
+                </div>
+
+                {/* Hidden file inputs */}
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  multiple
+                  onChange={handleFileSelect}
+                  className="hidden"
+                  accept=".mp4,.mov,.avi,.mkv,.jpg,.jpeg,.png,.gif,.webp,.pdf,.txt,.doc,.docx,.ppt,.pptx"
+                />
+                <input
+                  ref={zipInputRef}
+                  type="file"
+                  onChange={handleFileSelect}
+                  className="hidden"
+                  accept=".zip"
+                />
+                <input
+                  ref={folderInputRef}
+                  type="file"
+                  multiple
+                  onChange={handleFileSelect}
+                  className="hidden"
+                  {...{ webkitdirectory: '', directory: '' } as React.InputHTMLAttributes<HTMLInputElement>}
+                />
+              </div>
+            </div>
+
+            {/* 선택된 파일 목록 */}
+            {files.length > 0 && (
+              <div className="bg-bg-default rounded-xl p-6 border border-border mb-6">
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="text-text-primary">
+                    {getText('selectedFiles')} ({files.length}/10)
+                  </h2>
+                  <Button variant="ghost" size="sm" onClick={handleClearAll}>
+                    {getText('clearAll')}
+                  </Button>
+                </div>
+                <div className="space-y-2 max-h-80 overflow-y-auto">
+                  {files.map((item, index) => (
+                    <div
+                      key={index}
+                      className="flex items-center gap-3 p-3 bg-bg-secondary rounded-lg"
+                    >
+                      <File className="w-5 h-5 text-action-primary flex-shrink-0" />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm text-text-primary truncate">{item.file.name}</p>
+                        <p className="text-xs text-text-secondary">{formatFileSize(item.file.size)}</p>
+                      </div>
+                      {item.status === 'success' && (
+                        <CheckCircle className="w-5 h-5 text-status-success flex-shrink-0" />
+                      )}
+                      {item.status === 'error' && (
+                        <AlertCircle className="w-5 h-5 text-status-error flex-shrink-0" />
+                      )}
+                      {item.status === 'pending' && (
+                        <button
+                          onClick={() => handleRemoveFile(index)}
+                          className="p-1 hover:bg-bg-default rounded transition-colors"
+                        >
+                          <X className="w-4 h-4 text-text-secondary" />
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* 업로드 버튼 */}
+            <div className="flex justify-end">
+              <Button
+                onClick={handleUpload}
+                disabled={files.length === 0 || isUploading}
+                className="min-w-32"
+              >
+                {isUploading ? (
+                  <>
+                    <Loader2 className="w-5 h-5 animate-spin" />
+                    {getText('uploading')}
+                  </>
+                ) : (
+                  <>
+                    <Upload className="w-5 h-5" />
+                    {getText('upload')}
+                  </>
+                )}
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/teaching/content/MyContentPage.tsx
+++ b/src/pages/tu/teaching/content/MyContentPage.tsx
@@ -23,6 +23,7 @@ import {
   Folder,
   FolderInput,
   Download,
+  Upload,
 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button, Badge, ViewToggle, DataTable, DataTableColumnHeader, IconStatCard, Checkbox } from '@/components/common';
@@ -61,6 +62,7 @@ const t = {
   title: { ko: '내 콘텐츠', en: 'My Content' },
   subtitle: { ko: '등록한 콘텐츠를 관리하고 새로운 콘텐츠를 업로드하세요.', en: 'Manage your content and upload new materials.' },
   createContent: { ko: '콘텐츠 등록', en: 'Add Content' },
+  bulkUpload: { ko: '일괄 등록', en: 'Bulk Upload' },
   searchPlaceholder: { ko: '콘텐츠 검색...', en: 'Search content...' },
   filter: { ko: '필터', en: 'Filter' },
   contentType: { ko: '콘텐츠 유형', en: 'Content Type' },
@@ -428,6 +430,13 @@ export function MyContentPage({ language = 'ko' }: Readonly<MyContentPageProps>)
               <Button onClick={() => navigate(prefixPath('/tu/teaching/content/create'))}>
                 <Plus size={20} />
                 <span>{getText('createContent')}</span>
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => navigate(prefixPath('/tu/teaching/content/bulk-upload'))}
+              >
+                <Upload size={20} />
+                <span>{getText('bulkUpload')}</span>
               </Button>
               <Button
                 variant="ghost"

--- a/src/pages/tu/teaching/content/index.ts
+++ b/src/pages/tu/teaching/content/index.ts
@@ -1,3 +1,4 @@
 export { MyContentPage } from './MyContentPage';
 export { ContentCreatePage } from './ContentCreatePage';
 export { ContentDetailPage } from './ContentDetailPage';
+export { ContentBulkUploadPage } from './ContentBulkUploadPage';

--- a/src/pages/tu/teaching/index.ts
+++ b/src/pages/tu/teaching/index.ts
@@ -1,5 +1,5 @@
 export { MyCoursesPage, CourseCreatePage, CourseEditPage, CourseDetailPage, CourseApplyPage } from './courses';
-export { MyContentPage, ContentCreatePage as TuContentCreatePage, ContentDetailPage } from './content';
+export { MyContentPage, ContentCreatePage as TuContentCreatePage, ContentDetailPage, ContentBulkUploadPage } from './content';
 export { MyAssignmentsPage, AssignmentDetailPage } from './assignments';
 export {
   MyProgramsPage,

--- a/src/routes/tu.teaching.routes.tsx
+++ b/src/routes/tu.teaching.routes.tsx
@@ -11,6 +11,7 @@ import {
   CourseApplyPage,
   TuContentCreatePage,
   ContentDetailPage,
+  ContentBulkUploadPage,
   MyAssignmentsPage,
   AssignmentDetailPage,
   MyProgramsPage,
@@ -56,6 +57,7 @@ export const tuTeachingRoutes = (
     <Route path="teaching/programs/:programId/edit" element={<TuProgramEditPage />} />
     <Route path="teaching/content" element={<MyContentPage />} />
     <Route path="teaching/content/create" element={<TuContentCreatePage />} />
+    <Route path="teaching/content/bulk-upload" element={<ContentBulkUploadPage />} />
     <Route path="teaching/content/:id" element={<ContentDetailPage />} />
     <Route path="teaching/assignments" element={<MyAssignmentsPage />} />
     <Route path="teaching/assignments/:id" element={<AssignmentDetailPage />} />
@@ -84,6 +86,7 @@ export const tuTeachingRoutes = (
     {/* 내 콘텐츠 */}
     <Route path="teaching/content" element={<MyContentPage />} />
     <Route path="teaching/content/create" element={<TuContentCreatePage />} />
+    <Route path="teaching/content/bulk-upload" element={<ContentBulkUploadPage />} />
     <Route path="teaching/content/:id" element={<ContentDetailPage />} />
 
     {/* 내 과제 */}

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -144,7 +144,6 @@ export const API_ENDPOINTS = {
     BASE: '/contents',
     UPLOAD: '/contents/upload',
     BULK_UPLOAD: '/contents/bulk-upload',
-    BULK_UPLOAD_ZIP: '/contents/bulk-upload/zip',
     EXTERNAL_LINK: '/contents/external-link',
     MY: '/contents/my',
     BY_ID: (id: number) => `/contents/${id}`,

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -143,6 +143,8 @@ export const API_ENDPOINTS = {
   CONTENTS: {
     BASE: '/contents',
     UPLOAD: '/contents/upload',
+    BULK_UPLOAD: '/contents/bulk-upload',
+    BULK_UPLOAD_ZIP: '/contents/bulk-upload/zip',
     EXTERNAL_LINK: '/contents/external-link',
     MY: '/contents/my',
     BY_ID: (id: number) => `/contents/${id}`,

--- a/src/services/tu/contentService.ts
+++ b/src/services/tu/contentService.ts
@@ -37,6 +37,25 @@ interface UploadFileOptions {
   downloadable?: boolean;
 }
 
+// 일괄 업로드 옵션
+interface BulkUploadOptions {
+  folderId?: number;
+  completionCriteria?: CompletionCriteria;
+  downloadable?: boolean;
+}
+
+// 일괄 업로드 응답
+interface BulkUploadResponse {
+  totalCount: number;
+  successCount: number;
+  failCount: number;
+  successItems: ContentResponse[];
+  failedItems: {
+    fileName: string;
+    errorMessage: string;
+  }[];
+}
+
 export const contentService = {
   // 파일 업로드
   async uploadFile(file: File, options?: UploadFileOptions): Promise<ContentResponse> {
@@ -86,6 +105,64 @@ export const contentService = {
     const { data } = await axiosInstance.post<ContentResponse>(
       API_ENDPOINTS.CONTENTS.EXTERNAL_LINK,
       request
+    );
+    return data;
+  },
+
+  // 다중 파일 일괄 업로드 (최대 10개)
+  async bulkUploadFiles(files: File[], options?: BulkUploadOptions): Promise<BulkUploadResponse> {
+    const formData = new FormData();
+    files.forEach((file) => {
+      formData.append('files', file);
+    });
+
+    if (options?.folderId) {
+      formData.append('folderId', String(options.folderId));
+    }
+    if (options?.completionCriteria) {
+      formData.append('completionCriteria', options.completionCriteria);
+    }
+    if (options?.downloadable !== undefined) {
+      formData.append('downloadable', String(options.downloadable));
+    }
+
+    const { data } = await axiosInstance.post<BulkUploadResponse>(
+      API_ENDPOINTS.CONTENTS.BULK_UPLOAD,
+      formData,
+      {
+        headers: {
+          'Content-Type': undefined,
+        },
+        timeout: 600000, // 10분 (대용량 파일 다중 업로드용)
+      }
+    );
+    return data;
+  },
+
+  // ZIP 파일 일괄 업로드
+  async bulkUploadFromZip(zipFile: File, options?: BulkUploadOptions): Promise<BulkUploadResponse> {
+    const formData = new FormData();
+    formData.append('file', zipFile);
+
+    if (options?.folderId) {
+      formData.append('folderId', String(options.folderId));
+    }
+    if (options?.completionCriteria) {
+      formData.append('completionCriteria', options.completionCriteria);
+    }
+    if (options?.downloadable !== undefined) {
+      formData.append('downloadable', String(options.downloadable));
+    }
+
+    const { data } = await axiosInstance.post<BulkUploadResponse>(
+      API_ENDPOINTS.CONTENTS.BULK_UPLOAD_ZIP,
+      formData,
+      {
+        headers: {
+          'Content-Type': undefined,
+        },
+        timeout: 600000, // 10분
+      }
     );
     return data;
   },

--- a/src/services/tu/contentService.ts
+++ b/src/services/tu/contentService.ts
@@ -139,34 +139,6 @@ export const contentService = {
     return data;
   },
 
-  // ZIP 파일 일괄 업로드
-  async bulkUploadFromZip(zipFile: File, options?: BulkUploadOptions): Promise<BulkUploadResponse> {
-    const formData = new FormData();
-    formData.append('file', zipFile);
-
-    if (options?.folderId) {
-      formData.append('folderId', String(options.folderId));
-    }
-    if (options?.completionCriteria) {
-      formData.append('completionCriteria', options.completionCriteria);
-    }
-    if (options?.downloadable !== undefined) {
-      formData.append('downloadable', String(options.downloadable));
-    }
-
-    const { data } = await axiosInstance.post<BulkUploadResponse>(
-      API_ENDPOINTS.CONTENTS.BULK_UPLOAD_ZIP,
-      formData,
-      {
-        headers: {
-          'Content-Type': undefined,
-        },
-        timeout: 600000, // 10분
-      }
-    );
-    return data;
-  },
-
   // 콘텐츠 목록 조회
   async getContents(params?: ContentFilterParams): Promise<PageResponse<ContentListResponse>> {
     const { data } = await axiosInstance.get<PageResponse<ContentListResponse>>(


### PR DESCRIPTION
## Summary
- 다중 파일 일괄 업로드 기능 추가
- 파일/폴더 선택 업로드 모드 지원
- 파일 선택 시 UI 개선 (큰 드롭존 → 파일 목록 + 작은 추가 영역)

Closes #402

## Test plan
- [x] 파일 선택 모드에서 다중 파일 선택 후 업로드 확인
- [x] 폴더 업로드 모드에서 폴더 선택 후 업로드 확인
- [x] 10개 파일 제한 동작 확인
- [x] 업로드 결과 화면 표시 확인