### PR TITLE
feat: 콘텐츠 상세 페이지 인라인 뷰어 적용 (#410)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -196,6 +196,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -545,6 +546,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -588,6 +590,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -615,6 +618,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -3900,6 +3904,7 @@
       "resolved": "https://registry.npmjs.org/@svta/cml-xml/-/cml-xml-1.0.1.tgz",
       "integrity": "sha512-11LkJa5kDEcsRMWkVI1ABH3KLCxGoiSVe4kQ293ItVj8ncTTQ7htmCGiJDjS+Cmy35UgF3e/vc0ysJIiWRTx2g==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -4061,8 +4066,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4209,6 +4213,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4219,6 +4224,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4274,6 +4280,7 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -4632,6 +4639,7 @@
       "integrity": "sha512-rkoPH+RqWopVxDnCBE/ysIdfQ2A7j1eDmW8tCxxrR9nnFBa9jKf86VgsSAzxBd1x+ny0GC4JgiD3SNfRHv3pOg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.16",
         "fflate": "^0.8.2",
@@ -4675,6 +4683,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4965,8 +4974,7 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.5",
@@ -5047,7 +5055,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -5098,6 +5105,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5133,7 +5141,6 @@
       ],
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -5192,23 +5199,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/canvas": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.0.tgz",
-      "integrity": "sha512-jk0GxrLtUEmW/TmFsk2WghvgHe8B0pxGilqCL21y8lHkPUGa6FTsnCNtHPOzT8O3y+N+m3espawV80bbBlgfTA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-addon-api": "^7.0.0",
-        "prebuild-install": "^7.1.3"
-      },
-      "engines": {
-        "node": "^18.12.0 || >= 20.9.0"
-      }
     },
     "node_modules/castable-video": {
       "version": "1.1.11",
@@ -5299,8 +5289,7 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -5748,7 +5737,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -5766,7 +5754,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -5839,8 +5826,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5867,7 +5853,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5905,7 +5892,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -6056,6 +6042,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6260,7 +6247,6 @@
       "dev": true,
       "license": "(MIT OR WTFPL)",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6481,8 +6467,7 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/fs-extra": {
       "version": "11.3.2",
@@ -6647,8 +6632,7 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -6890,8 +6874,7 @@
         }
       ],
       "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -6990,8 +6973,7 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/input-otp": {
       "version": "1.4.2",
@@ -7138,6 +7120,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7167,6 +7150,7 @@
       "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.7.2",
         "cssstyle": "^5.3.1",
@@ -7383,7 +7367,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7497,7 +7480,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7535,7 +7517,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7603,8 +7584,7 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -7673,8 +7653,7 @@
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/native-promise-only": {
       "version": "0.8.1",
@@ -7706,7 +7685,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -7721,7 +7699,6 @@
       "dev": true,
       "license": "ISC",
       "optional": true,
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7735,8 +7712,7 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -8032,6 +8008,7 @@
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
       "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -8179,6 +8156,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8329,7 +8307,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -8367,7 +8344,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8383,7 +8359,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8396,8 +8371,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8439,7 +8413,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -8483,7 +8456,6 @@
       "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -8501,7 +8473,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8511,6 +8482,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8541,6 +8513,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8585,7 +8558,8 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
       "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-player": {
       "version": "3.4.0",
@@ -8615,6 +8589,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -8846,7 +8821,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -9160,7 +9136,6 @@
       ],
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -9504,7 +9479,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -9519,7 +9493,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -9663,6 +9636,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9782,7 +9756,6 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -9815,6 +9788,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10033,6 +10007,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10126,6 +10101,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10139,6 +10115,7 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",

--- a/src/components/domain/tu/content/ContentPreviewModal.tsx
+++ b/src/components/domain/tu/content/ContentPreviewModal.tsx
@@ -183,6 +183,24 @@ export function ContentPreviewModal({
             </div>
           );
         }
+        // 텍스트 파일인 경우 iframe으로 표시
+        if (previewData?.contentType?.includes('text')) {
+          return (
+            <div className="flex flex-col space-y-3">
+              <iframe
+                src={blobUrl}
+                className="w-full h-[70vh] rounded-lg border border-border bg-bg-default"
+                title="텍스트 미리보기"
+              />
+              <div className="flex justify-end gap-2">
+                <Button variant="ghost" className="border border-border" onClick={handleDownload}>
+                  <Download size={16} />
+                  다운로드
+                </Button>
+              </div>
+            </div>
+          );
+        }
         // 기타 문서는 다운로드 유도
         return (
           <div className="flex flex-col items-center justify-center py-12 space-y-4">

--- a/src/pages/tu/teaching/content/ContentDetailPage.tsx
+++ b/src/pages/tu/teaching/content/ContentDetailPage.tsx
@@ -1,8 +1,7 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
   Download,
-  Eye,
   Edit2,
   Save,
   X,
@@ -21,6 +20,7 @@ import {
   AlertCircle,
   Check,
   History,
+  ExternalLink,
 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button, Badge, BackButton } from '@/components/common';
@@ -34,10 +34,10 @@ import {
   useDeleteContent,
   useContentVersions,
   useRestoreVersion,
+  useContentPreview,
 } from '@/hooks/tu';
 import { useSubdomainPath } from '@/hooks/common/useSubdomainPath';
 import { contentService } from '@/services/tu';
-import { ContentPreviewModal } from '@/components/domain/tu/content';
 import type { ContentType, ContentVersionResponse } from '@/types/tu';
 
 // 콘텐츠 타입별 아이콘
@@ -209,8 +209,8 @@ export function ContentDetailPage({ language = 'ko' }: Readonly<ContentDetailPag
   const [editFileName, setEditFileName] = useState('');
   const [newFile, setNewFile] = useState<File | null>(null);
 
-  // 미리보기 모달 상태
-  const [previewModal, setPreviewModal] = useState(false);
+  // 인라인 뷰어를 위한 Blob URL 상태
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
 
   // React Query hooks
   const { data: content, isLoading, error } = useContent(contentId);
@@ -221,6 +221,26 @@ export function ContentDetailPage({ language = 'ko' }: Readonly<ContentDetailPag
   const restoreContent = useRestoreContent();
   const deleteContent = useDeleteContent();
   const restoreVersion = useRestoreVersion();
+
+  // 외부 링크 여부 확인
+  const isExternalLink = content?.contentType === 'EXTERNAL_LINK';
+
+  // 외부 링크가 아닌 경우 미리보기 데이터 로드
+  const { data: previewData, isLoading: previewLoading } = useContentPreview(
+    !isExternalLink && content ? contentId : null
+  );
+
+  // Blob URL 생성 및 정리
+  useEffect(() => {
+    if (previewData?.blob) {
+      const url = URL.createObjectURL(previewData.blob);
+      setBlobUrl(url);
+      return () => {
+        URL.revokeObjectURL(url);
+        setBlobUrl(null);
+      };
+    }
+  }, [previewData]);
 
   // 편집 모드 시작
   const handleStartEdit = () => {
@@ -378,7 +398,6 @@ export function ContentDetailPage({ language = 'ko' }: Readonly<ContentDetailPag
 
   const IconComponent = contentTypeIcon[content.contentType] || FileText;
   const isArchived = content.status === 'ARCHIVED';
-  const isExternalLink = content.contentType === 'EXTERNAL_LINK';
 
   return (
     <div className="h-full flex flex-col bg-[#FAFAFA]">
@@ -423,29 +442,18 @@ export function ContentDetailPage({ language = 'ko' }: Readonly<ContentDetailPag
               {/* Action Buttons */}
               <div className="flex items-center gap-2">
                 {!isExternalLink && (
-                  <>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="text-gray-600 border-gray-200 hover:bg-gray-50"
-                      onClick={() => setPreviewModal(true)}
-                    >
-                      <Eye size={16} className="mr-2" />
-                      {getText('preview')}
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="text-gray-600 border-gray-200 hover:bg-gray-50"
-                      onClick={handleDownload}
-                    >
-                      <Download size={16} className="mr-2" />
-                      {getText('download')}
-                    </Button>
-                  </>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="text-gray-600 border-gray-200 hover:bg-gray-50"
+                    onClick={handleDownload}
+                  >
+                    <Download size={16} className="mr-2" />
+                    {getText('download')}
+                  </Button>
                 )}
 
-                <div className="h-6 w-px bg-gray-200 mx-1" />
+                {!isExternalLink && <div className="h-6 w-px bg-gray-200 mx-1" />}
 
                 {isArchived ? (
                   <Button
@@ -492,6 +500,128 @@ export function ContentDetailPage({ language = 'ko' }: Readonly<ContentDetailPag
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             {/* Left Column - Metadata */}
             <div className="lg:col-span-2 space-y-6">
+              {/* Inline Viewer Section */}
+              {!isExternalLink && (
+                <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+                  <div className="px-6 py-4 border-b border-gray-100 bg-gray-50/50">
+                    <h3 className="font-semibold text-[#2A2A2A] flex items-center gap-2">
+                      <IconComponent size={18} className="text-gray-400" />
+                      콘텐츠 미리보기
+                    </h3>
+                  </div>
+                  <div className="p-6">
+                    {previewLoading ? (
+                      <div className="flex items-center justify-center py-12">
+                        <Loader2 className="w-8 h-8 animate-spin text-gray-400" />
+                        <span className="ml-2 text-gray-500">로딩 중...</span>
+                      </div>
+                    ) : blobUrl ? (
+                      <div>
+                        {content.contentType === 'VIDEO' && (
+                          <video
+                            src={blobUrl}
+                            controls
+                            className="w-full max-h-[60vh] bg-black rounded-lg"
+                          >
+                            브라우저가 비디오를 지원하지 않습니다.
+                          </video>
+                        )}
+                        {content.contentType === 'AUDIO' && (
+                          <div className="flex flex-col items-center justify-center py-8 space-y-4">
+                            <div className="w-24 h-24 rounded-full bg-gray-100 flex items-center justify-center">
+                              <Music size={48} className="text-gray-400" />
+                            </div>
+                            <audio src={blobUrl} controls className="w-full max-w-md">
+                              브라우저가 오디오를 지원하지 않습니다.
+                            </audio>
+                          </div>
+                        )}
+                        {content.contentType === 'IMAGE' && (
+                          <div className="flex items-center justify-center">
+                            <img
+                              src={blobUrl}
+                              alt={content.originalFileName}
+                              className="max-w-full max-h-[60vh] object-contain rounded-lg"
+                            />
+                          </div>
+                        )}
+                        {content.contentType === 'DOCUMENT' && (
+                          <>
+                            {previewData?.contentType?.includes('pdf') ? (
+                              <object
+                                data={`${blobUrl}#toolbar=1&view=FitH`}
+                                type="application/pdf"
+                                className="w-full h-[70vh] rounded-lg bg-gray-50"
+                              >
+                                <div className="flex flex-col items-center justify-center h-[70vh] space-y-4">
+                                  <FileText className="w-16 h-16 text-gray-400" />
+                                  <p className="text-gray-500">PDF를 표시할 수 없습니다.</p>
+                                  <Button onClick={handleDownload}>
+                                    <Download size={16} />
+                                    다운로드
+                                  </Button>
+                                </div>
+                              </object>
+                            ) : previewData?.contentType?.includes('text') ? (
+                              <div className="w-full">
+                                <iframe
+                                  src={blobUrl}
+                                  className="w-full h-[70vh] rounded-lg border border-gray-200 bg-white"
+                                  title="텍스트 미리보기"
+                                />
+                              </div>
+                            ) : (
+                              <div className="flex flex-col items-center justify-center py-12 space-y-4">
+                                <FileText className="w-16 h-16 text-gray-400" />
+                                <p className="text-gray-700 text-lg font-medium">{content.originalFileName}</p>
+                                <p className="text-gray-500 text-sm">
+                                  이 문서 형식은 미리보기를 지원하지 않습니다.
+                                </p>
+                                <Button onClick={handleDownload}>
+                                  <Download size={16} />
+                                  다운로드
+                                </Button>
+                              </div>
+                            )}
+                          </>
+                        )}
+                      </div>
+                    ) : (
+                      <div className="flex items-center justify-center py-12">
+                        <p className="text-gray-500">콘텐츠를 불러올 수 없습니다.</p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {/* External Link Display */}
+              {isExternalLink && content.externalUrl && (
+                <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+                  <div className="px-6 py-4 border-b border-gray-100 bg-gray-50/50">
+                    <h3 className="font-semibold text-[#2A2A2A] flex items-center gap-2">
+                      <ExternalLink size={18} className="text-gray-400" />
+                      외부 링크
+                    </h3>
+                  </div>
+                  <div className="p-6">
+                    <div className="flex flex-col items-center justify-center py-12 space-y-4">
+                      <ExternalLink className="w-16 h-16 text-gray-400" />
+                      <p className="text-gray-700 text-center">외부 링크 콘텐츠입니다.</p>
+                      <p className="text-sm text-gray-500 text-center break-all max-w-md">
+                        {content.externalUrl}
+                      </p>
+                      <Button
+                        onClick={() => content.externalUrl && window.open(content.externalUrl, '_blank', 'noopener,noreferrer')}
+                      >
+                        <ExternalLink size={16} className="mr-2" />
+                        외부 링크 열기
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              )}
+
               {/* Basic Info Card */}
               <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
                 <div className="px-6 py-4 border-b border-gray-100 flex items-center justify-between bg-gray-50/50">
@@ -720,15 +850,6 @@ export function ContentDetailPage({ language = 'ko' }: Readonly<ContentDetailPag
           </div>
         </div>
       </div>
-
-      {/* Preview Modal */}
-      <ContentPreviewModal
-        isOpen={previewModal}
-        onClose={() => setPreviewModal(false)}
-        contentId={contentId}
-        contentType={content.contentType}
-        fileName={content.originalFileName}
-      />
     </div>
   );
 }


### PR DESCRIPTION
## 관련 이슈
Closes #410

## 변경 사항
- 상세 페이지에서 미리보기 버튼 제거
- 콘텐츠를 페이지 내에 바로 표시하도록 인라인 뷰어 추가

## 구현 내용
- **VIDEO**: 플레이어 즉시 로드 (autoplay 없음)
- **AUDIO**: 오디오 플레이어 바로 표시
- **IMAGE**: 이미지 바로 표시
- **DOCUMENT/PDF**: 인라인 뷰어로 바로 표시
- **DOCUMENT/TEXT**: 텍스트 파일 iframe으로 바로 표시 (.txt, .csv, .html 등)
- **EXTERNAL_LINK**: 외부 링크 열기 버튼 표시

## 기술적 변경
- `useContentPreview` 훅 사용하여 미리보기 데이터 로드
- Blob URL 생성 및 정리 로직 추가
- ContentPreviewModal 의존성 제거 (상세 페이지에서만)
- ContentPreviewModal에도 텍스트 파일 미리보기 지원 추가

## 테스트 항목
- [x] 비디오 콘텐츠 상세 페이지에서 플레이어 표시 확인
- [ ] 오디오 콘텐츠 상세 페이지에서 플레이어 표시 확인
- [x] 이미지 콘텐츠 상세 페이지에서 이미지 표시 확인
- [x] PDF 문서 상세 페이지에서 PDF 뷰어 표시 확인
- [x] 텍스트 파일 상세 페이지에서 텍스트 내용 표시 확인
- [x] 외부 링크 콘텐츠 상세 페이지에서 링크 열기 버튼 확인
- [x] 콘텐츠 리스트의 미리보기 버튼은 정상 작동 확인
- [x] 콘텐츠 리스트 미리보기 모달에서 텍스트 파일 표시 확인

## 스크린샷
(필요시 추가)