### PR TITLE
[Feat] B2B/B2C 라우팅 분리 및 B2B 마이페이지 구현

### DIFF
--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -18,6 +18,10 @@ export { CourseOperatorSidebar } from './co/CourseOperatorSidebar';
 export { TenantUserLayout } from './tu/TenantUserLayout';
 export { TenantUserSidebar } from './tu/TenantUserSidebar';
 
-// MyPage
+// MyPage (B2C)
 export { MyPageLayout } from './mypage/MyPageLayout';
 export { MyPageSidebar } from './mypage/MyPageSidebar';
+
+// MyPage (B2B)
+export { B2BMyPageLayout } from './mypage/B2BMyPageLayout';
+export { B2BMyPageSidebar } from './mypage/B2BMyPageSidebar';

--- a/src/components/layout/mypage/B2BMyPageLayout.tsx
+++ b/src/components/layout/mypage/B2BMyPageLayout.tsx
@@ -1,0 +1,62 @@
+import { type ReactNode } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { B2BMyPageSidebar } from './B2BMyPageSidebar';
+import { LandingFooter } from '@/components/landing';
+import { B2BLandingHeader } from '@/pages/tu/b2b/components/B2BLandingHeader';
+import { b2bMyPageMenuData } from '@/config/sidebar-menus';
+import { useUIStore, useIsDarkMode } from '@/store/common/uiStore';
+
+interface B2BMyPageLayoutProps {
+  children: ReactNode;
+}
+
+export function B2BMyPageLayout({ children }: B2BMyPageLayoutProps) {
+  const navigate = useNavigate();
+  const { subdomain } = useParams<{ subdomain: string }>();
+  const { isSidebarExpanded, language, toggleSidebar } = useUIStore();
+  const isDarkMode = useIsDarkMode();
+
+  const prefixPath = (path: string) => {
+    if (subdomain) {
+      return `/${subdomain}${path}`;
+    }
+    return path;
+  };
+
+  const handleMenuItemClick = (itemId: string) => {
+    const menuItem = b2bMyPageMenuData.find((item) => item.id === itemId);
+    if (menuItem?.path) {
+      navigate(prefixPath(menuItem.path));
+      return;
+    }
+
+    for (const item of b2bMyPageMenuData) {
+      const subItem = item.subItems?.find((sub) => sub.id === itemId);
+      if (subItem?.path) {
+        navigate(prefixPath(subItem.path));
+        return;
+      }
+    }
+  };
+
+  return (
+    <div className={`flex flex-col min-h-screen ${isDarkMode ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
+      <B2BLandingHeader />
+
+      <div className="flex flex-1">
+        <B2BMyPageSidebar
+          isExpanded={isSidebarExpanded}
+          onToggle={toggleSidebar}
+          onMenuItemClick={handleMenuItemClick}
+          isDarkMode={isDarkMode}
+          language={language}
+          subdomain={subdomain}
+        />
+
+        <main className="flex-1 overflow-auto">{children}</main>
+      </div>
+
+      <LandingFooter />
+    </div>
+  );
+}

--- a/src/components/layout/mypage/B2BMyPageSidebar.tsx
+++ b/src/components/layout/mypage/B2BMyPageSidebar.tsx
@@ -1,0 +1,403 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { ChevronDown, ChevronRight, Loader2, BookOpen, GraduationCap } from 'lucide-react';
+import { toast } from 'sonner';
+import { b2bMyPageMenuData } from '@/config/sidebar-menus';
+import { useThemeStore } from '@/store/common/themeStore';
+import { useLanguageStore } from '@/store/common/languageStore';
+import { useAuthStore } from '@/store/common/authStore';
+import { userService } from '@/services/common/userService';
+import { authService } from '@/services/common/authService';
+import { useSubdomainPath } from '@/hooks/common';
+import { usePublicLayout } from '@/hooks/tu';
+import { useTenantFeatures } from '@/contexts/TenantFeaturesContext';
+import { cn } from '@/utils/cn';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/common';
+import type { MenuItem } from '@/types';
+
+interface BrandingSidebarItem {
+  id: string;
+  label: string;
+  url: string;
+  icon: string;
+  visible: boolean;
+  children?: BrandingSidebarItem[];
+}
+
+interface B2BMyPageSidebarProps {
+  isExpanded: boolean;
+  onToggle: () => void;
+  onMenuItemClick?: (itemId: string) => void;
+  isDarkMode?: boolean;
+  language?: 'ko' | 'en';
+  subdomain?: string;
+}
+
+type ViewMode = 'instructor' | 'learner';
+
+export function B2BMyPageSidebar({ onMenuItemClick }: B2BMyPageSidebarProps) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
+
+  const { data: layoutData } = usePublicLayout();
+  const sidebarSettings = layoutData?.sidebarTUSettings as { enabled?: boolean; items?: BrandingSidebarItem[] } | undefined;
+
+  const { isFeatureEnabled } = useTenantFeatures();
+  const userCourseCreationEnabled = isFeatureEnabled('userCourseCreationEnabled');
+  const instructorTabEnabled = isFeatureEnabled('instructorTabEnabled');
+
+  const filteredMenuData = useMemo((): MenuItem[] => {
+    const hiddenIds = new Set<string>();
+    if (sidebarSettings?.items && sidebarSettings.items.length > 0) {
+      const collectHiddenIds = (items: BrandingSidebarItem[]) => {
+        for (const item of items) {
+          if (!item.visible) {
+            hiddenIds.add(item.id);
+          }
+          if (item.children) {
+            collectHiddenIds(item.children);
+          }
+        }
+      };
+      collectHiddenIds(sidebarSettings.items);
+    }
+
+    if (!userCourseCreationEnabled) {
+      hiddenIds.add('my-teaching');
+      hiddenIds.add('create-course');
+    }
+
+    return b2bMyPageMenuData
+      .filter((item) => !hiddenIds.has(item.id))
+      .map((item) => ({
+        ...item,
+        subItems: item.subItems?.filter((sub) => !hiddenIds.has(sub.id)),
+      }));
+  }, [sidebarSettings, userCourseCreationEnabled]);
+
+  const { theme } = useThemeStore();
+  const { language } = useLanguageStore();
+  const { user, updateUser } = useAuthStore();
+  const isDark = theme === 'dark';
+  const [expandedMenus, setExpandedMenus] = useState<string[]>(['my-enrollments', 'my-teaching']);
+  const [currentMode, setCurrentMode] = useState<ViewMode>('learner');
+  const [showCreateCourseDialog, setShowCreateCourseDialog] = useState(false);
+  const [isGrantingRole, setIsGrantingRole] = useState(false);
+  const [courseRoleStatus, setCourseRoleStatus] = useState<'USER' | 'INSTRUCTOR' | 'DESIGNER' | 'OWNER'>('USER');
+
+  useEffect(() => {
+    const checkCourseRole = async () => {
+      try {
+        const roles = await userService.getMyCourseRoles();
+        if (Array.isArray(roles) && roles.length > 0) {
+          const hasOwner = roles.some((r: { role: string }) => r.role === 'OWNER');
+          const hasDesigner = roles.some((r: { role: string }) => r.role === 'DESIGNER');
+          const hasInstructor = roles.some((r: { role: string }) => r.role === 'INSTRUCTOR');
+
+          if (hasOwner) {
+            setCourseRoleStatus('OWNER');
+          } else if (hasDesigner) {
+            setCourseRoleStatus('DESIGNER');
+          } else if (hasInstructor) {
+            setCourseRoleStatus('INSTRUCTOR');
+          }
+        }
+      } catch (error) {
+        console.error('Failed to fetch course roles:', error);
+      }
+    };
+    checkCourseRole();
+  }, []);
+
+  const isDesigner = courseRoleStatus !== 'USER';
+
+  const handleCreateCourseClick = () => {
+    setShowCreateCourseDialog(true);
+  };
+
+  const handleCreateCourseConfirm = async () => {
+    if (isDesigner) {
+      setShowCreateCourseDialog(false);
+      onMenuItemClick?.('create-course');
+      return;
+    }
+
+    setIsGrantingRole(true);
+    try {
+      await userService.applyDesignerRole();
+
+      const refreshToken = useAuthStore.getState().refreshToken;
+      if (refreshToken) {
+        const tokenResponse = await authService.refresh(refreshToken);
+        useAuthStore.getState().setTokens(tokenResponse.accessToken, tokenResponse.refreshToken);
+      }
+
+      const updatedUser = await userService.getMe();
+      updateUser({ role: updatedUser.role });
+
+      toast.success(language === 'ko' ? '강의 디자인 권한이 부여되었습니다.' : 'Designer permission granted.');
+      setShowCreateCourseDialog(false);
+      onMenuItemClick?.('create-course');
+    } catch (error) {
+      const axiosError = error as { response?: { status?: number } };
+      if (axiosError.response?.status === 409) {
+        const refreshToken = useAuthStore.getState().refreshToken;
+        if (refreshToken) {
+          const tokenResponse = await authService.refresh(refreshToken);
+          useAuthStore.getState().setTokens(tokenResponse.accessToken, tokenResponse.refreshToken);
+        }
+
+        const updatedUser = await userService.getMe();
+        updateUser({ role: updatedUser.role });
+
+        toast.success(language === 'ko' ? '이미 강의 디자인 권한이 있습니다.' : 'You already have designer permission.');
+        setShowCreateCourseDialog(false);
+        onMenuItemClick?.('create-course');
+      } else {
+        toast.error(language === 'ko' ? '권한 부여에 실패했습니다.' : 'Failed to grant permission.');
+      }
+    } finally {
+      setIsGrantingRole(false);
+    }
+  };
+
+  const getCreateCourseDialogDescription = () => {
+    if (courseRoleStatus === 'OWNER') {
+      return language === 'ko'
+        ? '이미 강의 소유자입니다. 새 강의를 디자인하시겠습니까?'
+        : 'You are already a course owner. Would you like to design a new course?';
+    }
+    if (courseRoleStatus === 'DESIGNER') {
+      return language === 'ko'
+        ? '이미 강의 디자인 권한이 있습니다. 강의 디자인 페이지로 이동하시겠습니까?'
+        : 'You already have course design permission. Would you like to go to the course design page?';
+    }
+    return language === 'ko'
+      ? '강의 디자인을 위해 디자이너 권한이 부여됩니다. 강의 디자인 페이지로 이동하시겠습니까?'
+      : 'Designer permission will be granted for course design. Would you like to proceed to the course design page?';
+  };
+
+  const filterSubItemsByRole = (subItems?: MenuItem['subItems']) => {
+    if (!subItems) return [];
+    return subItems.filter((item) => {
+      if (!item.roles || item.roles.length === 0) return true;
+      return user?.role && item.roles.includes(user.role);
+    });
+  };
+
+  const toggleMenu = (menuId: string) => {
+    setExpandedMenus((prev) =>
+      prev.includes(menuId) ? prev.filter((id) => id !== menuId) : [...prev, menuId]
+    );
+  };
+
+  const isActive = (path?: string, isExactMatch?: boolean) => {
+    if (!path) return false;
+    if (isExactMatch) {
+      return location.pathname === path;
+    }
+    return location.pathname === path || location.pathname.startsWith(path + '/');
+  };
+
+  const renderMenuItem = (item: MenuItem) => {
+    const hasSubItems = item.subItems && item.subItems.length > 0;
+    const isExpanded = expandedMenus.includes(item.id);
+    // 홈 메뉴는 정확히 일치할 때만 활성화
+    const isHomeMenu = item.id === 'mypage-home';
+    const active = isActive(item.path, isHomeMenu);
+    const Icon = item.icon;
+
+    return (
+      <div key={item.id} className="mb-1">
+        <button
+          onClick={() => {
+            if (hasSubItems) {
+              toggleMenu(item.id);
+            } else if (item.path && onMenuItemClick) {
+              onMenuItemClick(item.id);
+            }
+          }}
+          className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl text-left transition-all ${
+            active
+              ? isDark
+                ? 'bg-gradient-to-r from-[#6778ff]/20 to-[#a855f7]/20 text-white'
+                : 'bg-blue-50 text-blue-600'
+              : isDark
+              ? 'text-gray-300 hover:bg-white/5 hover:text-white'
+              : 'text-gray-700 hover:bg-gray-100'
+          }`}
+        >
+          <Icon className={`w-5 h-5 ${active ? (isDark ? 'text-[#6778ff]' : 'text-blue-600') : ''}`} />
+          <span className="flex-1 font-medium text-sm">{item.label[language]}</span>
+          {hasSubItems && (
+            <span className={`transition-transform ${isExpanded ? 'rotate-0' : ''}`}>
+              {isExpanded ? (
+                <ChevronDown className="w-4 h-4" />
+              ) : (
+                <ChevronRight className="w-4 h-4" />
+              )}
+            </span>
+          )}
+        </button>
+
+        {hasSubItems && isExpanded && (
+          <div className="mt-1 ml-4 pl-4 border-l-2" style={{ borderColor: isDark ? 'rgba(255,255,255,0.1)' : '#e5e7eb' }}>
+            {filterSubItemsByRole(item.subItems).map((subItem) => {
+              const subActive = isActive(subItem.path);
+              const SubIcon = subItem.icon;
+              return (
+                <button
+                  key={subItem.id}
+                  onClick={() => {
+                    if (subItem.id === 'create-course') {
+                      handleCreateCourseClick();
+                      return;
+                    }
+                    subItem.path && onMenuItemClick?.(subItem.id);
+                  }}
+                  className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left transition-all text-sm ${
+                    subActive
+                      ? isDark
+                        ? 'bg-white/10 text-white'
+                        : 'bg-blue-50 text-blue-600'
+                      : isDark
+                      ? 'text-gray-400 hover:bg-white/5 hover:text-gray-200'
+                      : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+                  }`}
+                >
+                  <SubIcon className="w-4 h-4" />
+                  <span>{subItem.label[language]}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <aside
+      className={`w-72 flex-shrink-0 p-4 sticky top-0 h-[calc(100vh-64px)] ${
+        isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'
+      }`}
+    >
+      <div
+        className={`rounded-2xl p-4 h-full flex flex-col overflow-y-auto ${
+          isDark
+            ? 'bg-white/5 border border-white/10 backdrop-blur-sm'
+            : 'bg-white border border-gray-200 shadow-sm'
+        }`}
+      >
+        {/* 모드 스위처 (디자이너 권한 + 강사 탭 기능이 활성화된 경우에만 표시) */}
+        {isDesigner && instructorTabEnabled && (
+          <>
+            <div
+              className="relative rounded-lg p-1 mb-3"
+              style={{
+                backgroundColor: isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.03)',
+              }}
+            >
+              <div className="flex gap-1">
+                <button
+                  onClick={() => {
+                    setCurrentMode('instructor');
+                    navigate(prefixPath('/tu/dashboard'));
+                  }}
+                  className={cn(
+                    'flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-md',
+                    'transition-all duration-200 text-sm font-medium whitespace-nowrap'
+                  )}
+                  style={{
+                    backgroundColor: currentMode === 'instructor'
+                      ? (isDark ? '#7C5CBF' : '#D4CDEF')
+                      : 'transparent',
+                    color: currentMode === 'instructor'
+                      ? (isDark ? '#FFFFFF' : '#4C2D9A')
+                      : (isDark ? '#9E9E9E' : '#666666'),
+                  }}
+                >
+                  <BookOpen className="w-4 h-4" />
+                  <span>{language === 'ko' ? '강사' : 'Instructor'}</span>
+                </button>
+                <button
+                  onClick={() => {
+                    setCurrentMode('learner');
+                    navigate(prefixPath('/tu/b2b/mypage'));
+                  }}
+                  className={cn(
+                    'flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-md',
+                    'transition-all duration-200 text-sm font-medium whitespace-nowrap'
+                  )}
+                  style={{
+                    backgroundColor: currentMode === 'learner'
+                      ? (isDark ? '#7C5CBF' : '#D4CDEF')
+                      : 'transparent',
+                    color: currentMode === 'learner'
+                      ? (isDark ? '#FFFFFF' : '#4C2D9A')
+                      : (isDark ? '#9E9E9E' : '#666666'),
+                  }}
+                >
+                  <GraduationCap className="w-4 h-4" />
+                  <span>{language === 'ko' ? '학습자' : 'Learner'}</span>
+                </button>
+              </div>
+            </div>
+            <div
+              className="mb-3"
+              style={{
+                borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.1)' : '#e5e7eb'}`,
+              }}
+            />
+          </>
+        )}
+
+        {/* 메뉴 리스트 */}
+        <nav className="space-y-1 flex-1">
+          {filteredMenuData.map(renderMenuItem)}
+        </nav>
+      </div>
+
+      <AlertDialog open={showCreateCourseDialog} onOpenChange={setShowCreateCourseDialog}>
+        <AlertDialogContent className={isDark ? 'bg-[#2a2a2a] border-white/10' : ''}>
+          <AlertDialogHeader>
+            <AlertDialogTitle className={isDark ? 'text-white' : ''}>
+              {language === 'ko' ? '강의 디자인' : 'Course Design'}
+            </AlertDialogTitle>
+            <AlertDialogDescription className={isDark ? 'text-gray-300' : ''}>
+              {getCreateCourseDialogDescription()}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              disabled={isGrantingRole}
+              className={isDark ? 'bg-transparent border-white/20 text-gray-200 hover:bg-white/10 hover:text-white' : ''}
+            >
+              {language === 'ko' ? '취소' : 'Cancel'}
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={handleCreateCourseConfirm} disabled={isGrantingRole}>
+              {isGrantingRole ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  {language === 'ko' ? '처리 중...' : 'Processing...'}
+                </>
+              ) : (
+                language === 'ko' ? '이동' : 'Proceed'
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </aside>
+  );
+}

--- a/src/components/layout/tu/TenantUserSidebar/TenantUserSidebar.tsx
+++ b/src/components/layout/tu/TenantUserSidebar/TenantUserSidebar.tsx
@@ -3,6 +3,7 @@ import { BaseSidebar } from '../../common/BaseSidebar';
 import { tenantUserMenuData, roleLabels } from '@/config/sidebar-menus';
 import { usePublicLayout } from '@/hooks/tu';
 import { useTenantFeatures } from '@/contexts/TenantFeaturesContext';
+import { useAuthStore } from '@/store/common/authStore';
 import type { MenuItem } from '@/types';
 
 interface TenantUserSidebarProps {
@@ -27,38 +28,54 @@ export function TenantUserSidebar(props: TenantUserSidebarProps) {
   const { data: layoutData } = usePublicLayout();
   const sidebarSettings = layoutData?.sidebarTUSettings as { enabled?: boolean; items?: BrandingSidebarItem[] } | undefined;
 
+  // 사용자 역할 가져오기
+  const userRole = useAuthStore((state) => state.user?.role);
+
   // 기능 설정 가져오기
   const { isFeatureEnabled } = useTenantFeatures();
   const instructorTabEnabled = isFeatureEnabled('instructorTabEnabled');
 
-  // 브랜딩 설정을 기반으로 메뉴 필터링
+  // 브랜딩 설정 + 역할 기반 메뉴 필터링
   const filteredMenuData = useMemo((): MenuItem[] => {
-    if (!sidebarSettings?.items || sidebarSettings.items.length === 0) {
-      return tenantUserMenuData;
+    let menuData = tenantUserMenuData;
+
+    // 1. 역할 기반 필터링
+    if (userRole) {
+      menuData = menuData
+        .filter((item) => !item.roles || item.roles.includes(userRole))
+        .map((item) => ({
+          ...item,
+          subItems: item.subItems?.filter((sub) => !sub.roles || sub.roles.includes(userRole)),
+        }));
     }
 
-    // visible: false인 항목 찾기
-    const hiddenIds = new Set<string>();
-    const collectHiddenIds = (items: BrandingSidebarItem[]) => {
-      for (const item of items) {
-        if (!item.visible) {
-          hiddenIds.add(item.id);
+    // 2. 브랜딩 설정 기반 필터링
+    if (sidebarSettings?.items && sidebarSettings.items.length > 0) {
+      // visible: false인 항목 찾기
+      const hiddenIds = new Set<string>();
+      const collectHiddenIds = (items: BrandingSidebarItem[]) => {
+        for (const item of items) {
+          if (!item.visible) {
+            hiddenIds.add(item.id);
+          }
+          if (item.children) {
+            collectHiddenIds(item.children);
+          }
         }
-        if (item.children) {
-          collectHiddenIds(item.children);
-        }
-      }
-    };
-    collectHiddenIds(sidebarSettings.items);
+      };
+      collectHiddenIds(sidebarSettings.items);
 
-    // 숨겨진 항목 필터링
-    return tenantUserMenuData
-      .filter((item) => !hiddenIds.has(item.id))
-      .map((item) => ({
-        ...item,
-        subItems: item.subItems?.filter((sub) => !hiddenIds.has(sub.id)),
-      }));
-  }, [sidebarSettings]);
+      // 숨겨진 항목 필터링
+      menuData = menuData
+        .filter((item) => !hiddenIds.has(item.id))
+        .map((item) => ({
+          ...item,
+          subItems: item.subItems?.filter((sub) => !hiddenIds.has(sub.id)),
+        }));
+    }
+
+    return menuData;
+  }, [sidebarSettings, userRole]);
 
   return (
     <BaseSidebar

--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -37,10 +37,8 @@ import {
   Home,
   Award,
   PenTool,
-  CheckSquare,
   Briefcase,
   MessageSquare,
-  Package,
   Zap,
   FolderTree,
   Map,
@@ -227,6 +225,10 @@ export const courseOperatorMenuData: MenuItem[] = [
 
 /**
  * Tenant User (TU) 메뉴 - 강사/콘텐츠 제작자 공간
+ *
+ * 역할별 메뉴 구성:
+ * - 강사(INSTRUCTOR): 대시보드 + 내 교수 관리
+ * - 디자이너(DESIGNER): 내 과정(과정 관리) + 내 콘텐츠 (대시보드 없음)
  */
 export const tenantUserMenuData: MenuItem[] = [
   {
@@ -234,29 +236,37 @@ export const tenantUserMenuData: MenuItem[] = [
     label: { ko: '대시보드', en: 'Dashboard' },
     icon: LayoutDashboard,
     path: '/tu/dashboard',
+    roles: ['INSTRUCTOR', 'OPERATOR', 'TENANT_ADMIN'],
   },
   {
     id: 'my-teaching',
-    label: { ko: '내 강의', en: 'My Teaching' },
+    label: { ko: '내 교수 관리', en: 'My Teaching' },
     icon: Briefcase,
+    path: '/tu/teaching/assignments',
+    roles: ['INSTRUCTOR', 'OPERATOR', 'TENANT_ADMIN'],
+  },
+  {
+    id: 'my-courses',
+    label: { ko: '내 과정', en: 'My Courses' },
+    icon: BookOpen,
     subItems: [
-      { id: 'my-courses', label: { ko: '강의 디자인', en: 'Course Design' }, icon: BookOpen, path: '/tu/teaching/courses' },
-      { id: 'my-assignments', label: { ko: '강의 운영', en: 'Course Operations' }, icon: CheckSquare, path: '/tu/teaching/assignments' },
-      { id: 'my-programs', label: { ko: '개설 신청 현황', en: 'Submission Status' }, icon: Package, path: '/tu/teaching/programs' },
-      { id: 'my-roadmaps', label: { ko: '로드맵', en: 'Roadmaps' }, icon: Map, path: '/tu/teaching/roadmaps', roles: ['DESIGNER', 'OPERATOR', 'TENANT_ADMIN'] },
+      { id: 'course-management', label: { ko: '과정 관리', en: 'Course Management' }, icon: FolderEdit, path: '/tu/teaching/courses' },
+      { id: 'my-roadmaps', label: { ko: '로드맵', en: 'Roadmaps' }, icon: Map, path: '/tu/teaching/roadmaps', roles: ['DESIGNER'] },
     ],
+    roles: ['DESIGNER', 'OPERATOR', 'TENANT_ADMIN'],
   },
   {
     id: 'my-content',
     label: { ko: '내 콘텐츠', en: 'My Content' },
     icon: PenTool,
     path: '/tu/teaching/content',
+    roles: ['DESIGNER', 'OPERATOR', 'TENANT_ADMIN'],
   },
   // '과정 둘러보기' 메뉴 제거 - 모드 스위처의 '학습자 모드'로 대체
 ];
 
 /**
- * MyPage 메뉴 (일반 사용자용 - 학습자 개인 공간)
+ * MyPage 메뉴 (B2C 일반 사용자용 - 학습자 개인 공간)
  */
 export const myPageMenuData: MenuItem[] = [
   {
@@ -270,7 +280,7 @@ export const myPageMenuData: MenuItem[] = [
     label: { ko: '내 수강 강의', en: 'My Enrollments' },
     icon: BookOpen,
     subItems: [
-      { id: 'enrolled-courses', label: { ko: '수강 중인 강의', en: 'Enrolled Courses' }, icon: BookOpen, path: '/tu/b2c/mypage/learning' },
+      { id: 'enrolled-courses', label: { ko: '수강중인 강의', en: 'Enrolled Courses' }, icon: BookOpen, path: '/tu/b2c/mypage/learning' },
       { id: 'completed-courses', label: { ko: '완료한 강의', en: 'Completed Courses' }, icon: BookCheck, path: '/tu/b2c/mypage/completed' },
       { id: 'certificates', label: { ko: '수료증', en: 'Certificates' }, icon: Award, path: '/tu/b2c/mypage/certificates' },
     ],
@@ -303,6 +313,54 @@ export const myPageMenuData: MenuItem[] = [
       { id: 'language-region', label: { ko: '언어 및 지역', en: 'Language & Region' }, icon: Globe, path: '/tu/b2c/mypage/settings/language' },
       { id: 'notifications', label: { ko: '알림', en: 'Notifications' }, icon: Megaphone, path: '/tu/b2c/mypage/settings/notifications' },
     ],
+  },
+];
+
+/**
+ * B2B MyPage 메뉴 (기업용 학습자 공간)
+ *
+ * B2C와의 차이점:
+ * - 커뮤니티 → 내 활동 (내 댓글만, 레벨 1)
+ * - 설정 → 카드 형식 페이지로 이동 (프로필/환경설정)
+ */
+export const b2bMyPageMenuData: MenuItem[] = [
+  {
+    id: 'mypage-home',
+    label: { ko: '홈', en: 'Home' },
+    icon: Home,
+    path: '/tu/b2b/mypage',
+  },
+  {
+    id: 'my-enrollments',
+    label: { ko: '내 수강 강의', en: 'My Enrollments' },
+    icon: BookOpen,
+    subItems: [
+      { id: 'enrolled-courses', label: { ko: '수강중인 강의', en: 'Enrolled Courses' }, icon: BookOpen, path: '/tu/b2b/mypage/learning' },
+      { id: 'completed-courses', label: { ko: '완료한 강의', en: 'Completed Courses' }, icon: BookCheck, path: '/tu/b2b/mypage/completed' },
+      { id: 'certificates', label: { ko: '수료증', en: 'Certificates' }, icon: Award, path: '/tu/b2b/mypage/certificates' },
+    ],
+  },
+  {
+    id: 'my-teaching',
+    label: { ko: '내 강의 관리', en: 'My Teaching' },
+    icon: Briefcase,
+    subItems: [
+      { id: 'my-courses', label: { ko: '내 강의', en: 'My Courses' }, icon: BookOpen, path: '/tu/b2b/mypage/teaching' },
+      { id: 'create-course', label: { ko: '강의 디자인 시작하기', en: 'Start Course Design' }, icon: FolderEdit, path: '/tu/teaching/courses/create', roles: ['USER', 'DESIGNER'] },
+      { id: 'teaching-stats', label: { ko: '내 강의 통계', en: 'Teaching Stats' }, icon: TrendingUp, path: '/tu/b2b/mypage/teaching/stats' },
+    ],
+  },
+  {
+    id: 'my-activity',
+    label: { ko: '내 활동', en: 'My Activity' },
+    icon: MessageSquare,
+    path: '/tu/b2b/mypage/comments',
+  },
+  {
+    id: 'mypage-settings',
+    label: { ko: '설정', en: 'Settings' },
+    icon: Settings,
+    path: '/tu/b2b/mypage/settings',
   },
 ];
 

--- a/src/pages/tu/b2b/B2BMyActivityPage.tsx
+++ b/src/pages/tu/b2b/B2BMyActivityPage.tsx
@@ -1,9 +1,9 @@
 /**
- * MyCommentsPage
- * 내 댓글 목록 페이지 (내가 댓글 단 게시글 목록)
+ * B2BMyActivityPage
+ * B2B 내 활동 페이지 (내가 댓글 단 게시글 목록)
  */
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import {
   MessageSquare,
   Heart,
@@ -13,7 +13,6 @@ import {
   ChevronRight,
   Loader2,
   User,
-  MessageCircle,
   ArrowRight,
   Sparkles,
 } from 'lucide-react';
@@ -25,8 +24,7 @@ import { POST_TYPE_LABELS } from '@/types/tu/community.types';
 
 const PAGE_SIZE = 10;
 
-export function MyCommentsPage() {
-  const navigate = useNavigate();
+export function B2BMyActivityPage() {
   const { theme } = useThemeStore();
   const { prefixPath } = useSubdomainPath();
   const isDark = theme === 'dark';
@@ -38,7 +36,6 @@ export function MyCommentsPage() {
   const totalPages = data?.totalPages || 0;
   const totalCount = data?.totalCount || 0;
 
-  // 통계 계산
   const totalInteractions = posts.reduce(
     (sum, post) => sum + (post.likeCount || 0) + (post.commentCount || 0),
     0
@@ -84,19 +81,12 @@ export function MyCommentsPage() {
           <div className="flex items-start justify-between">
             <div>
               <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-                내 댓글
+                내 활동
               </h1>
               <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-                내가 댓글을 작성한 게시글을 확인하세요
+                내가 작성한 댓글과 활동을 확인하세요
               </p>
             </div>
-            <Button
-              onClick={() => navigate(prefixPath('/tu/b2c/community'))}
-              className="bg-emerald-500 hover:bg-emerald-600 text-white"
-            >
-              <MessageCircle className="w-4 h-4 mr-2" />
-              커뮤니티 가기
-            </Button>
           </div>
 
           {/* 통계 카드들 */}
@@ -199,18 +189,11 @@ export function MyCommentsPage() {
             <MessageSquare className={`w-10 h-10 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
           </div>
           <h3 className={`text-lg font-semibold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            아직 댓글을 작성한 게시글이 없어요
+            아직 활동 내역이 없어요
           </h3>
-          <p className={`text-sm mb-6 max-w-sm mx-auto ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-            커뮤니티에서 다양한 글에 의견을 남겨보세요
+          <p className={`text-sm max-w-sm mx-auto ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+            강의에서 다양한 활동에 참여해보세요
           </p>
-          <Button
-            onClick={() => navigate(prefixPath('/tu/b2c/community'))}
-            className="bg-emerald-500 hover:bg-emerald-600 text-white"
-          >
-            <MessageCircle className="w-4 h-4 mr-2" />
-            커뮤니티 둘러보기
-          </Button>
         </div>
       ) : (
         <div
@@ -222,7 +205,7 @@ export function MyCommentsPage() {
             {posts.map((post) => (
               <Link
                 key={post.id}
-                to={`/tu/b2c/community/${post.id}`}
+                to={prefixPath(`/tu/b2b/courses/${post.id}`)}
                 className={`block p-5 transition-all group ${
                   isDark ? 'hover:bg-white/5' : 'hover:bg-gray-50'
                 }`}
@@ -406,4 +389,4 @@ export function MyCommentsPage() {
   );
 }
 
-export default MyCommentsPage;
+export default B2BMyActivityPage;

--- a/src/pages/tu/b2b/B2BPreferencesPage.tsx
+++ b/src/pages/tu/b2b/B2BPreferencesPage.tsx
@@ -1,6 +1,6 @@
 import { Sun, Moon, Globe, Bell } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
-import { useLanguageStore, useTranslation } from '@/store/common/languageStore';
+import { useLanguageStore } from '@/store/common/languageStore';
 
 interface SettingItemProps {
   icon: React.ReactNode;
@@ -69,7 +69,6 @@ function ToggleSwitch({ checked, onChange, isDark }: ToggleSwitchProps) {
 export function B2BPreferencesPage() {
   const { theme, toggleTheme } = useThemeStore();
   const { language, toggleLanguage } = useLanguageStore();
-  const { t } = useTranslation();
   const isDark = theme === 'dark';
 
   return (

--- a/src/pages/tu/b2b/B2BPreferencesPage.tsx
+++ b/src/pages/tu/b2b/B2BPreferencesPage.tsx
@@ -1,0 +1,183 @@
+import { Sun, Moon, Globe, Bell } from 'lucide-react';
+import { useThemeStore } from '@/store/common/themeStore';
+import { useLanguageStore, useTranslation } from '@/store/common/languageStore';
+
+interface SettingItemProps {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  action: React.ReactNode;
+  isDark: boolean;
+}
+
+function SettingItem({ icon, title, description, action, isDark }: SettingItemProps) {
+  return (
+    <div
+      className={`flex items-center justify-between p-4 rounded-xl ${
+        isDark ? 'bg-white/5' : 'bg-gray-50'
+      }`}
+    >
+      <div className="flex items-center gap-4">
+        <div
+          className={`p-2.5 rounded-lg ${
+            isDark ? 'bg-white/10 text-gray-300' : 'bg-white text-gray-600'
+          }`}
+        >
+          {icon}
+        </div>
+        <div>
+          <h3
+            className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}
+          >
+            {title}
+          </h3>
+          <p
+            className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}
+          >
+            {description}
+          </p>
+        </div>
+      </div>
+      {action}
+    </div>
+  );
+}
+
+interface ToggleSwitchProps {
+  checked: boolean;
+  onChange: () => void;
+  isDark: boolean;
+}
+
+function ToggleSwitch({ checked, onChange, isDark }: ToggleSwitchProps) {
+  return (
+    <button
+      onClick={onChange}
+      className={`w-12 h-6 rounded-full p-1 transition-colors ${
+        checked ? 'bg-[#6778ff]' : isDark ? 'bg-white/20' : 'bg-gray-300'
+      }`}
+    >
+      <div
+        className={`w-4 h-4 rounded-full bg-white shadow-md transition-transform ${
+          checked ? 'translate-x-6' : 'translate-x-0'
+        }`}
+      />
+    </button>
+  );
+}
+
+export function B2BPreferencesPage() {
+  const { theme, toggleTheme } = useThemeStore();
+  const { language, toggleLanguage } = useLanguageStore();
+  const { t } = useTranslation();
+  const isDark = theme === 'dark';
+
+  return (
+    <div className={`min-h-full p-6 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+      <div className="max-w-2xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <h1
+            className={`text-2xl font-bold mb-2 ${
+              isDark ? 'text-white' : 'text-gray-900'
+            }`}
+          >
+            {language === 'ko' ? '환경설정' : 'Preferences'}
+          </h1>
+          <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+            {language === 'ko'
+              ? '앱 사용 환경을 설정하세요.'
+              : 'Configure your app experience.'}
+          </p>
+        </div>
+
+        {/* Settings Card */}
+        <div
+          className={`rounded-2xl p-6 ${
+            isDark
+              ? 'bg-white/5 border border-white/10'
+              : 'bg-white border border-gray-200 shadow-sm'
+          }`}
+        >
+          <div className="space-y-4">
+            {/* Theme */}
+            <SettingItem
+              icon={isDark ? <Moon className="w-5 h-5" /> : <Sun className="w-5 h-5" />}
+              title={language === 'ko' ? '다크 모드' : 'Dark Mode'}
+              description={
+                language === 'ko'
+                  ? '어두운 테마를 사용합니다.'
+                  : 'Use dark theme for the app.'
+              }
+              action={
+                <ToggleSwitch
+                  checked={isDark}
+                  onChange={toggleTheme}
+                  isDark={isDark}
+                />
+              }
+              isDark={isDark}
+            />
+
+            {/* Divider */}
+            <div
+              className={`border-t ${
+                isDark ? 'border-white/10' : 'border-gray-100'
+              }`}
+            />
+
+            {/* Language */}
+            <SettingItem
+              icon={<Globe className="w-5 h-5" />}
+              title={language === 'ko' ? '언어' : 'Language'}
+              description={
+                language === 'ko'
+                  ? '앱에서 사용할 언어를 선택합니다.'
+                  : 'Select your preferred language.'
+              }
+              action={
+                <button
+                  onClick={toggleLanguage}
+                  className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                    isDark
+                      ? 'bg-[#6778ff]/20 text-[#6778ff] hover:bg-[#6778ff]/30'
+                      : 'bg-blue-100 text-blue-600 hover:bg-blue-200'
+                  }`}
+                >
+                  {language === 'ko' ? '한국어' : 'English'}
+                </button>
+              }
+              isDark={isDark}
+            />
+
+            {/* Divider */}
+            <div
+              className={`border-t ${
+                isDark ? 'border-white/10' : 'border-gray-100'
+              }`}
+            />
+
+            {/* Notifications */}
+            <SettingItem
+              icon={<Bell className="w-5 h-5" />}
+              title={language === 'ko' ? '알림' : 'Notifications'}
+              description={
+                language === 'ko'
+                  ? '푸시 알림을 받습니다.'
+                  : 'Receive push notifications.'
+              }
+              action={
+                <ToggleSwitch
+                  checked={true}
+                  onChange={() => {}}
+                  isDark={isDark}
+                />
+              }
+              isDark={isDark}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/b2b/B2BSettingsPage.tsx
+++ b/src/pages/tu/b2b/B2BSettingsPage.tsx
@@ -1,0 +1,130 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import { User, Settings, ChevronRight } from 'lucide-react';
+import { useThemeStore } from '@/store/common/themeStore';
+import { useLanguageStore } from '@/store/common/languageStore';
+
+interface SettingsCardProps {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  onClick: () => void;
+  isDark: boolean;
+}
+
+function SettingsCard({ icon, title, description, onClick, isDark }: SettingsCardProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full p-6 rounded-2xl text-left transition-all group ${
+        isDark
+          ? 'bg-white/5 hover:bg-white/10 border border-white/10'
+          : 'bg-white hover:bg-gray-50 border border-gray-200 shadow-sm'
+      }`}
+    >
+      <div className="flex items-start gap-4">
+        <div
+          className={`p-3 rounded-xl ${
+            isDark ? 'bg-[#6778ff]/20 text-[#6778ff]' : 'bg-blue-100 text-blue-600'
+          }`}
+        >
+          {icon}
+        </div>
+        <div className="flex-1">
+          <h3
+            className={`text-lg font-semibold mb-1 ${
+              isDark ? 'text-white' : 'text-gray-900'
+            }`}
+          >
+            {title}
+          </h3>
+          <p
+            className={`text-sm ${
+              isDark ? 'text-gray-400' : 'text-gray-500'
+            }`}
+          >
+            {description}
+          </p>
+        </div>
+        <ChevronRight
+          className={`w-5 h-5 transition-transform group-hover:translate-x-1 ${
+            isDark ? 'text-gray-500' : 'text-gray-400'
+          }`}
+        />
+      </div>
+    </button>
+  );
+}
+
+export function B2BSettingsPage() {
+  const navigate = useNavigate();
+  const { subdomain } = useParams<{ subdomain: string }>();
+  const { theme } = useThemeStore();
+  const { language } = useLanguageStore();
+  const isDark = theme === 'dark';
+
+  const prefixPath = (path: string) => {
+    if (subdomain) {
+      return `/${subdomain}${path}`;
+    }
+    return path;
+  };
+
+  const settingsCards = [
+    {
+      id: 'profile',
+      icon: <User className="w-6 h-6" />,
+      title: language === 'ko' ? '프로필' : 'Profile',
+      description:
+        language === 'ko'
+          ? '이름, 이메일, 프로필 사진 등 개인 정보를 관리합니다.'
+          : 'Manage your personal information like name, email, and profile picture.',
+      path: '/tu/b2b/mypage/profile',
+    },
+    {
+      id: 'preferences',
+      icon: <Settings className="w-6 h-6" />,
+      title: language === 'ko' ? '환경설정' : 'Preferences',
+      description:
+        language === 'ko'
+          ? '언어, 알림, 테마 등 앱 환경을 설정합니다.'
+          : 'Configure app settings like language, notifications, and theme.',
+      path: '/tu/b2b/mypage/settings/preferences',
+    },
+  ];
+
+  return (
+    <div className={`min-h-full p-6 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+      <div className="max-w-2xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <h1
+            className={`text-2xl font-bold mb-2 ${
+              isDark ? 'text-white' : 'text-gray-900'
+            }`}
+          >
+            {language === 'ko' ? '설정' : 'Settings'}
+          </h1>
+          <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+            {language === 'ko'
+              ? '계정 및 앱 환경을 관리하세요.'
+              : 'Manage your account and app preferences.'}
+          </p>
+        </div>
+
+        {/* Settings Cards */}
+        <div className="space-y-4">
+          {settingsCards.map((card) => (
+            <SettingsCard
+              key={card.id}
+              icon={card.icon}
+              title={card.title}
+              description={card.description}
+              onClick={() => navigate(prefixPath(card.path))}
+              isDark={isDark}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/b2b/components/B2BLandingHeader.tsx
+++ b/src/pages/tu/b2b/components/B2BLandingHeader.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Search, Bell, Menu, X, LogOut, User, Sun, Moon, BookOpen, Shield, Globe } from 'lucide-react';
+import { Search, Bell, Menu, X, LogOut, User, Sun, Moon, BookOpen, Shield } from 'lucide-react';
 import { useAuth } from '@/hooks/common/auth';
 import { useMyProfile, useSubdomainPath } from '@/hooks/common';
 import { useThemeStore } from '@/store/common/themeStore';
@@ -296,7 +296,7 @@ export function B2BLandingHeader() {
 
                         <div className="py-2 space-y-1">
                           <Link
-                            to={prefixPath('/tu/b2c/mypage')}
+                            to={prefixPath('/tu/b2b/mypage')}
                             onClick={() => setShowDropdown(false)}
                             className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors text-sm ${
                               isDark
@@ -312,7 +312,7 @@ export function B2BLandingHeader() {
                         <div className={`py-2 border-t space-y-1 ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
                           <p className={`px-3 py-1 text-xs font-medium ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>{t.landing.settings}</p>
                           <Link
-                            to={prefixPath('/tu/b2c/mypage/profile')}
+                            to={prefixPath('/tu/b2b/mypage/profile')}
                             onClick={() => setShowDropdown(false)}
                             className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm ${
                               isDark
@@ -324,7 +324,7 @@ export function B2BLandingHeader() {
                             {t.landing.profileSecurity}
                           </Link>
                           <Link
-                            to={prefixPath('/tu/b2c/mypage/notifications')}
+                            to={prefixPath('/tu/b2b/mypage/settings')}
                             onClick={() => setShowDropdown(false)}
                             className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm ${
                               isDark
@@ -334,18 +334,6 @@ export function B2BLandingHeader() {
                           >
                             <Bell className="w-4 h-4" />
                             {t.landing.notifications}
-                          </Link>
-                          <Link
-                            to={prefixPath('/tu/b2c/mypage/language')}
-                            onClick={() => setShowDropdown(false)}
-                            className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm ${
-                              isDark
-                                ? 'text-gray-300 hover:text-white hover:bg-white/10'
-                                : 'text-gray-700 hover:text-gray-900 hover:bg-gray-100'
-                            }`}
-                          >
-                            <Globe className="w-4 h-4" />
-                            {t.landing.languageRegion}
                           </Link>
                         </div>
 

--- a/src/pages/tu/b2b/components/B2BLandingHeader.tsx
+++ b/src/pages/tu/b2b/components/B2BLandingHeader.tsx
@@ -310,7 +310,7 @@ export function B2BLandingHeader() {
                         </div>
 
                         <div className={`py-2 border-t space-y-1 ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
-                          <p className={`px-3 py-1 text-xs font-medium ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>{t.landing.settings}</p>
+                          <p className={`px-3 py-1 text-xs font-medium ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>설정</p>
                           <Link
                             to={prefixPath('/tu/b2b/mypage/profile')}
                             onClick={() => setShowDropdown(false)}
@@ -321,10 +321,10 @@ export function B2BLandingHeader() {
                             }`}
                           >
                             <Shield className="w-4 h-4" />
-                            {t.landing.profileSecurity}
+                            프로필
                           </Link>
                           <Link
-                            to={prefixPath('/tu/b2b/mypage/settings')}
+                            to={prefixPath('/tu/b2b/mypage/settings/preferences')}
                             onClick={() => setShowDropdown(false)}
                             className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm ${
                               isDark
@@ -333,7 +333,7 @@ export function B2BLandingHeader() {
                             }`}
                           >
                             <Bell className="w-4 h-4" />
-                            {t.landing.notifications}
+                            환경설정
                           </Link>
                         </div>
 

--- a/src/pages/tu/b2b/index.ts
+++ b/src/pages/tu/b2b/index.ts
@@ -10,3 +10,6 @@
 
 export { B2BLandingPage } from './B2BLandingPage';
 export { B2BCourseDetailPage } from './B2BCourseDetailPage';
+export { B2BSettingsPage } from './B2BSettingsPage';
+export { B2BPreferencesPage } from './B2BPreferencesPage';
+export { B2BMyActivityPage } from './B2BMyActivityPage';

--- a/src/routes/tu.b2b.routes.tsx
+++ b/src/routes/tu.b2b.routes.tsx
@@ -1,15 +1,56 @@
-import { Route } from 'react-router-dom';
+import { Route, Outlet } from 'react-router-dom';
+import { B2BMyPageLayout } from '@/components/layout';
+import { ProtectedRoute } from '@/components/common/ProtectedRoute';
+import { ProfileRequiredRoute } from '@/components/common/ProfileRequiredRoute';
 import {
   CoursesExplorePage,
   NotificationsPage,
   NotificationDetailPage,
   InstructorProfilePage,
   SearchPage,
+  MyPageHome,
+  ProfilePage,
+  MyLearningPage,
+  LearningDetailPage,
+  LearningPlayerPage,
+  MyTeachingPage,
+  TeachingStatsPage,
+  CompletedCoursesPage,
+  CertificationsPage,
+  UserNoticesPage,
 } from '@/pages/tu';
-import { B2BLandingPage, B2BCourseDetailPage } from '@/pages/tu/b2b';
+import {
+  B2BLandingPage,
+  B2BCourseDetailPage,
+  B2BSettingsPage,
+  B2BPreferencesPage,
+  B2BMyActivityPage,
+} from '@/pages/tu/b2b';
+
+function B2BMyPageWrapper() {
+  return (
+    <ProtectedRoute allowedRoles={['USER', 'DESIGNER', 'INSTRUCTOR', 'OPERATOR', 'TENANT_ADMIN']}>
+      <ProfileRequiredRoute>
+        <B2BMyPageLayout>
+          <Outlet />
+        </B2BMyPageLayout>
+      </ProfileRequiredRoute>
+    </ProtectedRoute>
+  );
+}
+
+function B2BPlayerWrapper() {
+  return (
+    <ProtectedRoute allowedRoles={['USER', 'DESIGNER', 'INSTRUCTOR', 'OPERATOR', 'TENANT_ADMIN']}>
+      <ProfileRequiredRoute>
+        <Outlet />
+      </ProfileRequiredRoute>
+    </ProtectedRoute>
+  );
+}
 
 /**
- * TU B2B 라우트 - 기업용 페이지 (사이드바 없음)
+ * TU B2B 라우트 - 기업용 페이지
  *
  * 경로: /:subdomain/tu/b2b/* 또는 /tu/b2b/* (기본)
  *
@@ -17,10 +58,77 @@ import { B2BLandingPage, B2BCourseDetailPage } from '@/pages/tu/b2b';
  * - 장바구니/결제 없음 (회사에서 일괄 배정)
  * - 가격 표시 없음
  * - 로드맵 없음
- * - 커뮤니티 없음
+ * - 커뮤니티 → 내 활동 (내 댓글만)
+ * - 설정 → 카드 형식 (프로필/환경설정)
  */
 export const tuB2bRoutes = (
   <>
+    {/* ===== 마이페이지 (로그인 필요) ===== */}
+
+    {/* 플레이어 라우트 - 레이아웃 없이 전체 화면 */}
+    <Route path="/:subdomain/tu/b2b/mypage/learning/:enrollmentId/player" element={<B2BPlayerWrapper />}>
+      <Route index element={<LearningPlayerPage />} />
+      <Route path=":itemId" element={<LearningPlayerPage />} />
+    </Route>
+    <Route path="/tu/b2b/mypage/learning/:enrollmentId/player" element={<B2BPlayerWrapper />}>
+      <Route index element={<LearningPlayerPage />} />
+      <Route path=":itemId" element={<LearningPlayerPage />} />
+    </Route>
+
+    {/* 마이페이지 라우트 (subdomain 있음) */}
+    <Route path="/:subdomain/tu/b2b/mypage" element={<B2BMyPageWrapper />}>
+      <Route index element={<MyPageHome />} />
+      <Route path="profile" element={<ProfilePage />} />
+
+      {/* 내 수강 강의 */}
+      <Route path="learning" element={<MyLearningPage />} />
+      <Route path="learning/:enrollmentId" element={<LearningDetailPage />} />
+      <Route path="completed" element={<CompletedCoursesPage />} />
+      <Route path="certificates" element={<CertificationsPage />} />
+
+      {/* 내 강의 관리 */}
+      <Route path="teaching" element={<MyTeachingPage />} />
+      <Route path="teaching/stats" element={<TeachingStatsPage />} />
+
+      {/* 내 활동 (커뮤니티 → 내 댓글만) */}
+      <Route path="comments" element={<B2BMyActivityPage />} />
+
+      {/* 공지사항 */}
+      <Route path="notices" element={<UserNoticesPage />} />
+
+      {/* 설정 (카드 형식) */}
+      <Route path="settings" element={<B2BSettingsPage />} />
+      <Route path="settings/preferences" element={<B2BPreferencesPage />} />
+    </Route>
+
+    {/* 마이페이지 라우트 (subdomain 없음) */}
+    <Route path="/tu/b2b/mypage" element={<B2BMyPageWrapper />}>
+      <Route index element={<MyPageHome />} />
+      <Route path="profile" element={<ProfilePage />} />
+
+      {/* 내 수강 강의 */}
+      <Route path="learning" element={<MyLearningPage />} />
+      <Route path="learning/:enrollmentId" element={<LearningDetailPage />} />
+      <Route path="completed" element={<CompletedCoursesPage />} />
+      <Route path="certificates" element={<CertificationsPage />} />
+
+      {/* 내 강의 관리 */}
+      <Route path="teaching" element={<MyTeachingPage />} />
+      <Route path="teaching/stats" element={<TeachingStatsPage />} />
+
+      {/* 내 활동 (커뮤니티 → 내 댓글만) */}
+      <Route path="comments" element={<B2BMyActivityPage />} />
+
+      {/* 공지사항 */}
+      <Route path="notices" element={<UserNoticesPage />} />
+
+      {/* 설정 (카드 형식) */}
+      <Route path="settings" element={<B2BSettingsPage />} />
+      <Route path="settings/preferences" element={<B2BPreferencesPage />} />
+    </Route>
+
+    {/* ===== 메인 페이지 (사이드바 없음) ===== */}
+
     {/* 랜딩 페이지 */}
     <Route path="/:subdomain/tu/b2b" element={<B2BLandingPage />} />
     <Route path="/tu/b2b" element={<B2BLandingPage />} />

--- a/src/routes/tu.routes.tsx
+++ b/src/routes/tu.routes.tsx
@@ -9,18 +9,19 @@ import { tuTeachingRoutes } from './tu.teaching.routes';
  * 구조:
  * - /tu/b2c/*         : B2C 메인 페이지 (사이드바 없음, 개인 고객용)
  * - /tu/b2b/*         : B2B 메인 페이지 (사이드바 없음, 기업 고객용 - 장바구니/가격/로드맵/커뮤니티 없음)
- * - /tu/b2c/mypage/*  : 마이페이지 (사이드바 있음, 로그인 필요)
+ * - /tu/b2c/mypage/*  : B2C 마이페이지 (사이드바 있음, 로그인 필요)
+ * - /tu/b2b/mypage/*  : B2B 마이페이지 (사이드바 있음, 로그인 필요)
  * - /tu/teaching/*    : 강의 관리 (사이드바 있음, 로그인 필요)
  */
 export const tuRoutes = (
   <>
-    {/* 마이페이지 (플레이어 포함 - 더 구체적인 경로 먼저) */}
+    {/* B2C 마이페이지 (플레이어 포함 - 더 구체적인 경로 먼저) */}
     {tuMyPageRoutes}
 
     {/* 강의 관리 */}
     {tuTeachingRoutes}
 
-    {/* B2B 메인 페이지 (기업용 - 기능 축소) */}
+    {/* B2B 페이지 (기업용 - 마이페이지 포함) */}
     {tuB2bRoutes}
 
     {/* B2C 메인 페이지 (개인용 - 가장 일반적인 경로 마지막) */}

--- a/src/types/common/sidebar.types.ts
+++ b/src/types/common/sidebar.types.ts
@@ -9,6 +9,7 @@ export interface MenuItem {
   icon: LucideIcon;
   path?: string;
   subItems?: SubMenuItem[];
+  roles?: string[]; // 특정 롤에만 표시 (예: ['INSTRUCTOR', 'DESIGNER'])
 }
 
 export interface SubMenuItem {


### PR DESCRIPTION
## Summary

B2B 환경에 맞는 마이페이지 구현 및 B2C와의 라우팅 분리

## Related Issue

- Closes #421

## Changes

- B2B 마이페이지 레이아웃 및 사이드바 구현
  - 강사/학습자 모드 전환 토글 추가 (디자이너 권한 + instructorTabEnabled 조건)
  - 사이드바 sticky 포지셔닝으로 크기 고정
  - 홈 메뉴 exact path matching 적용
- B2B 전용 페이지 생성
  - B2BSettingsPage: 카드 형식 설정 페이지 (프로필, 환경설정)
  - B2BPreferencesPage: 다크모드, 언어, 알림 설정 통합
  - B2BMyActivityPage: B2C와 분리된 내 활동 페이지
- B2B 헤더 드롭다운 메뉴 수정
  - B2B 전용 경로로 변경 (/tu/b2b/mypage/*)
  - 설정 > 프로필, 환경설정으로 분리
- B2B 라우트 통합 (tu.b2b.routes.tsx)

## Type of Change

- [x] Feat: 새로운 기능

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

B2B 마이페이지는 B2C와 달리:
- 장바구니/결제 기능 없음
- 커뮤니티 대신 내 활동 (내 댓글만)
- 카드 형식 설정 페이지
- 강사/학습자 모드 전환 지원