### PR TITLE
Add notification template management page for TA

### DIFF
--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -43,6 +43,7 @@ import {
   FolderTree,
   Map,
   UserSquare2,
+  Bell,
 } from 'lucide-react';
 import type { MenuItem } from '@/types';
 
@@ -120,6 +121,7 @@ export const tenantAdminMenuData: MenuItem[] = [
     icon: Server,
     subItems: [
       { id: 'domain-ssl', label: { ko: '도메인 및 SSL 설정', en: 'Domain & SSL Setup' }, icon: Globe, path: '/ta/system/domain' },
+      { id: 'notification-templates', label: { ko: '알림 템플릿 관리', en: 'Notification Templates' }, icon: Bell, path: '/ta/system/notification-templates' },
     ],
   },
   {

--- a/src/hooks/ta/index.ts
+++ b/src/hooks/ta/index.ts
@@ -151,3 +151,17 @@ export {
   useSystemNotice,
   useMarkSystemNoticeAsRead,
 } from './useSystemNoticeQueries';
+
+export {
+  notificationTemplateKeys,
+  useNotificationTemplates,
+  useNotificationTemplate,
+  useTriggerTypes,
+  useCategories,
+  useCreateNotificationTemplate,
+  useUpdateNotificationTemplate,
+  useDeleteNotificationTemplate,
+  useActivateNotificationTemplate,
+  useDeactivateNotificationTemplate,
+  useInitializeDefaultTemplates,
+} from './useNotificationTemplateQueries';

--- a/src/hooks/ta/useNotificationTemplateQueries.ts
+++ b/src/hooks/ta/useNotificationTemplateQueries.ts
@@ -1,0 +1,163 @@
+/**
+ * 알림 템플릿 관리 React Query 훅
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getNotificationTemplates,
+  getNotificationTemplate,
+  createNotificationTemplate,
+  updateNotificationTemplate,
+  deleteNotificationTemplate,
+  activateNotificationTemplate,
+  deactivateNotificationTemplate,
+  initializeDefaultTemplates,
+  getTriggerTypes,
+  getCategories,
+} from '@/services/ta/notificationTemplateService';
+import type {
+  NotificationCategory,
+  CreateNotificationTemplateRequest,
+  UpdateNotificationTemplateRequest,
+} from '@/types/ta/notificationTemplate.types';
+
+// Query Keys
+export const notificationTemplateKeys = {
+  all: ['notificationTemplates'] as const,
+  lists: () => [...notificationTemplateKeys.all, 'list'] as const,
+  list: (category?: NotificationCategory) =>
+    [...notificationTemplateKeys.lists(), { category }] as const,
+  details: () => [...notificationTemplateKeys.all, 'detail'] as const,
+  detail: (id: number) => [...notificationTemplateKeys.details(), id] as const,
+  triggers: () => [...notificationTemplateKeys.all, 'triggers'] as const,
+  categories: () => [...notificationTemplateKeys.all, 'categories'] as const,
+};
+
+/**
+ * 템플릿 목록 조회 훅
+ */
+export function useNotificationTemplates(category?: NotificationCategory) {
+  return useQuery({
+    queryKey: notificationTemplateKeys.list(category),
+    queryFn: () => getNotificationTemplates(category),
+  });
+}
+
+/**
+ * 템플릿 상세 조회 훅
+ */
+export function useNotificationTemplate(id: number) {
+  return useQuery({
+    queryKey: notificationTemplateKeys.detail(id),
+    queryFn: () => getNotificationTemplate(id),
+    enabled: !!id,
+  });
+}
+
+/**
+ * 트리거 타입 목록 조회 훅
+ */
+export function useTriggerTypes() {
+  return useQuery({
+    queryKey: notificationTemplateKeys.triggers(),
+    queryFn: getTriggerTypes,
+    staleTime: Infinity, // 정적 데이터
+  });
+}
+
+/**
+ * 카테고리 목록 조회 훅
+ */
+export function useCategories() {
+  return useQuery({
+    queryKey: notificationTemplateKeys.categories(),
+    queryFn: getCategories,
+    staleTime: Infinity, // 정적 데이터
+  });
+}
+
+/**
+ * 템플릿 생성 훅
+ */
+export function useCreateNotificationTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateNotificationTemplateRequest) =>
+      createNotificationTemplate(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationTemplateKeys.lists() });
+    },
+  });
+}
+
+/**
+ * 템플릿 수정 훅
+ */
+export function useUpdateNotificationTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: { id: number; request: UpdateNotificationTemplateRequest }) =>
+      updateNotificationTemplate(id, request),
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries({ queryKey: notificationTemplateKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: notificationTemplateKeys.detail(id) });
+    },
+  });
+}
+
+/**
+ * 템플릿 삭제 훅
+ */
+export function useDeleteNotificationTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => deleteNotificationTemplate(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationTemplateKeys.lists() });
+    },
+  });
+}
+
+/**
+ * 템플릿 활성화 훅
+ */
+export function useActivateNotificationTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => activateNotificationTemplate(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationTemplateKeys.lists() });
+    },
+  });
+}
+
+/**
+ * 템플릿 비활성화 훅
+ */
+export function useDeactivateNotificationTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => deactivateNotificationTemplate(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationTemplateKeys.lists() });
+    },
+  });
+}
+
+/**
+ * 기본 템플릿 초기화 훅
+ */
+export function useInitializeDefaultTemplates() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: initializeDefaultTemplates,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationTemplateKeys.lists() });
+    },
+  });
+}

--- a/src/pages/sa/notices/NoticesPage.tsx
+++ b/src/pages/sa/notices/NoticesPage.tsx
@@ -390,8 +390,8 @@ export function NoticesPage() {
               <Label>만료일 (선택)</Label>
               <Input
                 type="datetime-local"
-                value={formData.expiredAt || ''}
-                onChange={(e) => setFormData({ ...formData, expiredAt: e.target.value || undefined })}
+                value={formData.expiredAt ? formData.expiredAt.slice(0, 16) : ''}
+                onChange={(e) => setFormData({ ...formData, expiredAt: e.target.value ? new Date(e.target.value).toISOString() : undefined })}
               />
               <p className="text-xs text-text-secondary">설정하지 않으면 무기한 게시됩니다.</p>
             </div>
@@ -465,8 +465,8 @@ export function NoticesPage() {
               <Label>만료일 (선택)</Label>
               <Input
                 type="datetime-local"
-                value={formData.expiredAt || ''}
-                onChange={(e) => setFormData({ ...formData, expiredAt: e.target.value || undefined })}
+                value={formData.expiredAt ? formData.expiredAt.slice(0, 16) : ''}
+                onChange={(e) => setFormData({ ...formData, expiredAt: e.target.value ? new Date(e.target.value).toISOString() : undefined })}
               />
               <p className="text-xs text-text-secondary">설정하지 않으면 무기한 게시됩니다.</p>
             </div>

--- a/src/pages/ta/system/NotificationTemplatesPage.tsx
+++ b/src/pages/ta/system/NotificationTemplatesPage.tsx
@@ -1,0 +1,521 @@
+import { useState } from 'react';
+import {
+  Bell,
+  Plus,
+  Search,
+  Edit,
+  Eye,
+  Power,
+  PowerOff,
+  Trash2,
+  RefreshCw,
+  Info,
+} from 'lucide-react';
+import { AdminPageHeader } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Badge } from '@/components/common/Badge';
+import { Tabs, TabsList, TabsTrigger } from '@/components/common/Tabs';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/common/Dialog';
+import { Label } from '@/components/common/Label';
+import { Textarea } from '@/components/common/Textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/common/Select';
+import { toast } from 'sonner';
+import {
+  useNotificationTemplates,
+  useCreateNotificationTemplate,
+  useUpdateNotificationTemplate,
+  useDeleteNotificationTemplate,
+  useActivateNotificationTemplate,
+  useDeactivateNotificationTemplate,
+  useInitializeDefaultTemplates,
+  useTriggerTypes,
+} from '@/hooks/ta/useNotificationTemplateQueries';
+import type {
+  NotificationTemplateResponse,
+  NotificationCategory,
+  NotificationTrigger,
+  CreateNotificationTemplateRequest,
+  UpdateNotificationTemplateRequest,
+} from '@/types/ta/notificationTemplate.types';
+import { CATEGORY_CONFIG, TRIGGER_VARIABLES } from '@/types/ta/notificationTemplate.types';
+
+export function NotificationTemplatesPage() {
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState<string>('all');
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [isViewDialogOpen, setIsViewDialogOpen] = useState(false);
+  const [selectedTemplate, setSelectedTemplate] = useState<NotificationTemplateResponse | null>(null);
+
+  // Form state
+  const [formData, setFormData] = useState<{
+    triggerType: NotificationTrigger | '';
+    name: string;
+    titleTemplate: string;
+    messageTemplate: string;
+    description: string;
+  }>({
+    triggerType: '',
+    name: '',
+    titleTemplate: '',
+    messageTemplate: '',
+    description: '',
+  });
+
+  // Queries
+  const category = categoryFilter === 'all' ? undefined : (categoryFilter as NotificationCategory);
+  const { data: templates = [], isLoading } = useNotificationTemplates(category);
+  const { data: triggerTypes = [] } = useTriggerTypes();
+
+  // Mutations
+  const createMutation = useCreateNotificationTemplate();
+  const updateMutation = useUpdateNotificationTemplate();
+  const deleteMutation = useDeleteNotificationTemplate();
+  const activateMutation = useActivateNotificationTemplate();
+  const deactivateMutation = useDeactivateNotificationTemplate();
+  const initializeMutation = useInitializeDefaultTemplates();
+
+  // Filter templates by search keyword
+  const filteredTemplates = templates.filter((template) => {
+    const matchesSearch =
+      template.name.toLowerCase().includes(searchKeyword.toLowerCase()) ||
+      template.triggerType.toLowerCase().includes(searchKeyword.toLowerCase());
+    return matchesSearch;
+  });
+
+  // 이미 사용된 트리거 타입
+  const usedTriggers = new Set(templates.map((t) => t.triggerType));
+
+  // 사용 가능한 트리거 타입 (아직 생성되지 않은 것들)
+  const availableTriggers = triggerTypes.filter((t) => !usedTriggers.has(t.value));
+
+  const handleOpenCreateDialog = () => {
+    setFormData({
+      triggerType: '',
+      name: '',
+      titleTemplate: '',
+      messageTemplate: '',
+      description: '',
+    });
+    setIsCreateDialogOpen(true);
+  };
+
+  const handleOpenEditDialog = (template: NotificationTemplateResponse) => {
+    setSelectedTemplate(template);
+    setFormData({
+      triggerType: template.triggerType,
+      name: template.name,
+      titleTemplate: template.titleTemplate,
+      messageTemplate: template.messageTemplate,
+      description: template.description || '',
+    });
+    setIsEditDialogOpen(true);
+  };
+
+  const handleOpenViewDialog = (template: NotificationTemplateResponse) => {
+    setSelectedTemplate(template);
+    setIsViewDialogOpen(true);
+  };
+
+  const handleCreate = async () => {
+    if (!formData.triggerType || !formData.name || !formData.titleTemplate || !formData.messageTemplate) {
+      toast.error('필수 항목을 입력해주세요');
+      return;
+    }
+
+    try {
+      await createMutation.mutateAsync({
+        triggerType: formData.triggerType as NotificationTrigger,
+        name: formData.name,
+        titleTemplate: formData.titleTemplate,
+        messageTemplate: formData.messageTemplate,
+        description: formData.description || undefined,
+      } as CreateNotificationTemplateRequest);
+      toast.success('템플릿이 생성되었습니다');
+      setIsCreateDialogOpen(false);
+    } catch {
+      toast.error('템플릿 생성에 실패했습니다');
+    }
+  };
+
+  const handleUpdate = async () => {
+    if (!selectedTemplate) return;
+    if (!formData.name || !formData.titleTemplate || !formData.messageTemplate) {
+      toast.error('필수 항목을 입력해주세요');
+      return;
+    }
+
+    try {
+      await updateMutation.mutateAsync({
+        id: selectedTemplate.id,
+        request: {
+          name: formData.name,
+          titleTemplate: formData.titleTemplate,
+          messageTemplate: formData.messageTemplate,
+          description: formData.description || undefined,
+        } as UpdateNotificationTemplateRequest,
+      });
+      toast.success('템플릿이 수정되었습니다');
+      setIsEditDialogOpen(false);
+    } catch {
+      toast.error('템플릿 수정에 실패했습니다');
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('정말 삭제하시겠습니까?')) return;
+
+    try {
+      await deleteMutation.mutateAsync(id);
+      toast.success('템플릿이 삭제되었습니다');
+    } catch {
+      toast.error('템플릿 삭제에 실패했습니다');
+    }
+  };
+
+  const handleToggleActive = async (template: NotificationTemplateResponse) => {
+    try {
+      if (template.isActive) {
+        await deactivateMutation.mutateAsync(template.id);
+        toast.success('템플릿이 비활성화되었습니다');
+      } else {
+        await activateMutation.mutateAsync(template.id);
+        toast.success('템플릿이 활성화되었습니다');
+      }
+    } catch {
+      toast.error('상태 변경에 실패했습니다');
+    }
+  };
+
+  const handleInitialize = async () => {
+    if (!confirm('기본 템플릿을 초기화하시겠습니까? 존재하지 않는 트리거 타입의 템플릿만 생성됩니다.')) return;
+
+    try {
+      await initializeMutation.mutateAsync();
+      toast.success('기본 템플릿이 초기화되었습니다');
+    } catch {
+      toast.error('초기화에 실패했습니다');
+    }
+  };
+
+  // 트리거 타입 선택 시 기본값 설정
+  const handleTriggerChange = (value: string) => {
+    const trigger = triggerTypes.find((t) => t.value === value);
+    if (trigger) {
+      setFormData((prev) => ({
+        ...prev,
+        triggerType: value as NotificationTrigger,
+        name: prev.name || trigger.label,
+      }));
+    }
+  };
+
+  // 사용 가능한 변수 표시
+  const getAvailableVariables = (trigger: NotificationTrigger | '') => {
+    if (!trigger) return [];
+    return TRIGGER_VARIABLES[trigger] || [];
+  };
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="알림 템플릿 관리"
+        description="시스템에서 발송되는 알림 템플릿을 관리합니다"
+        actions={
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={handleInitialize} disabled={initializeMutation.isPending}>
+              <RefreshCw className="mr-2 h-4 w-4" />
+              기본 템플릿 초기화
+            </Button>
+            <Button onClick={handleOpenCreateDialog} disabled={availableTriggers.length === 0}>
+              <Plus className="mr-2 h-4 w-4" />
+              템플릿 추가
+            </Button>
+          </div>
+        }
+      />
+
+      <Tabs value={categoryFilter} onValueChange={setCategoryFilter} className="mb-6">
+        <TabsList>
+          <TabsTrigger value="all">전체</TabsTrigger>
+          <TabsTrigger value="AUTH">인증</TabsTrigger>
+          <TabsTrigger value="NOTIFICATION">알림</TabsTrigger>
+          <TabsTrigger value="MARKETING">마케팅</TabsTrigger>
+          <TabsTrigger value="SYSTEM">시스템</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      <div className="mb-6">
+        <div className="relative w-96">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-secondary" />
+          <Input
+            placeholder="템플릿 검색..."
+            value={searchKeyword}
+            onChange={(e) => setSearchKeyword(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <RefreshCw className="h-8 w-8 animate-spin text-text-secondary" />
+        </div>
+      ) : filteredTemplates.length === 0 ? (
+        <div className="text-center py-12 text-text-secondary">
+          <Bell className="h-12 w-12 mx-auto mb-4 opacity-50" />
+          <p>등록된 템플릿이 없습니다.</p>
+          <p className="text-sm mt-2">기본 템플릿 초기화 버튼을 클릭하여 템플릿을 생성하세요.</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filteredTemplates.map((template) => {
+            const categoryConfig = CATEGORY_CONFIG[template.category];
+            return (
+              <Card key={template.id} className={!template.isActive ? 'opacity-60' : ''}>
+                <CardHeader className="pb-2">
+                  <div className="flex items-start justify-between">
+                    <div className="flex items-center gap-2">
+                      <div className="p-2 bg-bg-secondary rounded-lg">
+                        <Bell className="h-4 w-4 text-text-secondary" />
+                      </div>
+                      <div>
+                        <CardTitle className="text-base">{template.name}</CardTitle>
+                        <code className="text-xs text-text-secondary">{template.triggerType}</code>
+                      </div>
+                    </div>
+                    <Badge className={categoryConfig.color}>{categoryConfig.label}</Badge>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm text-text-secondary mb-3 line-clamp-2">
+                    {template.description || template.titleTemplate}
+                  </p>
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-text-secondary">
+                      수정: {new Date(template.updatedAt).toLocaleDateString()}
+                    </span>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleOpenViewDialog(template)}
+                        title="미리보기"
+                      >
+                        <Eye className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleOpenEditDialog(template)}
+                        title="수정"
+                      >
+                        <Edit className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleToggleActive(template)}
+                        title={template.isActive ? '비활성화' : '활성화'}
+                      >
+                        {template.isActive ? (
+                          <PowerOff className="h-4 w-4 text-orange-500" />
+                        ) : (
+                          <Power className="h-4 w-4 text-green-500" />
+                        )}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDelete(template.id)}
+                        title="삭제"
+                      >
+                        <Trash2 className="h-4 w-4 text-red-500" />
+                      </Button>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      {/* 생성 다이얼로그 */}
+      <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>알림 템플릿 추가</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label>트리거 타입 *</Label>
+              <Select value={formData.triggerType} onValueChange={handleTriggerChange}>
+                <SelectTrigger>
+                  <SelectValue placeholder="트리거 타입 선택" />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableTriggers.map((trigger) => (
+                    <SelectItem key={trigger.value} value={trigger.value}>
+                      {trigger.label} ({trigger.categoryLabel})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>템플릿 이름 *</Label>
+              <Input
+                value={formData.name}
+                onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
+                placeholder="회원가입 환영"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>제목 템플릿 *</Label>
+              <Input
+                value={formData.titleTemplate}
+                onChange={(e) => setFormData((prev) => ({ ...prev, titleTemplate: e.target.value }))}
+                placeholder="회원가입을 환영합니다!"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>메시지 템플릿 *</Label>
+              <Textarea
+                value={formData.messageTemplate}
+                onChange={(e) => setFormData((prev) => ({ ...prev, messageTemplate: e.target.value }))}
+                placeholder="{{userName}}님, 가입을 환영합니다!"
+                rows={4}
+              />
+              {formData.triggerType && getAvailableVariables(formData.triggerType).length > 0 && (
+                <div className="flex items-center gap-2 text-xs text-text-secondary">
+                  <Info className="h-3 w-3" />
+                  사용 가능한 변수: {getAvailableVariables(formData.triggerType).map((v) => `{{${v}}}`).join(', ')}
+                </div>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label>설명</Label>
+              <Input
+                value={formData.description}
+                onChange={(e) => setFormData((prev) => ({ ...prev, description: e.target.value }))}
+                placeholder="새 사용자 회원가입 시 발송"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsCreateDialogOpen(false)}>
+              취소
+            </Button>
+            <Button onClick={handleCreate} disabled={createMutation.isPending}>
+              생성
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* 수정 다이얼로그 */}
+      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>알림 템플릿 수정</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label>트리거 타입</Label>
+              <Input value={selectedTemplate?.triggerDisplayName || ''} disabled />
+            </div>
+            <div className="space-y-2">
+              <Label>템플릿 이름 *</Label>
+              <Input
+                value={formData.name}
+                onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>제목 템플릿 *</Label>
+              <Input
+                value={formData.titleTemplate}
+                onChange={(e) => setFormData((prev) => ({ ...prev, titleTemplate: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>메시지 템플릿 *</Label>
+              <Textarea
+                value={formData.messageTemplate}
+                onChange={(e) => setFormData((prev) => ({ ...prev, messageTemplate: e.target.value }))}
+                rows={4}
+              />
+              {formData.triggerType && getAvailableVariables(formData.triggerType).length > 0 && (
+                <div className="flex items-center gap-2 text-xs text-text-secondary">
+                  <Info className="h-3 w-3" />
+                  사용 가능한 변수: {getAvailableVariables(formData.triggerType).map((v) => `{{${v}}}`).join(', ')}
+                </div>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label>설명</Label>
+              <Input
+                value={formData.description}
+                onChange={(e) => setFormData((prev) => ({ ...prev, description: e.target.value }))}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsEditDialogOpen(false)}>
+              취소
+            </Button>
+            <Button onClick={handleUpdate} disabled={updateMutation.isPending}>
+              저장
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* 미리보기 다이얼로그 */}
+      <Dialog open={isViewDialogOpen} onOpenChange={setIsViewDialogOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>템플릿 미리보기</DialogTitle>
+          </DialogHeader>
+          {selectedTemplate && (
+            <div className="space-y-4 py-4">
+              <div className="p-4 bg-bg-secondary rounded-lg space-y-3">
+                <div>
+                  <span className="text-xs text-text-secondary">트리거 타입</span>
+                  <p className="font-medium">{selectedTemplate.triggerDisplayName}</p>
+                </div>
+                <div>
+                  <span className="text-xs text-text-secondary">제목</span>
+                  <p className="font-medium">{selectedTemplate.titleTemplate}</p>
+                </div>
+                <div>
+                  <span className="text-xs text-text-secondary">메시지</span>
+                  <p className="whitespace-pre-wrap">{selectedTemplate.messageTemplate}</p>
+                </div>
+                {selectedTemplate.description && (
+                  <div>
+                    <span className="text-xs text-text-secondary">설명</span>
+                    <p>{selectedTemplate.description}</p>
+                  </div>
+                )}
+              </div>
+              <div className="flex items-center gap-4 text-sm text-text-secondary">
+                <span>상태: {selectedTemplate.isActive ? '활성' : '비활성'}</span>
+                <span>생성: {new Date(selectedTemplate.createdAt).toLocaleString()}</span>
+                <span>수정: {new Date(selectedTemplate.updatedAt).toLocaleString()}</span>
+              </div>
+            </div>
+          )}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsViewDialogOpen(false)}>
+              닫기
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/routes/ta.routes.tsx
+++ b/src/routes/ta.routes.tsx
@@ -28,6 +28,7 @@ import { EmployeeListPage } from '@/pages/ta/users/EmployeeListPage';
 import { AutoEnrollmentRulesPage } from '@/pages/ta/automation/AutoEnrollmentRulesPage';
 import { MemberPoolPage } from '@/pages/ta/automation/MemberPoolPage';
 import { DepartmentManagementPage } from '@/pages/ta/users/DepartmentManagementPage';
+import { NotificationTemplatesPage } from '@/pages/ta/system/NotificationTemplatesPage';
 
 function TenantAdminWrapper() {
   return (
@@ -46,6 +47,7 @@ const taChildRoutes = (
     <Route path="dashboard" element={<DashboardPage />} />
     {/* 시스템 기반 관리 */}
     <Route path="system/domain" element={<DomainSettingsPage />} />
+    <Route path="system/notification-templates" element={<NotificationTemplatesPage />} />
     {/* 브랜딩 설정 (통합) */}
     <Route path="branding" element={<BrandingSettingsPage />} />
     {/* 사용자 및 권한 */}

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -416,4 +416,15 @@ export const API_ENDPOINTS = {
     TU_BY_ID: (id: number) => `/tu/notices/${id}`,
     TU_COUNT: '/tu/notices/count',
   },
+  // Notification Templates (알림 템플릿) - TA 관리
+  NOTIFICATION_TEMPLATES: {
+    BASE: "/ta/notification-templates",
+    BY_ID: (id: number) => `/ta/notification-templates/${id}`,
+    INITIALIZE: "/ta/notification-templates/initialize",
+    ACTIVATE: (id: number) => `/ta/notification-templates/${id}/activate`,
+    DEACTIVATE: (id: number) => `/ta/notification-templates/${id}/deactivate`,
+    TRIGGERS: "/ta/notification-templates/triggers",
+    CATEGORIES: "/ta/notification-templates/categories",
+  },
 } as const;
+

--- a/src/services/ta/notificationTemplateService.ts
+++ b/src/services/ta/notificationTemplateService.ts
@@ -1,0 +1,112 @@
+/**
+ * 알림 템플릿 API 서비스
+ */
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type {
+  NotificationTemplateResponse,
+  CreateNotificationTemplateRequest,
+  UpdateNotificationTemplateRequest,
+  NotificationCategory,
+  TriggerInfo,
+  CategoryInfo,
+} from '@/types/ta/notificationTemplate.types';
+
+/**
+ * 템플릿 목록 조회
+ */
+export async function getNotificationTemplates(
+  category?: NotificationCategory
+): Promise<NotificationTemplateResponse[]> {
+  const params = category ? { category } : {};
+  const { data } = await axiosInstance.get<NotificationTemplateResponse[]>(
+    API_ENDPOINTS.NOTIFICATION_TEMPLATES.BASE,
+    { params }
+  );
+  return data;
+}
+
+/**
+ * 템플릿 상세 조회
+ */
+export async function getNotificationTemplate(id: number): Promise<NotificationTemplateResponse> {
+  const { data } = await axiosInstance.get<NotificationTemplateResponse>(
+    API_ENDPOINTS.NOTIFICATION_TEMPLATES.BY_ID(id)
+  );
+  return data;
+}
+
+/**
+ * 템플릿 생성
+ */
+export async function createNotificationTemplate(
+  request: CreateNotificationTemplateRequest
+): Promise<NotificationTemplateResponse> {
+  const { data } = await axiosInstance.post<NotificationTemplateResponse>(
+    API_ENDPOINTS.NOTIFICATION_TEMPLATES.BASE,
+    request
+  );
+  return data;
+}
+
+/**
+ * 템플릿 수정
+ */
+export async function updateNotificationTemplate(
+  id: number,
+  request: UpdateNotificationTemplateRequest
+): Promise<NotificationTemplateResponse> {
+  const { data } = await axiosInstance.put<NotificationTemplateResponse>(
+    API_ENDPOINTS.NOTIFICATION_TEMPLATES.BY_ID(id),
+    request
+  );
+  return data;
+}
+
+/**
+ * 템플릿 삭제
+ */
+export async function deleteNotificationTemplate(id: number): Promise<void> {
+  await axiosInstance.delete(API_ENDPOINTS.NOTIFICATION_TEMPLATES.BY_ID(id));
+}
+
+/**
+ * 템플릿 활성화
+ */
+export async function activateNotificationTemplate(id: number): Promise<void> {
+  await axiosInstance.post(API_ENDPOINTS.NOTIFICATION_TEMPLATES.ACTIVATE(id));
+}
+
+/**
+ * 템플릿 비활성화
+ */
+export async function deactivateNotificationTemplate(id: number): Promise<void> {
+  await axiosInstance.post(API_ENDPOINTS.NOTIFICATION_TEMPLATES.DEACTIVATE(id));
+}
+
+/**
+ * 기본 템플릿 초기화
+ */
+export async function initializeDefaultTemplates(): Promise<void> {
+  await axiosInstance.post(API_ENDPOINTS.NOTIFICATION_TEMPLATES.INITIALIZE);
+}
+
+/**
+ * 사용 가능한 트리거 타입 목록 조회
+ */
+export async function getTriggerTypes(): Promise<TriggerInfo[]> {
+  const { data } = await axiosInstance.get<TriggerInfo[]>(
+    API_ENDPOINTS.NOTIFICATION_TEMPLATES.TRIGGERS
+  );
+  return data;
+}
+
+/**
+ * 사용 가능한 카테고리 목록 조회
+ */
+export async function getCategories(): Promise<CategoryInfo[]> {
+  const { data } = await axiosInstance.get<CategoryInfo[]>(
+    API_ENDPOINTS.NOTIFICATION_TEMPLATES.CATEGORIES
+  );
+  return data;
+}

--- a/src/types/ta/notificationTemplate.types.ts
+++ b/src/types/ta/notificationTemplate.types.ts
@@ -1,0 +1,74 @@
+/**
+ * 알림 템플릿 관련 타입 정의
+ */
+
+// 알림 카테고리
+export type NotificationCategory = 'AUTH' | 'NOTIFICATION' | 'MARKETING' | 'SYSTEM';
+
+// 알림 트리거 타입 (작동하는 트리거만)
+export type NotificationTrigger =
+  | 'WELCOME'
+  | 'ENROLLMENT_COMPLETE'
+  | 'COURSE_COMPLETE';
+
+// 트리거 정보
+export interface TriggerInfo {
+  value: NotificationTrigger;
+  label: string;
+  category: NotificationCategory;
+  categoryLabel: string;
+}
+
+// 카테고리 정보
+export interface CategoryInfo {
+  value: NotificationCategory;
+  label: string;
+}
+
+// 알림 템플릿 응답
+export interface NotificationTemplateResponse {
+  id: number;
+  triggerType: NotificationTrigger;
+  triggerDisplayName: string;
+  category: NotificationCategory;
+  categoryDisplayName: string;
+  name: string;
+  titleTemplate: string;
+  messageTemplate: string;
+  description: string | null;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// 템플릿 생성 요청
+export interface CreateNotificationTemplateRequest {
+  triggerType: NotificationTrigger;
+  name: string;
+  titleTemplate: string;
+  messageTemplate: string;
+  description?: string;
+}
+
+// 템플릿 수정 요청
+export interface UpdateNotificationTemplateRequest {
+  name: string;
+  titleTemplate: string;
+  messageTemplate: string;
+  description?: string;
+}
+
+// 카테고리 설정
+export const CATEGORY_CONFIG: Record<NotificationCategory, { label: string; color: string }> = {
+  AUTH: { label: '인증', color: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' },
+  NOTIFICATION: { label: '알림', color: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' },
+  MARKETING: { label: '마케팅', color: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400' },
+  SYSTEM: { label: '시스템', color: 'bg-gray-100 text-gray-700 dark:bg-gray-700/30 dark:text-gray-400' },
+};
+
+// 트리거 타입별 사용 가능한 변수
+export const TRIGGER_VARIABLES: Record<NotificationTrigger, string[]> = {
+  WELCOME: ['userName'],
+  ENROLLMENT_COMPLETE: ['userName', 'courseName'],
+  COURSE_COMPLETE: ['userName', 'courseName'],
+};


### PR DESCRIPTION
## Summary

TA가 알림 템플릿을 관리할 수 있는 UI 페이지를 추가합니다. 회원가입, 수강신청 완료, 강의 완료 시 발송되는 알림의 제목과 내용을 커스터마이징할 수 있습니다.

## Related Issue

- N/A

## Changes

- `NotificationTemplatesPage` 추가 (TA 전용)
- 알림 템플릿 CRUD 기능 구현 (생성, 조회, 수정, 삭제)
- `useNotificationTemplateQueries` 훅 추가 (React Query 통합)
- 알림 템플릿 타입 정의 (`NotificationTrigger`: WELCOME, ENROLLMENT_COMPLETE, COURSE_COMPLETE)
- TA 사이드바에 "알림 템플릿" 메뉴 추가
- 알림 템플릿 API 서비스 레이어 추가

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

- 백엔드 PR과 함께 머지되어야 정상 동작합니다
- 템플릿 편집 시 실시간 미리보기 기능 지원
- 트리거별로 활성화/비활성화 토글 가능
