### PR TITLE
fix: 커뮤니티 페이지 React key 중복 경고 수정

### DIFF
--- a/src/pages/tu/main/CommunityPage.tsx
+++ b/src/pages/tu/main/CommunityPage.tsx
@@ -660,9 +660,9 @@ export function CommunityPage() {
                       이 태그를 관심 태그에 추가할까요?
                     </p>
                     <div className="flex flex-wrap gap-2">
-                      {pendingTags.map((tag) => (
+                      {pendingTags.map((tag, index) => (
                         <div
-                          key={tag}
+                          key={`pending-${tag}-${index}`}
                           className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-xs font-medium ${
                             isDark ? 'bg-white/10 text-gray-300' : 'bg-gray-100 text-gray-600'
                           }`}
@@ -703,9 +703,9 @@ export function CommunityPage() {
                       <Hash className="w-3 h-3" /> 나의 관심 태그
                     </p>
                     <div className="flex flex-wrap gap-2">
-                      {userInterestTags.map((tag) => (
+                      {userInterestTags.map((tag, index) => (
                         <div
-                          key={tag}
+                          key={`interest-${tag}-${index}`}
                           className={`group flex items-center gap-1 px-3 py-1.5 rounded-full text-xs font-medium transition-all ${
                             isDark
                               ? 'bg-[#6778ff]/20 text-[#6778ff]'
@@ -750,9 +750,9 @@ export function CommunityPage() {
                               {post.title}
                             </span>
                             <div className="flex items-center gap-2 mt-1">
-                              {post.tags?.slice(0, 2).map((tag) => (
+                              {post.tags?.slice(0, 2).map((tag, tagIndex) => (
                                 <span
-                                  key={tag}
+                                  key={`${post.id}-tag-${tagIndex}`}
                                   className={`text-[10px] px-1.5 py-0.5 rounded ${
                                     userInterestTags.includes(tag)
                                       ? isDark ? 'bg-[#6778ff]/20 text-[#6778ff]' : 'bg-[#6778ff]/10 text-[#6778ff]'

--- a/src/pages/tu/mypage/MyPageHome.tsx
+++ b/src/pages/tu/mypage/MyPageHome.tsx
@@ -104,7 +104,6 @@ export function MyPageHome() {
     const fetchCourseRoles = async () => {
       try {
         const roles = await userService.getMyCourseRoles();
-        console.log('MyPageHome - CourseRoles API response:', roles);
 
         if (Array.isArray(roles) && roles.length > 0) {
           // OWNER가 있으면 → 강의 소유자 (승인된 강의 있음)


### PR DESCRIPTION
## Summary

커뮤니티 페이지에서 발생하던 React key 중복 경고를 수정하고, 마이페이지 불필요한 console.log를 제거했습니다.

## Related Issue

- Closes #

## Changes

- `CommunityPage.tsx`: pendingTags, userInterestTags, post.tags map에 고유 key 추가
- `MyPageHome.tsx`: 불필요한 console.log 제거

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [x] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes

- 중복 태그가 있을 경우 발생하던 React key 경고 해결