### PR TITLE
feat: 오디오 콘텐츠 업로드 지원 (#415)

### DIFF
--- a/src/components/domain/tu/content/ContentPreviewModal.tsx
+++ b/src/components/domain/tu/content/ContentPreviewModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo } from 'react';
-import { Loader2, ExternalLink, Download, AlertCircle, FileText } from 'lucide-react';
+import { Loader2, ExternalLink, Download, AlertCircle, FileText, Music } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -136,7 +136,7 @@ export function ContentPreviewModal({
         return (
           <div className="flex flex-col items-center justify-center py-12 space-y-4">
             <div className="w-24 h-24 rounded-full bg-bg-secondary flex items-center justify-center">
-              <span className="text-4xl">🎵</span>
+              <Music size={48} className="text-text-secondary" />
             </div>
             <audio src={blobUrl} controls className="w-full max-w-md">
               브라우저가 오디오를 지원하지 않습니다.

--- a/src/components/domain/tu/content/ContentRegistrationWizard.tsx
+++ b/src/components/domain/tu/content/ContentRegistrationWizard.tsx
@@ -53,7 +53,7 @@ export function ContentRegistrationWizard({
     }
 
     // 파일 업로드 검증
-    if (formData.loType === 'video' || formData.loType === 'image' || formData.loType === 'document') {
+    if (formData.loType === 'video' || formData.loType === 'audio' || formData.loType === 'image' || formData.loType === 'document') {
       if (!formData.uploadedFile) {
         alert('파일을 업로드해주세요.');
         return;

--- a/src/components/domain/tu/content/Step1ContentDefinition.tsx
+++ b/src/components/domain/tu/content/Step1ContentDefinition.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, DragEvent } from 'react';
-import { FileText, FileVideo, Link as LinkIcon, X, Tag, Image as ImageIcon, Upload, File, ExternalLink } from 'lucide-react';
+import { FileText, FileVideo, Link as LinkIcon, X, Tag, Image as ImageIcon, Upload, File, ExternalLink, Music } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button, Input, Textarea, NativeSelect } from '@/components/common';
 import { inputVariants } from '@/styles/form';
@@ -16,6 +16,12 @@ const loTypeCards = [
     icon: FileVideo,
     title: '비디오',
     description: '동영상 콘텐츠를 업로드합니다',
+  },
+  {
+    type: 'audio' as LOType,
+    icon: Music,
+    title: '오디오',
+    description: 'MP3, WAV 등 오디오를 업로드합니다',
   },
   {
     type: 'image' as LOType,
@@ -178,17 +184,21 @@ export function Step1ContentDefinition({ data, onUpdate }: Readonly<Step1Props>)
     const acceptedFormats =
       data.loType === 'video'
         ? '.mp4,.mov,.avi,.mkv'
-        : data.loType === 'image'
-          ? '.jpg,.jpeg,.png,.gif,.webp'
-          : '.pdf,.txt,.doc,.docx,.ppt,.pptx';
+        : data.loType === 'audio'
+          ? '.mp3,.wav,.m4a,.flac'
+          : data.loType === 'image'
+            ? '.jpg,.jpeg,.png,.gif,.webp'
+            : '.pdf,.txt,.doc,.docx,.ppt,.pptx';
     const formatText =
       data.loType === 'video'
         ? 'MP4, MOV, AVI, MKV (최대 500MB)'
-        : data.loType === 'image'
-          ? 'JPG, PNG, GIF, WEBP (최대 20MB)'
-          : 'PDF, TXT, DOC, DOCX, PPT, PPTX (최대 100MB)';
+        : data.loType === 'audio'
+          ? 'MP3, WAV, M4A, FLAC (최대 100MB)'
+          : data.loType === 'image'
+            ? 'JPG, PNG, GIF, WEBP (최대 20MB)'
+            : 'PDF, TXT, DOC, DOCX, PPT, PPTX (최대 100MB)';
     const uploadTitle =
-      data.loType === 'video' ? '비디오 파일 업로드' : data.loType === 'image' ? '이미지 파일 업로드' : '문서 파일 업로드';
+      data.loType === 'video' ? '비디오 파일 업로드' : data.loType === 'audio' ? '오디오 파일 업로드' : data.loType === 'image' ? '이미지 파일 업로드' : '문서 파일 업로드';
 
     return (
       <div>

--- a/src/types/co/content.types.ts
+++ b/src/types/co/content.types.ts
@@ -3,7 +3,7 @@
  */
 
 // LO(Learning Object) 유형
-export type LOType = 'video' | 'image' | 'document' | 'external-link';
+export type LOType = 'video' | 'audio' | 'image' | 'document' | 'external-link';
 
 // 진도율 완료 기준
 export type CompletionCriteria = 'button-click' | '90-percent' | '100-percent';


### PR DESCRIPTION
## 개요
오디오 콘텐츠 업로드 기능을 추가합니다.

## 변경 사항
- 콘텐츠 타입에 audio 추가
- 오디오 파일 업로드 지원 (mp3, wav, m4a, flac)
- 오디오 타입 카드 UI 추가 (Music 아이콘)
- 파일 업로드 검증 로직에 오디오 타입 추가
- 미리보기 모달의 오디오 아이콘을 Music 아이콘으로 통일

## 관련 이슈
- Closes #415

## 테스트
- [x] 콘텐츠 업로드 페이지에서 오디오 타입 선택 가능
- [x] MP3, WAV, M4A, FLAC 파일 업로드 가능
- [x] 업로드된 오디오 파일 미리보기 동작 확인
- [x] 상세 페이지에서 오디오 재생 확인