### PR TITLE
fix: 멀티테넌트 환경에서 강의 목록 캐시 격리 문제 수정

### DIFF
--- a/src/hooks/tu/useCourseTimeCatalogQueries.ts
+++ b/src/hooks/tu/useCourseTimeCatalogQueries.ts
@@ -4,14 +4,22 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { courseTimeCatalogService } from '@/services/tu/courseTimeCatalogService';
+import { extractTenantIdentifier } from '@/utils/tenantUtils';
 import type { CourseTimeCatalogParams } from '@/types/tu/courseTimeCatalog.types';
 
-// Query Keys
+// 현재 서브도메인 가져오기
+function getCurrentSubdomain(): string | null {
+  const tenant = extractTenantIdentifier();
+  return tenant?.type === 'subdomain' ? tenant.identifier : null;
+}
+
+// Query Keys (서브도메인 포함)
 export const courseTimeCatalogKeys = {
   all: ['courseTimeCatalog'] as const,
-  catalog: (params?: CourseTimeCatalogParams) =>
-    [...courseTimeCatalogKeys.all, 'catalog', params] as const,
-  detail: (id: number) => [...courseTimeCatalogKeys.all, 'detail', id] as const,
+  catalog: (params?: CourseTimeCatalogParams, subdomain?: string | null) =>
+    [...courseTimeCatalogKeys.all, 'catalog', subdomain, params] as const,
+  detail: (id: number, subdomain?: string | null) =>
+    [...courseTimeCatalogKeys.all, 'detail', subdomain, id] as const,
 };
 
 /**
@@ -20,8 +28,9 @@ export const courseTimeCatalogKeys = {
  * @param enabled 쿼리 활성화 여부
  */
 export function useCourseTimeCatalog(params?: CourseTimeCatalogParams, enabled = true) {
+  const subdomain = getCurrentSubdomain();
   return useQuery({
-    queryKey: courseTimeCatalogKeys.catalog(params),
+    queryKey: courseTimeCatalogKeys.catalog(params, subdomain),
     queryFn: () => courseTimeCatalogService.getCatalog(params),
     enabled,
     staleTime: 1000 * 60 * 5, // 5분
@@ -34,8 +43,9 @@ export function useCourseTimeCatalog(params?: CourseTimeCatalogParams, enabled =
  * @param enabled 쿼리 활성화 여부
  */
 export function useCourseTimeDetail(id: number, enabled = true) {
+  const subdomain = getCurrentSubdomain();
   return useQuery({
-    queryKey: courseTimeCatalogKeys.detail(id),
+    queryKey: courseTimeCatalogKeys.detail(id, subdomain),
     queryFn: () => courseTimeCatalogService.getDetail(id),
     enabled: enabled && !!id,
     staleTime: 1000 * 60 * 5, // 5분

--- a/src/services/tu/courseTimeCatalogService.ts
+++ b/src/services/tu/courseTimeCatalogService.ts
@@ -18,7 +18,7 @@ import type { ApiResponse, PageResponse } from '@/types/common';
 function getSubdomainFromUrl(): string | null {
   const pathname = window.location.pathname;
   // 패턴: /:subdomain/tu/... 또는 /:subdomain/ta/... 등
-  const match = pathname.match(/^\/([^/]+)\/(?:tu|ta|to|sa)\//);
+  const match = pathname.match(/^\/([^/]+)\/(?:tu|ta|co)\//);
   if (match) {
     return match[1];
   }

--- a/src/utils/tenantUtils.ts
+++ b/src/utils/tenantUtils.ts
@@ -23,8 +23,8 @@ export interface TenantIdentifier {
 export function extractSubdomainFromPath(): string | null {
   const pathname = window.location.pathname;
 
-  // 경로 기반 서브도메인 패턴: /{subdomain}/(tu|ta|to)/...
-  const regex = /^\/([^/]+)\/(tu|ta|to)(\/|$)/;
+  // 경로 기반 서브도메인 패턴: /{subdomain}/(tu|ta|co)/...
+  const regex = /^\/([^/]+)\/(tu|ta|co)(\/|$)/;
   const match = regex.exec(pathname);
   const subdomain = match?.[1];
 


### PR DESCRIPTION
## Summary

멀티테넌트 환경에서 서브도메인별 강의 목록 캐시가 분리되지 않아 다른 테넌트의 데이터가 표시되는 문제를 수정했습니다.

## Related Issue

- Closes #

## Changes

- React Query queryKey에 서브도메인을 추가하여 테넌트별 캐시 격리
- 서브도메인 추출 정규식 패턴 `to` → `co` 변경 (TO → CO 리네이밍 반영)
- `useCourseTimeCatalog`, `useCourseTimeDetail` 훅에서 현재 서브도메인 기반 캐시키 생성

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes

### 문제 원인
- `/tu/b2c` 방문 시 기본 테넌트 데이터가 캐시됨
- `/company-a/tu/b2c` 방문 시 동일한 queryKey로 인해 캐시된 기본 테넌트 데이터가 반환됨

### 해결 방법
- `courseTimeCatalogKeys`에 서브도메인 파라미터 추가
- `getCurrentSubdomain()` 함수로 현재 URL에서 서브도메인 추출
- 각 테넌트별로 독립적인 캐시 유지