### PR TITLE
[Fix] CourseTimeCreatePage 렌더링 에러 수정 (courseId → id 매핑)

### DIFF
--- a/src/pages/co/time/CourseTimeCreatePage.tsx
+++ b/src/pages/co/time/CourseTimeCreatePage.tsx
@@ -153,9 +153,14 @@ export function CourseTimeCreatePage({ language = 'ko' }: Readonly<CourseTimeCre
 
   const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
 
-  // 승인된 프로그램 목록
+  // 승인된 프로그램 목록 (백엔드 courseId를 id로 매핑)
   const approvedPrograms = useMemo(() => {
-    return approvedProgramsData?.content ?? [];
+    const content = approvedProgramsData?.content ?? [];
+    // 백엔드에서 courseId로 반환되므로, id 필드가 없으면 courseId를 id로 매핑
+    return content.map((item) => ({
+      ...item,
+      id: item.id ?? (item as unknown as { courseId?: number }).courseId,
+    }));
   }, [approvedProgramsData]);
 
   // DESIGNER 역할 사용자 목록 (강사 후보)


### PR DESCRIPTION
## Summary
- `/megazone/co/times/create` 페이지 접근 시 `Cannot read properties of undefined (reading 'toString')` 에러 수정
- 백엔드 API가 `courseId`로 반환하지만, 프론트엔드에서 `id`를 기대하는 문제 해결
- `useMemo`에서 `courseId`를 `id`로 매핑하여 하위 호환성 유지

## 배경
- Program → Course 통합 작업 후 백엔드 API 응답 구조 변경 (`id` → `courseId`)
- 프론트엔드 일부 코드에서 기존 `id` 필드를 여전히 참조하여 런타임 에러 발생

## 변경 사항
- `CourseTimeCreatePage.tsx`: `approvedPrograms` useMemo에서 `courseId`를 `id`로 매핑

## Test plan
- [ ] `/megazone/co/times/create` 페이지 접근 시 정상 렌더링 확인
- [ ] 교육 과정 선택 드롭다운 정상 동작 확인

related to #428