### PR TITLE
fix: 강의 상세 페이지 강의소개 표시 오류 수정

### DIFF
--- a/src/pages/tu/main/CourseDetailPage.tsx
+++ b/src/pages/tu/main/CourseDetailPage.tsx
@@ -451,9 +451,9 @@ export function CourseDetailPage() {
               </h1>
 
               {/* Description */}
-              {courseTime.program?.description && (
+              {(courseTime.course?.description || courseTime.program?.description) && (
                 <p className={`mb-6 leading-relaxed ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
-                  {courseTime.program.description}
+                  {courseTime.course?.description || courseTime.program?.description}
                 </p>
               )}
 
@@ -858,7 +858,7 @@ export function CourseDetailPage() {
           {activeTab === 'intro' && (
             <>
               {/* 과정 설명 */}
-              {courseTime.program?.description && (
+              {(courseTime.course?.description || courseTime.program?.description) && (
                 <section className="mb-12">
                   <h2
                     className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}
@@ -871,7 +871,7 @@ export function CourseDetailPage() {
                     }`}
                   >
                     <p className={`leading-relaxed whitespace-pre-wrap ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
-                      {courseTime.program.description}
+                      {courseTime.course?.description || courseTime.program?.description}
                     </p>
                   </div>
                 </section>

--- a/src/types/tu/courseTimeCatalog.types.ts
+++ b/src/types/tu/courseTimeCatalog.types.ts
@@ -101,6 +101,13 @@ export interface CourseTimeCatalogResponse {
   instructors: InstructorSummaryResponse[];
 }
 
+/** 강의(Course) 요약 응답 */
+export interface CourseSummaryResponse {
+  id: number;
+  title: string;
+  description: string | null;
+}
+
 /** 차수 상세 응답 */
 export interface CourseTimePublicDetailResponse {
   id: number;
@@ -122,6 +129,7 @@ export interface CourseTimePublicDetailResponse {
   minProgressForCompletion: number | null;
   locationInfo: string | null;
   program: ProgramSummaryResponse | null;
+  course: CourseSummaryResponse | null;
   curriculum: CurriculumItemResponse[];
   instructors: InstructorSummaryResponse[];
 }


### PR DESCRIPTION
## Summary

강의 상세 페이지에서 강의 소개(description)가 표시되지 않는 문제를 수정했습니다.
백엔드에서 `course.description` 필드로 반환하는 데이터를 프론트엔드에서 처리하도록 타입과 컴포넌트를 수정했습니다.

## Related Issue

- Closes #

## Changes

- `CourseSummaryResponse` 타입 추가 (`courseTimeCatalog.types.ts`)
- `CourseTimePublicDetailResponse`에 `course` 필드 추가
- `CourseDetailPage.tsx`에서 `course.description` 표시 (기존 `program.description` 폴백 유지)

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes

- `course.description`이 없는 경우 기존 `program.description`으로 폴백되도록 처리
