### PR TITLE
feat: 상단 배너 TA 브랜딩 설정 및 내비게이션 링크 수정

### DIFF
--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Search, ShoppingCart, Bell, Menu, X, LogOut, User, Sun, Moon, BookOpen, PlusCircle, Shield, Globe, Heart } from 'lucide-react';
 import { useAuth } from '@/hooks/common/auth';
@@ -17,8 +17,14 @@ const DEFAULT_NAV_ITEMS: NavigationItemResponse[] = [
   { id: 3, label: '커뮤니티', icon: 'Users', path: '/tu/b2c/community', enabled: true, displayOrder: 3, target: null, createdAt: '', updatedAt: '' },
 ];
 
+const BANNER_DISMISSED_KEY = 'tu_top_banner_dismissed';
+
 export function LandingHeader() {
-  const [showBanner, setShowBanner] = useState(true);
+  // 배너 닫힘 상태를 localStorage에서 읽어서 초기화
+  const [showBanner, setShowBanner] = useState(() => {
+    const dismissed = localStorage.getItem(BANNER_DISMISSED_KEY);
+    return dismissed !== 'true';
+  });
   const [searchQuery, setSearchQuery] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
   const navigate = useNavigate();
@@ -38,6 +44,13 @@ export function LandingHeader() {
   // 네비게이션 메뉴 (TA 설정 또는 기본값)
   // headerSettings.navLinks가 있으면 그것을 사용 (visible 필터링), 없으면 API 데이터 사용
   const headerNavLinks = (layoutData?.headerSettings as { navLinks?: Array<{ label: string; url: string; visible: boolean }> })?.navLinks;
+
+  // URL 정규화: /courses -> /tu/b2c/courses (외부 링크는 제외)
+  const normalizeNavUrl = (url: string) => {
+    if (url.startsWith('http') || url.startsWith('/tu/')) return url;
+    return `/tu/b2c${url.startsWith('/') ? url : `/${url}`}`;
+  };
+
   const navItems = headerNavLinks && headerNavLinks.length > 0
     ? headerNavLinks
         .filter(link => link.visible)
@@ -45,7 +58,7 @@ export function LandingHeader() {
           id: index + 1,
           label: link.label,
           icon: 'BookOpen',
-          path: link.url,
+          path: normalizeNavUrl(link.url),
           enabled: true,
           displayOrder: index + 1,
           target: null,
@@ -93,7 +106,22 @@ export function LandingHeader() {
 
   const tenantName = branding?.tenantName || 'MZC Learn';
 
+  // 상단 배너 설정 (TA에서 설정 가능)
+  const topBannerSettings = (layoutData?.headerSettings as { topBanner?: { enabled?: boolean; text?: string; linkUrl?: string; linkText?: string } })?.topBanner;
+  const topBannerEnabled = topBannerSettings?.enabled !== false; // 기본값 true
+  const topBannerText = topBannerSettings?.text || t.landing.banner;
+  const topBannerLinkUrl = topBannerSettings?.linkUrl;
+  const topBannerLinkText = topBannerSettings?.linkText;
+
+  // 배너 닫기 핸들러 (localStorage에 저장)
+  const handleCloseBanner = useCallback(() => {
+    localStorage.setItem(BANNER_DISMISSED_KEY, 'true');
+    setShowBanner(false);
+  }, []);
+
   const handleLogout = () => {
+    // 로그아웃 시 배너 닫힘 상태 리셋
+    localStorage.removeItem(BANNER_DISMISSED_KEY);
     logout();
     setShowDropdown(false);
   };
@@ -108,11 +136,21 @@ export function LandingHeader() {
   return (
     <header className="w-full flex flex-col">
       {/* Top Notification Banner - Gradient */}
-      {showBanner && (
+      {showBanner && topBannerEnabled && (
         <div className="bg-gradient-to-r from-[#6778ff] via-[#a855f7] to-[#6bc2f0] text-white text-xs md:text-sm py-2.5 px-4 text-center font-medium flex justify-center items-center gap-2 relative">
-          <span>{t.landing.banner}</span>
+          <span>{topBannerText}</span>
+          {topBannerLinkUrl && topBannerLinkText && (
+            <a
+              href={topBannerLinkUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:no-underline ml-1"
+            >
+              {topBannerLinkText}
+            </a>
+          )}
           <button
-            onClick={() => setShowBanner(false)}
+            onClick={handleCloseBanner}
             className="absolute right-4 text-white/70 hover:text-white text-lg transition-colors"
             aria-label={t.landing.closeBanner}
           >

--- a/src/pages/ta/branding/BrandingSettingsPage.tsx
+++ b/src/pages/ta/branding/BrandingSettingsPage.tsx
@@ -281,6 +281,12 @@ interface BrandingSettings {
     showNotifications: boolean;
     showThemeToggle: boolean;
     navLinks: { label: string; url: string; visible: boolean }[];
+    topBanner: {
+      enabled: boolean;
+      text: string;
+      linkUrl: string;
+      linkText: string;
+    };
   };
   banner: {
     enabled: boolean;
@@ -362,10 +368,16 @@ const defaultBrandingSettings: BrandingSettings = {
     showNotifications: true,
     showThemeToggle: true,
     navLinks: [
-      { label: '강의 탐색', url: '/courses', visible: true },
-      { label: '로드맵', url: '/roadmaps', visible: true },
-      { label: '커뮤니티', url: '/community', visible: true },
+      { label: '강의 탐색', url: '/tu/b2c/courses', visible: true },
+      { label: '로드맵', url: '/tu/b2c/roadmaps', visible: true },
+      { label: '커뮤니티', url: '/tu/b2c/community', visible: true },
     ],
+    topBanner: {
+      enabled: true,
+      text: 'MZC Learn Platform - 클라우드 교육의 새로운 시작',
+      linkUrl: '',
+      linkText: '',
+    },
   },
   banner: {
     enabled: true,
@@ -559,6 +571,10 @@ const getExpandableItemIds = () => {
             showWishlist: (tenantSettings.headerSettings as { showWishlist?: boolean }).showWishlist ?? prev.header.showWishlist,
             showNotifications: (tenantSettings.headerSettings as { showNotifications?: boolean }).showNotifications ?? prev.header.showNotifications,
             showThemeToggle: (tenantSettings.headerSettings as { showThemeToggle?: boolean }).showThemeToggle ?? prev.header.showThemeToggle,
+            topBanner: {
+              ...prev.header.topBanner,
+              ...(tenantSettings.headerSettings as { topBanner?: typeof prev.header.topBanner }).topBanner,
+            },
           },
         }),
       }));
@@ -703,6 +719,7 @@ const getExpandableItemIds = () => {
           showNotifications: settings.header.showNotifications,
           showThemeToggle: settings.header.showThemeToggle,
           navLinks: settings.header.navLinks,
+          topBanner: settings.header.topBanner,
         } as unknown as Parameters<typeof updateLayoutMutation.mutateAsync>[0]['headerSettings'],
         footerSettings: {
           enabled: settings.footer.enabled,
@@ -1123,6 +1140,62 @@ const getExpandableItemIds = () => {
                     <div className="flex items-center justify-between">
                       <Label>테마 토글 표시</Label>
                       <Switch checked={settings.header.showThemeToggle} onCheckedChange={(v) => updateHeader('showThemeToggle', v)} />
+                    </div>
+
+                    {/* 상단 배너 설정 */}
+                    <div className="pt-3 border-t">
+                      <div className="flex items-center justify-between mb-3">
+                        <Label className="font-medium">상단 알림 배너</Label>
+                        <Switch
+                          checked={settings.header.topBanner.enabled}
+                          onCheckedChange={(v) => setSettings(prev => ({
+                            ...prev,
+                            header: { ...prev.header, topBanner: { ...prev.header.topBanner, enabled: v } }
+                          }))}
+                        />
+                      </div>
+                      {settings.header.topBanner.enabled && (
+                        <div className="space-y-3">
+                          <div>
+                            <Label className="text-xs text-muted-foreground mb-1 block">배너 텍스트</Label>
+                            <Input
+                              value={settings.header.topBanner.text}
+                              onChange={(e) => setSettings(prev => ({
+                                ...prev,
+                                header: { ...prev.header, topBanner: { ...prev.header.topBanner, text: e.target.value } }
+                              }))}
+                              placeholder="상단에 표시할 텍스트"
+                            />
+                          </div>
+                          <div className="grid grid-cols-2 gap-2">
+                            <div>
+                              <Label className="text-xs text-muted-foreground mb-1 block">링크 URL (선택)</Label>
+                              <Input
+                                value={settings.header.topBanner.linkUrl}
+                                onChange={(e) => setSettings(prev => ({
+                                  ...prev,
+                                  header: { ...prev.header, topBanner: { ...prev.header.topBanner, linkUrl: e.target.value } }
+                                }))}
+                                placeholder="https://..."
+                              />
+                            </div>
+                            <div>
+                              <Label className="text-xs text-muted-foreground mb-1 block">링크 텍스트 (선택)</Label>
+                              <Input
+                                value={settings.header.topBanner.linkText}
+                                onChange={(e) => setSettings(prev => ({
+                                  ...prev,
+                                  header: { ...prev.header, topBanner: { ...prev.header.topBanner, linkText: e.target.value } }
+                                }))}
+                                placeholder="자세히 보기"
+                              />
+                            </div>
+                          </div>
+                          <p className="text-xs text-muted-foreground">
+                            * 사용자가 X 버튼을 누르면 다음 로그인까지 숨겨집니다
+                          </p>
+                        </div>
+                      )}
                     </div>
 
                     {/* 내비게이션 링크 */}

--- a/src/types/admin/tenantSettings.types.ts
+++ b/src/types/admin/tenantSettings.types.ts
@@ -25,6 +25,12 @@ export interface HeaderSettings {
   shadow: 'none' | 'sm' | 'md'; // 그림자
   mobileMenuStyle: 'hamburger' | 'drawer' | 'bottomSheet'; // 모바일 메뉴
   navLinks?: Array<{ label: string; url: string; visible: boolean }>;
+  topBanner?: {
+    enabled?: boolean;
+    text?: string;
+    linkUrl?: string;
+    linkText?: string;
+  };
 }
 
 // 사이드바 설정

--- a/src/types/tu/branding.types.ts
+++ b/src/types/tu/branding.types.ts
@@ -47,6 +47,12 @@ export interface HeaderSettings {
   showShadow?: boolean;
   mobileMenuStyle?: 'drawer' | 'fullscreen';
   navLinks?: Array<{ label: string; url: string; visible: boolean }>;
+  topBanner?: {
+    enabled?: boolean;
+    text?: string;
+    linkUrl?: string;
+    linkText?: string;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

B2C 페이지의 상단 알림 배너를 TA 브랜딩 설정에서 커스터마이징 가능하도록 하고, 내비게이션 링크 URL 정규화 이슈를 수정합니다.

## Related Issue

- N/A

## Changes

- 상단 알림 배너 TA 브랜딩 설정 추가 (활성화, 텍스트, 링크 URL, 링크 텍스트)
- 배너 X 버튼 클릭 시 localStorage에 저장하여 새로고침 후에도 닫힘 상태 유지
- 로그아웃 시 배너 닫힘 상태 리셋 (다음 로그인 시 다시 표시)
- 내비게이션 링크 URL 정규화 (`/courses` → `/tu/b2c/courses`)
- HeaderSettings 타입에 topBanner 필드 추가

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

- 기존 DB에 `/courses` 형식으로 저장된 URL도 `normalizeNavUrl` 함수로 자동 변환됩니다