### PR TITLE
[Feat] courseService API 메서드 정비 (ready/register 분리)

### DIFF
--- a/src/hooks/tu/useCourseQueries.ts
+++ b/src/hooks/tu/useCourseQueries.ts
@@ -10,7 +10,6 @@ import type {
 import type {
   UpdateCourseRequest,
   RegisterCourseRequest,
-  UnreadyCourseRequest,
 } from '@/types/common/course.types';
 
 // Query Keys
@@ -177,17 +176,16 @@ export const useRegisterCourse = () => {
 };
 
 /**
- * 과정 반려 (READY → REJECTED)
- * @deprecated useRejectProgram 대체
+ * 과정 작성중으로 되돌리기 (READY → DRAFT)
+ * TU가 자신의 과정을 다시 수정할 때 사용
  */
 export const useUnreadyCourse = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, request }: { id: number; request: UnreadyCourseRequest }) =>
-      courseService.unready(id, request),
-    onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: courseRegistrationKeys.detail(variables.id) });
+    mutationFn: (id: number) => courseService.unready(id),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: courseRegistrationKeys.detail(id) });
       queryClient.invalidateQueries({ queryKey: courseRegistrationKeys.lists() });
       queryClient.invalidateQueries({ queryKey: courseRegistrationKeys.readyLists() });
     },

--- a/src/pages/co/course/CourseDetailPage.tsx
+++ b/src/pages/co/course/CourseDetailPage.tsx
@@ -131,10 +131,8 @@ export function CourseDetailPage({ language = 'ko' }: Readonly<CourseDetailPageP
       return;
     }
     try {
-      await unreadyCourse.mutateAsync({
-        id: courseId,
-        request: { reason: rejectReason },
-      });
+      // TODO: 백엔드에서 반려 사유 저장 기능 추가 시 reason 전달
+      await unreadyCourse.mutateAsync(courseId);
       setShowRejectModal(false);
       setRejectReason('');
     } catch (err) {

--- a/src/pages/co/course/CourseListPage.tsx
+++ b/src/pages/co/course/CourseListPage.tsx
@@ -226,10 +226,8 @@ export function CourseListPage({ language = 'ko' }: Readonly<CourseListPageProps
       return;
     }
     try {
-      await unreadyCourse.mutateAsync({
-        id: selectedCourse.id,
-        request: { reason: rejectReason },
-      });
+      // TODO: 백엔드에서 반려 사유 저장 기능 추가 시 reason 전달
+      await unreadyCourse.mutateAsync(selectedCourse.id);
       setShowRejectModal(false);
       setSelectedCourse(null);
       setRejectReason('');

--- a/src/pages/co/course/CoursePendingPage.tsx
+++ b/src/pages/co/course/CoursePendingPage.tsx
@@ -185,10 +185,8 @@ export function CoursePendingPage({ language = 'ko' }: Readonly<CoursePendingPag
       return;
     }
     try {
-      await unreadyCourse.mutateAsync({
-        id: selectedCourse.id,
-        request: { reason: rejectReason },
-      });
+      // TODO: 백엔드에서 반려 사유 저장 기능 추가 시 reason 전달
+      await unreadyCourse.mutateAsync(selectedCourse.id);
       setShowRejectModal(false);
       setSelectedCourse(null);
       setRejectReason('');

--- a/src/services/common/courseService.ts
+++ b/src/services/common/courseService.ts
@@ -22,7 +22,6 @@ import type {
   CourseRegistrationDetailResponse,
   ReadyCourseResponse,
   RegisterCourseRequest,
-  UnreadyCourseRequest,
 } from '@/types/common/course.types';
 
 // Spring Page 응답 타입
@@ -113,16 +112,25 @@ export const courseService = {
     await axiosInstance.delete(API_ENDPOINTS.COURSES.BY_ID(id));
   },
 
-  /** 강의 발행 */
+  /**
+   * @deprecated 백엔드에서 deprecated됨. ready() 또는 register() 사용 권장.
+   * 임시저장: create/update 사용
+   * 작성완료: ready() 사용
+   * 등록: register() 사용
+   */
   async publish(id: number): Promise<CourseResponse> {
+    console.warn('[courseService] publish()는 deprecated되었습니다. ready() 또는 register()를 사용하세요.');
     const { data } = await axiosInstance.post<CourseResponse>(
       `${API_ENDPOINTS.COURSES.BY_ID(id)}/publish`
     );
     return data;
   },
 
-  /** 강의 발행 취소 */
+  /**
+   * @deprecated 백엔드에서 deprecated됨. unready() 사용 권장.
+   */
   async unpublish(id: number): Promise<CourseResponse> {
+    console.warn('[courseService] unpublish()는 deprecated되었습니다. unready()를 사용하세요.');
     const { data } = await axiosInstance.post<CourseResponse>(
       `${API_ENDPOINTS.COURSES.BY_ID(id)}/unpublish`
     );
@@ -303,15 +311,12 @@ export const courseService = {
   },
 
   /**
-   * 과정 반려 (READY → REJECTED)
+   * 과정 작성중으로 되돌리기 (READY → DRAFT)
+   * TU가 자신의 과정을 다시 수정할 때 사용
    */
-  async unready(
-    id: number,
-    request: UnreadyCourseRequest
-  ): Promise<CourseRegistrationResponse> {
-    const { data } = await axiosInstance.post<CourseRegistrationResponse>(
-      API_ENDPOINTS.COURSES.UNREADY(id),
-      request
+  async unready(id: number): Promise<CourseResponse> {
+    const { data } = await axiosInstance.post<CourseResponse>(
+      API_ENDPOINTS.COURSES.UNREADY(id)
     );
     return data;
   },


### PR DESCRIPTION
## Summary
- `publish()`, `unpublish()` 메서드에 deprecated 표시 및 warning 추가
- `unready()` 메서드를 백엔드 API에 맞게 수정 (request 파라미터 제거)
- 미사용 `UnreadyCourseRequest` import 제거

## Test plan
- [ ] 기존 코드에서 `publish()`, `unpublish()` 호출 시 콘솔 warning 확인
- [ ] `ready()`, `register()`, `unready()` API 호출 정상 동작 확인

Closes #436