### PR TITLE
feat(tu): B2B 전용 랜딩 페이지 및 라우트 구현

### DIFF
--- a/src/pages/tu/b2b/B2BCourseDetailPage.tsx
+++ b/src/pages/tu/b2b/B2BCourseDetailPage.tsx
@@ -1,0 +1,873 @@
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { useSubdomainPath } from '@/hooks/common';
+import {
+  Clock,
+  Users,
+  PlayCircle,
+  FileText,
+  Heart,
+  Share2,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  CheckCircle,
+  Calendar,
+  MapPin,
+  AlertCircle,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { useThemeStore } from '@/store/common/themeStore';
+import { useAuthStore } from '@/store/common/authStore';
+import { LandingFooter } from '@/components/landing/LandingFooter';
+import { B2BLandingHeader } from './components/B2BLandingHeader';
+import { CourseReviewSection } from '@/components/domain/course-review';
+import { useCourseTimeDetail, useEnroll, useMyEnrollments, useCheckWishlistStatus, useToggleWishlist } from '@/hooks/tu';
+import type { CurriculumItemResponse } from '@/types/tu/courseTimeCatalog.types';
+import {
+  DELIVERY_TYPE_LABELS,
+  PROGRAM_LEVEL_LABELS,
+  ENROLLMENT_METHOD_LABELS,
+  COURSE_TIME_STATUS_LABELS,
+} from '@/types/tu/courseTimeCatalog.types';
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`;
+}
+
+interface CurriculumSectionProps {
+  item: CurriculumItemResponse;
+  isExpanded: boolean;
+  onToggle: () => void;
+  isDark: boolean;
+}
+
+function CurriculumSection({ item, isExpanded, onToggle, isDark }: CurriculumSectionProps) {
+  if (!item.isFolder) {
+    return (
+      <div
+        className={`flex items-center justify-between p-4 rounded-xl border transition-colors ${
+          isDark
+            ? 'glass border-white/10 hover:bg-white/5'
+            : 'bg-white border-gray-200 hover:bg-gray-50'
+        }`}
+      >
+        <div className="flex items-center gap-3">
+          <div
+            className={`w-8 h-8 rounded-lg flex items-center justify-center ${
+              isDark ? 'bg-white/10' : 'bg-gray-100'
+            }`}
+          >
+            <PlayCircle className={`w-4 h-4 ${isDark ? 'text-[#6bc2f0]' : 'text-[#6778ff]'}`} />
+          </div>
+          <span className={`font-medium ${isDark ? 'text-gray-200' : 'text-gray-700'}`}>
+            {item.itemName}
+          </span>
+        </div>
+        {item.duration && (
+          <span
+            className={`text-sm px-2 py-1 rounded-md ${
+              isDark ? 'bg-white/10 text-gray-400' : 'bg-gray-100 text-gray-500'
+            }`}
+          >
+            {Math.floor(item.duration / 60)}:{String(item.duration % 60).padStart(2, '0')}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  const childCount = item.children?.length || 0;
+
+  return (
+    <div
+      className={`rounded-xl overflow-hidden border ${
+        isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
+      }`}
+    >
+      <button
+        onClick={onToggle}
+        className={`w-full flex items-center justify-between p-4 transition-colors ${
+          isDark ? 'hover:bg-white/5' : 'hover:bg-gray-50'
+        }`}
+      >
+        <div className="flex items-center gap-3">
+          <ChevronDown
+            className={`w-5 h-5 transition-transform ${isExpanded ? 'rotate-180' : ''} ${
+              isDark ? 'text-gray-400' : 'text-gray-500'
+            }`}
+          />
+          <span className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            {item.itemName}
+          </span>
+        </div>
+        <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+          {childCount}개 항목
+        </span>
+      </button>
+      {isExpanded && item.children && item.children.length > 0 && (
+        <div className={`border-t ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
+          {item.children.map((child) => (
+            <div
+              key={child.id}
+              className={`flex items-center justify-between p-4 pl-12 transition-colors ${
+                isDark ? 'hover:bg-white/5' : 'hover:bg-gray-50'
+              }`}
+            >
+              <div className="flex items-center gap-3">
+                <div
+                  className={`w-8 h-8 rounded-lg flex items-center justify-center ${
+                    isDark ? 'bg-white/10' : 'bg-gray-100'
+                  }`}
+                >
+                  {child.isFolder ? (
+                    <FileText className={`w-4 h-4 ${isDark ? 'text-[#6bc2f0]' : 'text-[#6778ff]'}`} />
+                  ) : (
+                    <PlayCircle className={`w-4 h-4 ${isDark ? 'text-[#6bc2f0]' : 'text-[#6778ff]'}`} />
+                  )}
+                </div>
+                <span className={`font-medium ${isDark ? 'text-gray-200' : 'text-gray-700'}`}>{child.itemName}</span>
+              </div>
+              {child.duration && (
+                <span
+                  className={`text-sm px-2 py-1 rounded-md ${
+                    isDark ? 'bg-white/10 text-gray-400' : 'bg-gray-100 text-gray-500'
+                  }`}
+                >
+                  {Math.floor(child.duration / 60)}:{String(child.duration % 60).padStart(2, '0')}
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * B2B 강의 상세 페이지
+ * - 가격 표시 없음
+ * - 장바구니 버튼 없음
+ * - 커뮤니티 탭 없음
+ */
+export function B2BCourseDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const courseTimeId = id ? parseInt(id, 10) : 0;
+  const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
+
+  const { data: courseTime, isLoading, error } = useCourseTimeDetail(courseTimeId);
+  const enrollMutation = useEnroll();
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const { data: myEnrollments } = useMyEnrollments({ size: 100 });
+
+  const existingEnrollment = myEnrollments?.content.find(
+    (enrollment) => enrollment.courseTimeId === courseTimeId
+  );
+  const isAlreadyEnrolled = !!existingEnrollment;
+
+  const { data: isWishlisted = false, isLoading: isWishlistChecking } = useCheckWishlistStatus(
+    courseTimeId,
+    isAuthenticated
+  );
+  const { toggle: toggleWishlist, isLoading: isWishlistToggling } = useToggleWishlist();
+
+  const [expandedSections, setExpandedSections] = useState<number[]>([0]);
+  const [showCopiedToast, setShowCopiedToast] = useState(false);
+  const [activeTab, setActiveTab] = useState<'intro' | 'curriculum' | 'review'>('intro');
+  const { theme } = useThemeStore();
+  const isDark = theme === 'dark';
+
+  const toggleSection = (index: number) => {
+    if (expandedSections.includes(index)) {
+      setExpandedSections(expandedSections.filter((i) => i !== index));
+    } else {
+      setExpandedSections([...expandedSections, index]);
+    }
+  };
+
+  const handleWishlistToggle = async () => {
+    if (!isAuthenticated) {
+      toast.error('로그인이 필요합니다.');
+      navigate('/auth/login', { state: { from: prefixPath(`/tu/b2b/times/${courseTimeId}`) } });
+      return;
+    }
+
+    try {
+      await toggleWishlist(courseTimeId, isWishlisted);
+      toast.success(isWishlisted ? '찜 목록에서 제거되었습니다.' : '찜 목록에 추가되었습니다.');
+    } catch {
+      toast.error('찜 목록 변경에 실패했습니다.');
+    }
+  };
+
+  const handleShare = async () => {
+    const url = window.location.href;
+
+    const copyToClipboard = () => {
+      const textArea = document.createElement('textarea');
+      textArea.value = url;
+      textArea.style.position = 'fixed';
+      textArea.style.left = '-9999px';
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textArea);
+      setShowCopiedToast(true);
+      setTimeout(() => setShowCopiedToast(false), 2000);
+    };
+
+    if (navigator.share && /Android|iPhone|iPad|iPod/i.test(navigator.userAgent)) {
+      try {
+        await navigator.share({
+          title: courseTime?.title || '',
+          text: `"${courseTime?.title}" 강의를 확인해보세요!`,
+          url,
+        });
+        return;
+      } catch {
+        // fallback
+      }
+    }
+
+    if (navigator.clipboard && window.isSecureContext) {
+      try {
+        await navigator.clipboard.writeText(url);
+        setShowCopiedToast(true);
+        setTimeout(() => setShowCopiedToast(false), 2000);
+      } catch {
+        copyToClipboard();
+      }
+    } else {
+      copyToClipboard();
+    }
+  };
+
+  const handleEnroll = () => {
+    if (!isAuthenticated) {
+      toast.error('로그인이 필요합니다.');
+      navigate('/auth/login', { state: { from: prefixPath(`/tu/b2b/courses/${courseTimeId}`) } });
+      return;
+    }
+
+    if (isAlreadyEnrolled) {
+      toast.error('이미 수강 신청된 강의입니다.');
+      return;
+    }
+
+    enrollMutation.mutate(courseTimeId, {
+      onSuccess: () => {
+        toast.success('수강 신청이 완료되었습니다.');
+        navigate(prefixPath('/tu/b2c/mypage/learning'));
+      },
+      onError: (error: Error & { response?: { data?: { error?: { message?: string } } } }) => {
+        const message = error.response?.data?.error?.message || '수강 신청에 실패했습니다.';
+        toast.error(message);
+      },
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div
+        className={`min-h-screen flex items-center justify-center ${
+          isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'
+        }`}
+      >
+        <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
+      </div>
+    );
+  }
+
+  if (error || !courseTime) {
+    return (
+      <div
+        className={`min-h-screen flex items-center justify-center ${
+          isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'
+        }`}
+      >
+        <div className="text-center">
+          <p className={`text-xl ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            강의를 불러올 수 없습니다.
+          </p>
+          <Link to={prefixPath('/tu/b2b/courses')} className="text-[#6778ff] hover:underline mt-4 inline-block">
+            강의 목록으로 돌아가기
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const thumbnailUrl =
+    courseTime.program?.thumbnailUrl ||
+    'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=800&h=450&fit=crop';
+
+  const mainInstructor = courseTime.instructors.find((i) => i.role === 'MAIN');
+  const instructorName = mainInstructor?.name || courseTime.instructors[0]?.name || '';
+  const instructorImage = mainInstructor?.profileImageUrl || courseTime.instructors[0]?.profileImageUrl;
+
+  const levelLabel = courseTime.program?.level
+    ? PROGRAM_LEVEL_LABELS[courseTime.program.level]
+    : null;
+
+  const canEnroll = courseTime.status === 'RECRUITING' || courseTime.status === 'ONGOING';
+
+  return (
+    <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
+      <B2BLandingHeader />
+
+      {/* Hero Section */}
+      <div
+        className={`py-12 ${
+          isDark
+            ? 'bg-gradient-to-b from-[#1a1a2e] to-[#1e1e1e]'
+            : 'bg-gradient-to-b from-gray-100 to-gray-50'
+        }`}
+      >
+        <div className="w-full px-4 md:px-8 lg:px-16">
+          <div className="flex flex-col lg:flex-row gap-8 lg:items-start">
+            <div className="flex-1">
+              <nav
+                className={`flex items-center gap-2 text-sm mb-4 ${
+                  isDark ? 'text-gray-400' : 'text-gray-500'
+                }`}
+              >
+                <Link
+                  to="/tu/b2b/courses"
+                  className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}
+                >
+                  강의
+                </Link>
+                <ChevronRight className="w-4 h-4" />
+                <span className={isDark ? 'text-white' : 'text-gray-900'}>{courseTime.title}</span>
+              </nav>
+
+              {/* Tags (가격 관련 태그 제외) */}
+              <div className="flex gap-2 mb-4">
+                <span
+                  className={`px-3 py-1 rounded-full text-xs font-bold ${
+                    courseTime.status === 'RECRUITING'
+                      ? 'bg-green-500/20 text-green-400'
+                      : courseTime.status === 'ONGOING'
+                        ? 'bg-blue-500/20 text-blue-400'
+                        : 'bg-gray-500/20 text-gray-400'
+                  }`}
+                >
+                  {COURSE_TIME_STATUS_LABELS[courseTime.status]}
+                </span>
+
+                {courseTime.isOnDemand && (
+                  <span className="px-3 py-1 rounded-full text-xs font-bold bg-gradient-to-r from-[#70f2a0] to-[#6bc2f0] text-white">
+                    상시모집
+                  </span>
+                )}
+
+                <span
+                  className={`px-3 py-1 rounded-full text-xs font-medium ${
+                    isDark ? 'bg-white/10 text-gray-300' : 'bg-gray-100 text-gray-600'
+                  }`}
+                >
+                  {DELIVERY_TYPE_LABELS[courseTime.deliveryType]}
+                </span>
+              </div>
+
+              <h1
+                className={`text-3xl md:text-4xl font-bold mb-4 ${
+                  isDark ? 'text-white' : 'text-gray-900'
+                }`}
+              >
+                {courseTime.title}
+              </h1>
+
+              {courseTime.program?.description && (
+                <p className={`mb-6 leading-relaxed ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
+                  {courseTime.program.description}
+                </p>
+              )}
+
+              <div className="flex flex-wrap items-center gap-4 mb-6">
+                {courseTime.currentEnrollment > 0 && (
+                  <div
+                    className={`flex items-center gap-1 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}
+                  >
+                    <Users className="w-5 h-5" />
+                    <span>{courseTime.currentEnrollment.toLocaleString()}명 수강중</span>
+                  </div>
+                )}
+
+                {courseTime.program?.estimatedHours && (
+                  <div
+                    className={`flex items-center gap-1 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}
+                  >
+                    <Clock className="w-5 h-5" />
+                    <span>총 {courseTime.program.estimatedHours}시간</span>
+                  </div>
+                )}
+
+                {levelLabel && (
+                  <div
+                    className={`flex items-center gap-1 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}
+                  >
+                    <FileText className="w-5 h-5" />
+                    <span>{levelLabel}</span>
+                  </div>
+                )}
+              </div>
+
+              {instructorName && (
+                <div className="flex items-center gap-3 mb-8">
+                  {instructorImage ? (
+                    <img
+                      src={instructorImage}
+                      alt={instructorName}
+                      className="w-12 h-12 rounded-full object-cover"
+                    />
+                  ) : (
+                    <div
+                      className={`w-12 h-12 rounded-full flex items-center justify-center ${
+                        isDark ? 'bg-white/10' : 'bg-gray-200'
+                      }`}
+                    >
+                      <Users className="w-6 h-6" />
+                    </div>
+                  )}
+                  <div>
+                    <p className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                      {instructorName}
+                    </p>
+                    <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                      강사
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              <div
+                className={`rounded-xl overflow-hidden border ${
+                  isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
+                }`}
+              >
+                <div className="relative aspect-video">
+                  <img
+                    src={thumbnailUrl}
+                    alt={courseTime.title}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* Right - Course Card (가격/장바구니 제외) */}
+            <div className="lg:w-96">
+              <div
+                className={`rounded-2xl overflow-hidden sticky top-24 border ${
+                  isDark ? 'glass border-white/10' : 'bg-white border-gray-200 shadow-lg'
+                }`}
+              >
+                <div className="p-6">
+                  {/* B2B: 가격 표시 없음 */}
+
+                  {!courseTime.isOnDemand && (
+                    <div
+                      className={`mb-4 p-3 rounded-lg ${
+                        isDark ? 'bg-white/5' : 'bg-gray-50'
+                      }`}
+                    >
+                      <div className="flex items-center gap-2 mb-2">
+                        <Calendar className={`w-4 h-4 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+                        <span className={`text-sm font-medium ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                          모집 기간
+                        </span>
+                      </div>
+                      <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                        {formatDate(courseTime.enrollStartDate)} ~ {formatDate(courseTime.enrollEndDate)}
+                      </p>
+
+                      <div className="flex items-center gap-2 mt-3 mb-2">
+                        <Clock className={`w-4 h-4 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+                        <span className={`text-sm font-medium ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                          수강 기간
+                        </span>
+                      </div>
+                      <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                        {formatDate(courseTime.classStartDate)} ~ {formatDate(courseTime.classEndDate)}
+                      </p>
+                    </div>
+                  )}
+
+                  {courseTime.capacity !== null && (
+                    <div
+                      className={`mb-4 p-3 rounded-lg ${
+                        courseTime.availableSeats <= 5
+                          ? 'bg-orange-500/10'
+                          : isDark
+                            ? 'bg-white/5'
+                            : 'bg-gray-50'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className={`text-sm ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                          모집 인원
+                        </span>
+                        <span
+                          className={`text-sm font-medium ${
+                            courseTime.availableSeats <= 5
+                              ? 'text-orange-500'
+                              : isDark
+                                ? 'text-white'
+                                : 'text-gray-900'
+                          }`}
+                        >
+                          {courseTime.currentEnrollment} / {courseTime.capacity}명
+                          {courseTime.availableSeats <= 5 && ` (잔여 ${courseTime.availableSeats}석)`}
+                        </span>
+                      </div>
+                    </div>
+                  )}
+
+                  <div
+                    className={`mb-4 flex items-center gap-2 text-sm ${
+                      isDark ? 'text-gray-400' : 'text-gray-600'
+                    }`}
+                  >
+                    <AlertCircle className="w-4 h-4" />
+                    <span>{ENROLLMENT_METHOD_LABELS[courseTime.enrollmentMethod]} 방식</span>
+                  </div>
+
+                  {(courseTime.deliveryType === 'OFFLINE' || courseTime.deliveryType === 'BLENDED') &&
+                    courseTime.locationInfo && (
+                      <div
+                        className={`mb-4 flex items-start gap-2 text-sm ${
+                          isDark ? 'text-gray-400' : 'text-gray-600'
+                        }`}
+                      >
+                        <MapPin className="w-4 h-4 mt-0.5" />
+                        <span>{courseTime.locationInfo}</span>
+                      </div>
+                    )}
+
+                  {/* Buttons (장바구니 제외) */}
+                  <div className="space-y-3">
+                    {isAlreadyEnrolled ? (
+                      <>
+                        <button
+                          onClick={() => navigate(prefixPath(`/tu/b2c/mypage/learning/${existingEnrollment?.id}`))}
+                          className="w-full landing-btn-primary py-4 rounded-xl text-white font-bold text-lg flex items-center justify-center gap-2"
+                        >
+                          <PlayCircle className="w-5 h-5" />
+                          학습 계속하기
+                        </button>
+                        <p className={`text-center text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                          이미 수강 신청된 강의입니다
+                        </p>
+                      </>
+                    ) : canEnroll ? (
+                      <button
+                        onClick={handleEnroll}
+                        disabled={enrollMutation.isPending}
+                        className="w-full landing-btn-primary py-4 rounded-xl text-white font-bold text-lg disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                      >
+                        {enrollMutation.isPending ? (
+                          <>
+                            <Loader2 className="w-5 h-5 animate-spin" />
+                            신청 중...
+                          </>
+                        ) : (
+                          '수강 신청'
+                        )}
+                      </button>
+                    ) : (
+                      <button
+                        disabled
+                        className="w-full py-4 rounded-xl font-bold text-lg bg-gray-400 text-white cursor-not-allowed"
+                      >
+                        {courseTime.status === 'ONGOING'
+                          ? '진행 중인 강의입니다'
+                          : '모집이 마감되었습니다'}
+                      </button>
+                    )}
+
+                    <div className="flex gap-3">
+                      <button
+                        onClick={handleWishlistToggle}
+                        disabled={isWishlistToggling || isWishlistChecking}
+                        className={`flex-1 py-3 rounded-xl font-medium flex items-center justify-center gap-2 transition-colors border disabled:opacity-50 disabled:cursor-not-allowed ${
+                          isWishlisted
+                            ? 'bg-red-500/20 text-red-400 border-red-500/30'
+                            : isDark
+                              ? 'bg-white/5 text-gray-300 border-white/10 hover:bg-white/10'
+                              : 'bg-gray-50 text-gray-700 border-gray-200 hover:bg-gray-100'
+                        }`}
+                      >
+                        {isWishlistToggling ? (
+                          <Loader2 className="w-5 h-5 animate-spin" />
+                        ) : (
+                          <Heart className={`w-5 h-5 ${isWishlisted ? 'fill-current' : ''}`} />
+                        )}
+                        {isWishlisted ? '찜함' : '찜하기'}
+                      </button>
+                      <button
+                        onClick={handleShare}
+                        className={`flex-1 py-3 rounded-xl font-medium flex items-center justify-center gap-2 transition-colors border ${
+                          isDark
+                            ? 'bg-white/5 text-gray-300 border-white/10 hover:bg-white/10'
+                            : 'bg-gray-50 text-gray-700 border-gray-200 hover:bg-gray-100'
+                        }`}
+                      >
+                        <Share2 className="w-5 h-5" />
+                        공유
+                      </button>
+                    </div>
+                  </div>
+
+                  {courseTime.minProgressForCompletion && (
+                    <div
+                      className={`mt-6 pt-6 border-t text-sm ${
+                        isDark ? 'border-white/10 text-gray-400' : 'border-gray-200 text-gray-600'
+                      }`}
+                    >
+                      <div className="flex items-center gap-2">
+                        <CheckCircle className="w-4 h-4 text-green-500" />
+                        <span>수료 조건: 진도율 {courseTime.minProgressForCompletion}% 이상</span>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Tab Navigation (커뮤니티 탭 제외) */}
+      <div className={`border-b ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
+        <div className="w-full px-4 md:px-8 lg:px-16">
+          <div className="flex gap-8 max-w-4xl">
+            <button
+              onClick={() => setActiveTab('intro')}
+              className={`py-4 font-medium transition-colors relative ${
+                activeTab === 'intro'
+                  ? isDark
+                    ? 'text-white'
+                    : 'text-gray-900'
+                  : isDark
+                    ? 'text-gray-400 hover:text-gray-300'
+                    : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              강의 소개
+              {activeTab === 'intro' && (
+                <div
+                  className={`absolute bottom-0 left-0 right-0 h-0.5 ${
+                    isDark ? 'bg-white' : 'bg-gray-900'
+                  }`}
+                />
+              )}
+            </button>
+            <button
+              onClick={() => setActiveTab('curriculum')}
+              className={`py-4 font-medium transition-colors relative ${
+                activeTab === 'curriculum'
+                  ? isDark
+                    ? 'text-white'
+                    : 'text-gray-900'
+                  : isDark
+                    ? 'text-gray-400 hover:text-gray-300'
+                    : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              커리큘럼
+              {activeTab === 'curriculum' && (
+                <div
+                  className={`absolute bottom-0 left-0 right-0 h-0.5 ${
+                    isDark ? 'bg-white' : 'bg-gray-900'
+                  }`}
+                />
+              )}
+            </button>
+            <button
+              onClick={() => setActiveTab('review')}
+              className={`py-4 font-medium transition-colors relative ${
+                activeTab === 'review'
+                  ? isDark
+                    ? 'text-white'
+                    : 'text-gray-900'
+                  : isDark
+                    ? 'text-gray-400 hover:text-gray-300'
+                    : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              수강평
+              {activeTab === 'review' && (
+                <div
+                  className={`absolute bottom-0 left-0 right-0 h-0.5 ${
+                    isDark ? 'bg-white' : 'bg-gray-900'
+                  }`}
+                />
+              )}
+            </button>
+            {/* B2B: 커뮤니티 탭 제외 */}
+          </div>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <main className="w-full px-4 md:px-8 lg:px-16 py-12">
+        <div className="max-w-4xl">
+          {activeTab === 'intro' && (
+            <>
+              {courseTime.program?.description && (
+                <section className="mb-12">
+                  <h2
+                    className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}
+                  >
+                    강의 소개
+                  </h2>
+                  <div
+                    className={`rounded-xl p-6 border ${
+                      isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
+                    }`}
+                  >
+                    <p className={`leading-relaxed whitespace-pre-wrap ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
+                      {courseTime.program.description}
+                    </p>
+                  </div>
+                </section>
+              )}
+
+              {courseTime.instructors.length > 0 && (
+                <section className="mb-12">
+                  <h2
+                    className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}
+                  >
+                    강사 소개
+                  </h2>
+                  <div className="space-y-4">
+                    {courseTime.instructors.map((instructor) => (
+                      <div
+                        key={instructor.id}
+                        className={`rounded-xl p-6 border ${
+                          isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
+                        }`}
+                      >
+                        <div className="flex items-start gap-4">
+                          {instructor.profileImageUrl ? (
+                            <img
+                              src={instructor.profileImageUrl}
+                              alt={instructor.name}
+                              className="w-16 h-16 rounded-full object-cover"
+                            />
+                          ) : (
+                            <div
+                              className={`w-16 h-16 rounded-full flex items-center justify-center ${
+                                isDark ? 'bg-white/10' : 'bg-gray-200'
+                              }`}
+                            >
+                              <Users className="w-8 h-8" />
+                            </div>
+                          )}
+                          <div>
+                            <h3
+                              className={`text-lg font-bold ${
+                                isDark ? 'text-white' : 'text-gray-900'
+                              }`}
+                            >
+                              {instructor.name}
+                            </h3>
+                            <span
+                              className={`text-sm px-2 py-0.5 rounded ${
+                                instructor.role === 'MAIN'
+                                  ? 'bg-[#6778ff]/20 text-[#6778ff]'
+                                  : isDark
+                                    ? 'bg-white/10 text-gray-400'
+                                    : 'bg-gray-100 text-gray-600'
+                              }`}
+                            >
+                              {instructor.role === 'MAIN'
+                                ? '주강사'
+                                : instructor.role === 'SUB'
+                                  ? '보조강사'
+                                  : '조교'}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
+            </>
+          )}
+
+          {activeTab === 'curriculum' && (
+            <section className="mb-12">
+              <h2
+                className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}
+              >
+                커리큘럼
+              </h2>
+              {courseTime.curriculum && courseTime.curriculum.length > 0 ? (
+                <div className="space-y-3">
+                  {courseTime.curriculum.map((item, index) => (
+                    <CurriculumSection
+                      key={item.id}
+                      item={item}
+                      isExpanded={expandedSections.includes(index)}
+                      onToggle={() => toggleSection(index)}
+                      isDark={isDark}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <div
+                  className={`rounded-xl p-8 text-center border ${
+                    isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
+                  }`}
+                >
+                  <FileText
+                    className={`w-12 h-12 mx-auto mb-4 ${
+                      isDark ? 'text-gray-600' : 'text-gray-300'
+                    }`}
+                  />
+                  <p className={`font-medium mb-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                    커리큘럼 준비 중
+                  </p>
+                  <p className={`text-sm ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+                    상세 커리큘럼은 곧 업데이트될 예정입니다.
+                  </p>
+                </div>
+              )}
+            </section>
+          )}
+
+          {activeTab === 'review' && (
+            <section className="mb-12">
+              <CourseReviewSection
+                timeId={courseTimeId}
+                isDark={isDark}
+                canWrite={isAlreadyEnrolled}
+              />
+            </section>
+          )}
+        </div>
+      </main>
+
+      <LandingFooter />
+
+      {showCopiedToast && (
+        <div className="fixed bottom-8 left-1/2 -translate-x-1/2 z-50 animate-in fade-in slide-in-from-bottom-4 duration-300">
+          <div
+            className={`px-6 py-3 rounded-xl shadow-lg flex items-center gap-2 ${
+              isDark ? 'bg-[#6778ff] text-white' : 'bg-gray-900 text-white'
+            }`}
+          >
+            <CheckCircle className="w-5 h-5" />
+            <span className="font-medium">링크가 클립보드에 복사되었습니다</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/tu/b2b/B2BLandingPage.tsx
+++ b/src/pages/tu/b2b/B2BLandingPage.tsx
@@ -57,7 +57,7 @@ function convertCourseTimeToCardProps(courseTime: CourseTimeCatalogResponse) {
     instructor: instructorName,
     image: thumbnailUrl,
     tags,
-    category: courseTime.program?.categoryName,
+    category: courseTime.program?.categoryName ?? undefined,
     deliveryType: DELIVERY_TYPE_LABELS[courseTime.deliveryType] || courseTime.deliveryType,
     level: courseTime.program?.level ? PROGRAM_LEVEL_LABELS[courseTime.program.level] : undefined,
     studentCount: courseTime.currentEnrollment,

--- a/src/pages/tu/b2b/B2BLandingPage.tsx
+++ b/src/pages/tu/b2b/B2BLandingPage.tsx
@@ -1,0 +1,207 @@
+import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import {
+  HeroSection,
+  LandingFooter,
+} from '@/components/landing';
+import { B2BLandingHeader } from './components/B2BLandingHeader';
+import { B2BCourseCard } from './components/B2BCourseCard';
+import { useThemeStore } from '@/store/common/themeStore';
+import { useTranslation } from '@/store/common/languageStore';
+import { useCourseTimeCatalog, usePublicLayout } from '@/hooks/tu';
+import { useTenantBranding } from '@/contexts/TenantBrandingContext';
+import { useBrandingApply } from '@/hooks/tu/useBrandingApply';
+import type { CourseTimeCatalogResponse } from '@/types/tu/courseTimeCatalog.types';
+import { DELIVERY_TYPE_LABELS, PROGRAM_LEVEL_LABELS } from '@/types/tu/courseTimeCatalog.types';
+
+interface CategoryOption {
+  id: number | null;
+  name: string;
+  code: string;
+}
+
+const CATEGORY_OPTIONS: CategoryOption[] = [
+  { id: null, name: '전체', code: 'all' },
+  { id: 1, name: '개발', code: 'dev' },
+  { id: 2, name: 'AI', code: 'ai' },
+  { id: 3, name: '데이터', code: 'data' },
+  { id: 4, name: '디자인', code: 'design' },
+  { id: 5, name: '비즈니스', code: 'business' },
+  { id: 6, name: '마케팅', code: 'marketing' },
+  { id: 7, name: '외국어', code: 'language' },
+];
+
+/**
+ * CourseTime 데이터를 B2BCourseCard props로 변환
+ */
+function convertCourseTimeToCardProps(courseTime: CourseTimeCatalogResponse) {
+  const mainInstructor = courseTime.instructors.find((i) => i.role === 'MAIN');
+  const instructorName = mainInstructor?.name || courseTime.instructors[0]?.name || '';
+
+  const tags: string[] = [];
+  if (courseTime.isOnDemand) {
+    tags.push('상시모집');
+  } else if (courseTime.status === 'RECRUITING') {
+    tags.push('모집중');
+  } else if (courseTime.status === 'ONGOING') {
+    tags.push('진행중');
+  }
+
+  const thumbnailUrl =
+    courseTime.program?.thumbnailUrl ||
+    'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=400&h=250&fit=crop';
+
+  return {
+    id: courseTime.id,
+    title: courseTime.title,
+    instructor: instructorName,
+    image: thumbnailUrl,
+    tags,
+    category: courseTime.program?.categoryName,
+    deliveryType: DELIVERY_TYPE_LABELS[courseTime.deliveryType] || courseTime.deliveryType,
+    level: courseTime.program?.level ? PROGRAM_LEVEL_LABELS[courseTime.program.level] : undefined,
+    studentCount: courseTime.currentEnrollment,
+    classStartDate: courseTime.classStartDate,
+    isOnDemand: courseTime.isOnDemand,
+  };
+}
+
+/**
+ * B2B 랜딩 페이지
+ * - 가격 표시 없음
+ * - 장바구니 없음
+ * - 로드맵 섹션 없음
+ * - 커뮤니티 없음
+ */
+export function B2BLandingPage() {
+  const [activeCategoryId, setActiveCategoryId] = useState<number | null>(null);
+  const { theme } = useThemeStore();
+  const { t } = useTranslation();
+  const isDark = theme === 'dark';
+  const { branding } = useTenantBranding();
+
+  useBrandingApply(branding);
+
+  const { data: layoutData } = usePublicLayout();
+  const landingPageSettings = layoutData?.landingPageSettings;
+  const landingCategory = landingPageSettings?.landingCategory;
+
+  const categoryOptions: CategoryOption[] = landingCategory?.enabled && landingCategory?.items?.length > 0
+    ? [
+        { id: null, name: '전체', code: 'all' },
+        ...landingCategory.items.map((name, index) => ({
+          id: index + 1,
+          name,
+          code: name.toLowerCase().replace(/\s+/g, '-'),
+        })),
+      ]
+    : CATEGORY_OPTIONS;
+
+  const { data: courseTimeData, isLoading: isCoursesLoading } = useCourseTimeCatalog({
+    status: ['RECRUITING', 'ONGOING'],
+    categoryId: activeCategoryId ?? undefined,
+    size: 20,
+    sort: 'createdAt,desc',
+  });
+
+  const courseTimes = courseTimeData?.content || [];
+  const courses = courseTimes.map(convertCourseTimeToCardProps);
+
+  const activeCategory = categoryOptions.find((c) => c.id === activeCategoryId);
+  const filteredCourses = courses;
+
+  const featuredCourses = courses.filter((c) => c.tags.includes('상시모집')).slice(0, 5);
+  const recommendedCourses = featuredCourses.length > 0 ? featuredCourses : courses.slice(0, 5);
+
+  return (
+    <div className={`min-h-screen dark-scrollbar ${isDark ? 'landing-dark' : 'landing-light'}`}>
+      {/* B2B 전용 헤더 (장바구니 링크 없음) */}
+      <B2BLandingHeader />
+
+      <main>
+        <HeroSection />
+
+        {/* Category Bar */}
+        <div className="w-full px-4 md:px-8 lg:px-16 py-12">
+          <div className="flex flex-wrap items-center gap-3">
+            {categoryOptions.map((cat) => (
+              <button
+                key={cat.code}
+                onClick={() => setActiveCategoryId(cat.id)}
+                className={`px-5 py-2.5 rounded-full text-sm font-medium transition-all duration-300
+                  ${
+                    activeCategoryId === cat.id
+                      ? 'landing-btn-primary shadow-lg'
+                      : 'landing-chip-inactive'
+                  }
+                `}
+              >
+                {cat.name}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 당신을 위한 필수 강의 */}
+        <section className="w-full px-4 md:px-8 lg:px-16 pb-20">
+          <div className="flex items-center justify-between mb-8">
+            <div>
+              <h2 className="text-2xl md:text-3xl font-bold landing-text-primary">
+                {activeCategoryId === null
+                  ? '당신을 위한 필수 강의'
+                  : `${activeCategory?.name ?? ''} 필수 강의`}
+              </h2>
+              <p className="landing-text-muted text-sm mt-2">업무 역량 향상을 위한 핵심 강의를 확인해보세요</p>
+            </div>
+          </div>
+
+          {isCoursesLoading ? (
+            <div className="flex justify-center items-center py-20">
+              <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6">
+              {filteredCourses.length > 0 ? (
+                filteredCourses.slice(0, 10).map((course) => (
+                  <B2BCourseCard key={course.id} {...course} />
+                ))
+              ) : (
+                <p className="col-span-5 text-center landing-text-muted py-10">
+                  {t.landing.noCoursesInCategory}
+                </p>
+              )}
+            </div>
+          )}
+        </section>
+
+        {/* 당신을 위한 추천 강의 */}
+        <section className="landing-section-alt py-20">
+          <div className="w-full px-4 md:px-8 lg:px-16">
+            <div className="flex items-center justify-between mb-8">
+              <div>
+                <h2 className="text-2xl md:text-3xl font-bold landing-text-primary">당신을 위한 추천 강의</h2>
+                <p className="landing-text-muted text-sm mt-2">맞춤형 학습 경험을 위한 추천 강의입니다</p>
+              </div>
+            </div>
+
+            {isCoursesLoading ? (
+              <div className="flex justify-center items-center py-20">
+                <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6">
+                {recommendedCourses.map((course) => (
+                  <B2BCourseCard key={`rec-${course.id}`} {...course} />
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+
+        {/* B2B: 인기 강사 섹션 제외 */}
+      </main>
+
+      <LandingFooter />
+    </div>
+  );
+}

--- a/src/pages/tu/b2b/components/B2BCourseCard.tsx
+++ b/src/pages/tu/b2b/components/B2BCourseCard.tsx
@@ -1,0 +1,187 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { Users, Heart, Loader2, Calendar } from 'lucide-react';
+import { useSubdomainPath } from '@/hooks/common';
+import { useAuthStore } from '@/store/common/authStore';
+import { useCheckWishlistStatus, useToggleWishlist } from '@/hooks/tu';
+import { toast } from 'sonner';
+
+interface B2BCourseCardProps {
+  id: number;
+  title: string;
+  instructor: string;
+  image: string;
+  tags: string[];
+  category?: string;
+  deliveryType?: string;
+  level?: string;
+  studentCount: number;
+  classStartDate?: string;
+  isOnDemand?: boolean;
+}
+
+/**
+ * 날짜 포맷팅 (M/D)
+ */
+function formatShortDate(dateString: string): string {
+  const date = new Date(dateString);
+  return `${date.getMonth() + 1}/${date.getDate()}`;
+}
+
+/**
+ * B2B 전용 강의 카드
+ * - 별점/리뷰 없음
+ * - 가격 없음
+ * - 찜 버튼 있음
+ * - 개강일 표시
+ */
+export function B2BCourseCard({
+  id,
+  title,
+  instructor,
+  image,
+  tags,
+  category,
+  deliveryType,
+  level,
+  studentCount,
+  classStartDate,
+  isOnDemand,
+}: B2BCourseCardProps) {
+  const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
+  const { isAuthenticated } = useAuthStore();
+
+  // 찜 상태 확인 및 토글
+  const { data: isWishlisted = false, isLoading: isWishlistChecking } = useCheckWishlistStatus(
+    id,
+    isAuthenticated
+  );
+  const { toggle: toggleWishlist, isLoading: isWishlistToggling } = useToggleWishlist();
+
+  const handleWishlistToggle = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (!isAuthenticated) {
+      toast.error('로그인이 필요합니다.');
+      navigate('/login', { state: { from: prefixPath(`/tu/b2b/times/${id}`) } });
+      return;
+    }
+
+    try {
+      await toggleWishlist(id, isWishlisted);
+      toast.success(isWishlisted ? '찜 목록에서 제거되었습니다.' : '찜 목록에 추가되었습니다.');
+    } catch {
+      toast.error('찜 목록 변경에 실패했습니다.');
+    }
+  };
+
+  const isWishlistLoading = isWishlistChecking || isWishlistToggling;
+
+  const getTagStyle = (tag: string) => {
+    switch (tag) {
+      case '상시모집':
+        return 'bg-gradient-to-r from-[#70f2a0] to-[#6bc2f0]';
+      case '모집중':
+        return 'bg-gradient-to-r from-[#6778ff] to-[#a855f7]';
+      case '진행중':
+        return 'bg-gray-500';
+      default:
+        return 'bg-gradient-to-r from-[#ff7867] to-[#ff9a5a]';
+    }
+  };
+
+  return (
+    <Link to={prefixPath(`/tu/b2b/times/${id}`)} className="group block h-full">
+      <div className="h-full card-hover rounded-xl overflow-hidden landing-card-bg border landing-card-border">
+        {/* 썸네일 */}
+        <div className="relative aspect-[16/10] overflow-hidden">
+          <img
+            src={image}
+            alt={title}
+            className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+
+          {/* 상태 뱃지 */}
+          {tags.length > 0 && (
+            <div className="absolute top-3 left-3 flex gap-1.5">
+              {tags.map((tag) => (
+                <span
+                  key={tag}
+                  className={`text-white text-[10px] font-bold px-2.5 py-1 rounded-full shadow-lg ${getTagStyle(tag)}`}
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* 찜 버튼 */}
+          <button
+            onClick={handleWishlistToggle}
+            disabled={isWishlistLoading}
+            className={`absolute top-3 right-3 p-2 rounded-full transition-all duration-300 disabled:opacity-50 ${
+              isWishlisted
+                ? 'bg-red-500 text-white'
+                : 'bg-black/50 text-white hover:bg-red-500'
+            }`}
+            aria-label={isWishlisted ? '찜 해제' : '찜하기'}
+          >
+            {isWishlistLoading ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Heart className={`w-4 h-4 ${isWishlisted ? 'fill-current' : ''}`} />
+            )}
+          </button>
+        </div>
+
+        {/* 정보 영역 */}
+        <div className="p-4 space-y-2">
+          {/* 카테고리 태그 */}
+          {category && (
+            <span className="inline-block text-[10px] font-medium text-[#6778ff] bg-[#6778ff]/10 px-2 py-0.5 rounded">
+              {category}
+            </span>
+          )}
+
+          {/* 제목 */}
+          <h3 className="font-bold landing-text-primary line-clamp-2 text-[15px] group-hover:text-[#6778ff] transition-colors h-11">
+            {title}
+          </h3>
+
+          {/* 강사명 */}
+          <div className="text-xs landing-text-muted">{instructor}</div>
+
+          {/* 메타 정보 */}
+          <div className="flex items-center gap-2 text-xs">
+            {deliveryType && (
+              <span className="landing-badge-bg landing-text-muted px-2 py-0.5 rounded">
+                {deliveryType}
+              </span>
+            )}
+            {level && (
+              <span className="landing-text-muted">{level}</span>
+            )}
+          </div>
+
+          {/* 개강일 (상시모집이 아닌 경우만) */}
+          {!isOnDemand && classStartDate && (
+            <div className="flex items-center gap-1 text-xs landing-text-muted">
+              <Calendar className="w-3 h-3" />
+              <span>{formatShortDate(classStartDate)} 개강</span>
+            </div>
+          )}
+        </div>
+
+        {/* 하단 참여자 수 */}
+        <div className="px-4 pb-4 flex items-center justify-end">
+          <div className="flex items-center gap-1 text-xs landing-text-muted">
+            <Users className="w-3.5 h-3.5" />
+            <span>{studentCount.toLocaleString()}명</span>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/pages/tu/b2b/components/B2BLandingHeader.tsx
+++ b/src/pages/tu/b2b/components/B2BLandingHeader.tsx
@@ -1,0 +1,399 @@
+import { useState, useCallback } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Search, Bell, Menu, X, LogOut, User, Sun, Moon, BookOpen, Shield, Globe } from 'lucide-react';
+import { useAuth } from '@/hooks/common/auth';
+import { useMyProfile, useSubdomainPath } from '@/hooks/common';
+import { useThemeStore } from '@/store/common/themeStore';
+import { useTranslation } from '@/store/common/languageStore';
+import { useUnreadNotificationCount, usePublicLayout } from '@/hooks/tu';
+import { useTenantBranding } from '@/contexts/TenantBrandingContext';
+import type { NavigationItemResponse } from '@/types/tu/branding.types';
+
+// B2B 기본 네비게이션 (로드맵, 커뮤니티, 강의 탐색 제외)
+const DEFAULT_NAV_ITEMS: NavigationItemResponse[] = [];
+
+const BANNER_DISMISSED_KEY = 'tu_b2b_top_banner_dismissed';
+
+/**
+ * B2B 전용 랜딩 헤더
+ * - 장바구니 없음
+ * - 위시리스트 없음
+ * - 로드맵 메뉴 없음
+ * - 커뮤니티 메뉴 없음
+ */
+export function B2BLandingHeader() {
+  const [showBanner, setShowBanner] = useState(() => {
+    const dismissed = localStorage.getItem(BANNER_DISMISSED_KEY);
+    return dismissed !== 'true';
+  });
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showDropdown, setShowDropdown] = useState(false);
+  const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
+  const { user, isAuthenticated, logout } = useAuth();
+  const { data: profile } = useMyProfile();
+  const { theme, toggleTheme } = useThemeStore();
+  const { t } = useTranslation();
+  const isDark = theme === 'dark';
+  const { data: unreadCountData } = useUnreadNotificationCount(isAuthenticated);
+  const unreadCount = unreadCountData?.count || 0;
+  const { branding } = useTenantBranding();
+  const { data: layoutData } = usePublicLayout();
+
+  // 네비게이션 메뉴 (B2B용 - 로드맵/커뮤니티 제외)
+  const headerNavLinks = (layoutData?.headerSettings as { navLinks?: Array<{ label: string; url: string; visible: boolean }> })?.navLinks;
+
+  const normalizeNavUrl = (url: string) => {
+    if (url.startsWith('http')) return url;
+    // B2B 경로로 변환
+    if (url.startsWith('/tu/b2c')) {
+      return url.replace('/tu/b2c', '/tu/b2b');
+    }
+    if (url.startsWith('/tu/')) return url;
+    return `/tu/b2b${url.startsWith('/') ? url : `/${url}`}`;
+  };
+
+  const navItems = headerNavLinks && headerNavLinks.length > 0
+    ? headerNavLinks
+        .filter(link => link.visible)
+        // B2B에서 로드맵, 커뮤니티, 강의 탐색 링크 제외
+        .filter(link => !link.url.includes('roadmap') && !link.url.includes('community') && !link.url.includes('courses'))
+        .map((link, index) => ({
+          id: index + 1,
+          label: link.label,
+          icon: 'BookOpen',
+          path: normalizeNavUrl(link.url),
+          enabled: true,
+          displayOrder: index + 1,
+          target: null,
+          createdAt: '',
+          updatedAt: '',
+        }))
+    : DEFAULT_NAV_ITEMS;
+
+  const headerSettings = layoutData?.headerSettings;
+  const headerEnabled = headerSettings?.enabled !== false;
+  const showLogo = headerSettings?.showLogo !== false;
+  const showSearch = headerSettings?.showSearch !== false;
+  const showNotifications = headerSettings?.showNotifications !== false;
+  const showThemeToggle = headerSettings?.showThemeToggle !== false;
+
+  const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api').replace('/api', '');
+
+  const profileImageUrl = profile?.profileImageUrl
+    ? profile.profileImageUrl.startsWith('http')
+      ? profile.profileImageUrl
+      : `${apiBaseUrl}${profile.profileImageUrl}`
+    : null;
+
+  const logoUrl = isDark
+    ? (branding?.darkLogoUrl || branding?.logoUrl)
+    : branding?.logoUrl;
+
+  const fullLogoUrl = logoUrl
+    ? (logoUrl.startsWith('http') ? logoUrl : `${apiBaseUrl}${logoUrl}`)
+    : null;
+
+  const tenantName = branding?.tenantName || 'MZC Learn';
+
+  const topBannerSettings = (layoutData?.headerSettings as { topBanner?: { enabled?: boolean; text?: string; linkUrl?: string; linkText?: string } })?.topBanner;
+  const topBannerEnabled = topBannerSettings?.enabled !== false;
+  const topBannerText = topBannerSettings?.text || t.landing.banner;
+  const topBannerLinkUrl = topBannerSettings?.linkUrl;
+  const topBannerLinkText = topBannerSettings?.linkText;
+
+  const handleCloseBanner = useCallback(() => {
+    localStorage.setItem(BANNER_DISMISSED_KEY, 'true');
+    setShowBanner(false);
+  }, []);
+
+  const handleLogout = () => {
+    localStorage.removeItem(BANNER_DISMISSED_KEY);
+    logout();
+    setShowDropdown(false);
+  };
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (searchQuery.trim()) {
+      navigate(prefixPath(`/tu/b2b/search?search=${encodeURIComponent(searchQuery.trim())}`));
+    }
+  };
+
+  return (
+    <header className="w-full flex flex-col">
+      {/* Top Banner */}
+      {showBanner && topBannerEnabled && (
+        <div className="bg-gradient-to-r from-[#6778ff] via-[#a855f7] to-[#6bc2f0] text-white text-xs md:text-sm py-2.5 px-4 text-center font-medium flex justify-center items-center gap-2 relative">
+          <span>{topBannerText}</span>
+          {topBannerLinkUrl && topBannerLinkText && (
+            <a
+              href={topBannerLinkUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:no-underline ml-1"
+            >
+              {topBannerLinkText}
+            </a>
+          )}
+          <button
+            onClick={handleCloseBanner}
+            className="absolute right-4 text-white/70 hover:text-white text-lg transition-colors"
+            aria-label={t.landing.closeBanner}
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+
+      {/* Main Navigation */}
+      {headerEnabled && (
+        <div className={`w-full sticky top-0 z-50 border-b ${isDark ? 'glass-dark border-white/10' : 'border-gray-200'}`} style={{ backgroundColor: isDark ? undefined : '#fafafa' }}>
+          <div className="w-full px-6 md:px-12 lg:px-16 h-16 flex items-center justify-between gap-6">
+            {/* Left: Logo & Menu */}
+            <div className="flex items-center gap-8 ml-2 md:ml-4">
+              {showLogo && (
+                <Link to={prefixPath('/tu/b2b')} className={`flex items-center gap-2 font-bold text-xl tracking-tight ${isDark ? '' : 'text-gray-900'}`}>
+                  {fullLogoUrl ? (
+                    <img src={fullLogoUrl} alt={tenantName} className="h-8 object-contain" />
+                  ) : (
+                    <>
+                      <span className="text-2xl">M</span>
+                      <span className="gradient-text">{tenantName}</span>
+                    </>
+                  )}
+                </Link>
+              )}
+
+              {/* Desktop Nav Links (로드맵, 커뮤니티 제외) */}
+              <nav className={`hidden md:flex items-center gap-8 font-medium text-[15px] ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
+                {navItems.map((item) => {
+                  const isExternal = item.path.startsWith('http');
+                  const linkPath = isExternal ? item.path : prefixPath(item.path);
+
+                  return isExternal ? (
+                    <a
+                      key={item.id}
+                      href={linkPath}
+                      target={item.target || '_blank'}
+                      rel="noopener noreferrer"
+                      className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}
+                    >
+                      {item.label}
+                    </a>
+                  ) : (
+                    <Link
+                      key={item.id}
+                      to={linkPath}
+                      className={`transition-colors ${isDark ? 'hover:text-white' : 'hover:text-gray-900'}`}
+                    >
+                      {item.label}
+                    </Link>
+                  );
+                })}
+              </nav>
+            </div>
+
+            {/* Center: Search Bar */}
+            {showSearch && (
+              <form onSubmit={handleSearch} className="hidden lg:flex flex-1 max-w-xl relative">
+                <input
+                  type="text"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder={t.landing.searchPlaceholder}
+                  className={`w-full rounded-full pl-5 pr-12 py-2.5 text-sm focus:outline-none focus:ring-1 focus:ring-[#6778ff] focus:border-[#6778ff] transition-all ${
+                    isDark
+                      ? 'bg-white/5 border border-white/10 text-white placeholder-gray-500'
+                      : 'border border-gray-300 text-gray-900 placeholder-gray-400'
+                  }`}
+                  style={{ backgroundColor: isDark ? undefined : '#fafafa' }}
+                />
+                <button
+                  type="submit"
+                  className="absolute right-1 top-1/2 -translate-y-1/2 rounded-full bg-gradient-to-r from-[#6778ff] to-[#a855f7] hover:from-[#8b99ff] hover:to-[#c084fc] w-9 h-9 flex items-center justify-center transition-colors"
+                >
+                  <Search className="h-4 w-4 text-white" />
+                </button>
+              </form>
+            )}
+
+            {/* Right: Actions (장바구니, 위시리스트 제외) */}
+            <div className="flex items-center gap-3 md:gap-5 mr-2 md:mr-4">
+              <div className="flex items-center gap-2">
+                {showThemeToggle && (
+                  <button
+                    onClick={toggleTheme}
+                    className={`p-2 rounded-lg transition-colors ${
+                      isDark
+                        ? 'text-gray-400 hover:text-white hover:bg-white/10'
+                        : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100'
+                    }`}
+                    aria-label={isDark ? t.landing.switchToLight : t.landing.switchToDark}
+                  >
+                    {isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+                  </button>
+                )}
+                {/* 장바구니, 위시리스트 제외 - B2B에서는 표시 안함 */}
+                {showNotifications && (
+                  <Link
+                    to={prefixPath('/tu/b2b/notifications')}
+                    className={`p-2 rounded-lg transition-colors relative ${
+                      isDark
+                        ? 'text-gray-400 hover:text-white hover:bg-white/10'
+                        : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100'
+                    }`}
+                  >
+                    <Bell className="h-5 w-5" />
+                    {unreadCount > 0 && (
+                      <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] flex items-center justify-center px-1 text-[10px] font-bold text-white bg-gradient-to-r from-[#6778ff] to-[#a855f7] rounded-full">
+                        {unreadCount > 99 ? '99+' : unreadCount}
+                      </span>
+                    )}
+                  </Link>
+                )}
+                {isAuthenticated && user ? (
+                  <div className="relative">
+                    <button
+                      onClick={() => setShowDropdown(!showDropdown)}
+                      className={`hidden md:flex items-center gap-2 px-3 py-1.5 rounded-full transition-colors ${
+                        isDark
+                          ? 'bg-white/5 hover:bg-white/10'
+                          : 'bg-gray-100 hover:bg-gray-200'
+                      }`}
+                    >
+                      <div className="w-8 h-8 rounded-full bg-gradient-to-r from-[#6778ff] to-[#a855f7] flex items-center justify-center overflow-hidden">
+                        {profileImageUrl ? (
+                          <img src={profileImageUrl} alt="Profile" className="w-full h-full object-cover" />
+                        ) : (
+                          <User className="w-4 h-4 text-white" />
+                        )}
+                      </div>
+                      <span className={`text-sm font-medium max-w-[100px] truncate ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                        {user.name}
+                      </span>
+                    </button>
+
+                    {showDropdown && (
+                      <div className={`absolute right-0 top-12 w-64 rounded-xl p-4 shadow-xl border ${
+                        isDark
+                          ? 'bg-[#151515] border-white/10'
+                          : 'bg-white border-gray-200'
+                      }`}>
+                        <div className={`flex items-center gap-3 pb-3 border-b ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
+                          <div className="w-10 h-10 rounded-full bg-gradient-to-r from-[#6778ff] to-[#a855f7] flex items-center justify-center overflow-hidden">
+                            {profileImageUrl ? (
+                              <img src={profileImageUrl} alt="Profile" className="w-full h-full object-cover" />
+                            ) : (
+                              <User className="w-5 h-5 text-white" />
+                            )}
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <p className={`font-medium truncate ${isDark ? 'text-white' : 'text-gray-900'}`}>{user.name}</p>
+                            <p className={`text-xs truncate ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>{user.email}</p>
+                          </div>
+                        </div>
+
+                        <div className="py-2 space-y-1">
+                          <Link
+                            to={prefixPath('/tu/b2c/mypage')}
+                            onClick={() => setShowDropdown(false)}
+                            className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors text-sm ${
+                              isDark
+                                ? 'text-gray-300 hover:text-white hover:bg-white/10'
+                                : 'text-gray-700 hover:text-gray-900 hover:bg-gray-100'
+                            }`}
+                          >
+                            <BookOpen className="w-4 h-4" />
+                            {t.landing.mypage}
+                          </Link>
+                        </div>
+
+                        <div className={`py-2 border-t space-y-1 ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
+                          <p className={`px-3 py-1 text-xs font-medium ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>{t.landing.settings}</p>
+                          <Link
+                            to={prefixPath('/tu/b2c/mypage/profile')}
+                            onClick={() => setShowDropdown(false)}
+                            className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm ${
+                              isDark
+                                ? 'text-gray-300 hover:text-white hover:bg-white/10'
+                                : 'text-gray-700 hover:text-gray-900 hover:bg-gray-100'
+                            }`}
+                          >
+                            <Shield className="w-4 h-4" />
+                            {t.landing.profileSecurity}
+                          </Link>
+                          <Link
+                            to={prefixPath('/tu/b2c/mypage/notifications')}
+                            onClick={() => setShowDropdown(false)}
+                            className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm ${
+                              isDark
+                                ? 'text-gray-300 hover:text-white hover:bg-white/10'
+                                : 'text-gray-700 hover:text-gray-900 hover:bg-gray-100'
+                            }`}
+                          >
+                            <Bell className="w-4 h-4" />
+                            {t.landing.notifications}
+                          </Link>
+                          <Link
+                            to={prefixPath('/tu/b2c/mypage/language')}
+                            onClick={() => setShowDropdown(false)}
+                            className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm ${
+                              isDark
+                                ? 'text-gray-300 hover:text-white hover:bg-white/10'
+                                : 'text-gray-700 hover:text-gray-900 hover:bg-gray-100'
+                            }`}
+                          >
+                            <Globe className="w-4 h-4" />
+                            {t.landing.languageRegion}
+                          </Link>
+                        </div>
+
+                        <div className={`pt-2 border-t ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
+                          <button
+                            onClick={handleLogout}
+                            className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors text-sm ${
+                              isDark
+                                ? 'text-red-400 hover:bg-red-500/10'
+                                : 'text-red-500 hover:bg-red-50'
+                            }`}
+                          >
+                            <LogOut className="w-4 h-4" />
+                            {t.common.logout}
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <>
+                    <Link
+                      to="/login"
+                      className={`hidden md:flex px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+                        isDark
+                          ? 'landing-btn-outline text-white'
+                          : 'border border-gray-300 text-gray-700 hover:bg-gray-100'
+                      }`}
+                    >
+                      {t.common.login}
+                    </Link>
+                    <Link
+                      to="/register"
+                      className="hidden md:flex px-4 py-2 landing-btn-primary text-white font-bold rounded-full text-sm"
+                    >
+                      {t.common.signup}
+                    </Link>
+                  </>
+                )}
+
+                <button className={`p-2 md:hidden ${isDark ? 'text-gray-400' : 'text-gray-500'}`} aria-label={t.landing.openMenu}>
+                  <Menu className="h-6 w-6" />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/src/pages/tu/b2b/components/index.ts
+++ b/src/pages/tu/b2b/components/index.ts
@@ -1,0 +1,6 @@
+/**
+ * B2B 전용 컴포넌트 모듈
+ */
+
+export { B2BLandingHeader } from './B2BLandingHeader';
+export { B2BCourseCard } from './B2BCourseCard';

--- a/src/pages/tu/b2b/index.ts
+++ b/src/pages/tu/b2b/index.ts
@@ -1,0 +1,12 @@
+/**
+ * B2B 전용 페이지 모듈
+ *
+ * B2C와의 차이점:
+ * - 장바구니/결제 없음 (회사에서 일괄 배정)
+ * - 가격 표시 없음
+ * - 로드맵 없음
+ * - 커뮤니티 없음
+ */
+
+export { B2BLandingPage } from './B2BLandingPage';
+export { B2BCourseDetailPage } from './B2BCourseDetailPage';

--- a/src/routes/tu.b2b.routes.tsx
+++ b/src/routes/tu.b2b.routes.tsx
@@ -1,0 +1,52 @@
+import { Route } from 'react-router-dom';
+import {
+  CoursesExplorePage,
+  NotificationsPage,
+  NotificationDetailPage,
+  InstructorProfilePage,
+  SearchPage,
+} from '@/pages/tu';
+import { B2BLandingPage, B2BCourseDetailPage } from '@/pages/tu/b2b';
+
+/**
+ * TU B2B 라우트 - 기업용 페이지 (사이드바 없음)
+ *
+ * 경로: /:subdomain/tu/b2b/* 또는 /tu/b2b/* (기본)
+ *
+ * B2C와의 차이점:
+ * - 장바구니/결제 없음 (회사에서 일괄 배정)
+ * - 가격 표시 없음
+ * - 로드맵 없음
+ * - 커뮤니티 없음
+ */
+export const tuB2bRoutes = (
+  <>
+    {/* 랜딩 페이지 */}
+    <Route path="/:subdomain/tu/b2b" element={<B2BLandingPage />} />
+    <Route path="/tu/b2b" element={<B2BLandingPage />} />
+
+    {/* 통합 검색 */}
+    <Route path="/:subdomain/tu/b2b/search" element={<SearchPage />} />
+    <Route path="/tu/b2b/search" element={<SearchPage />} />
+
+    {/* 강의 탐색 */}
+    <Route path="/:subdomain/tu/b2b/courses" element={<CoursesExplorePage />} />
+    <Route path="/:subdomain/tu/b2b/courses/:id" element={<B2BCourseDetailPage />} />
+    <Route path="/tu/b2b/courses" element={<CoursesExplorePage />} />
+    <Route path="/tu/b2b/courses/:id" element={<B2BCourseDetailPage />} />
+
+    {/* 차수(Times) 상세 - CourseTime 기반 */}
+    <Route path="/:subdomain/tu/b2b/times/:id" element={<B2BCourseDetailPage />} />
+    <Route path="/tu/b2b/times/:id" element={<B2BCourseDetailPage />} />
+
+    {/* 알림 */}
+    <Route path="/:subdomain/tu/b2b/notifications" element={<NotificationsPage />} />
+    <Route path="/:subdomain/tu/b2b/notifications/:id" element={<NotificationDetailPage />} />
+    <Route path="/tu/b2b/notifications" element={<NotificationsPage />} />
+    <Route path="/tu/b2b/notifications/:id" element={<NotificationDetailPage />} />
+
+    {/* 강사 프로필 */}
+    <Route path="/:subdomain/tu/b2b/instructors/:instructorId" element={<InstructorProfilePage />} />
+    <Route path="/tu/b2b/instructors/:instructorId" element={<InstructorProfilePage />} />
+  </>
+);

--- a/src/routes/tu.routes.tsx
+++ b/src/routes/tu.routes.tsx
@@ -1,4 +1,5 @@
 import { tuB2cRoutes } from './tu.b2c.routes';
+import { tuB2bRoutes } from './tu.b2b.routes';
 import { tuMyPageRoutes } from './tu.mypage.routes';
 import { tuTeachingRoutes } from './tu.teaching.routes';
 
@@ -6,8 +7,8 @@ import { tuTeachingRoutes } from './tu.teaching.routes';
  * TU (Tenant User) 라우트 통합
  *
  * 구조:
- * - /                 : 랜딩 페이지
- * - /tu/b2c/*         : B2C 메인 페이지 (사이드바 없음)
+ * - /tu/b2c/*         : B2C 메인 페이지 (사이드바 없음, 개인 고객용)
+ * - /tu/b2b/*         : B2B 메인 페이지 (사이드바 없음, 기업 고객용 - 장바구니/가격/로드맵/커뮤니티 없음)
  * - /tu/b2c/mypage/*  : 마이페이지 (사이드바 있음, 로그인 필요)
  * - /tu/teaching/*    : 강의 관리 (사이드바 있음, 로그인 필요)
  */
@@ -19,7 +20,10 @@ export const tuRoutes = (
     {/* 강의 관리 */}
     {tuTeachingRoutes}
 
-    {/* B2C 메인 페이지 (가장 일반적인 경로 마지막) */}
+    {/* B2B 메인 페이지 (기업용 - 기능 축소) */}
+    {tuB2bRoutes}
+
+    {/* B2C 메인 페이지 (개인용 - 가장 일반적인 경로 마지막) */}
     {tuB2cRoutes}
   </>
 );


### PR DESCRIPTION
## Summary
- B2C와 분리된 B2B 전용 페이지 구현
- `/tu/b2b/*` 라우트 분리
- B2B에서 불필요한 기능 숨김 (가격, 장바구니, 로드맵, 커뮤니티, 별점/리뷰 등)

## 변경 사항

### 새 파일
| 파일 | 설명 |
|------|------|
| `tu.b2b.routes.tsx` | B2B 전용 라우트 정의 |
| `B2BLandingPage.tsx` | B2B 랜딩 페이지 |
| `B2BCourseDetailPage.tsx` | B2B 강의 상세 페이지 |
| `B2BCourseCard.tsx` | B2B 전용 간소화 카드 |
| `B2BLandingHeader.tsx` | B2B 전용 헤더 |

### B2B에서 숨긴 기능
- 장바구니/결제
- 가격 표시
- 로드맵
- 커뮤니티
- 강의 탐색 메뉴
- 인기 강사 섹션
- 별점/리뷰

### B2B 카드 구성
- 썸네일 + 상태뱃지 + 찜버튼
- 카테고리 태그
- 제목
- 강사명
- 운영방식/레벨
- 개강일
- 참여자 수

Closes #408

## Test plan
- [x] `/tu/b2b` 접속 시 B2B 랜딩 페이지 표시
- [x] 강의 카드에서 가격, 별점 숨김 확인
- [x] 헤더에서 장바구니/강의탐색/로드맵/커뮤니티 메뉴 숨김 확인
- [ ] 찜 기능 정상 동작 확인
- [x] 개강일 표시 확인