### PR TITLE
[Feat] Step3 버튼 구조 개선 - 임시저장/작성완료/등록 분리

### DIFF
--- a/src/pages/tu/teaching/courses/CourseCreatePage.tsx
+++ b/src/pages/tu/teaching/courses/CourseCreatePage.tsx
@@ -10,7 +10,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useSubdomainPath } from '@/hooks/common/useSubdomainPath';
-import { ArrowLeft, ArrowRight, Save, FileText, Loader2, Send } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Save, FileText, Loader2, CheckCircle, Upload } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button } from '@/components/common';
 import { courseService, categoryService } from '@/services/common';
@@ -83,7 +83,8 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
   const [categories, setCategories] = useState<CategoryResponse[]>([]);
   const [isSaving, setIsSaving] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [isPublishing, setIsPublishing] = useState(false);
+  const [isCompleting, setIsCompleting] = useState(false);
+  const [isRegistering, setIsRegistering] = useState(false);
   const [courseId, setCourseId] = useState<number | null>(
     courseIdParam ? Number(courseIdParam) : null
   );
@@ -243,60 +244,108 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
     }
   };
 
-  const handlePublish = async () => {
+  /**
+   * 강의 저장 공통 로직
+   * @returns 저장된 courseId 또는 null (실패 시)
+   */
+  const saveCourse = async (): Promise<number | null> => {
+    const request: CreateCourseRequest = {
+      title: formData.title,
+      description: formData.description || undefined,
+      thumbnailUrl: formData.thumbnailUrl || undefined,
+      level: formData.level || undefined,
+      type: formData.type || undefined,
+      categoryId: formData.categoryId ?? undefined,
+      startDate: formData.startDate || undefined,
+      endDate: formData.endDate || undefined,
+      tags: formData.tags.length > 0 ? formData.tags : undefined,
+    };
+
+    let targetCourseId = courseId;
+
+    if (courseId) {
+      // 기존 강의 수정
+      await courseService.update(courseId, request);
+
+      // 커리큘럼 저장
+      if (formData.curriculumItems.length > 0) {
+        await deleteAllCurriculumItems(courseId);
+        await createCurriculumItemsRecursively(courseId, formData.curriculumItems, null);
+      }
+    } else {
+      // 새 강의 생성
+      const response = await courseService.create(request);
+      targetCourseId = response.courseId;
+      setCourseId(response.courseId);
+      navigate(prefixPath(`/tu/teaching/courses/create?courseId=${response.courseId}`), { replace: true });
+
+      // 커리큘럼 생성
+      if (formData.curriculumItems.length > 0) {
+        await createCurriculumItemsRecursively(response.courseId, formData.curriculumItems, null);
+      }
+    }
+
+    return targetCourseId;
+  };
+
+  /**
+   * 작성완료 (DRAFT → READY)
+   * 완성 요건 충족 + 임시저장 마크 불필요, 추후 리스트에서 등록 가능
+   */
+  const handleComplete = async () => {
     if (!formData.title) {
       alert('강의명을 입력해주세요.');
       return;
     }
 
-    if (!confirm(getText('publishConfirm'))) return;
+    if (!confirm(getText('completeConfirm'))) return;
 
-    setIsPublishing(true);
+    setIsCompleting(true);
     try {
-      const request: CreateCourseRequest = {
-        title: formData.title,
-        description: formData.description || undefined,
-        thumbnailUrl: formData.thumbnailUrl || undefined,
-        level: formData.level || undefined,
-        type: formData.type || undefined,
-        categoryId: formData.categoryId ?? undefined,
-        startDate: formData.startDate || undefined,
-        endDate: formData.endDate || undefined,
-        tags: formData.tags.length > 0 ? formData.tags : undefined,
-      };
+      const targetCourseId = await saveCourse();
+      if (!targetCourseId) throw new Error('저장 실패');
 
-      let targetCourseId = courseId;
+      // 작성완료 API 호출 (DRAFT → READY)
+      await courseService.ready(targetCourseId);
 
-      if (courseId) {
-        // 기존 강의 수정
-        await courseService.update(courseId, request);
-
-        // 커리큘럼 저장
-        if (formData.curriculumItems.length > 0) {
-          await deleteAllCurriculumItems(courseId);
-          await createCurriculumItemsRecursively(courseId, formData.curriculumItems, null);
-        }
-      } else {
-        // 새 강의 생성
-        const response = await courseService.create(request);
-        targetCourseId = response.courseId;
-
-        // 커리큘럼 생성
-        if (formData.curriculumItems.length > 0) {
-          await createCurriculumItemsRecursively(response.courseId, formData.curriculumItems, null);
-        }
-      }
-
-      // 발행 API 호출
-      await courseService.publish(targetCourseId!);
-
-      alert(getText('publishSuccess'));
+      alert(getText('completeSuccess'));
       navigate(prefixPath('/tu/teaching/courses'));
     } catch (error) {
-      console.error('강의 발행 실패:', error);
-      alert(getText('publishError'));
+      console.error('작성완료 실패:', error);
+      alert(getText('completeError'));
     } finally {
-      setIsPublishing(false);
+      setIsCompleting(false);
+    }
+  };
+
+  /**
+   * 등록 (저장 → READY → REGISTERED)
+   * 저장과 동시에 CO가 볼 수 있는 상태로 전환
+   */
+  const handleRegister = async () => {
+    if (!formData.title) {
+      alert('강의명을 입력해주세요.');
+      return;
+    }
+
+    if (!confirm(getText('registerConfirm'))) return;
+
+    setIsRegistering(true);
+    try {
+      const targetCourseId = await saveCourse();
+      if (!targetCourseId) throw new Error('저장 실패');
+
+      // 먼저 READY 상태로 전환 후 REGISTERED로 전환
+      await courseService.ready(targetCourseId);
+      await courseService.register(targetCourseId);
+
+      alert(getText('registerSuccess'));
+      navigate(prefixPath('/tu/teaching/courses'));
+    } catch (error) {
+      console.error('등록 실패:', error);
+      alert(getText('registerError'));
+    } finally {
+      setIsRegistering(false);
     }
   };
 
@@ -433,43 +482,82 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
             </Button>
           </div>
 
-          <div>
+          <div className="flex gap-3">
             {currentStep < totalSteps ? (
               <Button onClick={handleNext}>
                 {getText('next')}
                 <ArrowRight size={18} />
               </Button>
             ) : (
-              <Button
-                onClick={handlePublish}
-                disabled={
-                  isPublishing ||
-                  !formData.title ||
-                  !formData.categoryId ||
-                  formData.curriculumItems.length === 0
-                }
-                title={
-                  !formData.title
-                    ? '강의명을 입력해주세요'
-                    : !formData.categoryId
-                      ? '카테고리를 선택해주세요'
-                      : formData.curriculumItems.length === 0
-                        ? '최소 1개의 차시가 필요합니다'
-                        : undefined
-                }
-              >
-                {isPublishing ? (
-                  <>
-                    <Loader2 size={18} className="animate-spin" />
-                    {getText('publishing')}
-                  </>
-                ) : (
-                  <>
-                    <Send size={18} />
-                    {getText('publish')}
-                  </>
-                )}
-              </Button>
+              <>
+                {/* 작성완료 버튼 (DRAFT → READY) */}
+                <Button
+                  variant="ghost"
+                  onClick={handleComplete}
+                  disabled={
+                    isCompleting ||
+                    isRegistering ||
+                    !formData.title ||
+                    !formData.categoryId ||
+                    formData.curriculumItems.length === 0
+                  }
+                  className="border border-border"
+                  title={
+                    !formData.title
+                      ? '강의명을 입력해주세요'
+                      : !formData.categoryId
+                        ? '카테고리를 선택해주세요'
+                        : formData.curriculumItems.length === 0
+                          ? '최소 1개의 차시가 필요합니다'
+                          : undefined
+                  }
+                >
+                  {isCompleting ? (
+                    <>
+                      <Loader2 size={18} className="animate-spin" />
+                      {getText('completing')}
+                    </>
+                  ) : (
+                    <>
+                      <CheckCircle size={18} />
+                      {getText('completeWriting')}
+                    </>
+                  )}
+                </Button>
+
+                {/* 등록 버튼 (DRAFT → READY → REGISTERED) */}
+                <Button
+                  onClick={handleRegister}
+                  disabled={
+                    isCompleting ||
+                    isRegistering ||
+                    !formData.title ||
+                    !formData.categoryId ||
+                    formData.curriculumItems.length === 0
+                  }
+                  title={
+                    !formData.title
+                      ? '강의명을 입력해주세요'
+                      : !formData.categoryId
+                        ? '카테고리를 선택해주세요'
+                        : formData.curriculumItems.length === 0
+                          ? '최소 1개의 차시가 필요합니다'
+                          : undefined
+                  }
+                >
+                  {isRegistering ? (
+                    <>
+                      <Loader2 size={18} className="animate-spin" />
+                      {getText('registering')}
+                    </>
+                  ) : (
+                    <>
+                      <Upload size={18} />
+                      {getText('register')}
+                    </>
+                  )}
+                </Button>
+              </>
             )}
           </div>
         </div>

--- a/src/pages/tu/teaching/courses/components/courseCreate.constants.ts
+++ b/src/pages/tu/teaching/courses/components/courseCreate.constants.ts
@@ -113,7 +113,19 @@ export const translations = {
   // 공통
   cancel: { ko: '취소', en: 'Cancel' },
   processing: { ko: '처리 중...', en: 'Processing...' },
-  // 발행
+  // 작성완료 (DRAFT → READY)
+  completeWriting: { ko: '작성완료', en: 'Complete' },
+  completing: { ko: '작성완료 처리 중...', en: 'Completing...' },
+  completeSuccess: { ko: '작성완료 되었습니다. 추후 리스트에서 등록할 수 있습니다.', en: 'Course marked as complete. You can register it later from the list.' },
+  completeError: { ko: '작성완료 처리에 실패했습니다. 다시 시도해주세요.', en: 'Failed to mark as complete. Please try again.' },
+  completeConfirm: { ko: '작성완료 하시겠습니까? 완료 후에도 수정이 가능합니다.', en: 'Mark as complete? You can still edit it later.' },
+  // 등록 (READY → REGISTERED)
+  register: { ko: '등록', en: 'Register' },
+  registering: { ko: '등록 중...', en: 'Registering...' },
+  registerSuccess: { ko: '등록되었습니다. 운영자가 차수를 개설할 수 있습니다.', en: 'Course has been registered. Operators can now create sessions.' },
+  registerError: { ko: '등록에 실패했습니다. 다시 시도해주세요.', en: 'Failed to register. Please try again.' },
+  registerConfirm: { ko: '등록하시겠습니까? 등록 후에는 운영자가 차수를 개설할 수 있습니다.', en: 'Register this course? After registration, operators can create course sessions.' },
+  // 발행 (deprecated)
   publish: { ko: '발행하기', en: 'Publish' },
   publishing: { ko: '발행 중...', en: 'Publishing...' },
   publishSuccess: { ko: '강의가 발행되었습니다.', en: 'Course has been published.' },


### PR DESCRIPTION
## Summary
- 기존 발행 버튼을 3개 버튼으로 분리:
  - **임시저장**: DRAFT 상태로 저장 (기존 유지)
  - **작성완료**: READY 상태로 저장 (추후 리스트에서 등록 가능)
  - **등록**: REGISTERED 상태로 저장 (CO가 바로 차수 개설 가능)
- `saveCourse()` 공통 저장 로직 추출
- 번역 키 추가 (completeWriting, register 관련)

## 버튼 동작
| 버튼 | API 호출 | 결과 상태 | 사용 케이스 |
|-----|---------|---------|-----------|
| 임시저장 | `create/update` | DRAFT | 미완성 또는 나중에 수정할 때 |
| 작성완료 | `create/update` → `ready()` | READY | 완성됐지만 CO 제출 전 |
| 등록 | `create/update` → `ready()` → `register()` | REGISTERED | 바로 CO가 차수 개설 가능 |

## Test plan
- [ ] 임시저장 버튼 클릭 시 DRAFT 상태로 저장되는지 확인
- [ ] 작성완료 버튼 클릭 시 READY 상태로 전환되는지 확인
- [ ] 등록 버튼 클릭 시 REGISTERED 상태로 전환되는지 확인
- [ ] 필수 항목 미입력 시 버튼 비활성화 확인

Closes #437