### PR TITLE
feat(tu): B2B 검색 페이지 개선 및 과정 상세 공지사항 추가

### DIFF
--- a/src/components/landing/LandingCourseCard.tsx
+++ b/src/components/landing/LandingCourseCard.tsx
@@ -23,6 +23,8 @@ interface LandingCourseCardProps {
   classStartDate?: string; // 개강일
   availableSeats?: number | null; // 잔여석
   isOnDemand?: boolean; // 상시모집 여부
+  /** 강의 상세 페이지 기본 경로 (기본: /tu/b2c/courses) */
+  courseBasePath?: string;
 }
 
 /**
@@ -48,6 +50,7 @@ export function LandingCourseCard({
   classStartDate,
   availableSeats,
   isOnDemand,
+  courseBasePath = '/tu/b2c/courses',
 }: LandingCourseCardProps) {
   const navigate = useNavigate();
   const { prefixPath } = useSubdomainPath();
@@ -101,7 +104,7 @@ export function LandingCourseCard({
   };
 
   return (
-    <Link to={prefixPath(`/tu/b2c/courses/${id}`)} className="group block h-full">
+    <Link to={prefixPath(`${courseBasePath}/${id}`)} className="group block h-full">
       <div className="h-full card-hover rounded-xl overflow-hidden landing-card-bg border landing-card-border">
         {/* 썸네일 영역 */}
         <div className="relative aspect-[16/10] overflow-hidden">

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -20,7 +20,6 @@ export { TenantUserSidebar } from './tu/TenantUserSidebar';
 
 // MyPage (B2C)
 export { MyPageLayout } from './mypage/MyPageLayout';
-export { B2BMyPageLayout } from './mypage/B2BMyPageLayout';
 export { MyPageSidebar } from './mypage/MyPageSidebar';
 
 // MyPage (B2B)

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -20,6 +20,7 @@ export { TenantUserSidebar } from './tu/TenantUserSidebar';
 
 // MyPage (B2C)
 export { MyPageLayout } from './mypage/MyPageLayout';
+export { B2BMyPageLayout } from './mypage/B2BMyPageLayout';
 export { MyPageSidebar } from './mypage/MyPageSidebar';
 
 // MyPage (B2B)

--- a/src/components/layout/mypage/MyPageSidebar.tsx
+++ b/src/components/layout/mypage/MyPageSidebar.tsx
@@ -41,11 +41,12 @@ interface MyPageSidebarProps {
   isDarkMode?: boolean;
   language?: 'ko' | 'en';
   subdomain?: string;
+  menuData?: MenuItem[];
 }
 
 type ViewMode = 'instructor' | 'learner';
 
-export function MyPageSidebar({ onMenuItemClick }: MyPageSidebarProps) {
+export function MyPageSidebar({ onMenuItemClick, menuData: externalMenuData }: MyPageSidebarProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const { prefixPath } = useSubdomainPath();
@@ -62,6 +63,9 @@ export function MyPageSidebar({ onMenuItemClick }: MyPageSidebarProps) {
 
   // 브랜딩 설정 + 기능 설정을 기반으로 메뉴 필터링
   const filteredMenuData = useMemo((): MenuItem[] => {
+    // 외부에서 메뉴 데이터가 전달된 경우 해당 데이터 사용
+    const baseMenuData = externalMenuData || myPageMenuData;
+
     // 1. 브랜딩 설정에서 visible: false인 항목 찾기
     const hiddenIds = new Set<string>();
     if (sidebarSettings?.items && sidebarSettings.items.length > 0) {
@@ -90,13 +94,13 @@ export function MyPageSidebar({ onMenuItemClick }: MyPageSidebarProps) {
     }
 
     // 3. 숨겨진 항목 필터링
-    return myPageMenuData
+    return baseMenuData
       .filter((item) => !hiddenIds.has(item.id))
       .map((item) => ({
         ...item,
         subItems: item.subItems?.filter((sub) => !hiddenIds.has(sub.id)),
       }));
-  }, [sidebarSettings, communityEnabled, userCourseCreationEnabled]);
+  }, [sidebarSettings, communityEnabled, userCourseCreationEnabled, externalMenuData]);
 
   const { theme, toggleTheme } = useThemeStore();
   const { language, toggleLanguage } = useLanguageStore();

--- a/src/pages/tu/b2b/B2BCourseDetailPage.tsx
+++ b/src/pages/tu/b2b/B2BCourseDetailPage.tsx
@@ -8,22 +8,21 @@ import {
   FileText,
   Heart,
   Share2,
-  ChevronDown,
   ChevronRight,
+  ChevronDown,
   Loader2,
   CheckCircle,
   Calendar,
   MapPin,
   AlertCircle,
+  Megaphone,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useThemeStore } from '@/store/common/themeStore';
 import { useAuthStore } from '@/store/common/authStore';
 import { LandingFooter } from '@/components/landing/LandingFooter';
 import { B2BLandingHeader } from './components/B2BLandingHeader';
-import { CourseReviewSection } from '@/components/domain/course-review';
 import { useCourseTimeDetail, useEnroll, useMyEnrollments, useCheckWishlistStatus, useToggleWishlist } from '@/hooks/tu';
-import type { CurriculumItemResponse } from '@/types/tu/courseTimeCatalog.types';
 import {
   DELIVERY_TYPE_LABELS,
   PROGRAM_LEVEL_LABELS,
@@ -36,112 +35,136 @@ function formatDate(dateString: string): string {
   return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`;
 }
 
-interface CurriculumSectionProps {
-  item: CurriculumItemResponse;
-  isExpanded: boolean;
-  onToggle: () => void;
+interface Announcement {
+  id: number;
+  type: 'important' | 'info';
+  title: string;
+  message: string;
+  date?: string;
+}
+
+// TODO: API 연동 시 실제 공지사항 데이터로 교체
+const MOCK_ANNOUNCEMENTS: Announcement[] = [
+  {
+    id: 1,
+    type: 'important',
+    title: '수강 안내',
+    message: '본 과정은 수료 후 인증서가 발급됩니다. 진도율 80% 이상 달성 시 수료 처리됩니다.',
+    date: '2025.01.10',
+  },
+  {
+    id: 2,
+    type: 'info',
+    title: '학습 팁',
+    message: '각 차시별 학습을 완료한 후 퀴즈를 풀면 학습 효과가 높아집니다.',
+    date: '2025.01.08',
+  },
+];
+
+interface AnnouncementSectionProps {
+  announcements: Announcement[];
   isDark: boolean;
 }
 
-function CurriculumSection({ item, isExpanded, onToggle, isDark }: CurriculumSectionProps) {
-  if (!item.isFolder) {
-    return (
-      <div
-        className={`flex items-center justify-between p-4 rounded-xl border transition-colors ${
-          isDark
-            ? 'glass border-white/10 hover:bg-white/5'
-            : 'bg-white border-gray-200 hover:bg-gray-50'
-        }`}
-      >
-        <div className="flex items-center gap-3">
-          <div
-            className={`w-8 h-8 rounded-lg flex items-center justify-center ${
-              isDark ? 'bg-white/10' : 'bg-gray-100'
-            }`}
-          >
-            <PlayCircle className={`w-4 h-4 ${isDark ? 'text-[#6bc2f0]' : 'text-[#6778ff]'}`} />
-          </div>
-          <span className={`font-medium ${isDark ? 'text-gray-200' : 'text-gray-700'}`}>
-            {item.itemName}
-          </span>
-        </div>
-        {item.duration && (
-          <span
-            className={`text-sm px-2 py-1 rounded-md ${
-              isDark ? 'bg-white/10 text-gray-400' : 'bg-gray-100 text-gray-500'
-            }`}
-          >
-            {Math.floor(item.duration / 60)}:{String(item.duration % 60).padStart(2, '0')}
-          </span>
-        )}
-      </div>
-    );
-  }
+function AnnouncementSection({ announcements, isDark }: AnnouncementSectionProps) {
+  const [isOpen, setIsOpen] = useState(false);
 
-  const childCount = item.children?.length || 0;
+  if (announcements.length === 0) return null;
 
   return (
     <div
-      className={`rounded-xl overflow-hidden border ${
-        isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
+      className={`rounded-xl border overflow-hidden mb-8 ${
+        isDark ? 'bg-white/5 border-white/10' : 'bg-white border-gray-200'
       }`}
     >
+      {/* 아코디언 헤더 */}
       <button
-        onClick={onToggle}
-        className={`w-full flex items-center justify-between p-4 transition-colors ${
+        onClick={() => setIsOpen(!isOpen)}
+        className={`w-full px-4 py-3 flex items-center justify-between transition-colors ${
           isDark ? 'hover:bg-white/5' : 'hover:bg-gray-50'
         }`}
       >
-        <div className="flex items-center gap-3">
-          <ChevronDown
-            className={`w-5 h-5 transition-transform ${isExpanded ? 'rotate-180' : ''} ${
-              isDark ? 'text-gray-400' : 'text-gray-500'
+        <div className="flex items-center gap-2">
+          <Megaphone className={`w-5 h-5 ${isDark ? 'text-orange-400' : 'text-orange-500'}`} />
+          <span className={`font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            공지사항
+          </span>
+          <span
+            className={`text-xs px-2 py-0.5 rounded-full ${
+              isDark ? 'bg-orange-500/20 text-orange-400' : 'bg-orange-100 text-orange-600'
             }`}
-          />
-          <span className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            {item.itemName}
+          >
+            {announcements.length}
           </span>
         </div>
-        <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
-          {childCount}개 항목
-        </span>
+        <ChevronDown
+          className={`w-5 h-5 transition-transform duration-200 ${
+            isDark ? 'text-gray-400' : 'text-gray-500'
+          } ${isOpen ? 'rotate-180' : ''}`}
+        />
       </button>
-      {isExpanded && item.children && item.children.length > 0 && (
-        <div className={`border-t ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
-          {item.children.map((child) => (
+
+      {/* 아코디언 콘텐츠 */}
+      <div
+        className={`transition-all duration-200 ease-in-out overflow-hidden ${
+          isOpen ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+        }`}
+      >
+        <div className={`border-t ${isDark ? 'border-white/10' : 'border-gray-100'}`}>
+          {announcements.map((announcement, index) => (
             <div
-              key={child.id}
-              className={`flex items-center justify-between p-4 pl-12 transition-colors ${
-                isDark ? 'hover:bg-white/5' : 'hover:bg-gray-50'
+              key={announcement.id}
+              className={`px-4 py-3 ${
+                index !== announcements.length - 1
+                  ? isDark
+                    ? 'border-b border-white/5'
+                    : 'border-b border-gray-50'
+                  : ''
               }`}
             >
-              <div className="flex items-center gap-3">
+              <div className="flex items-start gap-3">
                 <div
-                  className={`w-8 h-8 rounded-lg flex items-center justify-center ${
-                    isDark ? 'bg-white/10' : 'bg-gray-100'
+                  className={`w-1.5 h-1.5 rounded-full mt-2 shrink-0 ${
+                    announcement.type === 'important'
+                      ? 'bg-orange-500'
+                      : isDark
+                        ? 'bg-blue-400'
+                        : 'bg-blue-500'
                   }`}
-                >
-                  {child.isFolder ? (
-                    <FileText className={`w-4 h-4 ${isDark ? 'text-[#6bc2f0]' : 'text-[#6778ff]'}`} />
-                  ) : (
-                    <PlayCircle className={`w-4 h-4 ${isDark ? 'text-[#6bc2f0]' : 'text-[#6778ff]'}`} />
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span
+                      className={`text-xs px-1.5 py-0.5 rounded ${
+                        announcement.type === 'important'
+                          ? isDark
+                            ? 'bg-orange-500/20 text-orange-400'
+                            : 'bg-orange-100 text-orange-600'
+                          : isDark
+                            ? 'bg-blue-500/20 text-blue-400'
+                            : 'bg-blue-100 text-blue-600'
+                      }`}
+                    >
+                      {announcement.type === 'important' ? '중요' : '안내'}
+                    </span>
+                    <span className={`font-medium text-sm ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                      {announcement.title}
+                    </span>
+                  </div>
+                  <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                    {announcement.message}
+                  </p>
+                  {announcement.date && (
+                    <p className={`text-xs mt-1 ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
+                      {announcement.date}
+                    </p>
                   )}
                 </div>
-                <span className={`font-medium ${isDark ? 'text-gray-200' : 'text-gray-700'}`}>{child.itemName}</span>
               </div>
-              {child.duration && (
-                <span
-                  className={`text-sm px-2 py-1 rounded-md ${
-                    isDark ? 'bg-white/10 text-gray-400' : 'bg-gray-100 text-gray-500'
-                  }`}
-                >
-                  {Math.floor(child.duration / 60)}:{String(child.duration % 60).padStart(2, '0')}
-                </span>
-              )}
             </div>
           ))}
         </div>
-      )}
+      </div>
     </div>
   );
 }
@@ -174,19 +197,9 @@ export function B2BCourseDetailPage() {
   );
   const { toggle: toggleWishlist, isLoading: isWishlistToggling } = useToggleWishlist();
 
-  const [expandedSections, setExpandedSections] = useState<number[]>([0]);
   const [showCopiedToast, setShowCopiedToast] = useState(false);
-  const [activeTab, setActiveTab] = useState<'intro' | 'curriculum' | 'review'>('intro');
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
-
-  const toggleSection = (index: number) => {
-    if (expandedSections.includes(index)) {
-      setExpandedSections(expandedSections.filter((i) => i !== index));
-    } else {
-      setExpandedSections([...expandedSections, index]);
-    }
-  };
 
   const handleWishlistToggle = async () => {
     if (!isAuthenticated) {
@@ -444,6 +457,9 @@ export function B2BCourseDetailPage() {
                 </div>
               )}
 
+              {/* 공지사항 아코디언 섹션 */}
+              <AnnouncementSection announcements={MOCK_ANNOUNCEMENTS} isDark={isDark} />
+
               <div
                 className={`rounded-xl overflow-hidden border ${
                   isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
@@ -575,7 +591,7 @@ export function B2BCourseDetailPage() {
                             신청 중...
                           </>
                         ) : (
-                          '수강 신청'
+                          '수강하기'
                         )}
                       </button>
                     ) : (
@@ -641,218 +657,6 @@ export function B2BCourseDetailPage() {
         </div>
       </div>
 
-      {/* Tab Navigation (커뮤니티 탭 제외) */}
-      <div className={`border-b ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
-        <div className="w-full px-4 md:px-8 lg:px-16">
-          <div className="flex gap-8 max-w-4xl">
-            <button
-              onClick={() => setActiveTab('intro')}
-              className={`py-4 font-medium transition-colors relative ${
-                activeTab === 'intro'
-                  ? isDark
-                    ? 'text-white'
-                    : 'text-gray-900'
-                  : isDark
-                    ? 'text-gray-400 hover:text-gray-300'
-                    : 'text-gray-500 hover:text-gray-700'
-              }`}
-            >
-              강의 소개
-              {activeTab === 'intro' && (
-                <div
-                  className={`absolute bottom-0 left-0 right-0 h-0.5 ${
-                    isDark ? 'bg-white' : 'bg-gray-900'
-                  }`}
-                />
-              )}
-            </button>
-            <button
-              onClick={() => setActiveTab('curriculum')}
-              className={`py-4 font-medium transition-colors relative ${
-                activeTab === 'curriculum'
-                  ? isDark
-                    ? 'text-white'
-                    : 'text-gray-900'
-                  : isDark
-                    ? 'text-gray-400 hover:text-gray-300'
-                    : 'text-gray-500 hover:text-gray-700'
-              }`}
-            >
-              커리큘럼
-              {activeTab === 'curriculum' && (
-                <div
-                  className={`absolute bottom-0 left-0 right-0 h-0.5 ${
-                    isDark ? 'bg-white' : 'bg-gray-900'
-                  }`}
-                />
-              )}
-            </button>
-            <button
-              onClick={() => setActiveTab('review')}
-              className={`py-4 font-medium transition-colors relative ${
-                activeTab === 'review'
-                  ? isDark
-                    ? 'text-white'
-                    : 'text-gray-900'
-                  : isDark
-                    ? 'text-gray-400 hover:text-gray-300'
-                    : 'text-gray-500 hover:text-gray-700'
-              }`}
-            >
-              수강평
-              {activeTab === 'review' && (
-                <div
-                  className={`absolute bottom-0 left-0 right-0 h-0.5 ${
-                    isDark ? 'bg-white' : 'bg-gray-900'
-                  }`}
-                />
-              )}
-            </button>
-            {/* B2B: 커뮤니티 탭 제외 */}
-          </div>
-        </div>
-      </div>
-
-      {/* Main Content */}
-      <main className="w-full px-4 md:px-8 lg:px-16 py-12">
-        <div className="max-w-4xl">
-          {activeTab === 'intro' && (
-            <>
-              {courseTime.program?.description && (
-                <section className="mb-12">
-                  <h2
-                    className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}
-                  >
-                    강의 소개
-                  </h2>
-                  <div
-                    className={`rounded-xl p-6 border ${
-                      isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
-                    }`}
-                  >
-                    <p className={`leading-relaxed whitespace-pre-wrap ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
-                      {courseTime.program.description}
-                    </p>
-                  </div>
-                </section>
-              )}
-
-              {courseTime.instructors.length > 0 && (
-                <section className="mb-12">
-                  <h2
-                    className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}
-                  >
-                    강사 소개
-                  </h2>
-                  <div className="space-y-4">
-                    {courseTime.instructors.map((instructor) => (
-                      <div
-                        key={instructor.id}
-                        className={`rounded-xl p-6 border ${
-                          isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
-                        }`}
-                      >
-                        <div className="flex items-start gap-4">
-                          {instructor.profileImageUrl ? (
-                            <img
-                              src={instructor.profileImageUrl}
-                              alt={instructor.name}
-                              className="w-16 h-16 rounded-full object-cover"
-                            />
-                          ) : (
-                            <div
-                              className={`w-16 h-16 rounded-full flex items-center justify-center ${
-                                isDark ? 'bg-white/10' : 'bg-gray-200'
-                              }`}
-                            >
-                              <Users className="w-8 h-8" />
-                            </div>
-                          )}
-                          <div>
-                            <h3
-                              className={`text-lg font-bold ${
-                                isDark ? 'text-white' : 'text-gray-900'
-                              }`}
-                            >
-                              {instructor.name}
-                            </h3>
-                            <span
-                              className={`text-sm px-2 py-0.5 rounded ${
-                                instructor.role === 'MAIN'
-                                  ? 'bg-[#6778ff]/20 text-[#6778ff]'
-                                  : isDark
-                                    ? 'bg-white/10 text-gray-400'
-                                    : 'bg-gray-100 text-gray-600'
-                              }`}
-                            >
-                              {instructor.role === 'MAIN'
-                                ? '주강사'
-                                : instructor.role === 'SUB'
-                                  ? '보조강사'
-                                  : '조교'}
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </section>
-              )}
-            </>
-          )}
-
-          {activeTab === 'curriculum' && (
-            <section className="mb-12">
-              <h2
-                className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}
-              >
-                커리큘럼
-              </h2>
-              {courseTime.curriculum && courseTime.curriculum.length > 0 ? (
-                <div className="space-y-3">
-                  {courseTime.curriculum.map((item, index) => (
-                    <CurriculumSection
-                      key={item.id}
-                      item={item}
-                      isExpanded={expandedSections.includes(index)}
-                      onToggle={() => toggleSection(index)}
-                      isDark={isDark}
-                    />
-                  ))}
-                </div>
-              ) : (
-                <div
-                  className={`rounded-xl p-8 text-center border ${
-                    isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
-                  }`}
-                >
-                  <FileText
-                    className={`w-12 h-12 mx-auto mb-4 ${
-                      isDark ? 'text-gray-600' : 'text-gray-300'
-                    }`}
-                  />
-                  <p className={`font-medium mb-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
-                    커리큘럼 준비 중
-                  </p>
-                  <p className={`text-sm ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
-                    상세 커리큘럼은 곧 업데이트될 예정입니다.
-                  </p>
-                </div>
-              )}
-            </section>
-          )}
-
-          {activeTab === 'review' && (
-            <section className="mb-12">
-              <CourseReviewSection
-                timeId={courseTimeId}
-                isDark={isDark}
-                canWrite={isAlreadyEnrolled}
-              />
-            </section>
-          )}
-        </div>
-      </main>
 
       <LandingFooter />
 

--- a/src/pages/tu/b2b/B2BWishlistPage.tsx
+++ b/src/pages/tu/b2b/B2BWishlistPage.tsx
@@ -1,0 +1,292 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Trash2, Heart, ChevronRight, Clock, Loader2 } from 'lucide-react';
+import { useThemeStore } from '@/store/common/themeStore';
+import { useSubdomainPath } from '@/hooks/common';
+import { B2BLandingHeader } from './components/B2BLandingHeader';
+import { LandingFooter } from '@/components/landing/LandingFooter';
+import { useMyWishlist, useRemoveFromWishlist } from '@/hooks/tu/useWishlistQueries';
+import { useAuthStore } from '@/store/common/authStore';
+import type { WishlistItemResponse } from '@/types/tu/wishlist.types';
+
+// 레벨 라벨 매핑
+const LEVEL_LABELS: Record<string, string> = {
+  BEGINNER: '입문',
+  INTERMEDIATE: '초급',
+  ADVANCED: '중급',
+  EXPERT: '고급',
+};
+
+/**
+ * B2B 찜 목록 페이지
+ * - B2B 전용 헤더 사용
+ * - 가격 표시 없음
+ */
+export function B2BWishlistPage() {
+  const { theme } = useThemeStore();
+  const isDark = theme === 'dark';
+  const { prefixPath } = useSubdomainPath();
+  const { isAuthenticated } = useAuthStore();
+
+  // 페이징 상태
+  const [page, setPage] = useState(0);
+  const pageSize = 12;
+
+  // React Query 훅
+  const { data: wishlistData, isLoading, error } = useMyWishlist(page, pageSize, isAuthenticated);
+  const removeFromWishlistMutation = useRemoveFromWishlist();
+
+  const wishlistItems = wishlistData?.content || [];
+  const totalPages = wishlistData?.totalPages || 0;
+  const totalElements = wishlistData?.totalElements || 0;
+
+  const removeItem = (courseTimeId: number) => {
+    removeFromWishlistMutation.mutate(courseTimeId);
+  };
+
+  // 비로그인 상태
+  if (!isAuthenticated) {
+    return (
+      <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
+        <B2BLandingHeader />
+        <main className="w-full px-4 md:px-8 lg:px-16 py-12">
+          <div className="text-center py-20">
+            <Heart className={`w-20 h-20 mx-auto mb-6 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
+            <h2 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              로그인이 필요합니다
+            </h2>
+            <p className={`mb-8 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+              찜 목록을 보려면 로그인해주세요.
+            </p>
+            <Link
+              to="/login"
+              className="inline-flex items-center gap-2 landing-btn-primary px-6 py-3 rounded-full text-white font-medium"
+            >
+              로그인하기 <ChevronRight className="w-4 h-4" />
+            </Link>
+          </div>
+        </main>
+        <LandingFooter />
+      </div>
+    );
+  }
+
+  // 로딩 상태
+  if (isLoading) {
+    return (
+      <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
+        <B2BLandingHeader />
+        <main className="w-full px-4 md:px-8 lg:px-16 py-12">
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
+            <span className={`ml-3 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+              찜 목록을 불러오는 중...
+            </span>
+          </div>
+        </main>
+        <LandingFooter />
+      </div>
+    );
+  }
+
+  // 에러 상태
+  if (error) {
+    return (
+      <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
+        <B2BLandingHeader />
+        <main className="w-full px-4 md:px-8 lg:px-16 py-12">
+          <div className="text-center py-20">
+            <p className={`text-lg ${isDark ? 'text-red-400' : 'text-red-500'}`}>
+              찜 목록을 불러오는데 실패했습니다.
+            </p>
+            <button
+              onClick={() => window.location.reload()}
+              className="mt-4 px-6 py-2 landing-btn-primary rounded-full text-white"
+            >
+              다시 시도
+            </button>
+          </div>
+        </main>
+        <LandingFooter />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
+      <B2BLandingHeader />
+
+      <main className="w-full px-4 md:px-8 lg:px-16 py-12">
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className={`text-3xl md:text-4xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              찜한 강의
+            </h1>
+            {totalElements > 0 && (
+              <p className={`mt-2 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                총 {totalElements}개의 강의
+              </p>
+            )}
+          </div>
+        </div>
+
+        {wishlistItems.length === 0 ? (
+          <div className="text-center py-20">
+            <Heart className={`w-20 h-20 mx-auto mb-6 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
+            <h2 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              찜한 강의가 없습니다
+            </h2>
+            <p className={`mb-8 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+              관심 있는 강의에 하트를 눌러 저장해보세요!
+            </p>
+            <Link
+              to={prefixPath('/tu/b2b')}
+              className="inline-flex items-center gap-2 landing-btn-primary px-6 py-3 rounded-full text-white font-medium"
+            >
+              강의 둘러보기 <ChevronRight className="w-4 h-4" />
+            </Link>
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {wishlistItems.map((item: WishlistItemResponse) => (
+                <div
+                  key={item.id}
+                  className={`rounded-2xl overflow-hidden border group ${
+                    isDark
+                      ? 'glass border-white/10'
+                      : 'bg-white border-gray-200'
+                  }`}
+                >
+                  {/* Image */}
+                  <Link to={prefixPath(`/tu/b2b/times/${item.courseTimeId}`)} className="block relative">
+                    <div className="w-full aspect-video bg-gradient-to-br from-[#6778ff]/20 to-[#a855f7]/20 flex items-center justify-center">
+                      {item.thumbnailUrl ? (
+                        <img
+                          src={item.thumbnailUrl}
+                          alt={item.courseTimeTitle || '강의 썸네일'}
+                          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                        />
+                      ) : (
+                        <Heart className={`w-12 h-12 ${isDark ? 'text-gray-600' : 'text-gray-400'}`} />
+                      )}
+                    </div>
+                    {item.level && (
+                      <span className="absolute top-3 left-3 px-2 py-1 rounded-full text-xs font-bold bg-[#6778ff] text-white">
+                        {LEVEL_LABELS[item.level] || item.level}
+                      </span>
+                    )}
+                  </Link>
+
+                  {/* Content */}
+                  <div className="p-4">
+                    <Link to={prefixPath(`/tu/b2b/times/${item.courseTimeId}`)}>
+                      <h3 className={`font-semibold mb-2 line-clamp-2 group-hover:text-[#6778ff] transition-colors ${
+                        isDark ? 'text-white' : 'text-gray-900'
+                      }`}>
+                        {item.courseTimeTitle || '제목 없음'}
+                      </h3>
+                    </Link>
+
+                    {/* Stats - B2B: 가격 표시 없음 */}
+                    <div className={`flex items-center gap-3 mb-4 text-xs ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
+                      {item.estimatedHours && (
+                        <span className="flex items-center gap-1">
+                          <Clock className="w-3.5 h-3.5" />
+                          {item.estimatedHours}시간
+                        </span>
+                      )}
+                    </div>
+
+                    {/* Added Date */}
+                    <p className={`text-xs mb-4 ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
+                      {new Date(item.addedAt).toLocaleDateString('ko-KR')}에 찜함
+                    </p>
+
+                    {/* Actions */}
+                    <div className="flex gap-2">
+                      <Link
+                        to={prefixPath(`/tu/b2b/times/${item.courseTimeId}`)}
+                        className="flex-1 py-2.5 rounded-lg font-medium text-sm landing-btn-primary text-white flex items-center justify-center gap-2"
+                      >
+                        상세보기
+                      </Link>
+                      <button
+                        onClick={() => removeItem(item.courseTimeId)}
+                        disabled={removeFromWishlistMutation.isPending}
+                        className={`p-2.5 rounded-lg transition-colors disabled:opacity-50 ${
+                          isDark
+                            ? 'bg-white/10 text-gray-400 hover:text-red-400 hover:bg-red-500/10'
+                            : 'bg-gray-100 text-gray-500 hover:text-red-500 hover:bg-red-50'
+                        }`}
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+              <div className="flex justify-center gap-2 mt-8">
+                <button
+                  onClick={() => setPage(p => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                  className={`px-4 py-2 rounded-lg font-medium text-sm transition-colors disabled:opacity-50 ${
+                    isDark
+                      ? 'bg-white/10 text-white hover:bg-white/20 disabled:hover:bg-white/10'
+                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200 disabled:hover:bg-gray-100'
+                  }`}
+                >
+                  이전
+                </button>
+                <span className={`px-4 py-2 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  {page + 1} / {totalPages}
+                </span>
+                <button
+                  onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
+                  disabled={page >= totalPages - 1}
+                  className={`px-4 py-2 rounded-lg font-medium text-sm transition-colors disabled:opacity-50 ${
+                    isDark
+                      ? 'bg-white/10 text-white hover:bg-white/20 disabled:hover:bg-white/10'
+                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200 disabled:hover:bg-gray-100'
+                  }`}
+                >
+                  다음
+                </button>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* Recommendation Section */}
+        {wishlistItems.length > 0 && (
+          <div className="mt-16">
+            <h2 className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              이런 강의는 어떠세요?
+            </h2>
+            <div className={`rounded-2xl p-8 border text-center ${
+              isDark ? 'glass border-white/10' : 'bg-white border-gray-200'
+            }`}>
+              <p className={`mb-4 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                찜한 강의를 기반으로 추천 강의를 준비하고 있어요.
+              </p>
+              <Link
+                to={prefixPath('/tu/b2b')}
+                className={`inline-flex items-center gap-2 font-medium transition-colors ${
+                  isDark ? 'text-[#6778ff] hover:text-[#8b99ff]' : 'text-[#6778ff] hover:text-[#5566ee]'
+                }`}
+              >
+                더 많은 강의 보러가기 <ChevronRight className="w-4 h-4" />
+              </Link>
+            </div>
+          </div>
+        )}
+      </main>
+
+      <LandingFooter />
+    </div>
+  );
+}

--- a/src/pages/tu/b2b/components/B2BLandingHeader.tsx
+++ b/src/pages/tu/b2b/components/B2BLandingHeader.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Search, Bell, Menu, X, LogOut, User, Sun, Moon, BookOpen, Shield } from 'lucide-react';
+import { Search, Bell, Menu, X, LogOut, User, Sun, Moon, BookOpen, Shield, Heart } from 'lucide-react';
 import { useAuth } from '@/hooks/common/auth';
 import { useMyProfile, useSubdomainPath } from '@/hooks/common';
 import { useThemeStore } from '@/store/common/themeStore';
@@ -17,9 +17,9 @@ const BANNER_DISMISSED_KEY = 'tu_b2b_top_banner_dismissed';
 /**
  * B2B 전용 랜딩 헤더
  * - 장바구니 없음
- * - 위시리스트 없음
  * - 로드맵 메뉴 없음
  * - 커뮤니티 메뉴 없음
+ * - 위시리스트(찜) 아이콘 표시
  */
 export function B2BLandingHeader() {
   const [showBanner, setShowBanner] = useState(() => {
@@ -218,7 +218,7 @@ export function B2BLandingHeader() {
               </form>
             )}
 
-            {/* Right: Actions (장바구니, 위시리스트 제외) */}
+            {/* Right: Actions (장바구니 제외, 위시리스트 포함) */}
             <div className="flex items-center gap-3 md:gap-5 mr-2 md:mr-4">
               <div className="flex items-center gap-2">
                 {showThemeToggle && (
@@ -234,7 +234,18 @@ export function B2BLandingHeader() {
                     {isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
                   </button>
                 )}
-                {/* 장바구니, 위시리스트 제외 - B2B에서는 표시 안함 */}
+                {/* 위시리스트 (찜) - B2B에서도 표시 */}
+                <Link
+                  to={prefixPath('/tu/b2b/mypage/wishlist')}
+                  className={`p-2 rounded-lg transition-colors ${
+                    isDark
+                      ? 'text-gray-400 hover:text-white hover:bg-white/10'
+                      : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100'
+                  }`}
+                  aria-label="찜 목록"
+                >
+                  <Heart className="h-5 w-5" />
+                </Link>
                 {showNotifications && (
                   <Link
                     to={prefixPath('/tu/b2b/notifications')}

--- a/src/pages/tu/b2b/index.ts
+++ b/src/pages/tu/b2b/index.ts
@@ -6,6 +6,9 @@
  * - 가격 표시 없음
  * - 로드맵 없음
  * - 커뮤니티 없음
+ *
+ * 대부분의 페이지는 B2C 페이지를 재사용하며,
+ * HeaderComponent와 showPrice 등의 prop으로 B2B 스타일 적용
  */
 
 export { B2BLandingPage } from './B2BLandingPage';
@@ -13,3 +16,8 @@ export { B2BCourseDetailPage } from './B2BCourseDetailPage';
 export { B2BSettingsPage } from './B2BSettingsPage';
 export { B2BPreferencesPage } from './B2BPreferencesPage';
 export { B2BMyActivityPage } from './B2BMyActivityPage';
+export { B2BWishlistPage } from './B2BWishlistPage';
+
+// B2B 전용 컴포넌트
+export { B2BLandingHeader } from './components/B2BLandingHeader';
+export { B2BCourseCard } from './components/B2BCourseCard';

--- a/src/pages/tu/main/InstructorProfilePage.tsx
+++ b/src/pages/tu/main/InstructorProfilePage.tsx
@@ -2,7 +2,7 @@
  * InstructorProfilePage
  * 강사 프로필 상세 페이지
  */
-import { useState } from 'react';
+import { useState, ComponentType } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import {
   Star,
@@ -24,6 +24,18 @@ import {
 import { LandingHeader, LandingFooter } from '@/components/landing';
 import { Button } from '@/components/common';
 import { useThemeStore } from '@/store/common/themeStore';
+
+/** InstructorProfilePage props */
+interface InstructorProfilePageProps {
+  /** 커스텀 헤더 컴포넌트 (B2B 등에서 사용) */
+  HeaderComponent?: ComponentType;
+  /** 가격 표시 여부 (B2B에서는 false) */
+  showPrice?: boolean;
+  /** 강의 상세 페이지 기본 경로 (B2B: /tu/b2b/courses) */
+  courseBasePath?: string;
+  /** 로드맵 상세 페이지 기본 경로 */
+  roadmapBasePath?: string;
+}
 import {
   useInstructorProfile,
   useInstructorCourses,
@@ -198,7 +210,12 @@ const dummyReviews: InstructorReview[] = [
 
 type TabType = 'about' | 'courses' | 'roadmaps' | 'reviews';
 
-export function InstructorProfilePage() {
+export function InstructorProfilePage({
+  HeaderComponent = LandingHeader,
+  showPrice = true,
+  courseBasePath = '/tu/b2c/courses',
+  roadmapBasePath = '/tu/b2c/roadmaps'
+}: InstructorProfilePageProps = {}) {
   const { instructorId } = useParams<{ instructorId: string }>();
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
@@ -272,7 +289,7 @@ export function InstructorProfilePage() {
   if (isLoading) {
     return (
       <div className={`min-h-screen dark-scrollbar ${isDark ? 'landing-dark' : 'landing-light'}`}>
-        <LandingHeader />
+        <HeaderComponent />
         <div className="flex items-center justify-center min-h-[60vh]">
           <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
         </div>
@@ -284,7 +301,7 @@ export function InstructorProfilePage() {
   if (!instructor) {
     return (
       <div className={`min-h-screen dark-scrollbar ${isDark ? 'landing-dark' : 'landing-light'}`}>
-        <LandingHeader />
+        <HeaderComponent />
         <div className="flex flex-col items-center justify-center min-h-[60vh]">
           <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>강사를 찾을 수 없습니다.</p>
           <Link to="/tu/b2c" className="mt-4 text-[#6778ff] hover:underline">
@@ -305,7 +322,7 @@ export function InstructorProfilePage() {
 
   return (
     <div className={`min-h-screen dark-scrollbar ${isDark ? 'landing-dark' : 'landing-light'}`}>
-      <LandingHeader />
+      <HeaderComponent />
 
       {/* 커버 이미지 */}
       <div className="relative h-48 md:h-64 lg:h-80">
@@ -484,7 +501,7 @@ export function InstructorProfilePage() {
                   return (
                     <Link
                       key={course.id}
-                      to={`/tu/b2c/courses/${course.id}`}
+                      to={`${courseBasePath}/${course.id}`}
                       className="group block h-full"
                     >
                       <div className={`h-full card-hover rounded-xl overflow-hidden border ${
@@ -566,9 +583,11 @@ export function InstructorProfilePage() {
                           </div>
 
                           <div className="pt-2 flex items-center justify-between">
-                            <span className={`font-bold text-lg ${isDark ? 'text-[#6bc2f0]' : 'text-[#4C2D9A]'}`}>
-                              ₩{course.price.toLocaleString()}
-                            </span>
+                            {showPrice && (
+                              <span className={`font-bold text-lg ${isDark ? 'text-[#6bc2f0]' : 'text-[#4C2D9A]'}`}>
+                                ₩{course.price.toLocaleString()}
+                              </span>
+                            )}
                             <div className="flex gap-1.5">
                               <span className={`text-[10px] px-2 py-1 rounded-full ${
                                 isDark
@@ -595,7 +614,7 @@ export function InstructorProfilePage() {
             {roadmaps?.map((roadmap) => (
               <Link
                 key={roadmap.id}
-                to={`/tu/b2c/roadmaps/${roadmap.id}`}
+                to={`${roadmapBasePath}/${roadmap.id}`}
                 className={`block rounded-2xl p-6 card-hover cursor-pointer group border transition-all ${
                   isDark
                     ? 'glass border-white/10'

--- a/src/pages/tu/main/NotificationsPage.tsx
+++ b/src/pages/tu/main/NotificationsPage.tsx
@@ -1,10 +1,18 @@
-import { useState } from 'react';
+import { useState, ComponentType } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useSubdomainPath } from '@/hooks/common';
 import { Bell, CheckCheck, Trash2, Settings, Heart, MessageSquare, BookOpen, Megaphone, Loader2, FileText, AlertCircle, ChevronRight } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
+
+/** NotificationsPage props */
+interface NotificationsPageProps {
+  /** 커스텀 헤더 컴포넌트 (B2B 등에서 사용) */
+  HeaderComponent?: ComponentType;
+  /** 알림 상세 페이지 기본 경로 (B2B: /tu/b2b/notifications) */
+  detailBasePath?: string;
+}
 import { useNotifications, useMarkAsRead, useMarkAllAsRead, useDeleteNotification, useDeleteReadNotifications } from '@/hooks/tu';
 import type { NotificationType } from '@/types/tu';
 import { getNotificationDeepLink } from '@/types/tu';
@@ -57,7 +65,10 @@ const formatRelativeTime = (dateString: string): string => {
   return date.toLocaleDateString('ko-KR');
 };
 
-export function NotificationsPage() {
+export function NotificationsPage({
+  HeaderComponent = LandingHeader,
+  detailBasePath = '/tu/b2c/notifications'
+}: NotificationsPageProps = {}) {
   const { theme } = useThemeStore();
   const isDark = theme === 'dark';
   const navigate = useNavigate();
@@ -103,7 +114,7 @@ export function NotificationsPage() {
   if (!isAuthenticated) {
     return (
       <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
-        <LandingHeader />
+        <HeaderComponent />
         <main className="w-full px-4 md:px-8 lg:px-16 py-12">
           <div className="text-center py-20">
             <Bell className={`w-20 h-20 mx-auto mb-6 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
@@ -130,7 +141,7 @@ export function NotificationsPage() {
   if (isLoading) {
     return (
       <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
-        <LandingHeader />
+        <HeaderComponent />
         <main className="w-full px-4 md:px-8 lg:px-16 py-12">
           <div className="flex items-center justify-center py-20">
             <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
@@ -148,7 +159,7 @@ export function NotificationsPage() {
   if (error) {
     return (
       <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
-        <LandingHeader />
+        <HeaderComponent />
         <main className="w-full px-4 md:px-8 lg:px-16 py-12">
           <div className="text-center py-20">
             <p className={`text-lg ${isDark ? 'text-red-400' : 'text-red-500'}`}>
@@ -169,7 +180,7 @@ export function NotificationsPage() {
 
   return (
     <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
-      <LandingHeader />
+      <HeaderComponent />
 
       <main className="w-full px-4 md:px-8 lg:px-16 py-12">
         {/* Header */}
@@ -268,7 +279,7 @@ export function NotificationsPage() {
                   onClick={() => {
                     markAsRead(notification.id);
                     // 딥링크가 있으면 해당 페이지로, 없으면 알림 상세로
-                    const targetPath = deepLink || `/tu/b2c/notifications/${notification.id}`;
+                    const targetPath = deepLink || `${detailBasePath}/${notification.id}`;
                     navigate(prefixPath(targetPath));
                   }}
                   className={`rounded-xl p-4 flex gap-4 cursor-pointer transition-all border ${

--- a/src/pages/tu/main/SearchPage.tsx
+++ b/src/pages/tu/main/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, ComponentType } from 'react';
 import { useSearchParams, Link } from 'react-router-dom';
 import {
   Search,
@@ -16,16 +16,100 @@ import {
 import { useThemeStore } from '@/store/common/themeStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
+
+/** 강의 카드 props 인터페이스 */
+interface CourseCardProps {
+  id: number;
+  title: string;
+  instructor: string;
+  image: string;
+  tags: string[];
+  category: string;
+  studentCount: number;
+  // LandingCourseCard 전용
+  price?: string | null;
+  rating?: number;
+  reviewCount?: number;
+  courseBasePath?: string;
+  // 공통 옵션
+  deliveryType?: string;
+  level?: string;
+  classStartDate?: string;
+  isOnDemand?: boolean;
+}
+
+/** SearchPage props */
+interface SearchPageProps {
+  /** 커스텀 헤더 컴포넌트 (B2B 등에서 사용) */
+  HeaderComponent?: ComponentType;
+  /** 로드맵/커뮤니티 탭 표시 여부 (B2B에서는 false) */
+  showRoadmapAndCommunity?: boolean;
+  /** 가격 표시 여부 (B2B에서는 false) */
+  showPrice?: boolean;
+  /** 가격 필터 표시 여부 (B2B에서는 false) */
+  showPriceFilter?: boolean;
+  /** 강의 상세 페이지 기본 경로 (B2B: /tu/b2b/courses) */
+  courseBasePath?: string;
+  /** 페이지 제목 (기본: 통합 검색) */
+  pageTitle?: string;
+  /** 페이지 설명 (기본: 강의, 로드맵, 커뮤니티를 한 번에 검색하세요) */
+  pageDescription?: string;
+  /** 검색 입력란 플레이스홀더 */
+  searchPlaceholder?: string;
+  /** 커스텀 강의 카드 컴포넌트 (B2B에서 B2BCourseCard 사용) */
+  CourseCardComponent?: ComponentType<CourseCardProps>;
+}
 import { LandingCourseCard } from '@/components/landing';
 import { useCourseTimeCatalog, useRoadmapExplore, useCommunityPosts } from '@/hooks/tu';
 import { useSubdomainPath } from '@/hooks/common';
 import { useTenantFeatures } from '@/contexts/TenantFeaturesContext';
 import type { RoadmapExploreItem } from '@/types/tu/roadmapExplore.types';
 import type { CommunityPost } from '@/types/tu/community.types';
+import type { CourseTimeCatalogResponse } from '@/types/tu/courseTimeCatalog.types';
 import { ROADMAP_LEVEL_LABELS } from '@/types/tu/roadmapExplore.types';
+import { DELIVERY_TYPE_LABELS, PROGRAM_LEVEL_LABELS } from '@/types/tu/courseTimeCatalog.types';
 
 // API 사용 여부 (false면 더미 데이터 사용)
-const USE_API = false;
+const USE_API = true;
+
+/**
+ * CourseTime API 데이터를 카드 컴포넌트 props로 변환
+ */
+function convertCourseTimeToCardProps(courseTime: CourseTimeCatalogResponse): CourseCardProps {
+  const mainInstructor = courseTime.instructors.find((i) => i.role === 'MAIN');
+  const instructorName = mainInstructor?.name || courseTime.instructors[0]?.name || '';
+
+  const tags: string[] = [];
+  if (courseTime.isOnDemand) {
+    tags.push('상시모집');
+  } else if (courseTime.status === 'RECRUITING') {
+    tags.push('모집중');
+  } else if (courseTime.status === 'ONGOING') {
+    tags.push('진행중');
+  }
+
+  const thumbnailUrl =
+    courseTime.program?.thumbnailUrl ||
+    'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=400&h=250&fit=crop';
+
+  return {
+    id: courseTime.id,
+    title: courseTime.title,
+    instructor: instructorName,
+    image: thumbnailUrl,
+    tags,
+    category: courseTime.program?.categoryName ?? '',
+    deliveryType: DELIVERY_TYPE_LABELS[courseTime.deliveryType] || courseTime.deliveryType,
+    level: courseTime.program?.level ? PROGRAM_LEVEL_LABELS[courseTime.program.level] : undefined,
+    studentCount: courseTime.currentEnrollment,
+    classStartDate: courseTime.classStartDate,
+    isOnDemand: courseTime.isOnDemand,
+    // LandingCourseCard 전용 (선택적)
+    rating: 0,
+    reviewCount: 0,
+    price: null,
+  };
+}
 
 // 더미 강의 카드 데이터 (LandingCourseCard용)
 interface MockCourseCard {
@@ -867,7 +951,19 @@ const DEFAULT_FILTERS: Filters = {
   communityCategory: 'all',
 };
 
-export function SearchPage() {
+export function SearchPage({
+  HeaderComponent = LandingHeader,
+  showRoadmapAndCommunity = true,
+  showPrice = true,
+  showPriceFilter = true,
+  courseBasePath,
+  pageTitle = '통합 검색',
+  pageDescription = '강의, 로드맵, 커뮤니티를 한 번에 검색하세요',
+  searchPlaceholder = '강의, 로드맵, 커뮤니티 글을 검색하세요',
+  CourseCardComponent,
+}: SearchPageProps = {}) {
+  // 사용할 카드 컴포넌트 결정 (커스텀 또는 기본 LandingCourseCard)
+  const CardComponent = CourseCardComponent || LandingCourseCard;
   const [searchParams, setSearchParams] = useSearchParams();
   const [activeTab, setActiveTab] = useState<SearchTab>('all');
   const [searchQuery, setSearchQuery] = useState('');
@@ -1103,26 +1199,31 @@ export function SearchPage() {
     setSearchParams({});
   };
 
-  // 탭 데이터
-  const tabs = [
-    { id: 'all' as const, label: '전체', count: totalResults },
-    { id: 'courses' as const, label: '강의', count: totalCourses, icon: BookOpen },
-    { id: 'roadmaps' as const, label: '로드맵', count: totalRoadmaps, icon: Map },
-    { id: 'community' as const, label: '커뮤니티', count: totalCommunity, icon: MessageSquare },
-  ];
+  // 탭 데이터 (B2B에서는 로드맵/커뮤니티 제외)
+  const tabs = showRoadmapAndCommunity
+    ? [
+        { id: 'all' as const, label: '전체', count: totalResults },
+        { id: 'courses' as const, label: '강의', count: totalCourses, icon: BookOpen },
+        { id: 'roadmaps' as const, label: '로드맵', count: totalRoadmaps, icon: Map },
+        { id: 'community' as const, label: '커뮤니티', count: totalCommunity, icon: MessageSquare },
+      ]
+    : [
+        { id: 'all' as const, label: '전체', count: totalCourses },
+        { id: 'courses' as const, label: '강의', count: totalCourses, icon: BookOpen },
+      ];
 
   return (
     <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
-      <LandingHeader />
+      <HeaderComponent />
 
       <main className="w-full px-4 md:px-8 lg:px-16 py-12">
         {/* 검색 헤더 */}
         <div className="mb-8">
           <h1 className={`text-3xl md:text-4xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            통합 검색
+            {pageTitle}
           </h1>
           <p className={`mb-6 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-            강의, 로드맵, 커뮤니티를 한 번에 검색하세요
+            {pageDescription}
           </p>
 
           {/* 검색바 */}
@@ -1136,7 +1237,7 @@ export function SearchPage() {
               type="text"
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
-              placeholder="강의, 로드맵, 커뮤니티 글을 검색하세요"
+              placeholder={searchPlaceholder}
               className={`w-full rounded-xl pl-12 pr-12 py-3 focus:outline-none focus:ring-2 focus:ring-[#6778ff] focus:border-transparent transition-all ${
                 isDark
                   ? 'bg-white/5 border border-white/10 text-white placeholder-gray-500'
@@ -1251,8 +1352,8 @@ export function SearchPage() {
                   />
                 )}
 
-                {/* 강의: 가격 */}
-                {activeTab === 'courses' && (
+                {/* 강의: 가격 (B2B에서는 숨김) */}
+                {showPriceFilter && activeTab === 'courses' && (
                   <FilterDropdown
                     label="가격"
                     value={filters.price}
@@ -1361,27 +1462,37 @@ export function SearchPage() {
                       </div>
                     )}
                     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6">
-                      {(courses as MockCourseCard[]).map((course) => (
-                        <LandingCourseCard
-                          key={course.id}
-                          id={course.id}
-                          title={course.title}
-                          instructor={course.instructor}
-                          price={paidModeEnabled ? course.price : null}
-                          rating={course.rating}
-                          reviewCount={course.reviewCount}
-                          studentCount={course.studentCount}
-                          image={course.image}
-                          tags={course.tags}
-                          category={course.category}
-                        />
-                      ))}
+                      {(USE_API ? courses : (courses as MockCourseCard[])).map((course) => {
+                        // API 데이터인 경우 변환, 더미 데이터는 그대로 사용
+                        const cardProps = USE_API
+                          ? convertCourseTimeToCardProps(course as CourseTimeCatalogResponse)
+                          : {
+                              id: (course as MockCourseCard).id,
+                              title: (course as MockCourseCard).title,
+                              instructor: (course as MockCourseCard).instructor,
+                              price: showPrice && paidModeEnabled ? (course as MockCourseCard).price : null,
+                              rating: (course as MockCourseCard).rating,
+                              reviewCount: (course as MockCourseCard).reviewCount,
+                              studentCount: (course as MockCourseCard).studentCount,
+                              image: (course as MockCourseCard).image,
+                              tags: (course as MockCourseCard).tags,
+                              category: (course as MockCourseCard).category,
+                            };
+
+                        return (
+                          <CardComponent
+                            key={cardProps.id}
+                            {...cardProps}
+                            courseBasePath={courseBasePath}
+                          />
+                        );
+                      })}
                     </div>
                   </section>
                 )}
 
-                {/* 로드맵 섹션 */}
-                {(activeTab === 'all' || activeTab === 'roadmaps') && roadmaps.length > 0 && (
+                {/* 로드맵 섹션 (B2B에서는 숨김) */}
+                {showRoadmapAndCommunity && (activeTab === 'all' || activeTab === 'roadmaps') && roadmaps.length > 0 && (
                   <section>
                     {activeTab === 'all' && (
                       <div className="flex items-center justify-between mb-6">
@@ -1407,8 +1518,8 @@ export function SearchPage() {
                   </section>
                 )}
 
-                {/* 커뮤니티 섹션 */}
-                {(activeTab === 'all' || activeTab === 'community') && communityPosts.length > 0 && (
+                {/* 커뮤니티 섹션 (B2B에서는 숨김) */}
+                {showRoadmapAndCommunity && (activeTab === 'all' || activeTab === 'community') && communityPosts.length > 0 && (
                   <section>
                     {activeTab === 'all' && (
                       <div className="flex items-center justify-between mb-6">

--- a/src/pages/tu/main/SearchPage.tsx
+++ b/src/pages/tu/main/SearchPage.tsx
@@ -17,7 +17,7 @@ import { useThemeStore } from '@/store/common/themeStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
 
-/** 강의 카드 props 인터페이스 */
+/** 강의 카드 props 인터페이스 - LandingCourseCard와 B2BCourseCard 공통 */
 interface CourseCardProps {
   id: number;
   title: string;
@@ -26,10 +26,10 @@ interface CourseCardProps {
   tags: string[];
   category: string;
   studentCount: number;
-  // LandingCourseCard 전용
-  price?: string | null;
-  rating?: number;
-  reviewCount?: number;
+  // LandingCourseCard 전용 (필수)
+  price: string | null;
+  rating: number;
+  reviewCount: number;
   courseBasePath?: string;
   // 공통 옵션
   deliveryType?: string;

--- a/src/routes/tu.b2b.routes.tsx
+++ b/src/routes/tu.b2b.routes.tsx
@@ -3,11 +3,6 @@ import { B2BMyPageLayout } from '@/components/layout';
 import { ProtectedRoute } from '@/components/common/ProtectedRoute';
 import { ProfileRequiredRoute } from '@/components/common/ProfileRequiredRoute';
 import {
-  CoursesExplorePage,
-  NotificationsPage,
-  NotificationDetailPage,
-  InstructorProfilePage,
-  SearchPage,
   MyPageHome,
   ProfilePage,
   MyLearningPage,
@@ -18,13 +13,26 @@ import {
   CompletedCoursesPage,
   CertificationsPage,
   UserNoticesPage,
+  // B2C 페이지 재사용
+  SearchPage,
+  NotificationsPage,
+  InstructorProfilePage,
 } from '@/pages/tu';
+import {
+  SettingsPage,
+  SettingsSecurityPage,
+  SettingsNotificationsPage,
+  SettingsAppearancePage,
+} from '@/pages/common';
 import {
   B2BLandingPage,
   B2BCourseDetailPage,
   B2BSettingsPage,
   B2BPreferencesPage,
   B2BMyActivityPage,
+  B2BWishlistPage,
+  B2BLandingHeader,
+  B2BCourseCard,
 } from '@/pages/tu/b2b';
 
 function B2BMyPageWrapper() {
@@ -50,6 +58,58 @@ function B2BPlayerWrapper() {
 }
 
 /**
+ * B2B 검색 페이지 - B2C SearchPage 재사용
+ * - B2BLandingHeader 사용
+ * - 로드맵/커뮤니티 탭 숨김
+ * - 가격 표시/필터 숨김
+ * - B2BCourseCard 사용 (랜딩 페이지와 동일한 디자인)
+ */
+function B2BSearchPage() {
+  return (
+    <SearchPage
+      HeaderComponent={B2BLandingHeader}
+      showRoadmapAndCommunity={false}
+      showPrice={false}
+      showPriceFilter={false}
+      courseBasePath="/tu/b2b/times"
+      pageTitle="과정 검색"
+      pageDescription="배정된 과정을 검색하세요"
+      searchPlaceholder="과정명, 강사명으로 검색하세요"
+      CourseCardComponent={B2BCourseCard}
+    />
+  );
+}
+
+/**
+ * B2B 알림 페이지 - B2C NotificationsPage 재사용
+ * - B2BLandingHeader 사용
+ */
+function B2BNotificationsPage() {
+  return (
+    <NotificationsPage
+      HeaderComponent={B2BLandingHeader}
+      detailBasePath="/tu/b2b/notifications"
+    />
+  );
+}
+
+/**
+ * B2B 강사 프로필 페이지 - B2C InstructorProfilePage 재사용
+ * - B2BLandingHeader 사용
+ * - 가격 숨김
+ */
+function B2BInstructorProfilePage() {
+  return (
+    <InstructorProfilePage
+      HeaderComponent={B2BLandingHeader}
+      showPrice={false}
+      courseBasePath="/tu/b2b/courses"
+      roadmapBasePath="/tu/b2b/roadmaps"
+    />
+  );
+}
+
+/**
  * TU B2B 라우트 - 기업용 페이지
  *
  * 경로: /:subdomain/tu/b2b/* 또는 /tu/b2b/* (기본)
@@ -63,9 +123,7 @@ function B2BPlayerWrapper() {
  */
 export const tuB2bRoutes = (
   <>
-    {/* ===== 마이페이지 (로그인 필요) ===== */}
-
-    {/* 플레이어 라우트 - 레이아웃 없이 전체 화면 */}
+    {/* ===== 플레이어 라우트 - 레이아웃 없이 전체 화면 ===== */}
     <Route path="/:subdomain/tu/b2b/mypage/learning/:enrollmentId/player" element={<B2BPlayerWrapper />}>
       <Route index element={<LearningPlayerPage />} />
       <Route path=":itemId" element={<LearningPlayerPage />} />
@@ -74,6 +132,8 @@ export const tuB2bRoutes = (
       <Route index element={<LearningPlayerPage />} />
       <Route path=":itemId" element={<LearningPlayerPage />} />
     </Route>
+
+    {/* ===== 마이페이지 (로그인 필요) ===== */}
 
     {/* 마이페이지 라우트 (subdomain 있음) */}
     <Route path="/:subdomain/tu/b2b/mypage" element={<B2BMyPageWrapper />}>
@@ -93,12 +153,18 @@ export const tuB2bRoutes = (
       {/* 내 활동 (커뮤니티 → 내 댓글만) */}
       <Route path="comments" element={<B2BMyActivityPage />} />
 
+      {/* 찜 목록 */}
+      <Route path="wishlist" element={<B2BWishlistPage />} />
+
       {/* 공지사항 */}
       <Route path="notices" element={<UserNoticesPage />} />
 
-      {/* 설정 (카드 형식) */}
+      {/* 설정 (B2B 전용 카드 형식) */}
       <Route path="settings" element={<B2BSettingsPage />} />
       <Route path="settings/preferences" element={<B2BPreferencesPage />} />
+      <Route path="settings/security" element={<SettingsSecurityPage />} />
+      <Route path="settings/notifications" element={<SettingsNotificationsPage />} />
+      <Route path="settings/appearance" element={<SettingsAppearancePage />} />
     </Route>
 
     {/* 마이페이지 라우트 (subdomain 없음) */}
@@ -119,12 +185,18 @@ export const tuB2bRoutes = (
       {/* 내 활동 (커뮤니티 → 내 댓글만) */}
       <Route path="comments" element={<B2BMyActivityPage />} />
 
+      {/* 찜 목록 */}
+      <Route path="wishlist" element={<B2BWishlistPage />} />
+
       {/* 공지사항 */}
       <Route path="notices" element={<UserNoticesPage />} />
 
-      {/* 설정 (카드 형식) */}
+      {/* 설정 (B2B 전용 카드 형식) */}
       <Route path="settings" element={<B2BSettingsPage />} />
       <Route path="settings/preferences" element={<B2BPreferencesPage />} />
+      <Route path="settings/security" element={<SettingsSecurityPage />} />
+      <Route path="settings/notifications" element={<SettingsNotificationsPage />} />
+      <Route path="settings/appearance" element={<SettingsAppearancePage />} />
     </Route>
 
     {/* ===== 메인 페이지 (사이드바 없음) ===== */}
@@ -133,28 +205,24 @@ export const tuB2bRoutes = (
     <Route path="/:subdomain/tu/b2b" element={<B2BLandingPage />} />
     <Route path="/tu/b2b" element={<B2BLandingPage />} />
 
-    {/* 통합 검색 */}
-    <Route path="/:subdomain/tu/b2b/search" element={<SearchPage />} />
-    <Route path="/tu/b2b/search" element={<SearchPage />} />
+    {/* 통합 검색 (B2B 전용 - 로드맵/커뮤니티 제외) */}
+    <Route path="/:subdomain/tu/b2b/search" element={<B2BSearchPage />} />
+    <Route path="/tu/b2b/search" element={<B2BSearchPage />} />
 
-    {/* 강의 탐색 */}
-    <Route path="/:subdomain/tu/b2b/courses" element={<CoursesExplorePage />} />
+    {/* 강의 상세 (B2B에서는 강의 탐색 목록 없음, 상세만 접근 가능) */}
     <Route path="/:subdomain/tu/b2b/courses/:id" element={<B2BCourseDetailPage />} />
-    <Route path="/tu/b2b/courses" element={<CoursesExplorePage />} />
     <Route path="/tu/b2b/courses/:id" element={<B2BCourseDetailPage />} />
 
     {/* 차수(Times) 상세 - CourseTime 기반 */}
     <Route path="/:subdomain/tu/b2b/times/:id" element={<B2BCourseDetailPage />} />
     <Route path="/tu/b2b/times/:id" element={<B2BCourseDetailPage />} />
 
-    {/* 알림 */}
-    <Route path="/:subdomain/tu/b2b/notifications" element={<NotificationsPage />} />
-    <Route path="/:subdomain/tu/b2b/notifications/:id" element={<NotificationDetailPage />} />
-    <Route path="/tu/b2b/notifications" element={<NotificationsPage />} />
-    <Route path="/tu/b2b/notifications/:id" element={<NotificationDetailPage />} />
+    {/* 알림 (B2B - B2C 페이지 재사용) */}
+    <Route path="/:subdomain/tu/b2b/notifications" element={<B2BNotificationsPage />} />
+    <Route path="/tu/b2b/notifications" element={<B2BNotificationsPage />} />
 
-    {/* 강사 프로필 */}
-    <Route path="/:subdomain/tu/b2b/instructors/:instructorId" element={<InstructorProfilePage />} />
-    <Route path="/tu/b2b/instructors/:instructorId" element={<InstructorProfilePage />} />
+    {/* 강사 프로필 (B2B - B2C 페이지 재사용) */}
+    <Route path="/:subdomain/tu/b2b/instructors/:instructorId" element={<B2BInstructorProfilePage />} />
+    <Route path="/tu/b2b/instructors/:instructorId" element={<B2BInstructorProfilePage />} />
   </>
 );

--- a/src/routes/tu.b2b.routes.tsx
+++ b/src/routes/tu.b2b.routes.tsx
@@ -19,7 +19,6 @@ import {
   InstructorProfilePage,
 } from '@/pages/tu';
 import {
-  SettingsPage,
   SettingsSecurityPage,
   SettingsNotificationsPage,
   SettingsAppearancePage,


### PR DESCRIPTION
## Summary
- B2B 검색 페이지에서 랜딩 페이지와 동일한 카드 디자인(B2BCourseCard) 적용
- B2B 과정 상세 페이지에 아코디언 스타일 공지사항 섹션 추가
- B2BMyPageLayout, B2BWishlistPage 등 B2B 전용 컴포넌트/페이지 추가

## Changes

### B2B 검색 페이지
- SearchPage에 B2B 전용 props 추가 (showPrice, showPriceFilter, CourseCardComponent 등)
- API 데이터 변환 함수 추가로 실제 API 연동

### B2B 과정 상세 페이지
- 공지사항 아코디언 컴포넌트 추가 (썸네일 상단 배치)
- 중요/일반 공지 구분 표시

### 기타
- B2BMyPageLayout 레이아웃 컴포넌트 추가
- B2BWishlistPage 찜 목록 페이지 추가
- InstructorProfilePage, NotificationsPage B2B 지원

## Test plan
- [x] B2B 검색 페이지 (`/tu/b2b/search`) 접속 후 카드 디자인 확인
- [x] 검색 결과 카드 클릭 시 과정 상세 페이지로 정상 이동 확인
- [x] 과정 상세 페이지에서 공지사항 아코디언 펼침/접힘 동작 확인
- [x] 다크모드에서 UI 정상 표시 확인

Closes #424
