### PR TITLE
[Feat] Course 상태 전환 API 변경에 따른 프론트엔드 수정 (#397)

### DIFF
--- a/src/pages/tu/teaching/courses/CourseCreatePage.tsx
+++ b/src/pages/tu/teaching/courses/CourseCreatePage.tsx
@@ -27,7 +27,8 @@ interface CourseCreatePageProps {
 }
 
 /**
- * 커리큘럼 트리를 재귀적으로 순회하며 API 호출
+ * 커리큘럼 트리를 재귀적으로 순회하며 API 호출 (신규 항목만)
+ * itemId가 있는 항목은 이미 저장된 항목이므로 건너뜀
  */
 async function createCurriculumItemsRecursively(
   courseId: number,
@@ -36,20 +37,40 @@ async function createCurriculumItemsRecursively(
 ): Promise<void> {
   for (const item of items) {
     if (isCurriculumFolder(item)) {
-      // 폴더 생성
-      const folderResponse = await courseService.createFolder(courseId, {
-        folderName: item.name,
-        parentId: parentId ?? undefined,
-      });
+      let currentFolderId: number;
+
+      // itemId가 있으면 이미 저장된 폴더
+      if (item.itemId) {
+        currentFolderId = item.itemId;
+      } else {
+        // 새 폴더 생성
+        const folderResponse = await courseService.createFolder(courseId, {
+          folderName: item.name,
+          parentId: parentId ?? undefined,
+        });
+        currentFolderId = folderResponse.itemId;
+      }
+
       // 하위 항목 재귀 생성
       if (item.children.length > 0) {
         await createCurriculumItemsRecursively(
           courseId,
           item.children,
-          folderResponse.itemId
+          currentFolderId
         );
       }
     } else if (isCurriculumContent(item)) {
+      // itemId가 있으면 이미 저장된 콘텐츠, 건너뜀
+      if (item.itemId) {
+        continue;
+      }
+
+      // contentId가 없으면 에러 (신규 항목인데 contentId가 없음)
+      if (!item.contentId) {
+        console.error('신규 콘텐츠 항목에 contentId가 없습니다:', item);
+        continue;
+      }
+
       // 콘텐츠(차시) 생성 - contentId로 백엔드에서 LO 자동 생성
       await courseService.createItem(courseId, {
         itemName: item.name,
@@ -65,13 +86,14 @@ async function createCurriculumItemsRecursively(
 /**
  * 기존 회차/콘텐츠를 모두 삭제
  * 루트 레벨 항목만 삭제 (하위 항목은 cascade 삭제됨)
+ * @deprecated 더 이상 사용하지 않음. 신규 항목만 추가하는 방식으로 변경됨.
  */
-async function deleteAllCurriculumItems(courseId: number): Promise<void> {
-  const hierarchy = await courseService.getItemsHierarchy(courseId);
-  for (const item of hierarchy) {
-    await courseService.deleteItem(courseId, item.itemId);
-  }
-}
+// async function deleteAllCurriculumItems(courseId: number): Promise<void> {
+//   const hierarchy = await courseService.getItemsHierarchy(courseId);
+//   for (const item of hierarchy) {
+//     await courseService.deleteItem(courseId, item.itemId);
+//   }
+// }
 
 export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageProps>) {
   const navigate = useNavigate();
@@ -88,6 +110,7 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
   const [courseId, setCourseId] = useState<number | null>(
     courseIdParam ? Number(courseIdParam) : null
   );
+  const [courseStatus, setCourseStatus] = useState<'DRAFT' | 'READY' | 'REGISTERED'>('DRAFT');
   const [formData, setFormData] = useState<CourseFormData>({
     title: '',
     description: '',
@@ -139,6 +162,16 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
 
         // 회차 계층구조를 CurriculumItem 형태로 변환
         const curriculumItems = convertHierarchyToCurriculumItems(hierarchyData);
+
+        // Course 상태 설정
+        setCourseStatus(course.status);
+
+        // REGISTERED 상태이면 편집 불가 안내
+        if (course.status === 'REGISTERED') {
+          alert('이미 등록된 강의는 수정할 수 없습니다.');
+          navigate(prefixPath('/tu/teaching/courses'));
+          return;
+        }
 
         setFormData((prev) => ({
           ...prev,
@@ -198,9 +231,8 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
         // 기존 강의 수정
         await courseService.update(courseId, request);
 
-        // 기존 회차/콘텐츠 삭제 후 재생성
+        // 신규 항목만 추가 (기존 항목은 유지)
         if (formData.curriculumItems.length > 0) {
-          await deleteAllCurriculumItems(courseId);
           await createCurriculumItemsRecursively(courseId, formData.curriculumItems, null);
         }
       } else {
@@ -211,7 +243,7 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
         // URL 업데이트 (뒤로가기 시에도 courseId 유지)
         navigate(prefixPath(`/tu/teaching/courses/create?courseId=${response.courseId}`), { replace: true });
 
-        // 회차/콘텐츠 생성
+        // 회차/콘텐츠 생성 (모두 신규)
         if (formData.curriculumItems.length > 0) {
           await createCurriculumItemsRecursively(response.courseId, formData.curriculumItems, null);
         }
@@ -267,9 +299,8 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
       // 기존 강의 수정
       await courseService.update(courseId, request);
 
-      // 커리큘럼 저장
+      // 신규 항목만 추가 (기존 항목은 유지)
       if (formData.curriculumItems.length > 0) {
-        await deleteAllCurriculumItems(courseId);
         await createCurriculumItemsRecursively(courseId, formData.curriculumItems, null);
       }
     } else {
@@ -279,7 +310,7 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
       setCourseId(response.courseId);
       navigate(prefixPath(`/tu/teaching/courses/create?courseId=${response.courseId}`), { replace: true });
 
-      // 커리큘럼 생성
+      // 커리큘럼 생성 (모두 신규)
       if (formData.curriculumItems.length > 0) {
         await createCurriculumItemsRecursively(response.courseId, formData.curriculumItems, null);
       }
@@ -319,7 +350,7 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
   };
 
   /**
-   * 등록 (저장 → READY → REGISTERED)
+   * 등록 (DRAFT → READY → REGISTERED 또는 READY → REGISTERED)
    * 저장과 동시에 CO가 볼 수 있는 상태로 전환
    */
   const handleRegister = async () => {
@@ -332,12 +363,21 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
 
     setIsRegistering(true);
     try {
-      const targetCourseId = await saveCourse();
-      if (!targetCourseId) throw new Error('저장 실패');
+      let targetCourseId = courseId;
 
-      // 먼저 READY 상태로 전환 후 REGISTERED로 전환
-      await courseService.ready(targetCourseId);
-      await courseService.register(targetCourseId);
+      // DRAFT 상태이면 먼저 저장
+      if (courseStatus === 'DRAFT') {
+        targetCourseId = await saveCourse();
+        if (!targetCourseId) throw new Error('저장 실패');
+
+        // DRAFT → READY
+        await courseService.ready(targetCourseId);
+      }
+
+      // READY → REGISTERED (DRAFT였어도 이제 READY 상태)
+      if (targetCourseId) {
+        await courseService.register(targetCourseId);
+      }
 
       alert(getText('registerSuccess'));
       navigate(prefixPath('/tu/teaching/courses'));
@@ -346,6 +386,24 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
       alert(getText('registerError'));
     } finally {
       setIsRegistering(false);
+    }
+  };
+
+  /**
+   * 작성중으로 되돌리기 (READY → DRAFT)
+   */
+  const handleUnready = async () => {
+    if (!courseId) return;
+
+    if (!confirm('작성중 상태로 되돌리시겠습니까?')) return;
+
+    try {
+      await courseService.unready(courseId);
+      setCourseStatus('DRAFT');
+      alert('작성중 상태로 변경되었습니다.');
+    } catch (error) {
+      console.error('상태 변경 실패:', error);
+      alert('상태 변경에 실패했습니다.');
     }
   };
 
@@ -508,42 +566,56 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
               </Button>
             ) : (
               <>
-                {/* 작성완료 버튼 (DRAFT → READY) */}
-                <Button
-                  variant="ghost"
-                  onClick={handleComplete}
-                  disabled={
-                    isCompleting ||
-                    isRegistering ||
-                    !formData.title ||
-                    !formData.categoryId ||
-                    formData.curriculumItems.length === 0
-                  }
-                  className="border border-border"
-                  title={
-                    !formData.title
-                      ? '강의명을 입력해주세요'
-                      : !formData.categoryId
-                        ? '카테고리를 선택해주세요'
-                        : formData.curriculumItems.length === 0
-                          ? '최소 1개의 차시가 필요합니다'
-                          : undefined
-                  }
-                >
-                  {isCompleting ? (
-                    <>
-                      <Loader2 size={18} className="animate-spin" />
-                      {getText('completing')}
-                    </>
-                  ) : (
-                    <>
-                      <CheckCircle size={18} />
-                      {getText('completeWriting')}
-                    </>
-                  )}
-                </Button>
+                {/* DRAFT 상태: 작성완료 버튼 */}
+                {courseStatus === 'DRAFT' && (
+                  <Button
+                    variant="ghost"
+                    onClick={handleComplete}
+                    disabled={
+                      isCompleting ||
+                      isRegistering ||
+                      !formData.title ||
+                      !formData.categoryId ||
+                      formData.curriculumItems.length === 0
+                    }
+                    className="border border-border"
+                    title={
+                      !formData.title
+                        ? '강의명을 입력해주세요'
+                        : !formData.categoryId
+                          ? '카테고리를 선택해주세요'
+                          : formData.curriculumItems.length === 0
+                            ? '최소 1개의 차시가 필요합니다'
+                            : undefined
+                    }
+                  >
+                    {isCompleting ? (
+                      <>
+                        <Loader2 size={18} className="animate-spin" />
+                        {getText('completing')}
+                      </>
+                    ) : (
+                      <>
+                        <CheckCircle size={18} />
+                        {getText('completeWriting')}
+                      </>
+                    )}
+                  </Button>
+                )}
 
-                {/* 등록 버튼 (DRAFT → READY → REGISTERED) */}
+                {/* READY 상태: 작성중으로 되돌리기 버튼 */}
+                {courseStatus === 'READY' && (
+                  <Button
+                    variant="ghost"
+                    onClick={handleUnready}
+                    className="border border-border"
+                  >
+                    <ArrowLeft size={18} />
+                    작성중으로 되돌리기
+                  </Button>
+                )}
+
+                {/* 등록 버튼 (DRAFT → REGISTERED 또는 READY → REGISTERED) */}
                 <Button
                   onClick={handleRegister}
                   disabled={

--- a/src/pages/tu/teaching/courses/CourseEditPage.tsx
+++ b/src/pages/tu/teaching/courses/CourseEditPage.tsx
@@ -27,7 +27,8 @@ interface CourseEditPageProps {
 }
 
 /**
- * 커리큘럼 트리를 재귀적으로 순회하며 API 호출
+ * 커리큘럼 트리를 재귀적으로 순회하며 API 호출 (신규 항목만)
+ * itemId가 있는 항목은 이미 저장된 항목이므로 건너뜀
  */
 async function createCurriculumItemsRecursively(
   courseId: number,
@@ -36,18 +37,41 @@ async function createCurriculumItemsRecursively(
 ): Promise<void> {
   for (const item of items) {
     if (isCurriculumFolder(item)) {
-      const folderResponse = await courseService.createFolder(courseId, {
-        folderName: item.name,
-        parentId: parentId ?? undefined,
-      });
+      let currentFolderId: number;
+
+      // itemId가 있으면 이미 저장된 폴더
+      if (item.itemId) {
+        currentFolderId = item.itemId;
+      } else {
+        // 새 폴더 생성
+        const folderResponse = await courseService.createFolder(courseId, {
+          folderName: item.name,
+          parentId: parentId ?? undefined,
+        });
+        currentFolderId = folderResponse.itemId;
+      }
+
+      // 하위 항목 재귀 생성
       if (item.children.length > 0) {
         await createCurriculumItemsRecursively(
           courseId,
           item.children,
-          folderResponse.itemId
+          currentFolderId
         );
       }
     } else if (isCurriculumContent(item)) {
+      // itemId가 있으면 이미 저장된 콘텐츠, 건너뜀
+      if (item.itemId) {
+        continue;
+      }
+
+      // contentId가 없으면 에러 (신규 항목인데 contentId가 없음)
+      if (!item.contentId) {
+        console.error('신규 콘텐츠 항목에 contentId가 없습니다:', item);
+        continue;
+      }
+
+      // 콘텐츠(차시) 생성 - contentId로 백엔드에서 LO 자동 생성
       await courseService.createItem(courseId, {
         itemName: item.name,
         parentId: parentId ?? undefined,

--- a/src/pages/tu/teaching/courses/MyCoursesPage.tsx
+++ b/src/pages/tu/teaching/courses/MyCoursesPage.tsx
@@ -7,10 +7,10 @@ import { Button, IconStatCard } from '@/components/common';
 import { CourseCard } from '@/components/domain/tu/course';
 import { useMyCourses, useApplyProgramsBulk, toCourseForApplication } from '@/hooks/tu';
 import type { Course } from '@/types';
-import type { CourseResponse, CoursePublishStatus } from '@/types/common/course.types';
+import type { CourseResponse, CourseStatus } from '@/types/common/course.types';
 
-/** 발행 상태 필터 타입 */
-type StatusFilter = 'all' | 'draft' | 'published';
+/** 과정 상태 필터 타입 */
+type StatusFilter = 'all' | 'draft' | 'ready' | 'registered';
 
 interface MyCoursesPageProps {
   language?: 'ko' | 'en';
@@ -19,7 +19,7 @@ interface MyCoursesPageProps {
 const DEFAULT_THUMBNAIL = 'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=400&h=250&fit=crop';
 
 /** CourseResponse를 UI용 Course 타입으로 변환 */
-function mapCourseResponseToCourse(response: CourseResponse): Course & { isComplete: boolean; courseStatus: CoursePublishStatus } {
+function mapCourseResponseToCourse(response: CourseResponse): Course & { isComplete: boolean; courseStatus: CourseStatus } {
   return {
     id: String(response.courseId),
     title: response.title,
@@ -31,7 +31,7 @@ function mapCourseResponseToCourse(response: CourseResponse): Course & { isCompl
     category: response.tags?.[0] || '미분류',
     students: 0,
     lastAccessed: new Date(response.updatedAt).toLocaleDateString('ko-KR'),
-    status: response.status === 'PUBLISHED' ? 'active' : 'draft',
+    status: response.status === 'REGISTERED' ? 'active' : 'draft',
     isComplete: response.isComplete,
     courseStatus: response.status,
   };
@@ -42,7 +42,9 @@ const t = {
   subtitle: { ko: '개설한 강의를 관리하고 수강생을 확인하세요', en: 'Manage your courses and track student progress' },
   createCourse: { ko: '강의 생성', en: 'Create Course' },
   all: { ko: '전체', en: 'All' },
-  draft: { ko: '임시저장', en: 'Draft' },
+  draft: { ko: '작성중', en: 'Draft' },
+  ready: { ko: '작성완료', en: 'Ready' },
+  registered: { ko: '등록됨', en: 'Registered' },
   published: { ko: '발행됨', en: 'Published' },
   sortBy: { ko: '정렬', en: 'Sort By' },
   recent: { ko: '최신순', en: 'Recent' },
@@ -180,7 +182,8 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
   const filteredCourses = courses.filter((course) => {
     if (filterStatus === 'all') return true;
     if (filterStatus === 'draft') return course.courseStatus === 'DRAFT';
-    if (filterStatus === 'published') return course.courseStatus === 'PUBLISHED';
+    if (filterStatus === 'ready') return course.courseStatus === 'READY';
+    if (filterStatus === 'registered') return course.courseStatus === 'REGISTERED';
     return true;
   });
 
@@ -223,7 +226,7 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
         <div className="flex gap-2 items-center">
           <Filter size={18} className="text-text-secondary" />
           <div className="flex gap-1 bg-bg-secondary p-1 rounded-lg">
-            {(['all', 'draft', 'published'] as const).map((status) => (
+            {(['all', 'draft', 'ready', 'registered'] as const).map((status) => (
               <button
                 key={status}
                 onClick={() => setFilterStatus(status)}
@@ -334,7 +337,7 @@ export function MyCoursesPage({ language = 'ko' }: Readonly<MyCoursesPageProps>)
                     manageCourse: getText('manageCourse'),
                   }}
                   renderActions={
-                    course.courseStatus === 'PUBLISHED' ? (
+                    course.courseStatus === 'REGISTERED' ? (
                       <>
                         <Button
                           size="sm"

--- a/src/types/co/course.types.ts
+++ b/src/types/co/course.types.ts
@@ -85,8 +85,11 @@ export {
  */
 export type CourseDifficulty = 'beginner' | 'elementary' | 'intermediate' | 'advanced' | '';
 
-/** 강의 상태 (UI 전용) */
-export type CourseStatus = 'active' | 'completed' | 'draft';
+/**
+ * 강의 표시 상태 (UI 전용)
+ * @deprecated Course.status 필드에 사용되던 UI 전용 타입. 향후 제거 예정.
+ */
+export type CourseDisplayStatus = 'active' | 'completed' | 'draft';
 
 /** 다국어 버전 타입 */
 export interface LanguageVersion {
@@ -142,7 +145,7 @@ export interface Course {
   deadline?: string;
   lastAccessed?: string;
   students?: number;
-  status?: CourseStatus;
+  status?: CourseDisplayStatus;
 }
 
 // ============================================

--- a/src/types/common/course.types.ts
+++ b/src/types/common/course.types.ts
@@ -13,7 +13,18 @@ export type CourseLevel = 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED';
 /** 강의 유형 */
 export type CourseType = 'ONLINE' | 'OFFLINE' | 'BLENDED';
 
-/** 강의 발행 상태 (API용, UI용 CourseStatus와 구분) */
+/**
+ * 강의 상태 (Phase 1: Course 등록 및 동결)
+ * - DRAFT: 작성 중 (수정 가능)
+ * - READY: 작성 완료 (수정 가능, 등록 대기)
+ * - REGISTERED: 등록됨 (수정 불가, 차수 생성 가능)
+ */
+export type CourseStatus = 'DRAFT' | 'READY' | 'REGISTERED';
+
+/**
+ * @deprecated Phase 1 이후 사용 중지. CourseStatus 사용 권장.
+ * 하위 호환성을 위해 유지.
+ */
 export type CoursePublishStatus = 'DRAFT' | 'PUBLISHED';
 
 /**
@@ -41,8 +52,8 @@ export interface CourseResponse {
   thumbnailUrl: string | null;
   level: CourseLevel | null;
   type: CourseType | null;
-  /** 발행 상태 (DRAFT: 임시저장, PUBLISHED: 발행됨) */
-  status: CoursePublishStatus;
+  /** 강의 상태 (DRAFT: 작성중, READY: 작성완료, REGISTERED: 등록됨) */
+  status: CourseStatus;
   estimatedHours: number | null;
   categoryId: number | null;
   startDate: string | null;
@@ -90,8 +101,8 @@ export interface CourseDetailResponse {
   thumbnailUrl: string | null;
   level: CourseLevel | null;
   type: CourseType | null;
-  /** 발행 상태 (DRAFT: 임시저장, PUBLISHED: 발행됨) */
-  status: CoursePublishStatus;
+  /** 강의 상태 (DRAFT: 작성중, READY: 작성완료, REGISTERED: 등록됨) */
+  status: CourseStatus;
   estimatedHours: number | null;
   categoryId: number | null;
   startDate: string | null;
@@ -137,6 +148,7 @@ export interface UpdateCourseRequest {
   startDate?: string;
   endDate?: string;
   tags?: string[];
+  /** @deprecated status는 상태 전환 API 사용 (ready, unready, register) */
   status?: CoursePublishStatus;
 }
 
@@ -200,7 +212,26 @@ export const COURSE_TYPE_LABELS: Record<CourseType, string> = {
   BLENDED: '블렌디드',
 };
 
-/** CoursePublishStatus 라벨 맵 */
+/** CourseStatus 라벨 맵 */
+export const COURSE_STATUS_LABELS: Record<CourseStatus, string> = {
+  DRAFT: '작성중',
+  READY: '작성완료',
+  REGISTERED: '등록됨',
+};
+
+/** CourseStatus 색상 맵 (UI용) */
+export const COURSE_STATUS_COLORS: Record<
+  CourseStatus,
+  { bg: string; text: string }
+> = {
+  DRAFT: { bg: 'bg-gray-100', text: 'text-gray-700' },
+  READY: { bg: 'bg-blue-100', text: 'text-blue-700' },
+  REGISTERED: { bg: 'bg-green-100', text: 'text-green-700' },
+};
+
+/**
+ * @deprecated Phase 1 이후 사용 중지. COURSE_STATUS_LABELS 사용 권장.
+ */
 export const COURSE_PUBLISH_STATUS_LABELS: Record<CoursePublishStatus, string> = {
   DRAFT: '임시저장',
   PUBLISHED: '발행됨',

--- a/src/types/tu/curriculum.types.ts
+++ b/src/types/tu/curriculum.types.ts
@@ -34,6 +34,8 @@ interface CurriculumItemBase {
 /** 폴더 타입 커리큘럼 항목 */
 export interface CurriculumFolderItem extends CurriculumItemBase {
   type: 'folder';
+  /** 백엔드 CourseItem ID (저장된 항목만 존재) */
+  itemId?: number;
   /** 하위 항목 목록 */
   children: CurriculumItem[];
 }
@@ -41,8 +43,12 @@ export interface CurriculumFolderItem extends CurriculumItemBase {
 /** 콘텐츠(LO) 타입 커리큘럼 항목 */
 export interface CurriculumContentItem extends CurriculumItemBase {
   type: 'content';
-  /** 콘텐츠 ID (백엔드에서 LO 자동 생성) */
-  contentId: number;
+  /** 백엔드 CourseItem ID (저장된 항목만 존재, 있으면 기존 항목) */
+  itemId?: number;
+  /** 콘텐츠 ID (신규 항목 생성 시 사용, 백엔드에서 LO 자동 생성) */
+  contentId?: number;
+  /** Learning Object ID (기존 항목, 읽기 전용) */
+  learningObjectId?: number;
   /** 원본 파일명 */
   originalFileName: string;
   /** 콘텐츠 타입 */
@@ -96,7 +102,7 @@ export function createFolderItem(
   };
 }
 
-/** 새 콘텐츠 항목 생성 */
+/** 새 콘텐츠 항목 생성 (신규 추가용) */
 export function createContentItem(
   contentId: number,
   originalFileName: string,
@@ -155,7 +161,10 @@ export function findParentInTree(
 // Conversion Functions (백엔드 ↔ 프론트엔드)
 // ============================================
 
-/** 백엔드 계층 응답을 프론트엔드 CurriculumItem으로 변환 */
+/**
+ * 백엔드 계층 응답을 프론트엔드 CurriculumItem으로 변환
+ * 저장된 항목은 itemId와 learningObjectId를 포함 (기존 항목 표시)
+ */
 export function convertHierarchyToCurriculumItems(
   items: CourseItemHierarchyResponse[],
   depth: number = 0
@@ -168,6 +177,7 @@ export function convertHierarchyToCurriculumItems(
         type: 'folder',
         depth,
         order: index,
+        itemId: item.itemId,
         isExpanded: true,
         children: convertHierarchyToCurriculumItems(item.children, depth + 1),
       };
@@ -178,7 +188,8 @@ export function convertHierarchyToCurriculumItems(
         type: 'content',
         depth,
         order: index,
-        contentId: item.learningObjectId!,
+        itemId: item.itemId,
+        learningObjectId: item.learningObjectId ?? undefined,
         originalFileName: item.itemName,
         contentType: '',
         displayName: item.displayName ?? undefined,


### PR DESCRIPTION
## 관련 이슈
Closes #397

## 변경 사항 요약

### 1. 타입 정의 수정
- `CourseStatus` 타입 추가: `'DRAFT' | 'READY' | 'REGISTERED'`
- `CoursePublishStatus` deprecated 처리 (하위 호환성 유지)
- `CourseResponse`, `CourseDetailResponse`의 status 타입 변경
- 상태 라벨 및 색상 맵 추가 (`COURSE_STATUS_LABELS`, `COURSE_STATUS_COLORS`)

### 2. Curriculum 타입 개선
- `CurriculumContentItem`에 `itemId` 필드 추가 (기존 항목 구분용)
- `learningObjectId` 필드 추가 (읽기 전용, 기존 항목)
- `contentId` 필드를 선택적으로 변경 (신규 항목만 필수)
- `convertHierarchyToCurriculumItems` 수정: learningObjectId를 별도 필드로 보존

### 3. 저장 로직 개선
**CourseCreatePage.tsx, CourseEditPage.tsx**
- `createCurriculumItemsRecursively` 개선
  - 기존 항목(`itemId` 있음) 건너뛰기
  - 신규 항목(`contentId` 있음)만 생성
  - 전체 삭제 후 재생성 방식 제거
- **핵심 문제 해결**: learningObjectId를 contentId로 잘못 사용하여 발생하던 에러 수정

### 4. UI 상태 처리
**CourseCreatePage.tsx**
- `courseStatus` 상태 추가 및 관리
- REGISTERED 상태 Course 편집 불가 처리
- 상태별 버튼 표시 분기:
  - **DRAFT**: 작성완료 + 등록 버튼
  - **READY**: 작성중으로 되돌리기 + 등록 버튼
- `handleRegister` 수정: courseStatus에 따라 READY 단계 건너뛰기
- `handleUnready` 추가: READY → DRAFT 상태 전환

**MyCoursesPage.tsx**
- 필터 타입 업데이트: `'draft' | 'ready' | 'registered'`
- 상태별 필터링 로직 수정
- REGISTERED 상태만 프로그램 신청 가능하도록 변경
- 상태 라벨 추가

### 5. 타입 충돌 해결
- `co/course.types.ts`의 `CourseStatus` → `CourseDisplayStatus`로 변경 (UI 전용 타입)

## 테스트
- ✅ TypeScript 컴파일 에러 없음
- ✅ 타입 정의 일관성 확인
- ✅ 기존/신규 항목 구분 로직 검증

## 체크리스트
- [x] TypeScript 컴파일 통과
- [x] 타입 정의 수정 완료
- [x] 저장 로직 개선 완료
- [x] UI 상태 처리 완료
- [x] 이슈 #397 요구사항 충족