### PR TITLE
[Feat] subdomain setting

### DIFF
--- a/src/hooks/common/useSubdomainPath.ts
+++ b/src/hooks/common/useSubdomainPath.ts
@@ -1,9 +1,33 @@
-import { useCallback } from 'react';
-import { useParams } from 'react-router-dom';
+import { useCallback, useMemo } from 'react';
+import { useParams, useLocation } from 'react-router-dom';
+
+/**
+ * 경로에서 서브도메인 추출
+ * 경로 패턴: /{subdomain}/(tu|ta|co)/...
+ */
+function extractSubdomainFromPath(pathname: string): string | null {
+  const regex = /^\/([^/]+)\/(tu|ta|co)(\/|$)/;
+  const match = regex.exec(pathname);
+  const subdomain = match?.[1];
+
+  if (subdomain) {
+    // 시스템 경로는 제외
+    if (['admin', 'sa', 'auth', 'public'].includes(subdomain)) {
+      return null;
+    }
+    return subdomain;
+  }
+
+  return null;
+}
 
 /**
  * 서브도메인 기반 경로 프리픽스 훅
  * URL에서 subdomain 파라미터를 추출하여 경로 앞에 추가
+ *
+ * 두 가지 방법으로 서브도메인 추출:
+ * 1. useParams() - React Router 라우트 파라미터
+ * 2. pathname 파싱 - 폴백 방식
  *
  * @example
  * const { prefixPath } = useSubdomainPath();
@@ -13,7 +37,12 @@ import { useParams } from 'react-router-dom';
  * prefixPath('/ta/settings') // => '/ta/settings'
  */
 export function useSubdomainPath() {
-  const { subdomain } = useParams<{ subdomain: string }>();
+  const { subdomain: routeSubdomain } = useParams<{ subdomain: string }>();
+  const location = useLocation();
+
+  // useParams에서 가져온 subdomain이 없으면 pathname에서 추출 (폴백)
+  const extractedSubdomain = extractSubdomainFromPath(location.pathname);
+  const subdomain = routeSubdomain || extractedSubdomain;
 
   const prefixPath = useCallback(
     (path: string) => {

--- a/src/pages/tu/main/CoursesExplorePage.tsx
+++ b/src/pages/tu/main/CoursesExplorePage.tsx
@@ -6,6 +6,7 @@ import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
 import { useCourseTimeCatalog, useCheckWishlistStatus, useToggleWishlist } from '@/hooks/tu';
 import { useAuthStore } from '@/store/common/authStore';
+import { useSubdomainPath } from '@/hooks/common';
 import { toast } from 'sonner';
 import type {
   CourseTimeCatalogResponse,
@@ -75,6 +76,7 @@ function formatShortDate(dateString: string): string {
 function CourseTimeCard({ courseTime, isDark }: CourseTimeCardProps) {
   const navigate = useNavigate();
   const { isAuthenticated } = useAuthStore();
+  const { prefixPath } = useSubdomainPath();
 
   // 찜 상태 확인 및 토글
   const { data: isWishlisted = false, isLoading: isWishlistChecking } = useCheckWishlistStatus(
@@ -91,7 +93,7 @@ function CourseTimeCard({ courseTime, isDark }: CourseTimeCardProps) {
 
     if (!isAuthenticated) {
       toast.error('로그인이 필요합니다.');
-      navigate('/auth/login', { state: { from: `/tu/b2c/times/${courseTime.id}` } });
+      navigate('/login', { state: { from: prefixPath(`/tu/b2c/times/${courseTime.id}`) } });
       return;
     }
 
@@ -132,7 +134,7 @@ function CourseTimeCard({ courseTime, isDark }: CourseTimeCardProps) {
     : null;
 
   return (
-    <Link to={`/tu/b2c/courses/${courseTime.id}`} className="group block h-full">
+    <Link to={prefixPath(`/tu/b2c/courses/${courseTime.id}`)} className="group block h-full">
       <div
         className={`h-full card-hover rounded-xl overflow-hidden border ${
           isDark ? 'bg-white/5 border-white/10' : 'bg-white border-gray-200 shadow-sm'

--- a/src/pages/tu/main/LandingPage.tsx
+++ b/src/pages/tu/main/LandingPage.tsx
@@ -13,6 +13,7 @@ import { usePopularInstructors, useCourseTimeCatalog, usePublicLayout } from '@/
 import { useTenantBranding } from '@/contexts/TenantBrandingContext';
 import { useBrandingApply } from '@/hooks/tu/useBrandingApply';
 import { useAuth } from '@/hooks/common/auth/useAuth';
+import { useSubdomainPath } from '@/hooks/common';
 import type { InstructorSummary } from '@/types/tu';
 import type { CourseTimeCatalogResponse } from '@/types/tu/courseTimeCatalog.types';
 import { DELIVERY_TYPE_LABELS, PROGRAM_LEVEL_LABELS } from '@/types/tu/courseTimeCatalog.types';
@@ -142,6 +143,7 @@ export function LandingPage() {
   const { theme } = useThemeStore();
   const { t } = useTranslation();
   const { isAuthenticated } = useAuth();
+  const { prefixPath } = useSubdomainPath();
   const isDark = theme === 'dark';
   const { branding } = useTenantBranding();
 
@@ -237,12 +239,12 @@ export function LandingPage() {
               </h2>
               <p className="landing-text-muted text-sm mt-2">{t.landing.featuredCoursesDesc}</p>
             </div>
-            <a
-              href="/tu/b2c/courses"
+            <Link
+              to={prefixPath('/tu/b2c/courses')}
               className="text-sm landing-text-secondary hover:opacity-80 flex items-center gap-1 transition-colors"
             >
               {t.landing.viewAll} <ChevronRight className="w-4 h-4" />
-            </a>
+            </Link>
           </div>
 
           {isCoursesLoading ? (
@@ -299,12 +301,12 @@ export function LandingPage() {
               <h2 className="text-2xl md:text-3xl font-bold landing-text-primary">{t.landing.beginnerCourses}</h2>
               <p className="landing-text-muted text-sm mt-2">{t.landing.beginnerCoursesDesc}</p>
             </div>
-            <a
-              href="/tu/b2c/courses"
+            <Link
+              to={prefixPath('/tu/b2c/courses')}
               className="text-sm landing-text-secondary hover:opacity-80 flex items-center gap-1 transition-colors"
             >
               {t.landing.viewAll} <ChevronRight className="w-4 h-4" />
-            </a>
+            </Link>
           </div>
           {isCoursesLoading ? (
             <div className="flex justify-center items-center py-20">
@@ -342,7 +344,7 @@ export function LandingPage() {
               {popularInstructors.map((instructor) => (
                 <Link
                   key={instructor.id}
-                  to={`/tu/b2c/instructors/${instructor.id}`}
+                  to={prefixPath(`/tu/b2c/instructors/${instructor.id}`)}
                   className={`group block rounded-2xl p-6 transition-all duration-300 border ${
                     isDark
                       ? 'glass border-white/10 hover:border-[#6778ff]/50'
@@ -414,7 +416,7 @@ export function LandingPage() {
                 </p>
               </div>
               <Link
-                to={isAuthenticated ? "/tu/b2c/mypage/teaching" : "/login"}
+                to={isAuthenticated ? prefixPath("/tu/b2c/mypage/teaching") : "/login"}
                 className="flex items-center gap-2 px-8 py-4 bg-white text-[#6778ff] font-semibold rounded-xl hover:bg-gray-100 transition-colors shadow-lg"
               >
                 강사 시작하기

--- a/src/pages/tu/main/NotificationDetailPage.tsx
+++ b/src/pages/tu/main/NotificationDetailPage.tsx
@@ -97,13 +97,9 @@ function NotificationMetadataInfo({ type, metadata, isDark }: NotificationMetada
                 </span>
               </div>
             )}
-            {metadata.enrollmentStatus && (
-              <span className={`px-2.5 py-1 rounded-full text-xs font-medium ${
-                metadata.enrollmentStatus === 'APPROVED'
-                  ? 'bg-emerald-500/20 text-emerald-400'
-                  : 'bg-red-500/20 text-red-400'
-              }`}>
-                {metadata.enrollmentStatus === 'APPROVED' ? '승인됨' : '거절됨'}
+            {metadata.enrollmentStatus === 'APPROVED' && (
+              <span className="px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/20 text-emerald-400">
+                승인됨
               </span>
             )}
           </div>
@@ -251,7 +247,7 @@ export function NotificationDetailPage() {
             <p className={`mb-6 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
               해당 알림이 삭제되었거나 존재하지 않습니다.
             </p>
-            <Button onClick={() => navigate('/tu/b2c/notifications')}>
+            <Button onClick={() => navigate(prefixPath('/tu/b2c/notifications'))}>
               알림 목록으로 돌아가기
             </Button>
           </div>
@@ -271,7 +267,7 @@ export function NotificationDetailPage() {
         <div className="max-w-3xl mx-auto">
           {/* Back Button */}
           <button
-            onClick={() => navigate('/tu/b2c/notifications')}
+            onClick={() => navigate(prefixPath('/tu/b2c/notifications'))}
             className={`flex items-center gap-2 mb-6 transition-colors ${
               isDark
                 ? 'text-gray-400 hover:text-white'

--- a/src/pages/tu/main/SearchPage.tsx
+++ b/src/pages/tu/main/SearchPage.tsx
@@ -18,6 +18,7 @@ import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
 import { LandingCourseCard } from '@/components/landing';
 import { useCourseTimeCatalog, useRoadmapExplore, useCommunityPosts } from '@/hooks/tu';
+import { useSubdomainPath } from '@/hooks/common';
 import type { RoadmapExploreItem } from '@/types/tu/roadmapExplore.types';
 import type { CommunityPost } from '@/types/tu/community.types';
 import { ROADMAP_LEVEL_LABELS } from '@/types/tu/roadmapExplore.types';
@@ -685,8 +686,9 @@ function searchCommunity(posts: CommunityPost[], keyword: string): CommunityPost
  * 로드맵 카드 컴포넌트
  */
 function RoadmapCard({ roadmap, isDark }: { roadmap: RoadmapExploreItem; isDark: boolean }) {
+  const { prefixPath } = useSubdomainPath();
   return (
-    <Link to={`/tu/b2c/roadmaps/${roadmap.id}`} className="group block">
+    <Link to={prefixPath(`/tu/b2c/roadmaps/${roadmap.id}`)} className="group block">
       <div
         className={`rounded-2xl overflow-hidden border transition-all duration-300 ${
           isDark
@@ -818,9 +820,10 @@ function FilterDropdown({
  * 커뮤니티 게시글 카드 컴포넌트
  */
 function CommunityCard({ post, isDark }: { post: CommunityPost; isDark: boolean }) {
+  const { prefixPath } = useSubdomainPath();
   return (
     <Link
-      to={`/tu/b2c/community/${post.id}`}
+      to={prefixPath(`/tu/b2c/community/${post.id}`)}
       className={`block p-4 rounded-xl border transition-all duration-300 ${
         isDark
           ? 'bg-white/5 border-white/10 hover:border-[#6778ff]/50'

--- a/src/routes/tu.b2c.routes.tsx
+++ b/src/routes/tu.b2c.routes.tsx
@@ -40,6 +40,10 @@ export const tuB2cRoutes = (
     <Route path="/:subdomain/tu/b2c/times/:id" element={<CourseDetailPage />} />
     <Route path="/tu/b2c/times/:id" element={<CourseDetailPage />} />
 
+    {/* 차수별 커뮤니티 상세 */}
+    <Route path="/:subdomain/tu/b2c/times/:courseTimeId/community/:id" element={<CommunityDetailPage />} />
+    <Route path="/tu/b2c/times/:courseTimeId/community/:id" element={<CommunityDetailPage />} />
+
     {/* 로드맵 */}
     <Route path="/:subdomain/tu/b2c/roadmaps" element={<RoadmapExplorePage />} />
     <Route path="/:subdomain/tu/b2c/roadmaps/:id" element={<RoadmapDetailPage />} />

--- a/src/types/tu/notification.types.ts
+++ b/src/types/tu/notification.types.ts
@@ -16,7 +16,7 @@ export interface NotificationMetadata {
   courseName?: string;
   courseId?: number;
   courseTimeId?: number;
-  enrollmentStatus?: 'APPROVED' | 'REJECTED';
+  enrollmentStatus?: 'APPROVED';
 
   // ASSIGNMENT 알림
   assignmentName?: string;
@@ -103,7 +103,6 @@ export type NotificationReferenceType =
 // COURSE 알림 서브타입
 export type CourseNotificationSubtype =
   | 'ENROLLMENT_APPROVED'   // 수강신청 승인
-  | 'ENROLLMENT_REJECTED'   // 수강신청 거절
   | 'COURSE_STARTED'        // 강의 시작
   | 'COURSE_ENDED';         // 강의 종료
 
@@ -149,20 +148,12 @@ export function getNotificationDeepLink(notification: NotificationItem): string 
 function getCourseNotificationLink(
   referenceType: string,
   referenceId: number,
-  message?: string,
+  _message?: string,
   metadata?: NotificationMetadata
 ): string | null {
   const courseTimeId = metadata?.courseTimeId;
 
-  // 수강신청 거절 시 강의 상세 페이지로 (재신청 유도)
-  if (message?.includes('거절') || message?.includes('반려')) {
-    if (courseTimeId) {
-      return `/tu/b2c/times/${courseTimeId}`;
-    }
-    return '/tu/b2c/courses';
-  }
-
-  // 승인/강의 시작/종료는 내 강의 페이지로
+  // courseTimeId가 있으면 해당 강의 페이지로
   if (courseTimeId) {
     return `/tu/b2c/times/${courseTimeId}`;
   }


### PR DESCRIPTION
## Summary

서브도메인 경로에서 네비게이션 시 서브도메인이 유실되는 문제를 수정하고, 관련 기능을 병합했습니다.

## Related Issue

- Closes #

## Changes

- `useSubdomainPath` 훅에 pathname 기반 서브도메인 추출 폴백 로직 추가
- `SearchPage`의 RoadmapCard, CommunityCard 컴포넌트에 `prefixPath` 적용
- `CoursesExplorePage`의 CourseTimeCard 컴포넌트에 `prefixPath` 적용
- `LandingPage`의 하드코딩된 링크들을 `prefixPath` 사용하도록 수정
- `NotificationDetailPage`의 navigate 호출에 `prefixPath` 적용
- TenantFeatures 관련 기능 병합

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes

- `/company-b/tu/b2c`에서 강의 카드 클릭 시 `/company-b/tu/b2c/courses/{id}`로 정상 이동하도록 수정
- `useParams()`가 서브도메인을 반환하지 않는 경우를 대비해 pathname에서 직접 추출하는 폴백 로직 추가