### PR TITLE
[Bug] snapshotId를 CourseTime에서 조회하도록 수정

### DIFF
--- a/src/pages/tu/learning/LearningPlayerPage.tsx
+++ b/src/pages/tu/learning/LearningPlayerPage.tsx
@@ -285,6 +285,14 @@ export function LearningPlayerPage() {
     }
   }, [orderedCurriculumItems, itemId]);
 
+  // 현재 아이템의 완료 상태 동기화
+  useEffect(() => {
+    if (currentItemId && progressRecords.length > 0) {
+      const itemProgress = progressRecords.find((r) => r.itemId === currentItemId);
+      setIsCompleted(itemProgress?.completed ?? false);
+    }
+  }, [currentItemId, progressRecords]);
+
   // 진도 저장 (임시 비활성화)
   const saveProgress = useCallback(async () => {
     // TODO: 테스트 후 다시 활성화

--- a/src/services/tu/enrollmentService.ts
+++ b/src/services/tu/enrollmentService.ts
@@ -5,7 +5,6 @@ import type {
   EnrollmentWithCurriculumResponse,
   EnrollmentPlayerData,
 } from '@/types/tu';
-import type { ProgramDetailResponse } from '@/types/common';
 
 /**
  * 수강 신청 상태
@@ -37,6 +36,8 @@ interface BackendCourseTimeResponse {
   programName: string | null;
   classStartDate: string;
   classEndDate: string;
+  snapshotId: number | null;
+  courseTitle: string | null;
 }
 
 /**
@@ -282,39 +283,20 @@ export const enrollmentService = {
 
   /**
    * 학습 플레이어용 Enrollment 데이터 조회
-   * - Enrollment + CourseTime + Program 정보를 조합하여 snapshotId까지 획득
+   * - Enrollment + CourseTime 정보를 조합하여 snapshotId까지 획득
    */
   getEnrollmentForPlayer: async (enrollmentId: number): Promise<EnrollmentPlayerData> => {
     // 1. 수강 정보 조회
-    // axiosInstance가 ApiResponse wrapper를 자동으로 언래핑하므로 .data만 사용
     const enrollmentRes = await axiosInstance.get<BackendEnrollmentResponse>(
       API_ENDPOINTS.ENROLLMENTS.BY_ID(enrollmentId)
     );
     const enrollment = enrollmentRes.data;
 
-    // 2. 차수(CourseTime) 정보 조회 - programId 획득
+    // 2. 차수(CourseTime) 정보 조회 - snapshotId 포함
     const courseTimeRes = await axiosInstance.get<BackendCourseTimeResponse>(
       API_ENDPOINTS.TIMES.BY_ID(enrollment.courseTimeId)
     );
     const courseTime = courseTimeRes.data;
-
-    // 3. 프로그램(Program) 정보 조회 - snapshotId 획득
-    let snapshotId = 0;
-    let programTitle = courseTime.programName ?? '';
-
-    if (courseTime.programId) {
-      try {
-        const programRes = await axiosInstance.get<ProgramDetailResponse>(
-          API_ENDPOINTS.PROGRAMS.BY_ID(courseTime.programId)
-        );
-        const program = programRes.data;
-        snapshotId = program.snapshotId ?? 0;
-        programTitle = program.title ?? programTitle;
-      } catch {
-        // 프로그램 조회 실패 시 snapshotId는 0으로 유지
-        console.warn('Failed to fetch program for player:', courseTime.programId);
-      }
-    }
 
     return {
       enrollmentId: enrollment.id,
@@ -322,8 +304,8 @@ export const enrollmentService = {
       courseTimeId: enrollment.courseTimeId,
       courseTimeName: courseTime.title,
       programId: courseTime.programId ?? 0,
-      programTitle,
-      snapshotId,
+      programTitle: courseTime.courseTitle ?? courseTime.programName ?? '',
+      snapshotId: courseTime.snapshotId ?? 0,
       status: enrollment.status,
       progressPercent: enrollment.progressPercent ?? 0,
       enrolledAt: enrollment.enrolledAt,


### PR DESCRIPTION
## 개요
학습 상세 페이지에서 "과정에 스냅샷이 연결되지 않았습니다" 오류를 수정합니다.

## 변경 사항
- `BackendCourseTimeResponse` 타입에 `snapshotId`, `courseTitle` 필드 추가
- `getEnrollmentForPlayer`에서 Program 대신 CourseTime의 `snapshotId` 사용
- 플레이어 페이지 로드 시 완료 상태 동기화 추가

## 관련 이슈
- closes #432