### PR TITLE
[Fix] 콘텐츠 유형 변경 시 업로드 파일 초기화

### DIFF
--- a/.vite/deps/_metadata.json
+++ b/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "f2bb9759",
+  "configHash": "94dcf27e",
+  "lockfileHash": "d88c39ba",
+  "browserHash": "0a87fcc8",
+  "optimized": {},
+  "chunks": {}
+}

--- a/.vite/deps/package.json
+++ b/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/src/components/domain/tu/content/Step1ContentDefinition.tsx
+++ b/src/components/domain/tu/content/Step1ContentDefinition.tsx
@@ -386,7 +386,7 @@ export function Step1ContentDefinition({ data, onUpdate }: Readonly<Step1Props>)
               <button
                 key={card.type}
                 type="button"
-                onClick={() => onUpdate({ loType: card.type })}
+                onClick={() => onUpdate({ loType: card.type, uploadedFile: undefined, externalUrl: undefined })}
                 className={cn(
                   'p-6 border-2 rounded-lg transition-all hover:border-action-primary cursor-pointer bg-bg-default',
                   isSelected ? 'border-action-primary bg-bg-secondary' : 'border-border'


### PR DESCRIPTION
## Summary
- 콘텐츠 유형 변경 시 uploadedFile, externalUrl 초기화
- 동영상→문서 등 유형 변경 시 이전 파일 정보가 남아있던 버그 수정

## Changes
- `Step1ContentDefinition.tsx`: loType 변경 시 uploadedFile, externalUrl을 undefined로 초기화

## Test plan
- [x] 동영상 파일 업로드 후 문서로 유형 변경 시 파일이 초기화되는지 확인
- [x] 외부 링크 입력 후 다른 유형으로 변경 시 URL이 초기화되는지 확인

Fixes #429