### PR TITLE
refactor: Program → Course Phase 1 API 연동 변경

### DIFF
--- a/src/hooks/co/useProgramQueries.ts
+++ b/src/hooks/co/useProgramQueries.ts
@@ -1,5 +1,9 @@
 /**
  * TO(Tenant Operator) 프로그램(Program) React Query Hooks
+ *
+ * @deprecated Phase 3: Program 엔티티가 제거되었습니다.
+ * 이 hooks는 내부적으로 Course API를 호출합니다.
+ * 점진적 전환을 위해 유지됩니다.
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '@/store/common/authStore';
@@ -36,13 +40,17 @@ export const usePrograms = (params?: ProgramFilterParams) => {
   });
 };
 
-/** 승인된 프로그램 목록 조회 (차수 생성용) */
+/**
+ * 승인된 프로그램 목록 조회 (차수 생성용)
+ * @deprecated Phase 3: status 'APPROVED' → 'REGISTERED'
+ */
 export const useApprovedPrograms = () => {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
   return useQuery({
-    queryKey: programKeys.list({ status: 'APPROVED' }),
-    queryFn: () => programService.getPrograms({ status: 'APPROVED', size: 100 }),
+    // Phase 3: APPROVED → REGISTERED (Course의 등록 완료 상태)
+    queryKey: programKeys.list({ status: 'REGISTERED' as ProgramFilterParams['status'] }),
+    queryFn: () => programService.getPrograms({ status: 'REGISTERED' as ProgramFilterParams['status'], size: 100 }),
     enabled: isAuthenticated,
   });
 };

--- a/src/hooks/tu/useMyProgramQueries.ts
+++ b/src/hooks/tu/useMyProgramQueries.ts
@@ -3,6 +3,10 @@
  *
  * TO의 programService와 snapshotService를 사용하여
  * 현재 사용자가 생성한 프로그램을 관리합니다.
+ *
+ * @deprecated Phase 3: Program 엔티티가 제거되었습니다.
+ * 이 hooks는 내부적으로 Course API를 호출합니다.
+ * 점진적 전환을 위해 유지됩니다.
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '@/store/common/authStore';

--- a/src/pages/co/time/CourseTimeCreatePage.tsx
+++ b/src/pages/co/time/CourseTimeCreatePage.tsx
@@ -173,7 +173,7 @@ export function CourseTimeCreatePage({ language = 'ko' }: Readonly<CourseTimeCre
 
   // Form State
   const [formData, setFormData] = useState<CreateCourseTimeRequest>({
-    programId: 0,
+    courseId: 0, // Phase 3: programId → courseId
     title: '',
     description: '',
     deliveryType: 'ONLINE',
@@ -207,7 +207,8 @@ export function CourseTimeCreatePage({ language = 'ko' }: Readonly<CourseTimeCre
     const newErrors: Partial<Record<keyof CreateCourseTimeRequest, string>> = {};
 
     if (step === 1) {
-      if (!formData.programId) newErrors.programId = getText('required');
+      // Phase 3: programId → courseId
+      if (!formData.courseId) newErrors.courseId = getText('required');
       if (!formData.title.trim()) newErrors.title = getText('required');
     } else if (step === 2) {
       if (!formData.enrollStartDate) newErrors.enrollStartDate = getText('required');
@@ -280,27 +281,27 @@ export function CourseTimeCreatePage({ language = 'ko' }: Readonly<CourseTimeCre
     }
   };
 
-  // 프로그램 선택 핸들러
-  const handleProgramSelect = (programIdStr: string) => {
-    const programId = parseInt(programIdStr);
-    if (!programId) {
+  // 프로그램 선택 핸들러 (Phase 3: programId → courseId)
+  const handleProgramSelect = (courseIdStr: string) => {
+    const courseId = parseInt(courseIdStr);
+    if (!courseId) {
       setSelectedProgram(null);
-      setFormData((prev) => ({ ...prev, programId: 0 }));
+      setFormData((prev) => ({ ...prev, courseId: 0 }));
       return;
     }
 
-    const program = approvedPrograms.find((p) => p.id === programId);
+    const program = approvedPrograms.find((p) => p.id === courseId);
     if (program) {
       setSelectedProgram(program);
       setFormData((prev) => ({
         ...prev,
-        programId: program.id,
+        courseId: program.id,
         // 차수명이 비어있으면 교육 과정명으로 자동 설정
         title: prev.title || program.title,
       }));
       // 에러 클리어
-      if (errors.programId) {
-        setErrors((prev) => ({ ...prev, programId: undefined }));
+      if (errors.courseId) {
+        setErrors((prev) => ({ ...prev, courseId: undefined }));
       }
     }
   };
@@ -565,12 +566,12 @@ export function CourseTimeCreatePage({ language = 'ko' }: Readonly<CourseTimeCre
                   </div>
                 ) : (
                   <Select
-                    value={formData.programId ? formData.programId.toString() : ''}
+                    value={formData.courseId ? formData.courseId.toString() : ''}
                     onValueChange={handleProgramSelect}
                   >
                     <SelectTrigger
                       id="programSelect"
-                      className={errors.programId ? 'border-status-error' : ''}
+                      className={errors.courseId ? 'border-status-error' : ''}
                     >
                       <SelectValue placeholder={getText('selectProgramPlaceholder')} />
                     </SelectTrigger>
@@ -583,8 +584,8 @@ export function CourseTimeCreatePage({ language = 'ko' }: Readonly<CourseTimeCre
                     </SelectContent>
                   </Select>
                 )}
-                {errors.programId && (
-                  <p className="text-sm text-status-error">{errors.programId}</p>
+                {errors.courseId && (
+                  <p className="text-sm text-status-error">{errors.courseId}</p>
                 )}
               </div>
 

--- a/src/pages/co/time/CourseTimeDetailPage.tsx
+++ b/src/pages/co/time/CourseTimeDetailPage.tsx
@@ -476,12 +476,12 @@ export function CourseTimeDetailPage({ language = 'ko' }: Readonly<CourseTimeDet
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                       <div>
                         <Label className="text-text-secondary">{getText('programTitle')}</Label>
-                        <p className="text-text-primary font-medium">{courseTime.programTitle || '-'}</p>
+                        <p className="text-text-primary font-medium">{courseTime.courseTitle || '-'}</p>
                       </div>
-                      {courseTime.programDescription && (
+                      {courseTime.courseDescription && (
                         <div className="md:col-span-2">
                           <Label className="text-text-secondary">{getText('description')}</Label>
-                          <p className="text-text-primary whitespace-pre-wrap text-sm">{courseTime.programDescription}</p>
+                          <p className="text-text-primary whitespace-pre-wrap text-sm">{courseTime.courseDescription}</p>
                         </div>
                       )}
                     </div>

--- a/src/pages/co/time/CourseTimesPage.tsx
+++ b/src/pages/co/time/CourseTimesPage.tsx
@@ -369,7 +369,7 @@ export function CourseTimesPage({ language = 'ko' }: Readonly<CourseTimesPagePro
           <div className="flex items-center gap-1.5 max-w-xs">
             <BookOpen size={14} className="text-text-secondary flex-shrink-0" />
             <span className="text-sm text-text-secondary truncate">
-              {row.original.programTitle || '-'}
+              {row.original.courseTitle || '-'}
             </span>
           </div>
         ),

--- a/src/pages/co/user/UserManagementPage.tsx
+++ b/src/pages/co/user/UserManagementPage.tsx
@@ -393,7 +393,7 @@ export function UserManagementPage({ language = 'ko' }: Readonly<UserManagementP
     const allTimes = timesData?.content ?? [];
     // 선택된 프로그램이 있으면 해당 프로그램의 차수만 필터링
     const filteredTimes = selectedProgramTitle
-      ? allTimes.filter((t) => t.programTitle === selectedProgramTitle)
+      ? allTimes.filter((t) => t.courseTitle === selectedProgramTitle)
       : allTimes;
     return filteredTimes.map((t) => ({
       value: String(t.id),
@@ -412,7 +412,7 @@ export function UserManagementPage({ language = 'ko' }: Readonly<UserManagementP
   const enrollTimeOptions = useMemo(() => {
     const allTimes = timesData?.content ?? [];
     const filteredTimes = enrollProgramTitle
-      ? allTimes.filter((t) => t.programTitle === enrollProgramTitle)
+      ? allTimes.filter((t) => t.courseTitle === enrollProgramTitle)
       : [];
     return filteredTimes.map((t) => ({
       value: String(t.id),

--- a/src/services/co/programService.ts
+++ b/src/services/co/programService.ts
@@ -1,5 +1,9 @@
 /**
  * Program API 서비스 (TO - Tenant Operator)
+ *
+ * @deprecated Phase 3: Program 엔티티가 제거되었습니다.
+ * 이 서비스는 내부적으로 Course API를 호출합니다.
+ * 점진적 전환을 위해 유지되며, 새 코드에서는 Course 관련 서비스 사용을 권장합니다.
  */
 import axiosInstance from '@/services/common/api/axiosInstance';
 import { API_ENDPOINTS } from '@/services/common/api/endpoints';
@@ -96,13 +100,17 @@ export const programService = {
     return data;
   },
 
-  /** 검토 대기 프로그램 목록 조회 (OPERATOR용) */
+  /**
+   * 검토 대기 프로그램 목록 조회 (OPERATOR용)
+   * @deprecated Phase 3: Course API의 status 필터 사용
+   */
   async getPendingPrograms(
     params?: Pick<ProgramFilterParams, 'page' | 'size' | 'sort'>
   ): Promise<PageResponse<PendingProgramResponse>> {
+    // Phase 3: /programs/pending → /courses?status=READY
     const { data } = await axiosInstance.get<PageResponse<PendingProgramResponse>>(
-      API_ENDPOINTS.PROGRAMS.PENDING,
-      { params }
+      API_ENDPOINTS.PROGRAMS.BASE,
+      { params: { ...params, status: 'READY' } }
     );
     return data;
   },

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -133,6 +133,10 @@ export const API_ENDPOINTS = {
       `/courses/${courseId}/items/${itemId}/display-info`,
     // Course Folders
     FOLDERS: (courseId: number) => `/courses/${courseId}/folders`,
+    // Phase 3: 승인 워크플로우 (Program에서 이관)
+    READY: (id: number) => `/courses/${id}/ready`,
+    UNREADY: (id: number) => `/courses/${id}/unready`,
+    REGISTER: (id: number) => `/courses/${id}/register`,
   },
 
   // Content (TO, TU) - Legacy
@@ -179,16 +183,19 @@ export const API_ENDPOINTS = {
     MOVE: (id: number) => `/content-folders/${id}/move`,
   },
 
-  // Programs (TO)
+  /**
+   * @deprecated Phase 3: Program 엔티티 제거됨. COURSES 섹션 사용.
+   * 점진적 전환을 위해 유지하되, 새 코드에서는 COURSES 사용 권장.
+   */
   PROGRAMS: {
-    BASE: '/programs',
-    BY_ID: (id: number) => `/programs/${id}`,
-    SUBMIT: (id: number) => `/programs/${id}/submit`,
-    PENDING: '/programs/pending',
-    APPROVE: (id: number) => `/programs/${id}/approve`,
-    REJECT: (id: number) => `/programs/${id}/reject`,
-    CLOSE: (id: number) => `/programs/${id}/close`,
-    SNAPSHOT: (id: number) => `/programs/${id}/snapshot`,
+    BASE: '/courses', // /programs → /courses
+    BY_ID: (id: number) => `/courses/${id}`,
+    SUBMIT: (id: number) => `/courses/${id}/ready`, // submit → ready
+    PENDING: '/courses', // 별도 pending 엔드포인트 없음
+    APPROVE: (id: number) => `/courses/${id}/register`, // approve → register
+    REJECT: (id: number) => `/courses/${id}/unready`, // reject → unready
+    CLOSE: (id: number) => `/courses/${id}`, // close 개념 없음
+    SNAPSHOT: (id: number) => `/courses/${id}/snapshots`,
   },
 
   // Instructor Assignments (TU - 내 배정, TO - 전체 관리)

--- a/src/types/co/time.types.ts
+++ b/src/types/co/time.types.ts
@@ -53,7 +53,7 @@ export interface CourseTimeResponse {
   allowLateEnrollment: boolean;
   createdAt: string;
   instructors: CourseTimeInstructor[];
-  programTitle: string | null; // 프로그램명
+  courseTitle: string | null; // Phase 3: programTitle → courseTitle
 }
 
 /** 강사 정보 (상세 조회용) */
@@ -68,9 +68,9 @@ export interface CourseTimeInstructor {
 
 /** 차수 상세 조회 응답 (백엔드 CourseTimeDetailResponse 매칭) */
 export interface CourseTimeDetailResponse extends CourseTimeResponse {
-  programId: number | null;
-  programTitle: string | null;
-  programDescription: string | null;
+  courseId: number | null; // Phase 3: programId → courseId
+  courseTitle: string | null; // Phase 3: programTitle → courseTitle
+  courseDescription: string | null; // Phase 3: programDescription → courseDescription
   maxWaitingCount: number | null;
   minProgressForCompletion: number | null;
   locationInfo: string | null;
@@ -101,9 +101,7 @@ export interface PriceResponse {
 
 /** 차수 생성 요청 (백엔드 CreateCourseTimeRequest 매칭) */
 export interface CreateCourseTimeRequest {
-  programId: number;
-  cmCourseId?: number; // deprecated
-  cmCourseVersionId?: number; // deprecated
+  courseId: number; // Phase 3: programId → courseId
   title: string;
   description?: string; // 차수 설명
   deliveryType: DeliveryType;
@@ -152,8 +150,7 @@ export interface CloneCourseTimeRequest {
 
 /** 차수 목록 조회 필터 */
 export interface CourseTimeFilterParams {
-  programId?: number;
-  cmCourseId?: number;
+  courseId?: number; // Phase 3: programId → courseId
   status?: CourseTimeStatus;
   page?: number;
   size?: number;


### PR DESCRIPTION
## Summary

백엔드 Phase 3 (Program 엔티티 제거) 대응을 위한 프론트엔드 점진적 전환 Phase 1

- API 레이어만 변경, UI 텍스트는 기존 유지
- `programId` → `courseId` 필드명 변경
- PROGRAMS 엔드포인트 deprecated 처리 및 /courses로 리다이렉트

## 관련 이슈

- Related to #414 (Program → Course 점진적 전환)
- mzc-lp-backend #381 (Phase 3: Program 엔티티 제거)

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `src/types/co/time.types.ts` | programId → courseId |
| `src/services/common/api/endpoints.ts` | PROGRAMS deprecated, /courses 리다이렉트 |
| `src/services/co/programService.ts` | deprecation 주석 |
| `src/hooks/co/useProgramQueries.ts` | APPROVED → REGISTERED 매핑 |
| `src/hooks/tu/useMyProgramQueries.ts` | deprecation 주석 |
| `src/pages/co/time/CourseTimeCreatePage.tsx` | programId → courseId |

## Test Plan

- [x] 차수 생성 페이지에서 과정 선택 및 차수 생성 정상 동작
- [x] CO 프로그램 목록/상세/검토 페이지 정상 조회
- [x] TU 내 프로그램 목록/상세/수정 페이지 정상 동작