### PR TITLE
feat(course): Step3 강의 미리보기 기능 추가

### DIFF
--- a/src/pages/tu/index.ts
+++ b/src/pages/tu/index.ts
@@ -4,6 +4,7 @@ export {
   CourseCreatePage,
   CourseEditPage,
   CourseDetailPage as TeachingCourseDetailPage,
+  CoursePreviewPage,
   TuContentCreatePage,
   ContentDetailPage,
   ContentBulkUploadPage,

--- a/src/pages/tu/teaching/courses/CourseCreatePage.tsx
+++ b/src/pages/tu/teaching/courses/CourseCreatePage.tsx
@@ -354,6 +354,23 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
     setFormData((prev) => ({ ...prev, ...updates }));
   };
 
+  /**
+   * 미리보기 - 새 탭에서 수강생 뷰로 강의 정보 표시
+   * sessionStorage에 formData를 저장하고 미리보기 페이지를 새 탭으로 열기
+   */
+  const handlePreview = () => {
+    // formData와 categories 정보를 sessionStorage에 저장
+    const previewData = {
+      formData,
+      categories,
+      language,
+    };
+    sessionStorage.setItem('course-preview-data', JSON.stringify(previewData));
+
+    // 새 탭에서 미리보기 페이지 열기
+    window.open(prefixPath('/tu/teaching/courses/preview'), '_blank');
+  };
+
   const stepLabels = [getText('step1'), getText('step2'), getText('step3')];
 
   // 로딩 중일 때
@@ -458,6 +475,7 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
               formData={formData}
               categories={categories}
               onGoToStep={handleGoToStep}
+              onPreview={handlePreview}
             />
           )}
         </div>

--- a/src/pages/tu/teaching/courses/CourseEditPage.tsx
+++ b/src/pages/tu/teaching/courses/CourseEditPage.tsx
@@ -149,6 +149,19 @@ export function CourseEditPage({ language = 'ko' }: Readonly<CourseEditPageProps
   const handleGoToStep = (step: number) => setCurrentStep(step);
   const handleClose = () => navigate(prefixPath('/tu/teaching/courses'));
 
+  /**
+   * 미리보기 - 새 탭에서 수강생 뷰로 강의 정보 표시
+   */
+  const handlePreview = () => {
+    const previewData = {
+      formData,
+      categories,
+      language,
+    };
+    sessionStorage.setItem('course-preview-data', JSON.stringify(previewData));
+    window.open(prefixPath('/tu/teaching/courses/preview'), '_blank');
+  };
+
   const [isSaving, setIsSaving] = useState(false);
 
   const handleSaveDraft = async () => {
@@ -342,6 +355,7 @@ export function CourseEditPage({ language = 'ko' }: Readonly<CourseEditPageProps
               formData={formData}
               categories={categories}
               onGoToStep={handleGoToStep}
+              onPreview={handlePreview}
             />
           )}
         </div>

--- a/src/pages/tu/teaching/courses/CoursePreviewPage.tsx
+++ b/src/pages/tu/teaching/courses/CoursePreviewPage.tsx
@@ -1,0 +1,283 @@
+/**
+ * 강의 미리보기 페이지
+ * 수강생이 보게 될 강의 모습을 미리보기
+ * sessionStorage에서 formData를 읽어와 표시
+ */
+import { useState, useEffect } from 'react';
+import {
+  X,
+  Eye,
+  BookOpen,
+  Tag,
+  Calendar,
+  Folder,
+  File,
+  ChevronRight,
+  ChevronDown,
+  AlertCircle,
+} from 'lucide-react';
+import { Button, Card, CardHeader, CardContent } from '@/components/common';
+import type { CourseFormData } from '@/types';
+import type { CategoryResponse } from '@/types/common';
+import type { CurriculumItem } from '@/types/tu';
+import { isCurriculumFolder, isCurriculumContent } from '@/types/tu';
+import { translations, levelOptions, type TranslationKey } from './components/courseCreate.constants';
+
+interface PreviewData {
+  formData: CourseFormData;
+  categories: CategoryResponse[];
+  language: 'ko' | 'en';
+}
+
+/** 커리큘럼 트리 아이템 렌더링 */
+function PreviewTreeItem({
+  item,
+  depth = 0,
+  expandedIds,
+  onToggle,
+}: {
+  item: CurriculumItem;
+  depth?: number;
+  expandedIds: Set<string>;
+  onToggle: (id: string) => void;
+}) {
+  const isFolder = isCurriculumFolder(item);
+  const isContent = isCurriculumContent(item);
+  const isExpanded = expandedIds.has(item.id);
+
+  return (
+    <div>
+      <div
+        className="flex items-center gap-2 py-2 px-3 rounded hover:bg-bg-secondary"
+        style={{ paddingLeft: `${depth * 20 + 12}px` }}
+      >
+        {isFolder ? (
+          <button
+            type="button"
+            onClick={() => onToggle(item.id)}
+            className="p-0.5 hover:bg-bg-tertiary rounded"
+          >
+            {isExpanded ? (
+              <ChevronDown size={16} className="text-text-secondary" />
+            ) : (
+              <ChevronRight size={16} className="text-text-secondary" />
+            )}
+          </button>
+        ) : (
+          <span className="w-6" />
+        )}
+        {isFolder ? (
+          <Folder size={18} className="text-yellow-500 shrink-0" />
+        ) : (
+          <File size={18} className="text-blue-500 shrink-0" />
+        )}
+        <span className="text-text-primary">
+          {isContent && item.displayName ? item.displayName : item.name}
+        </span>
+      </div>
+      {isFolder && isExpanded && item.children.length > 0 && (
+        <div>
+          {item.children.map((child) => (
+            <PreviewTreeItem
+              key={child.id}
+              item={child}
+              depth={depth + 1}
+              expandedIds={expandedIds}
+              onToggle={onToggle}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function CoursePreviewPage() {
+  const [previewData, setPreviewData] = useState<PreviewData | null>(null);
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  // sessionStorage에서 미리보기 데이터 로드
+  useEffect(() => {
+    const stored = sessionStorage.getItem('course-preview-data');
+    if (stored) {
+      try {
+        const data: PreviewData = JSON.parse(stored);
+        setPreviewData(data);
+
+        // 모든 폴더 기본 확장
+        const ids = new Set<string>();
+        const collectFolderIds = (items: CurriculumItem[]) => {
+          for (const item of items) {
+            if (isCurriculumFolder(item)) {
+              ids.add(item.id);
+              collectFolderIds(item.children);
+            }
+          }
+        };
+        collectFolderIds(data.formData.curriculumItems);
+        setExpandedIds(ids);
+      } catch {
+        console.error('미리보기 데이터 파싱 실패');
+      }
+    }
+  }, []);
+
+  const handleToggleExpand = (id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleClose = () => {
+    window.close();
+  };
+
+  if (!previewData) {
+    return (
+      <div className="bg-bg-app min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <AlertCircle size={48} className="text-text-tertiary mx-auto mb-4" />
+          <p className="text-text-secondary">미리보기 데이터가 없습니다.</p>
+          <Button variant="ghost" onClick={handleClose} className="mt-4 border border-border">
+            창 닫기
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const { formData, categories, language } = previewData;
+
+  const getText = (key: TranslationKey) =>
+    language === 'ko' ? translations[key].ko : translations[key].en;
+
+  const categoryName = categories.find((cat) => cat.id === formData.categoryId)?.name;
+  const levelLabel = levelOptions.find((opt) => opt.value === formData.level)?.label;
+
+  return (
+    <div className="bg-bg-app min-h-screen">
+      {/* 미리보기 모드 배너 */}
+      <div className="bg-action-primary text-white px-6 py-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Eye size={18} />
+          <span className="font-medium">{getText('previewMode')}</span>
+          <span className="text-white/80 text-sm ml-2">- {getText('previewDesc')}</span>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleClose}
+          className="text-white hover:bg-white/20 border-white/30"
+        >
+          <X size={16} />
+          {getText('closePreview')}
+        </Button>
+      </div>
+
+      {/* 강의 헤더 영역 */}
+      <div className="bg-bg-default border-b border-border">
+        <div className="max-w-4xl mx-auto px-6 py-8">
+          {/* 썸네일이 있으면 표시 */}
+          {formData.thumbnailUrl && (
+            <div className="mb-6">
+              <img
+                src={formData.thumbnailUrl}
+                alt={formData.title || '강의 썸네일'}
+                className="w-full max-h-64 object-cover rounded-lg"
+              />
+            </div>
+          )}
+
+          {/* 강의 제목 */}
+          <h1 className="text-2xl font-bold text-text-primary mb-4">
+            {formData.title || <span className="text-text-tertiary italic">{getText('notEntered')}</span>}
+          </h1>
+
+          {/* 메타 정보 */}
+          <div className="flex flex-wrap gap-4 mb-4">
+            {categoryName && (
+              <span className="inline-flex items-center gap-1 px-3 py-1 bg-bg-secondary rounded-full text-sm text-text-secondary">
+                <BookOpen size={14} />
+                {categoryName}
+              </span>
+            )}
+            {levelLabel && (
+              <span className="inline-flex items-center gap-1 px-3 py-1 bg-bg-secondary rounded-full text-sm text-text-secondary">
+                {levelLabel}
+              </span>
+            )}
+            {(formData.startDate || formData.endDate) && (
+              <span className="inline-flex items-center gap-1 px-3 py-1 bg-bg-secondary rounded-full text-sm text-text-secondary">
+                <Calendar size={14} />
+                {formData.startDate && formData.endDate
+                  ? `${formData.startDate} ~ ${formData.endDate}`
+                  : formData.startDate
+                    ? `${formData.startDate} ~`
+                    : `~ ${formData.endDate}`}
+              </span>
+            )}
+          </div>
+
+          {/* 태그 */}
+          {formData.tags.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {formData.tags.map((tag, index) => (
+                <span
+                  key={index}
+                  className="inline-flex items-center gap-1 px-2.5 py-1 bg-action-primary/10 text-action-primary text-sm rounded-md"
+                >
+                  <Tag size={12} />
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 메인 콘텐츠 */}
+      <div className="max-w-4xl mx-auto px-6 py-8">
+        {/* 강의 설명 */}
+        {formData.description && (
+          <Card className="mb-6">
+            <CardHeader>
+              <h2 className="text-lg font-medium text-text-primary m-0">{getText('courseDescription')}</h2>
+            </CardHeader>
+            <CardContent>
+              <p className="text-text-primary whitespace-pre-wrap m-0">{formData.description}</p>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* 커리큘럼 */}
+        <Card>
+          <CardHeader>
+            <h2 className="text-lg font-medium text-text-primary m-0">{getText('curriculum')}</h2>
+          </CardHeader>
+          <CardContent>
+            {formData.curriculumItems.length > 0 ? (
+              <div className="border border-border rounded-lg overflow-hidden">
+                {formData.curriculumItems.map((item) => (
+                  <PreviewTreeItem
+                    key={item.id}
+                    item={item}
+                    expandedIds={expandedIds}
+                    onToggle={handleToggleExpand}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className="text-text-tertiary text-center py-8 m-0">{getText('noCurriculum')}</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/teaching/courses/components/Step3Review.tsx
+++ b/src/pages/tu/teaching/courses/components/Step3Review.tsx
@@ -16,6 +16,7 @@ import {
   File,
   ChevronRight,
   ChevronDown,
+  Eye,
 } from 'lucide-react';
 import { useState } from 'react';
 import { Button, Label, Card, CardHeader, CardContent, Alert, AlertDescription } from '@/components/common';
@@ -117,6 +118,7 @@ interface Step3ReviewProps {
   formData: CourseFormData;
   categories: CategoryResponse[];
   onGoToStep: (step: number) => void;
+  onPreview: () => void;
 }
 
 export function Step3Review({
@@ -124,6 +126,7 @@ export function Step3Review({
   formData,
   categories,
   onGoToStep,
+  onPreview,
 }: Readonly<Step3ReviewProps>) {
   const getText = (key: TranslationKey) =>
     language === 'ko' ? translations[key].ko : translations[key].en;
@@ -167,9 +170,15 @@ export function Step3Review({
   return (
     <div className="flex flex-col gap-6">
       {/* 헤더 */}
-      <div>
-        <h2 className="text-text-primary mb-2">{getText('reviewTitle')}</h2>
-        <p className="text-text-secondary m-0">{getText('reviewDesc')}</p>
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-text-primary mb-2">{getText('reviewTitle')}</h2>
+          <p className="text-text-secondary m-0">{getText('reviewDesc')}</p>
+        </div>
+        <Button variant="outline" size="sm" onClick={onPreview} className="shrink-0">
+          <Eye size={14} />
+          {getText('preview')}
+        </Button>
       </div>
 
       {/* 경고 메시지 또는 완료 메시지 */}

--- a/src/pages/tu/teaching/courses/components/courseCreate.constants.ts
+++ b/src/pages/tu/teaching/courses/components/courseCreate.constants.ts
@@ -136,6 +136,13 @@ export const translations = {
   // 페이지네이션
   prev: { ko: '이전', en: 'Prev' },
   pageInfo: { ko: '{current} / {total} 페이지', en: 'Page {current} of {total}' },
+  // 미리보기
+  preview: { ko: '미리보기', en: 'Preview' },
+  previewTitle: { ko: '강의 미리보기', en: 'Course Preview' },
+  previewDesc: { ko: '수강생이 보게 될 강의 모습입니다.', en: 'This is how learners will see this course.' },
+  previewMode: { ko: '미리보기 모드', en: 'Preview Mode' },
+  closePreview: { ko: '미리보기 닫기', en: 'Close Preview' },
+  noPreviewData: { ko: '미리보기 데이터가 없습니다.', en: 'No preview data available.' },
 } as const;
 
 export type TranslationKey = keyof typeof translations;

--- a/src/pages/tu/teaching/courses/index.ts
+++ b/src/pages/tu/teaching/courses/index.ts
@@ -2,3 +2,4 @@ export { MyCoursesPage } from './MyCoursesPage';
 export { CourseCreatePage } from './CourseCreatePage';
 export { CourseEditPage } from './CourseEditPage';
 export { CourseDetailPage } from './CourseDetailPage';
+export { CoursePreviewPage } from './CoursePreviewPage';

--- a/src/pages/tu/teaching/index.ts
+++ b/src/pages/tu/teaching/index.ts
@@ -1,4 +1,4 @@
-export { MyCoursesPage, CourseCreatePage, CourseEditPage, CourseDetailPage } from './courses';
+export { MyCoursesPage, CourseCreatePage, CourseEditPage, CourseDetailPage, CoursePreviewPage } from './courses';
 export { MyContentPage, ContentCreatePage as TuContentCreatePage, ContentDetailPage, ContentBulkUploadPage } from './content';
 export { MyAssignmentsPage, AssignmentDetailPage } from './assignments';
 export { RoadmapListPage, RoadmapCreatePage, TeachingRoadmapDetailPage } from './roadmaps';

--- a/src/routes/tu.teaching.routes.tsx
+++ b/src/routes/tu.teaching.routes.tsx
@@ -7,6 +7,7 @@ import {
   MyContentPage,
   CourseCreatePage,
   CourseEditPage,
+  CoursePreviewPage,
   TeachingCourseDetailPage,
   TuContentCreatePage,
   ContentDetailPage,
@@ -45,6 +46,7 @@ export const tuTeachingRoutes = (
     <Route path="dashboard" element={<TUDashboardPage />} />
     <Route path="teaching/courses" element={<MyCoursesPage />} />
     <Route path="teaching/courses/create" element={<CourseCreatePage />} />
+    <Route path="teaching/courses/preview" element={<CoursePreviewPage />} />
     <Route path="teaching/courses/:courseId" element={<TeachingCourseDetailPage />} />
     <Route path="teaching/courses/:courseId/edit" element={<CourseEditPage />} />
     <Route path="teaching/content" element={<MyContentPage />} />
@@ -66,6 +68,7 @@ export const tuTeachingRoutes = (
     {/* 내 강의계획 */}
     <Route path="teaching/courses" element={<MyCoursesPage />} />
     <Route path="teaching/courses/create" element={<CourseCreatePage />} />
+    <Route path="teaching/courses/preview" element={<CoursePreviewPage />} />
     <Route path="teaching/courses/:courseId" element={<TeachingCourseDetailPage />} />
     <Route path="teaching/courses/:courseId/edit" element={<CourseEditPage />} />
 


### PR DESCRIPTION
## Summary
- Step3 검토 화면에 "미리보기" 버튼 추가 (헤더 우측)
- 새 탭에서 수강생이 보게 될 강의 모습을 미리보기
- 저장 전 formData 기반으로 동작하여 즉시 확인 가능

## Changes
- `courseCreate.constants.ts`: 미리보기 관련 번역 키 추가
- `Step3Review.tsx`: onPreview prop 및 미리보기 버튼 추가
- `CourseCreatePage.tsx`, `CourseEditPage.tsx`: handlePreview 핸들러 추가
- `CoursePreviewPage.tsx`: 신규 생성 (수강생 뷰 렌더링)
- `tu.teaching.routes.tsx`: preview 라우트 추가
- export 설정 추가

## Data Flow
```
Step3 [미리보기 버튼 클릭]
  ↓
sessionStorage.setItem('course-preview-data', formData)
  ↓
window.open('/tu/teaching/courses/preview', '_blank')
  ↓
CoursePreviewPage에서 sessionStorage 데이터 읽어서 렌더링
```

## Test Plan
- [ ] Step3에서 미리보기 버튼 표시 확인
- [ ] 버튼 클릭 시 새 탭에서 미리보기 페이지 열림 확인
- [ ] 강의 정보 및 커리큘럼이 올바르게 표시되는지 확인
- [ ] 저장 전 상태에서도 미리보기 가능한지 확인
- [ ] CourseEditPage에서도 동일하게 동작하는지 확인

Closes #438