### PR TITLE
feat: GlobalRoleSwitcher - TA/CO/TU 간 역할 전환 기능 (#444)

### DIFF
--- a/src/components/layout/co/CourseOperatorSidebar/CourseOperatorSidebar.tsx
+++ b/src/components/layout/co/CourseOperatorSidebar/CourseOperatorSidebar.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { BaseSidebar } from '../../common/BaseSidebar';
 import { courseOperatorMenuData, roleLabels } from '@/config/sidebar-menus';
 import { usePublicLayout } from '@/hooks/tu';
+import { useAuthStore } from '@/store/common/authStore';
 import type { MenuItem } from '@/types';
 
 interface CourseOperatorSidebarProps {
@@ -25,6 +26,12 @@ interface BrandingSidebarItem {
 export function CourseOperatorSidebar(props: CourseOperatorSidebarProps) {
   const { data: layoutData } = usePublicLayout();
   const sidebarSettings = layoutData?.sidebarCOSettings as { enabled?: boolean; items?: BrandingSidebarItem[] } | undefined;
+
+  // 사용자 역할 가져오기
+  const userRole = useAuthStore((state) => state.user?.role);
+
+  // TENANT_ADMIN만 글로벌 역할 스위처 표시
+  const showGlobalRoleSwitcher = userRole === 'TENANT_ADMIN';
 
   // 브랜딩 설정을 기반으로 메뉴 필터링
   const filteredMenuData = useMemo((): MenuItem[] => {
@@ -60,6 +67,7 @@ export function CourseOperatorSidebar(props: CourseOperatorSidebarProps) {
       {...props}
       menuData={filteredMenuData}
       roleLabel={roleLabels.courseOperator}
+      showGlobalRoleSwitcher={showGlobalRoleSwitcher}
       roleType="co"
     />
   );

--- a/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
+++ b/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
@@ -8,6 +8,7 @@ import {
   PanelLeft,
   GraduationCap,
   LogOut,
+  ArrowLeft,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import type { BaseSidebarProps, SidebarColors } from '@/types';
@@ -15,6 +16,7 @@ import { designTokens } from '@/styles/admin-design-tokens';
 import { cn } from '@/utils/cn';
 import { useTenantBranding } from '@/contexts/TenantBrandingContext';
 import { ModeSwitcher, type ViewMode } from '../ModeSwitcher';
+import { GlobalRoleSwitcher, type GlobalRole } from '../GlobalRoleSwitcher';
 import { useAuthStore } from '@/store/common/authStore';
 import { authService } from '@/services/common/authService';
 import { useSubdomainPath } from '@/hooks/common';
@@ -31,9 +33,11 @@ export function BaseSidebar({
   menuData,
   roleLabel,
   showModeSwitcher = false,
+  showGlobalRoleSwitcher = false,
   currentMode = 'instructor',
   roleType = 'tu',
-}: BaseSidebarProps & { showModeSwitcher?: boolean; currentMode?: ViewMode; roleType?: RoleType }) {
+  showBackToTA = false,
+}: BaseSidebarProps & { showModeSwitcher?: boolean; showGlobalRoleSwitcher?: boolean; currentMode?: ViewMode; roleType?: RoleType }) {
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();
@@ -82,6 +86,15 @@ export function BaseSidebar({
 
   // 어드민 역할 여부 (SA, TA, CO)
   const isAdminRole = roleType === 'sa' || roleType === 'ta' || roleType === 'co';
+
+  // 글로벌 역할 타입 매핑
+  const globalRoleMap: Record<RoleType, GlobalRole> = {
+    sa: 'TA', // SA는 TA로 매핑 (SA에서는 글로벌 스위처 안 씀)
+    ta: 'TA',
+    co: 'CO',
+    tu: 'TU',
+  };
+  const currentGlobalRole = globalRoleMap[roleType];
 
   // 로그아웃 핸들러
   const handleLogout = async () => {
@@ -227,8 +240,8 @@ export function BaseSidebar({
               >
                 {platformName}
               </h1>
-              {/* TU는 모드 스위처로 대체, 나머지 역할은 라벨 표시 */}
-              {!showModeSwitcher && (
+              {/* 모드 스위처나 글로벌 역할 스위처가 없을 때만 라벨 표시 */}
+              {!showModeSwitcher && !showGlobalRoleSwitcher && (
                 <p
                   className="text-xs whitespace-nowrap"
                   style={{ color: colors.textSecondary }}
@@ -249,6 +262,19 @@ export function BaseSidebar({
               language={language}
               colors={colors}
               onModeChange={handleModeChange}
+              isDarkMode={isDarkMode}
+            />
+          </div>
+        )}
+
+        {/* Global Role Switcher (TA, CO, TU 간 전환) */}
+        {showGlobalRoleSwitcher && (
+          <div className={cn('mb-3', !isExpanded && 'flex justify-center')}>
+            <GlobalRoleSwitcher
+              currentRole={currentGlobalRole}
+              isExpanded={isExpanded}
+              language={language}
+              colors={colors}
               isDarkMode={isDarkMode}
             />
           </div>
@@ -471,6 +497,44 @@ export function BaseSidebar({
             borderTop: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.1)' : colors.border}`,
           }}
         >
+          {/* Back to TA Button (TENANT_ADMIN이 TU/CO 페이지 접근 시) */}
+          {showBackToTA && (
+            <button
+              onClick={() => navigate(prefixPath('/ta/dashboard'))}
+              className="flex items-center rounded-xl transition-all duration-300 overflow-hidden"
+              style={{
+                width: isExpanded ? '100%' : '44px',
+                height: '44px',
+                padding: isExpanded ? '0 16px' : '0',
+                justifyContent: 'center',
+                color: colors.textPrimary,
+                margin: isExpanded ? '0' : '0 auto',
+                backgroundColor: isDarkMode ? 'rgba(99, 102, 241, 0.2)' : 'rgba(99, 102, 241, 0.1)',
+                border: `1px solid ${isDarkMode ? 'rgba(99, 102, 241, 0.4)' : 'rgba(99, 102, 241, 0.3)'}`,
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.backgroundColor = isDarkMode ? 'rgba(99, 102, 241, 0.3)' : 'rgba(99, 102, 241, 0.2)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.backgroundColor = isDarkMode ? 'rgba(99, 102, 241, 0.2)' : 'rgba(99, 102, 241, 0.1)';
+              }}
+              title={language === 'ko' ? 'TA로 돌아가기' : 'Back to TA'}
+            >
+              <ArrowLeft
+                className="w-5 h-5 flex-shrink-0"
+                style={{ color: isDarkMode ? '#a5b4fc' : '#6366f1' }}
+              />
+              {isExpanded && (
+                <span
+                  className="flex-1 text-left text-sm font-medium whitespace-nowrap ml-3"
+                  style={{ color: isDarkMode ? '#a5b4fc' : '#6366f1' }}
+                >
+                  {language === 'ko' ? 'TA로 돌아가기' : 'Back to TA'}
+                </span>
+              )}
+            </button>
+          )}
+
           {/* Logout Button */}
           <button
             onClick={handleLogout}

--- a/src/components/layout/common/GlobalRoleSwitcher/GlobalRoleSwitcher.tsx
+++ b/src/components/layout/common/GlobalRoleSwitcher/GlobalRoleSwitcher.tsx
@@ -1,0 +1,256 @@
+import { useState, useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ChevronDown, Shield, Briefcase, GraduationCap } from 'lucide-react';
+import type { SidebarColors } from '@/types';
+import { cn } from '@/utils/cn';
+import { useSubdomainPath } from '@/hooks/common';
+import { useAuthStore } from '@/store/common/authStore';
+
+// 글로벌 역할 타입 (TA, CO, TU)
+export type GlobalRole = 'TA' | 'CO' | 'TU';
+
+interface GlobalRoleSwitcherProps {
+  currentRole: GlobalRole;
+  isExpanded: boolean;
+  language: 'ko' | 'en';
+  colors: SidebarColors;
+  isDarkMode?: boolean;
+}
+
+// 역할별 아이콘
+const roleIcons: Record<GlobalRole, typeof Shield> = {
+  TA: Shield,
+  CO: Briefcase,
+  TU: GraduationCap,
+};
+
+// 역할별 라벨
+const roleLabels: Record<GlobalRole, { ko: string; en: string }> = {
+  TA: { ko: '테넌트 관리자', en: 'Tenant Admin' },
+  CO: { ko: '교육 운영자', en: 'Course Operator' },
+  TU: { ko: '강의 관리자', en: 'Course Manager' },
+};
+
+// 역할별 기본 경로
+const roleDefaultPaths: Record<GlobalRole, string> = {
+  TA: '/ta/dashboard',
+  CO: '/co/dashboard',
+  TU: '/tu/dashboard',
+};
+
+export function GlobalRoleSwitcher({
+  currentRole,
+  isExpanded,
+  language,
+  colors,
+  isDarkMode = true,
+}: GlobalRoleSwitcherProps) {
+  const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // 사용자의 역할 가져오기 (현재는 단일 role, 향후 roles 배열로 확장 가능)
+  const userRole = useAuthStore((state) => state.user?.role);
+  const userRoles = useAuthStore((state) => state.user?.roles) as string[] | undefined;
+
+  // 외부 클릭 시 드롭다운 닫기
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // 사용자가 가진 역할만 표시
+  const availableRoles: GlobalRole[] = (() => {
+    const roles: GlobalRole[] = [];
+
+    // roles 배열이 있으면 사용 (1:N 관계 지원)
+    if (userRoles && userRoles.length > 0) {
+      if (userRoles.includes('TENANT_ADMIN')) {
+        roles.push('TA');
+      }
+      if (userRoles.includes('OPERATOR') || userRoles.includes('TENANT_ADMIN')) {
+        roles.push('CO');
+      }
+      roles.push('TU');
+      return roles;
+    }
+
+    // 단일 role 기반 (기존 호환)
+    if (userRole === 'TENANT_ADMIN') {
+      roles.push('TA', 'CO', 'TU');
+    } else if (userRole === 'OPERATOR') {
+      roles.push('CO', 'TU');
+    } else {
+      // 기본: 현재 역할만
+      return [currentRole];
+    }
+
+    return roles;
+  })();
+
+  const CurrentIcon = roleIcons[currentRole];
+
+  const handleRoleChange = (role: GlobalRole) => {
+    if (role !== currentRole) {
+      navigate(prefixPath(roleDefaultPaths[role]));
+    }
+    setIsOpen(false);
+  };
+
+  // 접힌 상태 - 아이콘만 표시
+  if (!isExpanded) {
+    return (
+      <div ref={dropdownRef} className="relative">
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          className="w-11 h-11 rounded-xl flex items-center justify-center transition-all duration-200"
+          style={{
+            backgroundColor: isDarkMode ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.05)',
+            color: colors.textPrimary,
+          }}
+          title={roleLabels[currentRole][language]}
+        >
+          <CurrentIcon className="w-5 h-5" />
+        </button>
+
+        {/* 드롭다운 메뉴 (접힌 상태) */}
+        {isOpen && (
+          <div
+            className="absolute left-full top-0 ml-2 z-50 min-w-[180px] py-2 rounded-xl shadow-lg border"
+            style={{
+              backgroundColor: colors.tooltipBg,
+              borderColor: colors.border,
+            }}
+          >
+            <div
+              className="px-3 py-1.5 text-xs border-b mb-1"
+              style={{
+                color: colors.textSecondary,
+                borderColor: isDarkMode ? 'rgba(255,255,255,0.1)' : colors.border,
+              }}
+            >
+              {language === 'ko' ? '역할 전환' : 'Switch Role'}
+            </div>
+            {availableRoles.map((role) => {
+              const Icon = roleIcons[role];
+              const isActive = currentRole === role;
+
+              return (
+                <button
+                  key={role}
+                  onClick={() => handleRoleChange(role)}
+                  className="w-full flex items-center gap-3 px-3 py-2.5 transition-all text-sm"
+                  style={{
+                    backgroundColor: isActive ? colors.activeBg : 'transparent',
+                    color: isActive ? colors.activeText : colors.textPrimary,
+                  }}
+                  onMouseEnter={(e) => {
+                    if (!isActive) {
+                      e.currentTarget.style.backgroundColor = colors.hover;
+                    }
+                  }}
+                  onMouseLeave={(e) => {
+                    if (!isActive) {
+                      e.currentTarget.style.backgroundColor = 'transparent';
+                    }
+                  }}
+                >
+                  <Icon className="w-4 h-4" style={{ color: isActive ? colors.activeText : colors.textSecondary }} />
+                  <span>{roleLabels[role][language]}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // 펼친 상태 - 드롭다운 버튼
+  return (
+    <div ref={dropdownRef} className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className={cn(
+          'w-full flex items-center gap-3 px-4 py-3 rounded-xl transition-all duration-200',
+          'border'
+        )}
+        style={{
+          backgroundColor: isDarkMode ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.03)',
+          borderColor: isDarkMode ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.08)',
+          color: colors.textPrimary,
+        }}
+      >
+        <CurrentIcon className="w-5 h-5" style={{ color: colors.textSecondary }} />
+        <span className="flex-1 text-left text-sm font-medium">
+          {roleLabels[currentRole][language]}
+        </span>
+        <ChevronDown
+          className={cn('w-4 h-4 transition-transform duration-200', isOpen && 'rotate-180')}
+          style={{ color: colors.textSecondary }}
+        />
+      </button>
+
+      {/* 드롭다운 메뉴 (펼친 상태) */}
+      {isOpen && (
+        <div
+          className="absolute top-full left-0 right-0 mt-2 z-50 py-1 rounded-xl shadow-lg border"
+          style={{
+            backgroundColor: colors.tooltipBg,
+            borderColor: colors.border,
+          }}
+        >
+          {availableRoles.map((role) => {
+            const Icon = roleIcons[role];
+            const isActive = currentRole === role;
+
+            return (
+              <button
+                key={role}
+                onClick={() => handleRoleChange(role)}
+                className="w-full flex items-center gap-3 px-4 py-3 transition-all text-sm"
+                style={{
+                  backgroundColor: isActive ? colors.activeBg : 'transparent',
+                  color: isActive ? colors.activeText : colors.textPrimary,
+                }}
+                onMouseEnter={(e) => {
+                  if (!isActive) {
+                    e.currentTarget.style.backgroundColor = colors.hover;
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (!isActive) {
+                    e.currentTarget.style.backgroundColor = 'transparent';
+                  }
+                }}
+              >
+                <Icon
+                  className="w-5 h-5"
+                  style={{ color: isActive ? colors.activeText : colors.textSecondary }}
+                />
+                <span className="flex-1 text-left font-medium">
+                  {roleLabels[role][language]}
+                </span>
+                {isActive && (
+                  <span className="text-xs px-2 py-0.5 rounded-full" style={{
+                    backgroundColor: isDarkMode ? 'rgba(124, 92, 191, 0.3)' : 'rgba(76, 45, 154, 0.1)',
+                    color: isDarkMode ? '#C4B5FD' : '#4C2D9A',
+                  }}>
+                    {language === 'ko' ? '현재' : 'Current'}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/common/GlobalRoleSwitcher/index.ts
+++ b/src/components/layout/common/GlobalRoleSwitcher/index.ts
@@ -1,0 +1,1 @@
+export { GlobalRoleSwitcher, type GlobalRole } from './GlobalRoleSwitcher';

--- a/src/components/layout/ta/TenantAdminSidebar/TenantAdminSidebar.tsx
+++ b/src/components/layout/ta/TenantAdminSidebar/TenantAdminSidebar.tsx
@@ -1,5 +1,23 @@
-import { BaseSidebar } from '../../common/BaseSidebar';
-import { tenantAdminMenuData, roleLabels } from '@/config/sidebar-menus';
+import { useState, useEffect, useMemo } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  ChevronDown,
+  ChevronRight,
+  PanelLeftClose,
+  PanelLeft,
+  GraduationCap,
+  LogOut,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import type { SidebarColors } from '@/types';
+import { designTokens } from '@/styles/admin-design-tokens';
+import { cn } from '@/utils/cn';
+import { useTenantBranding } from '@/contexts/TenantBrandingContext';
+import { GlobalRoleSwitcher } from '../../common/GlobalRoleSwitcher';
+import { useAuthStore } from '@/store/common/authStore';
+import { authService } from '@/services/common/authService';
+import { tenantAdminMenuData } from '@/config/sidebar-menus';
 
 interface TenantAdminSidebarProps {
   isExpanded: boolean;
@@ -9,13 +27,499 @@ interface TenantAdminSidebarProps {
   language?: 'ko' | 'en';
 }
 
-export function TenantAdminSidebar(props: TenantAdminSidebarProps) {
+export function TenantAdminSidebar({
+  isExpanded,
+  onToggle,
+  onMenuItemClick,
+  isDarkMode = true,
+  language = 'ko',
+}: TenantAdminSidebarProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const queryClient = useQueryClient();
+
+  const [expandedItems, setExpandedItems] = useState<string[]>([]);
+  const [activeItem, setActiveItem] = useState<string>('dashboard');
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  // 인증 스토어
+  const { refreshToken, logout } = useAuthStore();
+
+  // 테넌트 브랜딩
+  const { branding } = useTenantBranding();
+
+  // 현재 경로에 맞는 메뉴 아이템 찾기
+  const findActiveMenuItem = useMemo(() => {
+    const { pathname } = location;
+
+    for (const item of tenantAdminMenuData) {
+      if (item.subItems) {
+        for (const subItem of item.subItems) {
+          if (subItem.path && pathname.startsWith(subItem.path)) {
+            return { itemId: subItem.id, parentId: item.id };
+          }
+        }
+      }
+
+      if (item.path && pathname.startsWith(item.path)) {
+        return { itemId: item.id, parentId: null };
+      }
+    }
+
+    return { itemId: 'dashboard', parentId: null };
+  }, [location.pathname]);
+
+  // URL 변경 시 활성 상태 동기화
+  useEffect(() => {
+    setActiveItem(findActiveMenuItem.itemId);
+
+    if (findActiveMenuItem.parentId && !expandedItems.includes(findActiveMenuItem.parentId)) {
+      setExpandedItems(prev => [...prev, findActiveMenuItem.parentId!]);
+    }
+  }, [findActiveMenuItem]);
+
+  // 로그아웃 핸들러
+  const handleLogout = async () => {
+    if (isLoggingOut) return;
+
+    setIsLoggingOut(true);
+    try {
+      if (refreshToken) {
+        await authService.logout(refreshToken);
+      }
+    } catch (error) {
+      console.error('Logout error:', error);
+    } finally {
+      logout();
+      queryClient.clear();
+      toast.success(language === 'ko' ? '로그아웃되었습니다.' : 'Logged out successfully.');
+      navigate('/admin/login');
+      setIsLoggingOut(false);
+    }
+  };
+
+  const logoUrl = (isDarkMode ? branding?.darkLogoUrl : branding?.logoUrl) || branding?.logoUrl;
+  const platformName = branding?.tenantName || 'Learning Hub';
+
+  // Color tokens
+  const colors: SidebarColors = isDarkMode
+    ? {
+        bg: designTokens.darkMode.bg,
+        border: designTokens.darkMode.border,
+        textPrimary: designTokens.darkMode.textPrimary,
+        textSecondary: designTokens.darkMode.textSecondary,
+        hover: designTokens.darkMode.hover,
+        activeBg: designTokens.darkMode.activeBg,
+        activeText: designTokens.darkMode.activeText,
+        tooltipBg: designTokens.darkMode.tooltipBg,
+      }
+    : {
+        bg: designTokens.lightMode.bg,
+        border: designTokens.lightMode.border,
+        textPrimary: designTokens.lightMode.textPrimary,
+        textSecondary: designTokens.lightMode.textSecondary,
+        hover: designTokens.lightMode.hover,
+        activeBg: designTokens.lightMode.activeBg,
+        activeText: designTokens.lightMode.activeText,
+        tooltipBg: designTokens.lightMode.tooltipBg,
+      };
+
+  const toggleExpand = (itemId: string) => {
+    setExpandedItems((prev) =>
+      prev.includes(itemId)
+        ? prev.filter((id) => id !== itemId)
+        : [...prev, itemId]
+    );
+  };
+
+  const handleItemClick = (itemId: string, hasSubItems: boolean) => {
+    if (hasSubItems) {
+      toggleExpand(itemId);
+    } else {
+      setActiveItem(itemId);
+      if (onMenuItemClick) {
+        onMenuItemClick(itemId);
+      }
+    }
+  };
+
+  const handleSubItemClick = (subItemId: string, parentId: string) => {
+    setActiveItem(subItemId);
+    if (!expandedItems.includes(parentId)) {
+      setExpandedItems([...expandedItems, parentId]);
+    }
+    if (onMenuItemClick) {
+      onMenuItemClick(subItemId);
+    }
+  };
+
   return (
-    <BaseSidebar
-      {...props}
-      menuData={tenantAdminMenuData}
-      roleLabel={roleLabels.tenantAdmin}
-      roleType="ta"
-    />
+    <aside
+      className="flex-shrink-0 transition-all duration-300"
+      style={{
+        width: isExpanded ? '300px' : '84px',
+        padding: isExpanded ? '16px' : '8px',
+        backgroundColor: isDarkMode ? '#1e1e1e' : designTokens.bg.app_default,
+      }}
+    >
+      <div
+        className={cn(
+          'rounded-2xl h-full flex flex-col',
+          isExpanded ? 'p-4' : 'py-3 px-2',
+          isDarkMode
+            ? 'bg-white/5 border border-white/10 backdrop-blur-sm'
+            : 'bg-white border border-gray-200 shadow-sm'
+        )}
+      >
+        {/* Logo Section */}
+        <div
+          className={cn(
+            'flex items-center gap-3 mb-4',
+            !isExpanded && 'justify-center'
+          )}
+        >
+          {logoUrl ? (
+            <img
+              src={logoUrl}
+              alt={platformName}
+              className="w-10 h-10 rounded-xl object-contain flex-shrink-0"
+            />
+          ) : (
+            <div
+              className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
+              style={{
+                background: 'linear-gradient(135deg, #667EEA 0%, #764BA2 100%)',
+              }}
+            >
+              <GraduationCap size={22} color="#FFFFFF" />
+            </div>
+          )}
+          {isExpanded && (
+            <div className="overflow-hidden">
+              <h1
+                className="text-lg font-semibold whitespace-nowrap"
+                style={{ color: colors.textPrimary }}
+              >
+                {platformName}
+              </h1>
+            </div>
+          )}
+        </div>
+
+        {/* Global Role Switcher (TA/CO/TU 전환) */}
+        <div className={cn('mb-3', !isExpanded && 'flex justify-center')}>
+          <GlobalRoleSwitcher
+            currentRole="TA"
+            isExpanded={isExpanded}
+            language={language}
+            colors={colors}
+            isDarkMode={isDarkMode}
+          />
+        </div>
+
+        {/* Divider */}
+        <div
+          className="mb-4"
+          style={{
+            borderBottom: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.1)' : colors.border}`,
+          }}
+        />
+
+        {/* Navigation Menu */}
+        <nav
+          className={cn(
+            'flex-1 overflow-y-auto overflow-x-hidden space-y-1',
+            'sidebar-scrollbar',
+            !isDarkMode && 'sidebar-scrollbar-light'
+          )}
+        >
+          {tenantAdminMenuData.map((item) => {
+            const Icon = item.icon;
+            const hasSubItems = item.subItems && item.subItems.length > 0;
+            const isExpandedItem = expandedItems.includes(item.id);
+            const isActive = activeItem === item.id;
+
+            return (
+              <div key={item.id} className="mb-1">
+                {/* Level 1 Menu Item */}
+                <button
+                  onClick={() => handleItemClick(item.id, !!hasSubItems)}
+                  className="flex items-center rounded-xl transition-all duration-300 overflow-hidden"
+                  style={{
+                    width: isExpanded ? '100%' : '44px',
+                    height: '44px',
+                    padding: isExpanded ? '0 16px' : '0',
+                    justifyContent: 'center',
+                    backgroundColor:
+                      isActive && !hasSubItems ? colors.activeBg : 'transparent',
+                    color:
+                      isActive && !hasSubItems
+                        ? colors.activeText
+                        : colors.textPrimary,
+                    margin: isExpanded ? '0' : '0 auto',
+                  }}
+                  onMouseEnter={(e) => {
+                    if (!(isActive && !hasSubItems)) {
+                      e.currentTarget.style.backgroundColor = colors.hover;
+                    }
+                  }}
+                  onMouseLeave={(e) => {
+                    if (!(isActive && !hasSubItems)) {
+                      e.currentTarget.style.backgroundColor = 'transparent';
+                    }
+                  }}
+                  title={!isExpanded ? item.label[language] : ''}
+                >
+                  <Icon
+                    className="w-5 h-5 flex-shrink-0"
+                    style={{
+                      color:
+                        isActive && !hasSubItems
+                          ? colors.activeText
+                          : colors.textSecondary,
+                    }}
+                  />
+                  {isExpanded && (
+                    <>
+                      <span className="flex-1 text-left text-sm font-medium whitespace-nowrap ml-3">
+                        {item.label[language]}
+                      </span>
+                      {hasSubItems && (
+                        <span style={{ color: colors.textSecondary }}>
+                          {isExpandedItem ? (
+                            <ChevronDown className="w-4 h-4" />
+                          ) : (
+                            <ChevronRight className="w-4 h-4" />
+                          )}
+                        </span>
+                      )}
+                    </>
+                  )}
+                </button>
+
+                {/* Level 2 Sub-Menu Items */}
+                {hasSubItems && isExpanded && isExpandedItem && (
+                  <div
+                    className="mt-1 ml-4 pl-4 border-l-2 space-y-1"
+                    style={{ borderColor: isDarkMode ? 'rgba(255,255,255,0.1)' : '#e5e7eb' }}
+                  >
+                    {item.subItems!.map((subItem) => {
+                      const SubIcon = subItem.icon;
+                      const isSubActive = activeItem === subItem.id;
+
+                      return (
+                        <button
+                          key={subItem.id}
+                          onClick={() =>
+                            handleSubItemClick(subItem.id, item.id)
+                          }
+                          className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all text-sm"
+                          style={{
+                            backgroundColor: isSubActive
+                              ? colors.activeBg
+                              : 'transparent',
+                            color: isSubActive
+                              ? colors.activeText
+                              : colors.textPrimary,
+                          }}
+                          onMouseEnter={(e) => {
+                            if (!isSubActive) {
+                              e.currentTarget.style.backgroundColor =
+                                colors.hover;
+                            }
+                          }}
+                          onMouseLeave={(e) => {
+                            if (!isSubActive) {
+                              e.currentTarget.style.backgroundColor =
+                                'transparent';
+                            }
+                          }}
+                        >
+                          <SubIcon
+                            className="w-4 h-4 flex-shrink-0"
+                            style={{
+                              color: isSubActive
+                                ? colors.activeText
+                                : colors.textSecondary,
+                            }}
+                          />
+                          <span className="flex-1 text-left">
+                            {subItem.label[language]}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {/* Collapsed State - Tooltip */}
+                {hasSubItems && !isExpanded && (
+                  <div className="relative group">
+                    <div className="absolute left-full top-0 ml-2 hidden group-hover:block z-50">
+                      <div
+                        className="border rounded-xl shadow-lg py-2 px-1 min-w-[200px]"
+                        style={{
+                          backgroundColor: colors.tooltipBg,
+                          borderColor: colors.border,
+                        }}
+                      >
+                        <div
+                          className="px-3 py-1.5 text-xs border-b mb-1"
+                          style={{
+                            color: colors.textSecondary,
+                            borderColor: isDarkMode ? 'rgba(255,255,255,0.1)' : colors.border,
+                          }}
+                        >
+                          {item.label[language]}
+                        </div>
+                        {item.subItems!.map((subItem) => {
+                          const SubIcon = subItem.icon;
+                          const isSubActive = activeItem === subItem.id;
+
+                          return (
+                            <button
+                              key={subItem.id}
+                              onClick={() =>
+                                handleSubItemClick(subItem.id, item.id)
+                              }
+                              className="w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-all text-sm"
+                              style={{
+                                backgroundColor: isSubActive
+                                  ? colors.activeBg
+                                  : 'transparent',
+                                color: isSubActive
+                                  ? colors.activeText
+                                  : colors.textPrimary,
+                              }}
+                              onMouseEnter={(e) => {
+                                if (!isSubActive) {
+                                  e.currentTarget.style.backgroundColor =
+                                    colors.hover;
+                                }
+                              }}
+                              onMouseLeave={(e) => {
+                                if (!isSubActive) {
+                                  e.currentTarget.style.backgroundColor =
+                                    'transparent';
+                                }
+                              }}
+                            >
+                              <SubIcon
+                                className="w-4 h-4 flex-shrink-0"
+                                style={{
+                                  color: isSubActive
+                                    ? colors.activeText
+                                    : colors.textSecondary,
+                                }}
+                              />
+                              <span className="flex-1 text-left">
+                                {subItem.label[language]}
+                              </span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </nav>
+
+        {/* Footer */}
+        <div
+          className="mt-4 pt-4 space-y-1"
+          style={{
+            borderTop: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.1)' : colors.border}`,
+          }}
+        >
+          {/* Logout Button */}
+          <button
+            onClick={handleLogout}
+            disabled={isLoggingOut}
+            className="flex items-center rounded-xl transition-all duration-300 overflow-hidden"
+            style={{
+              width: isExpanded ? '100%' : '44px',
+              height: '44px',
+              padding: isExpanded ? '0 16px' : '0',
+              justifyContent: 'center',
+              color: colors.textPrimary,
+              margin: isExpanded ? '0' : '0 auto',
+              opacity: isLoggingOut ? 0.5 : 1,
+              cursor: isLoggingOut ? 'not-allowed' : 'pointer',
+            }}
+            onMouseEnter={(e) => {
+              if (!isLoggingOut) {
+                e.currentTarget.style.backgroundColor = colors.hover;
+              }
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = 'transparent';
+            }}
+            title={language === 'ko' ? '로그아웃' : 'Logout'}
+          >
+            <LogOut
+              className="w-5 h-5 flex-shrink-0"
+              style={{ color: colors.textSecondary }}
+            />
+            {isExpanded && (
+              <span className="flex-1 text-left text-sm font-medium whitespace-nowrap ml-3">
+                {isLoggingOut
+                  ? (language === 'ko' ? '로그아웃 중...' : 'Logging out...')
+                  : (language === 'ko' ? '로그아웃' : 'Logout')
+                }
+              </span>
+            )}
+          </button>
+
+          {/* Collapse Toggle */}
+          <button
+            onClick={onToggle}
+            className="flex items-center rounded-xl transition-all duration-300 overflow-hidden"
+            style={{
+              width: isExpanded ? '100%' : '44px',
+              height: '44px',
+              padding: isExpanded ? '0 16px' : '0',
+              justifyContent: 'center',
+              color: colors.textPrimary,
+              margin: isExpanded ? '0' : '0 auto',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.backgroundColor = colors.hover;
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = 'transparent';
+            }}
+            title={
+              isExpanded
+                ? language === 'ko'
+                  ? '사이드바 접기'
+                  : 'Collapse Sidebar'
+                : language === 'ko'
+                ? '사이드바 펼치기'
+                : 'Expand Sidebar'
+            }
+          >
+            {isExpanded ? (
+              <PanelLeftClose
+                className="w-5 h-5 flex-shrink-0"
+                style={{ color: colors.textSecondary }}
+              />
+            ) : (
+              <PanelLeft
+                className="w-5 h-5 flex-shrink-0"
+                style={{ color: colors.textSecondary }}
+              />
+            )}
+            {isExpanded && (
+              <span className="flex-1 text-left text-sm font-medium whitespace-nowrap ml-3">
+                {language === 'ko' ? '접기' : 'Collapse'}
+              </span>
+            )}
+          </button>
+        </div>
+      </div>
+    </aside>
   );
 }

--- a/src/components/layout/tu/TenantUserSidebar/TenantUserSidebar.tsx
+++ b/src/components/layout/tu/TenantUserSidebar/TenantUserSidebar.tsx
@@ -31,6 +31,9 @@ export function TenantUserSidebar(props: TenantUserSidebarProps) {
   // 사용자 역할 가져오기
   const userRole = useAuthStore((state) => state.user?.role);
 
+  // TENANT_ADMIN만 글로벌 역할 스위처 표시
+  const showGlobalRoleSwitcher = userRole === 'TENANT_ADMIN';
+
   // 기능 설정 가져오기
   const { isFeatureEnabled } = useTenantFeatures();
   const instructorTabEnabled = isFeatureEnabled('instructorTabEnabled');
@@ -83,6 +86,7 @@ export function TenantUserSidebar(props: TenantUserSidebarProps) {
       menuData={filteredMenuData}
       roleLabel={roleLabels.tenantUser}
       showModeSwitcher={instructorTabEnabled}
+      showGlobalRoleSwitcher={showGlobalRoleSwitcher}
       currentMode="instructor"
       roleType="tu"
     />

--- a/src/routes/co.routes.tsx
+++ b/src/routes/co.routes.tsx
@@ -35,8 +35,9 @@ function CourseOperatorWrapper() {
   );
 }
 
-export const coRoutes = (
-  <Route path="/:subdomain/co" element={<CourseOperatorWrapper />}>
+// CO 하위 라우트
+const coChildRoutes = (
+  <>
     <Route index element={<DashboardPage />} />
     <Route path="dashboard" element={<DashboardPage />} />
     {/* 교육 과정 탐색 */}
@@ -68,5 +69,18 @@ export const coRoutes = (
     <Route path="settings/notifications" element={<SettingsNotificationsPage />} />
     <Route path="settings/appearance" element={<SettingsAppearancePage />} />
     <Route path="settings/content-defaults" element={<PlaceholderPage title="콘텐츠 기본 설정" />} />
-  </Route>
+  </>
+);
+
+export const coRoutes = (
+  <>
+    {/* 기본 테넌트용 (subdomain 없음) */}
+    <Route path="/co" element={<CourseOperatorWrapper />}>
+      {coChildRoutes}
+    </Route>
+    {/* 특정 테넌트용 (subdomain 있음) */}
+    <Route path="/:subdomain/co" element={<CourseOperatorWrapper />}>
+      {coChildRoutes}
+    </Route>
+  </>
 );

--- a/src/routes/ta.routes.tsx
+++ b/src/routes/ta.routes.tsx
@@ -40,7 +40,7 @@ function TenantAdminWrapper() {
   );
 }
 
-// TA 하위 라우트
+// TA 하위 라우트 (Admin 메뉴)
 const taChildRoutes = (
   <>
     <Route index element={<DashboardPage />} />

--- a/src/types/common/auth.types.ts
+++ b/src/types/common/auth.types.ts
@@ -82,6 +82,7 @@ export interface AuthUser {
   email: string;
   name: string;
   role: TenantRole;
+  roles?: TenantRole[];  // 1:N 역할 지원 (향후 확장용)
   tenantId?: number;
   tenantSubdomain?: string;
 }

--- a/src/types/common/sidebar.types.ts
+++ b/src/types/common/sidebar.types.ts
@@ -46,6 +46,8 @@ export interface BaseSidebarProps {
   language?: 'ko' | 'en';
   menuData: MenuItem[];
   roleLabel: { ko: string; en: string };
+  /** TA로 돌아가기 버튼 표시 여부 (TENANT_ADMIN이 TU/CO 페이지 접근 시) */
+  showBackToTA?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- GlobalRoleSwitcher 컴포넌트 신규 생성
- TA, CO, TU 사이드바에 역할 전환 드롭다운 추가
- TENANT_ADMIN 사용자가 TA/CO/TU 레이아웃 간 쉽게 전환 가능
- CO 라우트에 서브도메인 없는 경로 추가 (`/co/*`)

## Test plan
- [x] TENANT_ADMIN 계정으로 로그인
- [x] TA 페이지에서 드롭다운으로 CO/TU 전환 확인
- [x] CO 페이지에서 드롭다운으로 TA/TU 전환 확인
- [x] TU 페이지에서 드롭다운으로 TA/CO 전환 확인
- [x] 사이드바 접힘 상태에서도 드롭다운 동작 확인

Closes #444