### PR TITLE
[Feat] B2B/B2C 페이지 분리 및 랜딩 페이지 UX 개선

### DIFF
--- a/src/components/layout/mypage/B2BMyPageSidebar.tsx
+++ b/src/components/layout/mypage/B2BMyPageSidebar.tsx
@@ -114,14 +114,15 @@ export function B2BMyPageSidebar({ onMenuItemClick }: B2BMyPageSidebarProps) {
     checkCourseRole();
   }, []);
 
-  const isDesigner = courseRoleStatus !== 'USER';
+  // 관리자이거나 강의 역할이 있으면 토글 표시 가능
+  const isAdminOrDesigner = courseRoleStatus !== 'USER' || user?.role === 'TENANT_ADMIN' || user?.roles?.includes('TENANT_ADMIN');
 
   const handleCreateCourseClick = () => {
     setShowCreateCourseDialog(true);
   };
 
   const handleCreateCourseConfirm = async () => {
-    if (isDesigner) {
+    if (isAdminOrDesigner) {
       setShowCreateCourseDialog(false);
       onMenuItemClick?.('create-course');
       return;
@@ -295,7 +296,7 @@ export function B2BMyPageSidebar({ onMenuItemClick }: B2BMyPageSidebarProps) {
         }`}
       >
         {/* 글로벌 역할 스위처 (디자이너 권한 + 강사 탭 기능이 활성화된 경우에만 표시) */}
-        {isDesigner && instructorTabEnabled && (
+        {isAdminOrDesigner && instructorTabEnabled && (
           <>
             <div className="mb-3">
               <GlobalRoleSwitcher

--- a/src/components/layout/mypage/MyPageSidebar.tsx
+++ b/src/components/layout/mypage/MyPageSidebar.tsx
@@ -134,7 +134,8 @@ export function MyPageSidebar({ onMenuItemClick, menuData: externalMenuData }: M
   }, []);
 
   // 사용자가 강사/디자이너 역할을 가지고 있는지 확인 (CourseRole 기준)
-  const isDesigner = courseRoleStatus !== 'USER';
+  // 관리자이거나 강의 역할이 있으면 토글 표시 가능
+  const isAdminOrDesigner = courseRoleStatus !== 'USER' || user?.role === 'TENANT_ADMIN' || user?.roles?.includes('TENANT_ADMIN');
 
   // 강의 개설하기 클릭 핸들러
   const handleCreateCourseClick = () => {
@@ -143,7 +144,7 @@ export function MyPageSidebar({ onMenuItemClick, menuData: externalMenuData }: M
 
   const handleCreateCourseConfirm = async () => {
     // 이미 DESIGNER인 경우 바로 이동
-    if (isDesigner) {
+    if (isAdminOrDesigner) {
       setShowCreateCourseDialog(false);
       onMenuItemClick?.('create-course');
       return;
@@ -321,7 +322,7 @@ export function MyPageSidebar({ onMenuItemClick, menuData: externalMenuData }: M
         }`}
       >
         {/* 글로벌 역할 스위처 (디자이너 권한 + 강사 탭 기능이 활성화된 경우에만 표시) */}
-        {isDesigner && instructorTabEnabled && (
+        {isAdminOrDesigner && instructorTabEnabled && (
           <>
             <div className="mb-3">
               <GlobalRoleSwitcher

--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -333,3 +333,15 @@ export {
 // Question Section Hook (질문 섹션 공통 로직)
 export { useQuestionSection } from './useQuestionSection';
 export type { TabType, SortType } from './useQuestionSection';
+
+// Search Logic Hook (검색 로직 공통)
+export {
+  useSearchLogic,
+  convertCourseTimeToCardProps,
+  SORT_OPTIONS,
+  CATEGORY_OPTIONS,
+  LEVEL_OPTIONS,
+  STATUS_OPTIONS,
+  PRICE_OPTIONS,
+  type SearchFilters,
+} from './useSearchLogic';

--- a/src/hooks/tu/useSearchLogic.ts
+++ b/src/hooks/tu/useSearchLogic.ts
@@ -1,0 +1,215 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useCourseTimeCatalog } from './useCourseTimeCatalog';
+import type { CourseTimeCatalogResponse } from '@/types/tu/courseTimeCatalog.types';
+import { DELIVERY_TYPE_LABELS, PROGRAM_LEVEL_LABELS } from '@/types/tu/courseTimeCatalog.types';
+
+// 필터 타입
+export interface SearchFilters {
+  sort: string;
+  category: string;
+  level: string;
+  status?: string;
+  price?: string;
+}
+
+// 필터 옵션 상수
+export const SORT_OPTIONS = [
+  { value: 'relevance', label: '관련도순' },
+  { value: 'latest', label: '최신순' },
+  { value: 'popular', label: '인기순' },
+  { value: 'rating', label: '평점순' },
+];
+
+export const CATEGORY_OPTIONS = [
+  { value: 'all', label: '전체' },
+  { value: '개발', label: '개발' },
+  { value: 'AI', label: 'AI' },
+  { value: '클라우드', label: '클라우드' },
+  { value: '데이터', label: '데이터' },
+  { value: '디자인', label: '디자인' },
+];
+
+export const LEVEL_OPTIONS = [
+  { value: 'all', label: '전체' },
+  { value: 'beginner', label: '입문' },
+  { value: 'intermediate', label: '중급' },
+  { value: 'advanced', label: '고급' },
+];
+
+export const STATUS_OPTIONS = [
+  { value: 'all', label: '전체' },
+  { value: 'recruiting', label: '모집중' },
+  { value: 'ongoing', label: '상시모집' },
+];
+
+export const PRICE_OPTIONS = [
+  { value: 'all', label: '전체' },
+  { value: 'free', label: '무료' },
+  { value: 'paid', label: '유료' },
+];
+
+/**
+ * CourseTime API 데이터를 카드 컴포넌트 props로 변환
+ */
+export function convertCourseTimeToCardProps(
+  courseTime: CourseTimeCatalogResponse,
+  includePrice: boolean = true
+) {
+  const mainInstructor = courseTime.instructors.find((i) => i.role === 'MAIN');
+  const instructorName = mainInstructor?.name || courseTime.instructors[0]?.name || '';
+
+  const tags: string[] = [];
+  if (courseTime.isOnDemand) {
+    tags.push('상시모집');
+  } else if (courseTime.status === 'RECRUITING') {
+    tags.push('모집중');
+  } else if (courseTime.status === 'ONGOING') {
+    tags.push('진행중');
+  }
+
+  const thumbnailUrl =
+    courseTime.program?.thumbnailUrl ||
+    'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=400&h=250&fit=crop';
+
+  const baseProps = {
+    id: courseTime.id,
+    title: courseTime.title,
+    instructor: instructorName,
+    image: thumbnailUrl,
+    tags,
+    category: courseTime.program?.categoryName ?? '',
+    deliveryType: DELIVERY_TYPE_LABELS[courseTime.deliveryType] || courseTime.deliveryType,
+    level: courseTime.program?.level ? PROGRAM_LEVEL_LABELS[courseTime.program.level] : undefined,
+    studentCount: courseTime.currentEnrollment,
+    classStartDate: courseTime.classStartDate,
+    isOnDemand: courseTime.isOnDemand,
+  };
+
+  // B2C에서만 가격 정보 포함
+  if (includePrice) {
+    return {
+      ...baseProps,
+      rating: 0,
+      reviewCount: 0,
+      price: null,
+    };
+  }
+
+  return baseProps;
+}
+
+/**
+ * 공통 검색 로직을 담당하는 커스텀 훅
+ * B2C와 B2B 검색 페이지에서 공유
+ */
+export function useSearchLogic(includePrice: boolean = true) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchInput, setSearchInput] = useState('');
+  const [isSearchFocused, setIsSearchFocused] = useState(false);
+  const [showFilters, setShowFilters] = useState(false);
+
+  // URL에서 검색어 가져오기
+  const query = searchParams.get('q') || '';
+
+  // 필터 상태
+  const [filters, setFilters] = useState<SearchFilters>({
+    sort: 'relevance',
+    category: 'all',
+    level: 'all',
+    status: 'all',
+    price: 'all',
+  });
+
+  // 검색 입력값 초기화
+  useEffect(() => {
+    setSearchInput(query);
+  }, [query]);
+
+  // 강의 데이터 가져오기
+  const {
+    data: coursesData,
+    isLoading: isCoursesLoading,
+    error: coursesError,
+  } = useCourseTimeCatalog({
+    search: query || undefined,
+    categoryName: filters.category !== 'all' ? filters.category : undefined,
+    level: filters.level !== 'all' ? filters.level.toUpperCase() : undefined,
+    status:
+      filters.status !== 'all'
+        ? filters.status === 'recruiting'
+          ? 'RECRUITING'
+          : 'ONGOING'
+        : undefined,
+    sort:
+      filters.sort === 'latest'
+        ? 'classStartDate,desc'
+        : filters.sort === 'popular'
+          ? 'currentEnrollment,desc'
+          : undefined,
+    page: 0,
+    size: 50,
+  });
+
+  // 검색 결과 처리
+  const courses = useMemo(() => {
+    if (!coursesData?.content) return [];
+    return coursesData.content.map((course) => convertCourseTimeToCardProps(course, includePrice));
+  }, [coursesData, includePrice]);
+
+  // 검색 실행
+  const handleSearch = (e?: React.FormEvent) => {
+    if (e) e.preventDefault();
+    if (searchInput.trim()) {
+      setSearchParams({ q: searchInput.trim() });
+    }
+  };
+
+  // 검색어 초기화
+  const clearSearch = () => {
+    setSearchInput('');
+    setSearchParams({});
+  };
+
+  // 필터 업데이트
+  const updateFilter = (key: keyof SearchFilters, value: string) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  };
+
+  // 필터 초기화
+  const resetFilters = () => {
+    setFilters({
+      sort: 'relevance',
+      category: 'all',
+      level: 'all',
+      status: 'all',
+      price: 'all',
+    });
+  };
+
+  return {
+    // 검색 상태
+    query,
+    searchInput,
+    setSearchInput,
+    isSearchFocused,
+    setIsSearchFocused,
+
+    // 필터 상태
+    filters,
+    showFilters,
+    setShowFilters,
+    updateFilter,
+    resetFilters,
+
+    // 데이터
+    courses,
+    isLoading: isCoursesLoading,
+    error: coursesError,
+    totalElements: coursesData?.totalElements || 0,
+
+    // 액션
+    handleSearch,
+    clearSearch,
+  };
+}

--- a/src/hooks/tu/useSearchLogic.ts
+++ b/src/hooks/tu/useSearchLogic.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { useCourseTimeCatalog } from './useCourseTimeCatalog';
+import { useCourseTimeCatalog } from './useCourseTimeCatalogQueries';
 import type { CourseTimeCatalogResponse } from '@/types/tu/courseTimeCatalog.types';
 import { DELIVERY_TYPE_LABELS, PROGRAM_LEVEL_LABELS } from '@/types/tu/courseTimeCatalog.types';
 

--- a/src/hooks/tu/useSearchLogic.ts
+++ b/src/hooks/tu/useSearchLogic.ts
@@ -132,14 +132,12 @@ export function useSearchLogic(includePrice: boolean = true) {
     isLoading: isCoursesLoading,
     error: coursesError,
   } = useCourseTimeCatalog({
-    search: query || undefined,
-    categoryName: filters.category !== 'all' ? filters.category : undefined,
-    level: filters.level !== 'all' ? filters.level.toUpperCase() : undefined,
+    keyword: query || undefined,
     status:
       filters.status !== 'all'
         ? filters.status === 'recruiting'
-          ? 'RECRUITING'
-          : 'ONGOING'
+          ? ['RECRUITING']
+          : ['ONGOING']
         : undefined,
     sort:
       filters.sort === 'latest'

--- a/src/index.css
+++ b/src/index.css
@@ -251,11 +251,13 @@
 /* Landing Button styles - Uses dynamic branding variables */
 .landing-btn-primary {
   background: linear-gradient(135deg, var(--landing-primary-color, #6778ff) 0%, var(--landing-secondary-color, #a855f7) 100%);
+  color: #ffffff;
   transition: all 0.3s ease;
 }
 
 .landing-btn-primary:hover {
   background: linear-gradient(135deg, var(--landing-primary-hover, #8b99ff) 0%, var(--landing-secondary-hover, #c084fc) 100%);
+  color: #ffffff;
   transform: translateY(-2px);
   box-shadow: 0 10px 30px color-mix(in srgb, var(--landing-primary-color, #6778ff) 40%, transparent);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -759,9 +759,11 @@
   color: #6778ff;
 }
 
-/* Hero section for light mode - lighter gradient background */
+/* Hero section for light mode - use same dark gradient as dark mode */
 .landing-light .animated-bg {
-  background: linear-gradient(135deg, #4a4a80 0%, #6060a0 50%, #4a4a80 100%);
+  background: linear-gradient(-45deg, #1a1a2e, #2a2a4e, #243358, #1a1a2e);
+  background-size: 400% 400%;
+  animation: bg-gradient 15s ease infinite;
 }
 
 .landing-light .animated-bg h2.text-white {

--- a/src/index.css
+++ b/src/index.css
@@ -614,14 +614,14 @@
 }
 
 .landing-light .landing-chip-inactive {
-  background: #FFFFFF;
-  color: #666666;
-  border: 1px solid #E0E0E0;
+  background: #F5F5F5;
+  color: #424242;
+  border: 1px solid #D0D0D0;
 }
 
 .landing-light .landing-chip-inactive:hover {
-  background: #F4F4F4;
-  color: #333333;
+  background: #E8E8E8;
+  color: #212121;
 }
 
 /* Header glass effect for themes */

--- a/src/pages/tu/b2b/B2BCertificationsPage.tsx
+++ b/src/pages/tu/b2b/B2BCertificationsPage.tsx
@@ -1,0 +1,237 @@
+import { useState } from 'react';
+import { Award, Loader2 } from 'lucide-react';
+import { useThemeStore } from '@/store/common/themeStore';
+import { useTranslation, useLanguageStore } from '@/store/common/languageStore';
+import { useAuthStore } from '@/store/common/authStore';
+import { useMyCertificates, useDownloadCertificate } from '@/hooks/tu';
+import {
+  Button,
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/common';
+import { CertificateCard, CertificatePreviewModal } from '@/components/domain/tu/certificate';
+import type { CertificateResponse } from '@/types/tu';
+
+export function B2BCertificationsPage() {
+  const { theme } = useThemeStore();
+  const { language } = useLanguageStore();
+  const { t } = useTranslation();
+  const isDark = theme === 'dark';
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  const [page, setPage] = useState(0);
+  const pageSize = 12;
+
+  // 수료증 미리보기 모달 상태
+  const [selectedCertificate, setSelectedCertificate] = useState<CertificateResponse | null>(null);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const [downloadingId, setDownloadingId] = useState<number | null>(null);
+
+  // Certificate API로 수료증 목록 조회
+  const { data, isLoading, isFetching, isError } = useMyCertificates({
+    page,
+    size: pageSize,
+  });
+
+  // 실제 로딩 상태 (초기 로딩 또는 페칭 중)
+  const showLoading = isLoading || (isFetching && !data);
+
+  // PDF 다운로드 mutation
+  const downloadMutation = useDownloadCertificate();
+
+  // 수료증 카드 라벨
+  const cardLabels = {
+    completedOn: language === 'ko' ? '수료일' : 'Completed on',
+    view: language === 'ko' ? '보기' : 'View',
+    download: language === 'ko' ? '다운로드' : 'Download',
+    downloading: language === 'ko' ? '다운로드 중...' : 'Downloading...',
+    preparing: language === 'ko' ? '준비 중' : 'Preparing',
+    certificateOf: language === 'ko' ? '수료증' : 'Certificate of',
+    completion: language === 'ko' ? '수료' : 'Completion',
+  };
+
+  // 수료증 모달 라벨
+  const modalLabels = {
+    title: language === 'ko' ? '수료증 미리보기' : 'Certificate Preview',
+    certificateOf: language === 'ko' ? '수료증' : 'Certificate of',
+    completion: language === 'ko' ? '수료' : 'Completion',
+    certifyThat: language === 'ko' ? '다음의 사용자가' : 'This is to certify that',
+    hasCompleted: language === 'ko' ? '아래 과정을 성공적으로 수료하였음을 인증합니다.' : 'has successfully completed the following course.',
+    issuedOn: language === 'ko' ? '발급일' : 'Issued on',
+    completedOn: language === 'ko' ? '수료일' : 'Completed on',
+    certificateNumber: language === 'ko' ? '수료증 번호' : 'Certificate No.',
+    download: language === 'ko' ? 'PDF 다운로드' : 'Download PDF',
+    downloading: language === 'ko' ? '다운로드 중...' : 'Downloading...',
+    close: language === 'ko' ? '닫기' : 'Close',
+    organization: language === 'ko' ? '발급 기관' : 'Organization',
+  };
+
+  const handlePreview = (certificate: CertificateResponse) => {
+    setSelectedCertificate(certificate);
+    setIsPreviewOpen(true);
+  };
+
+  const handleClosePreview = () => {
+    setIsPreviewOpen(false);
+    setSelectedCertificate(null);
+  };
+
+  const handleDownload = async (certificate: CertificateResponse) => {
+    if (downloadMutation.isPending) return;
+
+    setDownloadingId(certificate.id);
+    try {
+      const fileName = `certificate_${certificate.certificateNumber}.pdf`;
+      await downloadMutation.mutateAsync({ id: certificate.id, fileName });
+    } catch (error) {
+      console.error('Failed to download certificate:', error);
+    } finally {
+      setDownloadingId(null);
+    }
+  };
+
+  return (
+    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+      <div className="max-w-5xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            {t.mypage.certificates}
+          </h1>
+          <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
+            {t.mypage.certificatesDesc}
+          </p>
+        </div>
+
+        {/* Results Count */}
+        {isAuthenticated && data && (
+          <p className={`mb-4 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+            {language === 'ko' ? '총 ' : 'Total '}
+            <span className={`font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              {data.totalElements}
+            </span>
+            {language === 'ko' ? '개의 수료증' : ' certificates'}
+          </p>
+        )}
+
+        {/* Loading State */}
+        {showLoading && (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className={`w-8 h-8 animate-spin ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+          </div>
+        )}
+
+        {/* Not Authenticated State */}
+        {!isAuthenticated && !showLoading && (
+          <div className="text-center py-20">
+            <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
+              {language === 'ko' ? '로그인이 필요합니다.' : 'Please log in to view certificates.'}
+            </p>
+          </div>
+        )}
+
+        {/* Error State */}
+        {isError && (
+          <div className="text-center py-20">
+            <p className="text-red-500">
+              {language === 'ko' ? '데이터를 불러오는데 실패했습니다.' : 'Failed to load data.'}
+            </p>
+          </div>
+        )}
+
+        {/* Empty State */}
+        {isAuthenticated && data && data.content.length === 0 && (
+          <div
+            className={`text-center py-20 rounded-xl ${
+              isDark ? 'bg-white/5 border border-white/10' : 'bg-white border border-gray-200'
+            }`}
+          >
+            <Award className={`w-16 h-16 mx-auto mb-4 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
+            <h3 className={`text-lg font-medium mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              {language === 'ko' ? '발급된 수료증이 없습니다' : 'No certificates issued'}
+            </h3>
+            <p className={`mb-4 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+              {language === 'ko'
+                ? '강의를 수료하면 수료증이 여기에 표시됩니다.'
+                : 'Certificates will appear here when you complete courses.'}
+            </p>
+            <Button variant="brand" onClick={() => window.location.href = '/tu/b2c/mypage/learning'}>
+              {language === 'ko' ? '학습 중인 강의 보기' : 'View Current Courses'}
+            </Button>
+          </div>
+        )}
+
+        {/* Certificates Grid */}
+        {isAuthenticated && data && data.content.length > 0 && (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mb-8">
+              {data.content.map((certificate) => (
+                <CertificateCard
+                  key={certificate.id}
+                  certificate={certificate}
+                  labels={cardLabels}
+                  onPreview={() => handlePreview(certificate)}
+                  onDownload={() => handleDownload(certificate)}
+                  isDownloading={downloadingId === certificate.id}
+                  isDark={isDark}
+                />
+              ))}
+            </div>
+
+            {/* Pagination */}
+            {data.totalPages > 1 && (
+              <Pagination>
+                <PaginationContent>
+                  <PaginationItem>
+                    <PaginationPrevious
+                      onClick={() => setPage(Math.max(0, page - 1))}
+                      className={page === 0 ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
+                    />
+                  </PaginationItem>
+
+                  {Array.from({ length: Math.min(5, data.totalPages) }, (_, i) => {
+                    const pageNum = Math.max(0, Math.min(page - 2, data.totalPages - 5)) + i;
+                    if (pageNum >= data.totalPages) return null;
+                    return (
+                      <PaginationItem key={pageNum}>
+                        <PaginationLink
+                          onClick={() => setPage(pageNum)}
+                          isActive={pageNum === page}
+                          className="cursor-pointer"
+                        >
+                          {pageNum + 1}
+                        </PaginationLink>
+                      </PaginationItem>
+                    );
+                  })}
+
+                  <PaginationItem>
+                    <PaginationNext
+                      onClick={() => setPage(Math.min(data.totalPages - 1, page + 1))}
+                      className={page >= data.totalPages - 1 ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
+                    />
+                  </PaginationItem>
+                </PaginationContent>
+              </Pagination>
+            )}
+          </>
+        )}
+
+        {/* Certificate Preview Modal */}
+        <CertificatePreviewModal
+          isOpen={isPreviewOpen}
+          onClose={handleClosePreview}
+          certificate={selectedCertificate}
+          labels={modalLabels}
+          onDownload={() => selectedCertificate && handleDownload(selectedCertificate)}
+          isDownloading={selectedCertificate ? downloadingId === selectedCertificate.id : false}
+          isDark={isDark}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/b2b/B2BCompletedCoursesPage.tsx
+++ b/src/pages/tu/b2b/B2BCompletedCoursesPage.tsx
@@ -1,0 +1,405 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSubdomainPath } from '@/hooks/common/useSubdomainPath';
+import {
+  CheckCircle,
+  BookOpen,
+  Loader2,
+  Award,
+  Calendar,
+  FileText,
+} from 'lucide-react';
+import { useThemeStore } from '@/store/common/themeStore';
+import { useTranslation, useLanguageStore } from '@/store/common/languageStore';
+import { useMyEnrollments, useCertificateByEnrollment, useDownloadCertificate, useIssueCertificate } from '@/hooks/tu';
+import {
+  Card,
+  CardContent,
+  Button,
+  Badge,
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/common';
+import { CertificatePreviewModal } from '@/components/domain/tu/certificate';
+import type { Enrollment } from '@/services/tu/enrollmentService';
+
+interface CompletedCourseCardProps {
+  enrollment: Enrollment;
+  onClick: () => void;
+  onViewCertificate: () => void;
+  isDark: boolean;
+  language: string;
+}
+
+function CompletedCourseCard({ enrollment, onClick, onViewCertificate, isDark, language }: CompletedCourseCardProps) {
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`;
+  };
+
+  return (
+    <Card
+      className={`cursor-pointer transition-all hover:shadow-md ${
+        isDark ? 'bg-white/5 border-white/10 hover:bg-white/10' : 'bg-white border-gray-200'
+      }`}
+      onClick={onClick}
+    >
+      <CardContent className="p-5">
+        {/* Header: Completed Badge */}
+        <div className="flex items-center justify-between mb-3">
+          <Badge variant="green" className="text-xs flex items-center gap-1">
+            <CheckCircle className="w-3.5 h-3.5" />
+            {language === 'ko' ? '수료 완료' : 'Completed'}
+          </Badge>
+          <div className={`flex items-center gap-1 text-xs ${isDark ? 'text-green-400' : 'text-green-600'}`}>
+            <Award className="w-3.5 h-3.5" />
+            <span>100%</span>
+          </div>
+        </div>
+
+        {/* Program Title */}
+        <h3 className={`font-semibold text-base mb-2 line-clamp-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+          {enrollment.programTitle}
+        </h3>
+
+        {/* Course Time Name */}
+        <p className={`text-sm mb-3 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+          {enrollment.courseTimeName}
+        </p>
+
+        {/* Progress Bar (100%) */}
+        <div className="mb-3">
+          <div className={`flex items-center justify-between text-xs mb-1 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+            <span>{language === 'ko' ? '진도율' : 'Progress'}</span>
+            <span className={`font-medium ${isDark ? 'text-green-400' : 'text-green-600'}`}>100%</span>
+          </div>
+          <div className={`w-full h-2 rounded-full overflow-hidden ${isDark ? 'bg-white/10' : 'bg-gray-200'}`}>
+            <div
+              className="h-full rounded-full bg-green-500"
+              style={{ width: '100%' }}
+            />
+          </div>
+        </div>
+
+        {/* Date Info */}
+        <div className={`space-y-1 text-xs ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+          <div className="flex items-center gap-2">
+            <Calendar className="w-3.5 h-3.5" />
+            <span>
+              {language === 'ko' ? '학습 기간: ' : 'Period: '}
+              {formatDate(enrollment.startDate)} ~ {formatDate(enrollment.endDate)}
+            </span>
+          </div>
+          {enrollment.completedAt && (
+            <div className="flex items-center gap-2">
+              <CheckCircle className="w-3.5 h-3.5" />
+              <span>
+                {language === 'ko' ? '수료일: ' : 'Completed: '}
+                {formatDate(enrollment.completedAt)}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* Action Buttons */}
+        <div className="flex items-center gap-2 mt-4">
+          <Button
+            variant="outline"
+            className={`flex-1 ${isDark ? '!bg-transparent !border-white/20 !text-white hover:!bg-white/10' : ''}`}
+            size="sm"
+            onClick={(e) => {
+              e.stopPropagation();
+              onClick();
+            }}
+          >
+            <BookOpen className="w-4 h-4 mr-2" />
+            {language === 'ko' ? '학습 내용' : 'Course'}
+          </Button>
+          <Button
+            variant="brand"
+            size="sm"
+            className="flex-1"
+            onClick={(e) => {
+              e.stopPropagation();
+              onViewCertificate();
+            }}
+          >
+            <FileText className="w-4 h-4 mr-2" />
+            {language === 'ko' ? '수료증' : 'Certificate'}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function B2BCompletedCoursesPage() {
+  const { theme } = useThemeStore();
+  const { language } = useLanguageStore();
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
+  const isDark = theme === 'dark';
+
+  const [page, setPage] = useState(0);
+  const pageSize = 12;
+
+  // 수료증 모달 상태
+  const [selectedEnrollmentId, setSelectedEnrollmentId] = useState<number | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  // COMPLETED 상태의 수강 목록만 조회
+  const { data, isLoading, isError } = useMyEnrollments({
+    page,
+    size: pageSize,
+    status: 'COMPLETED',
+  });
+
+  // 선택된 수강의 수료증 조회
+  const { data: certificate, isLoading: isCertificateLoading, isError: isCertificateError, refetch: refetchCertificate } = useCertificateByEnrollment(
+    selectedEnrollmentId ?? 0,
+    { enabled: !!selectedEnrollmentId && isModalOpen }
+  );
+
+  // PDF 다운로드 mutation
+  const downloadMutation = useDownloadCertificate();
+
+  // 수료증 발급 mutation
+  const issueMutation = useIssueCertificate();
+
+  const handleCourseClick = (enrollmentId: number) => {
+    navigate(prefixPath(`/tu/b2c/mypage/learning/${enrollmentId}`));
+  };
+
+  const handleViewCertificate = (enrollmentId: number) => {
+    setSelectedEnrollmentId(enrollmentId);
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setSelectedEnrollmentId(null);
+  };
+
+  const handleDownload = async () => {
+    if (!certificate || isDownloading) return;
+
+    setIsDownloading(true);
+    try {
+      const fileName = `certificate_${certificate.certificateNumber}.pdf`;
+      await downloadMutation.mutateAsync({ id: certificate.id, fileName });
+    } catch (error) {
+      console.error('Failed to download certificate:', error);
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  const handleIssueCertificate = async () => {
+    if (!selectedEnrollmentId || issueMutation.isPending) return;
+
+    try {
+      await issueMutation.mutateAsync(selectedEnrollmentId);
+      // 발급 성공 후 수료증 다시 조회
+      refetchCertificate();
+    } catch (error) {
+      console.error('Failed to issue certificate:', error);
+    }
+  };
+
+  // 수료증 모달 라벨
+  const modalLabels = {
+    title: language === 'ko' ? '수료증 미리보기' : 'Certificate Preview',
+    certificateOf: language === 'ko' ? '수료증' : 'Certificate of',
+    completion: language === 'ko' ? '수료' : 'Completion',
+    certifyThat: language === 'ko' ? '다음의 사용자가' : 'This is to certify that',
+    hasCompleted: language === 'ko' ? '아래 과정을 성공적으로 수료하였음을 인증합니다.' : 'has successfully completed the following course.',
+    issuedOn: language === 'ko' ? '발급일' : 'Issued on',
+    completedOn: language === 'ko' ? '수료일' : 'Completed on',
+    certificateNumber: language === 'ko' ? '수료증 번호' : 'Certificate No.',
+    download: language === 'ko' ? 'PDF 다운로드' : 'Download PDF',
+    downloading: language === 'ko' ? '다운로드 중...' : 'Downloading...',
+    close: language === 'ko' ? '닫기' : 'Close',
+    organization: language === 'ko' ? '발급 기관' : 'Organization',
+  };
+
+  return (
+    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+      <div className="max-w-5xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            {t.mypage.completedCourses}
+          </h1>
+          <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
+            {t.mypage.completedDesc}
+          </p>
+        </div>
+
+        {/* Results Count */}
+        {data && (
+          <p className={`mb-4 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+            {language === 'ko' ? '총 ' : 'Total '}
+            <span className={`font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              {data.totalElements}
+            </span>
+            {language === 'ko' ? '개의 수료 강의' : ' completed courses'}
+          </p>
+        )}
+
+        {/* Loading State */}
+        {isLoading && (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className={`w-8 h-8 animate-spin ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+          </div>
+        )}
+
+        {/* Error State */}
+        {isError && (
+          <div className="text-center py-20">
+            <p className="text-red-500">
+              {language === 'ko' ? '데이터를 불러오는데 실패했습니다.' : 'Failed to load data.'}
+            </p>
+          </div>
+        )}
+
+        {/* Empty State */}
+        {data && data.content.length === 0 && (
+          <div
+            className={`text-center py-20 rounded-xl ${
+              isDark ? 'bg-white/5 border border-white/10' : 'bg-white border border-gray-200'
+            }`}
+          >
+            <CheckCircle className={`w-16 h-16 mx-auto mb-4 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
+            <h3 className={`text-lg font-medium mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              {language === 'ko' ? '수료한 강의가 없습니다' : 'No completed courses'}
+            </h3>
+            <p className={`mb-4 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+              {language === 'ko'
+                ? '강의를 완료하면 여기에 표시됩니다.'
+                : 'Completed courses will appear here.'}
+            </p>
+            <Button variant="brand" onClick={() => navigate(prefixPath('/tu/b2c/mypage/learning'))}>
+              {language === 'ko' ? '학습 중인 강의 보기' : 'View Current Courses'}
+            </Button>
+          </div>
+        )}
+
+        {/* Completed Courses Grid */}
+        {data && data.content.length > 0 && (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mb-8">
+              {data.content.map((enrollment) => (
+                <CompletedCourseCard
+                  key={enrollment.id}
+                  enrollment={enrollment}
+                  onClick={() => handleCourseClick(enrollment.id)}
+                  onViewCertificate={() => handleViewCertificate(enrollment.id)}
+                  isDark={isDark}
+                  language={language}
+                />
+              ))}
+            </div>
+
+            {/* Pagination */}
+            {data.totalPages > 1 && (
+              <Pagination>
+                <PaginationContent>
+                  <PaginationItem>
+                    <PaginationPrevious
+                      onClick={() => setPage(Math.max(0, page - 1))}
+                      className={page === 0 ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
+                    />
+                  </PaginationItem>
+
+                  {Array.from({ length: Math.min(5, data.totalPages) }, (_, i) => {
+                    const pageNum = Math.max(0, Math.min(page - 2, data.totalPages - 5)) + i;
+                    if (pageNum >= data.totalPages) return null;
+                    return (
+                      <PaginationItem key={pageNum}>
+                        <PaginationLink
+                          onClick={() => setPage(pageNum)}
+                          isActive={pageNum === page}
+                          className="cursor-pointer"
+                        >
+                          {pageNum + 1}
+                        </PaginationLink>
+                      </PaginationItem>
+                    );
+                  })}
+
+                  <PaginationItem>
+                    <PaginationNext
+                      onClick={() => setPage(Math.min(data.totalPages - 1, page + 1))}
+                      className={page >= data.totalPages - 1 ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
+                    />
+                  </PaginationItem>
+                </PaginationContent>
+              </Pagination>
+            )}
+          </>
+        )}
+
+        {/* Certificate Modal - 발급 또는 미리보기 */}
+        {isModalOpen && (
+          isCertificateLoading || issueMutation.isPending ? (
+            // 로딩 상태
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+              <div className={`p-8 rounded-xl ${isDark ? 'bg-gray-800' : 'bg-white'}`}>
+                <Loader2 className={`w-8 h-8 animate-spin mx-auto ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+                <p className={`mt-4 text-center ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
+                  {issueMutation.isPending
+                    ? (language === 'ko' ? '수료증 발급 중...' : 'Issuing certificate...')
+                    : (language === 'ko' ? '수료증 조회 중...' : 'Loading certificate...')}
+                </p>
+              </div>
+            </div>
+          ) : isCertificateError && !certificate ? (
+            // 수료증 없음 - 발급 필요
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={handleCloseModal}>
+              <div
+                className={`p-8 rounded-xl max-w-md mx-4 ${isDark ? 'bg-gray-800' : 'bg-white'}`}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Award className={`w-16 h-16 mx-auto mb-4 ${isDark ? 'text-yellow-400' : 'text-amber-500'}`} />
+                <h3 className={`text-lg font-semibold text-center mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                  {language === 'ko' ? '수료증 발급' : 'Issue Certificate'}
+                </h3>
+                <p className={`text-center mb-6 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  {language === 'ko'
+                    ? '아직 수료증이 발급되지 않았습니다. 수료증을 발급하시겠습니까?'
+                    : 'Certificate has not been issued yet. Would you like to issue it?'}
+                </p>
+                <div className="flex gap-3">
+                  <Button variant="outline" className="flex-1" onClick={handleCloseModal}>
+                    {language === 'ko' ? '취소' : 'Cancel'}
+                  </Button>
+                  <Button variant="brand" className="flex-1" onClick={handleIssueCertificate}>
+                    <FileText className="w-4 h-4 mr-2" />
+                    {language === 'ko' ? '발급하기' : 'Issue'}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ) : certificate ? (
+            // 수료증 미리보기
+            <CertificatePreviewModal
+              isOpen={isModalOpen}
+              onClose={handleCloseModal}
+              certificate={certificate}
+              labels={modalLabels}
+              onDownload={handleDownload}
+              isDownloading={isDownloading}
+              isDark={isDark}
+            />
+          ) : null
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/b2b/B2BLandingPage.tsx
+++ b/src/pages/tu/b2b/B2BLandingPage.tsx
@@ -188,12 +188,16 @@ export function B2BLandingPage() {
               <div className="flex justify-center items-center py-20">
                 <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
               </div>
-            ) : (
+            ) : recommendedCourses.length > 0 ? (
               <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6">
                 {recommendedCourses.map((course) => (
                   <B2BCourseCard key={`rec-${course.id}`} {...course} />
                 ))}
               </div>
+            ) : (
+              <p className="text-center landing-text-muted py-10">
+                해당 카테고리에 강의가 없습니다.
+              </p>
             )}
           </div>
         </section>

--- a/src/pages/tu/b2b/B2BLearningDetailPage.tsx
+++ b/src/pages/tu/b2b/B2BLearningDetailPage.tsx
@@ -1,0 +1,511 @@
+import { useState, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useSubdomainPath } from '@/hooks/common';
+import {
+  PlayCircle,
+  CheckCircle,
+  Clock,
+  Calendar,
+  AlertCircle,
+  XCircle,
+  Loader2,
+  BookOpen,
+  ChevronRight,
+  FileText,
+  Video,
+  Link as LinkIcon,
+  Music,
+  Image,
+  Folder,
+} from 'lucide-react';
+import {
+  Button,
+  Badge,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+  BackButton,
+} from '@/components/common';
+import { useQuery } from '@tanstack/react-query';
+import { useEnrollmentForPlayer, useCancelEnrollment } from '@/hooks/tu';
+import { useTranslation } from '@/store/common/languageStore';
+import { useThemeStore } from '@/store/common/themeStore';
+import axiosInstance from '@/services/common/api/axiosInstance';
+import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type { EnrollmentStatus } from '@/services/tu/enrollmentService';
+import type { SnapshotItemResponse, SnapshotRelationsResponse } from '@/types/common/snapshot.types';
+
+const statusColors: Record<EnrollmentStatus, 'blue' | 'green' | 'red' | 'gray' | 'orange'> = {
+  PENDING: 'orange',
+  APPROVED: 'blue',
+  REJECTED: 'red',
+  CANCELLED: 'gray',
+  COMPLETED: 'green',
+};
+
+const statusIcons: Record<EnrollmentStatus, React.ReactNode> = {
+  PENDING: <AlertCircle className="w-4 h-4" />,
+  APPROVED: <PlayCircle className="w-4 h-4" />,
+  REJECTED: <XCircle className="w-4 h-4" />,
+  CANCELLED: <XCircle className="w-4 h-4" />,
+  COMPLETED: <CheckCircle className="w-4 h-4" />,
+};
+
+// 커리큘럼 아이템 타입
+interface CurriculumDisplayItem {
+  itemId: number;
+  itemName: string; // 표시용 이름 (displayName 또는 itemName)
+  itemType: string | null;
+  duration: number | null;
+  pageCount: number | null;
+  isFolder: boolean;
+  seq: number;
+  isCompleted: boolean;
+}
+
+// 콘텐츠 타입별 아이콘
+const getTypeIcon = (itemType: string | null, isFolder: boolean) => {
+  if (isFolder) return <Folder className="w-4 h-4" />;
+  if (!itemType) return <Video className="w-4 h-4" />;
+  const iconMap: Record<string, React.ReactNode> = {
+    VIDEO: <Video className="w-4 h-4" />,
+    AUDIO: <Music className="w-4 h-4" />,
+    DOCUMENT: <FileText className="w-4 h-4" />,
+    IMAGE: <Image className="w-4 h-4" />,
+    EXTERNAL_LINK: <LinkIcon className="w-4 h-4" />,
+  };
+  return iconMap[itemType.toUpperCase()] || <Video className="w-4 h-4" />;
+};
+
+interface CurriculumListItemProps {
+  item: CurriculumDisplayItem;
+  isDark: boolean;
+  onClick: () => void;
+}
+
+function CurriculumListItem({ item, isDark, onClick }: CurriculumListItemProps) {
+  // 폴더인 경우 다르게 표시
+  if (item.isFolder) {
+    return (
+      <div className={`flex items-center gap-3 px-4 py-2 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+        <Folder className="w-4 h-4" />
+        <span className="font-medium text-sm">{item.itemName}</span>
+      </div>
+    );
+  }
+
+  const formatDuration = (seconds: number | null) => {
+    if (!seconds) return null;
+    const mins = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  return (
+    <div
+      onClick={onClick}
+      className={`flex items-center gap-4 p-4 rounded-lg transition-colors cursor-pointer ${
+        item.isCompleted
+          ? isDark
+            ? 'bg-green-500/10 border border-green-500/20 hover:bg-green-500/20'
+            : 'bg-green-50 border border-green-200 hover:bg-green-100'
+          : isDark
+            ? 'bg-white/5 border border-white/10 hover:bg-white/10'
+            : 'bg-white border border-gray-200 hover:bg-gray-50'
+      }`}
+    >
+      {/* Type Icon or Completed Check */}
+      <div
+        className={`w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0 ${
+          item.isCompleted
+            ? 'bg-green-100 text-green-600'
+            : isDark ? 'bg-white/10 text-gray-400' : 'bg-gray-100 text-gray-500'
+        }`}
+      >
+        {item.isCompleted ? <CheckCircle className="w-5 h-5" /> : getTypeIcon(item.itemType, item.isFolder)}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <h4 className={`font-medium text-sm truncate ${isDark ? 'text-white' : 'text-gray-900'}`}>
+          {item.itemName}
+        </h4>
+        {(item.duration || item.pageCount) && (
+          <p className={`text-xs mt-0.5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+            {item.duration && formatDuration(item.duration)}
+            {item.pageCount && `${item.pageCount}p`}
+          </p>
+        )}
+      </div>
+
+      {/* Arrow */}
+      <div className="flex items-center gap-2 flex-shrink-0">
+        <ChevronRight className={`w-5 h-5 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
+      </div>
+    </div>
+  );
+}
+
+export function B2BLearningDetailPage() {
+  const { enrollmentId } = useParams<{ enrollmentId: string }>();
+  const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
+  const { t } = useTranslation();
+  const { theme } = useThemeStore();
+  const isDark = theme === 'dark';
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+
+  const statusLabels: Record<EnrollmentStatus, string> = {
+    PENDING: t.learning.statusPending,
+    APPROVED: t.learning.statusApproved,
+    REJECTED: t.learning.statusRejected,
+    CANCELLED: t.learning.statusCancelled,
+    COMPLETED: t.learning.statusCompleted,
+  };
+
+  // Enrollment + Program + snapshotId 조회
+  const { data: playerData, isLoading, isError } = useEnrollmentForPlayer(Number(enrollmentId));
+  const cancelEnrollment = useCancelEnrollment();
+
+  // snapshotId가 있으면 스냅샷 아이템 조회
+  const snapshotId = playerData?.snapshotId ?? 0;
+
+  // 스냅샷 아이템 조회
+  // axiosInstance가 ApiResponse wrapper를 자동으로 언래핑하므로 .data만 사용
+  const { data: snapshotItems, isLoading: itemsLoading } = useQuery({
+    queryKey: ['snapshot', 'items', snapshotId],
+    queryFn: async () => {
+      const response = await axiosInstance.get<SnapshotItemResponse[]>(
+        API_ENDPOINTS.SNAPSHOTS.ITEMS(snapshotId)
+      );
+      return response.data;
+    },
+    enabled: snapshotId > 0,
+  });
+
+  // 스냅샷 관계(순서) 조회
+  const { data: relationsData, isLoading: relationsLoading } = useQuery({
+    queryKey: ['snapshot', 'relations', 'ordered', snapshotId],
+    queryFn: async () => {
+      const response = await axiosInstance.get<SnapshotRelationsResponse>(
+        API_ENDPOINTS.SNAPSHOTS.RELATIONS_ORDERED(snapshotId)
+      );
+      return response.data;
+    },
+    enabled: snapshotId > 0,
+  });
+
+  // 아이템별 진도 조회
+  const { data: itemsProgressData } = useQuery({
+    queryKey: ['enrollment', 'items', 'progress', enrollmentId],
+    queryFn: async () => {
+      const response = await axiosInstance.get<{ itemId: number; progressPercent: number; completed: boolean; completedAt: string | null }[]>(
+        API_ENDPOINTS.ENROLLMENTS.ITEMS_PROGRESS(Number(enrollmentId))
+      );
+      return response.data;
+    },
+    enabled: !!enrollmentId,
+  });
+
+  // 진도 데이터를 Map으로 변환
+  const progressMap = useMemo(() => {
+    const map = new Map<number, boolean>();
+    itemsProgressData?.forEach((item) => {
+      map.set(item.itemId, item.completed);
+    });
+    return map;
+  }, [itemsProgressData]);
+
+  // 순서가 있는 커리큘럼 아이템 목록 생성
+  const curriculumItems = useMemo((): CurriculumDisplayItem[] => {
+    if (!snapshotItems) return [];
+
+    // 아이템을 평탄화
+    const flatItems: CurriculumDisplayItem[] = [];
+    let seq = 1;
+
+    const flattenItems = (items: SnapshotItemResponse[]) => {
+      items.forEach((item) => {
+        // displayName이 있으면 우선 사용, 없으면 itemName(파일명) 사용
+        const displayName = item.snapshotLearningObject?.displayName || item.itemName;
+        flatItems.push({
+          itemId: item.itemId,
+          itemName: displayName,
+          itemType: item.itemType,
+          duration: item.snapshotLearningObject?.duration ?? null,
+          pageCount: item.snapshotLearningObject?.pageCount ?? null,
+          isFolder: item.isFolder,
+          seq: item.isFolder ? 0 : seq++,
+          isCompleted: progressMap.get(item.itemId) ?? false,
+        });
+        if (item.children && item.children.length > 0) {
+          flattenItems(item.children);
+        }
+      });
+    };
+    flattenItems(snapshotItems);
+
+    // relationsData가 있으면 순서대로, 없으면 평탄화된 순서대로 반환
+    if (relationsData?.orderedItems && relationsData.orderedItems.length > 0) {
+      const itemsMap = new Map<number, CurriculumDisplayItem>();
+      flatItems.forEach(item => itemsMap.set(item.itemId, item));
+
+      return relationsData.orderedItems
+        .map((orderedItem) => {
+          const item = itemsMap.get(orderedItem.itemId);
+          if (!item) return null;
+          return { ...item, seq: orderedItem.seq, isCompleted: progressMap.get(orderedItem.itemId) ?? false };
+        })
+        .filter((item): item is CurriculumDisplayItem => item !== null);
+    }
+
+    return flatItems;
+  }, [snapshotItems, relationsData, progressMap]);
+
+  // enrollment 형태로 변환 (기존 코드 호환용)
+  const enrollment = playerData ? {
+    id: playerData.enrollmentId,
+    programTitle: playerData.programTitle,
+    courseTimeName: playerData.courseTimeName,
+    status: playerData.status as EnrollmentStatus,
+    progress: playerData.progressPercent,
+    startDate: playerData.classStartDate,
+    endDate: playerData.classEndDate,
+    enrolledAt: playerData.enrolledAt,
+  } : null;
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`;
+  };
+
+  const handleCancel = async () => {
+    if (!enrollment) return;
+
+    try {
+      await cancelEnrollment.mutateAsync(enrollment.id);
+      setCancelDialogOpen(false);
+      navigate(prefixPath('/tu/b2c/mypage/learning'));
+    } catch (error) {
+      console.error('Failed to cancel enrollment:', error);
+    }
+  };
+
+  const handleContinueLearning = () => {
+    // 플레이어 페이지로 이동 (첫 아이템 선택은 플레이어에서 자동 처리)
+    navigate(`/tu/b2c/mypage/learning/${enrollmentId}/player`);
+  };
+
+  // Loading State
+  if (isLoading) {
+    return (
+      <div className={`flex items-center justify-center min-h-full ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+        <Loader2 className={`w-8 h-8 animate-spin ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+      </div>
+    );
+  }
+
+  // Error State
+  if (isError || !enrollment) {
+    return (
+      <div className={`flex flex-col items-center justify-center min-h-full ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+        <BookOpen className={`w-16 h-16 mb-4 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
+        <h3 className={`text-lg font-medium mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+          {t.learning.enrollmentNotFound}
+        </h3>
+        <Button onClick={() => navigate(prefixPath('/tu/b2c/mypage/learning'))}>
+          {t.learning.backToLearning}
+        </Button>
+      </div>
+    );
+  }
+
+  // 실제 enrollment 데이터에서 진도율 가져오기 (API 데이터 우선)
+  const progressPercent = enrollment.progress ?? 0;
+
+  return (
+    <div className={`min-h-full p-6 sm:p-10 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+      <div className="max-w-[1200px] mx-auto">
+        {/* Back Button */}
+        <BackButton
+          onClick={() => navigate(prefixPath('/tu/b2c/mypage/learning'))}
+          label={t.learning.backToLearning}
+          className={`mb-6 ${isDark ? 'text-gray-400 hover:text-white hover:bg-white/10' : ''}`}
+        />
+
+        {/* Header Section */}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
+          {/* Course Info Card */}
+          <Card
+            className={`lg:col-span-2 ${
+              isDark ? 'bg-white/5 border-white/10' : 'bg-white border-gray-200'
+            }`}
+          >
+            <CardContent className="p-6">
+              {/* Status Badge */}
+              <Badge variant={statusColors[enrollment.status]} className="mb-4 flex items-center gap-1 w-fit">
+                {statusIcons[enrollment.status]}
+                {statusLabels[enrollment.status]}
+              </Badge>
+
+              {/* Program Title */}
+              <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                {enrollment.programTitle}
+              </h1>
+
+              {/* Course Time Name */}
+              <p className={`text-base mb-4 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                {enrollment.courseTimeName}
+              </p>
+
+              {/* Date Info */}
+              <div className={`flex flex-wrap items-center gap-6 text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                <span className="flex items-center gap-2">
+                  <Calendar className="w-4 h-4" />
+                  {t.learning.enrollmentPeriod}: {formatDate(enrollment.startDate)} ~ {formatDate(enrollment.endDate)}
+                </span>
+                <span className="flex items-center gap-2">
+                  <Clock className="w-4 h-4" />
+                  {t.learning.enrolledDate}: {formatDate(enrollment.enrolledAt)}
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Progress Card */}
+          <Card className={isDark ? 'bg-white/5 border-white/10' : 'bg-white border-gray-200'}>
+            <CardContent className="p-6">
+              <h3 className={`text-sm font-medium mb-4 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                {t.learning.learningProgress}
+              </h3>
+
+              {/* Progress Circle */}
+              <div className="flex items-center justify-center mb-4">
+                <div
+                  className="relative w-32 h-32 rounded-full flex items-center justify-center"
+                  style={{
+                    background: `conic-gradient(${progressPercent === 100 ? '#22c55e' : '#6778ff'} ${progressPercent * 3.6}deg, ${isDark ? 'rgba(255,255,255,0.1)' : '#e5e7eb'} 0deg)`,
+                  }}
+                >
+                  <div
+                    className={`w-24 h-24 rounded-full flex items-center justify-center ${
+                      isDark ? 'bg-[#1e1e1e]' : 'bg-white'
+                    }`}
+                  >
+                    <span className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                      {progressPercent}%
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Stats */}
+              <div className={`text-center text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                {progressPercent === 100 ? t.learning.statusCompleted : `${progressPercent}% ${t.learning.completed}`}
+              </div>
+
+              {/* Continue Button */}
+              {enrollment.status === 'APPROVED' && (
+                <Button
+                  variant="brand"
+                  className="w-full mt-4"
+                  onClick={handleContinueLearning}
+                >
+                  <PlayCircle className="w-4 h-4 mr-2" />
+                  {t.learning.continueLearning}
+                </Button>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Curriculum Section */}
+        <Card className={`mb-8 ${isDark ? 'bg-white/5 border-white/10' : 'bg-white border-gray-200'}`}>
+          <CardHeader>
+            <CardTitle className={isDark ? 'text-white' : 'text-gray-900'}>
+              {t.learning.curriculum}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-6 pt-0">
+            {(itemsLoading || relationsLoading) ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className={`w-6 h-6 animate-spin ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+              </div>
+            ) : curriculumItems.length > 0 ? (
+              <div className="space-y-3">
+                {curriculumItems.map((item) => (
+                  <CurriculumListItem
+                    key={item.itemId}
+                    item={item}
+                    isDark={isDark}
+                    onClick={() => navigate(`/tu/b2c/mypage/learning/${enrollmentId}/player/${item.itemId}`)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className={`text-center py-8 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                {snapshotId === 0 ? '과정에 스냅샷이 연결되지 않았습니다.' : '커리큘럼이 없습니다.'}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Actions Section */}
+        {(enrollment.status === 'PENDING' || enrollment.status === 'APPROVED') && (
+          <div className="flex justify-end gap-4">
+            <AlertDialog open={cancelDialogOpen} onOpenChange={setCancelDialogOpen}>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="outline"
+                  className={
+                    isDark
+                      ? 'text-red-400 border-red-400/30 hover:bg-red-400/10'
+                      : 'text-red-600 border-red-200 hover:bg-red-50'
+                  }
+                >
+                  <XCircle className="w-4 h-4 mr-2" />
+                  {t.learning.cancelEnrollment}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent className={isDark ? 'bg-[#2a2a2a] border-white/10' : ''}>
+                <AlertDialogHeader>
+                  <AlertDialogTitle className={isDark ? 'text-white' : ''}>
+                    {t.learning.cancelConfirmTitle}
+                  </AlertDialogTitle>
+                  <AlertDialogDescription className={isDark ? 'text-gray-400' : ''}>
+                    {t.learning.cancelConfirmDesc}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel className={isDark ? 'bg-white/10 border-white/10 text-white hover:bg-white/20' : ''}>
+                    {t.common.cancel}
+                  </AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={handleCancel}
+                    className="bg-red-600 hover:bg-red-700"
+                    disabled={cancelEnrollment.isPending}
+                  >
+                    {cancelEnrollment.isPending ? (
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    ) : null}
+                    {t.learning.cancelEnrollment}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/b2b/B2BMyLearningPage.tsx
+++ b/src/pages/tu/b2b/B2BMyLearningPage.tsx
@@ -1,0 +1,380 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSubdomainPath } from '@/hooks/common/useSubdomainPath';
+import {
+  Search,
+  Filter,
+  BookOpen,
+  Clock,
+  ChevronDown,
+  Loader2,
+  PlayCircle,
+  CheckCircle,
+  XCircle,
+  AlertCircle,
+} from 'lucide-react';
+import {
+  Button,
+  Badge,
+  Input,
+  Card,
+  CardContent,
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/common';
+import { useMyEnrollments } from '@/hooks/tu';
+import { useTranslation } from '@/store/common/languageStore';
+import { useThemeStore } from '@/store/common/themeStore';
+import type { Enrollment, EnrollmentStatus, EnrollmentFilterParams } from '@/services/tu/enrollmentService';
+
+type StatusFilter = EnrollmentStatus | 'all';
+
+const statusColors: Record<EnrollmentStatus, 'blue' | 'green' | 'red' | 'gray' | 'orange'> = {
+  PENDING: 'orange',
+  APPROVED: 'blue',
+  REJECTED: 'red',
+  CANCELLED: 'gray',
+  COMPLETED: 'green',
+};
+
+const statusIcons: Record<EnrollmentStatus, React.ReactNode> = {
+  PENDING: <AlertCircle className="w-4 h-4" />,
+  APPROVED: <PlayCircle className="w-4 h-4" />,
+  REJECTED: <XCircle className="w-4 h-4" />,
+  CANCELLED: <XCircle className="w-4 h-4" />,
+  COMPLETED: <CheckCircle className="w-4 h-4" />,
+};
+
+function ProgressBar({ progress, isDark }: { progress: number; isDark: boolean }) {
+  return (
+    <div className={`w-full h-2 rounded-full overflow-hidden ${isDark ? 'bg-white/10' : 'bg-gray-200'}`}>
+      <div
+        className="h-full rounded-full transition-all"
+        style={{
+          width: `${progress}%`,
+          backgroundColor: progress === 100 ? '#22c55e' : '#6778ff',
+        }}
+      />
+    </div>
+  );
+}
+
+interface EnrollmentCardProps {
+  enrollment: Enrollment;
+  onClick: () => void;
+  onContinueLearning: () => void;
+  t: ReturnType<typeof useTranslation>['t'];
+  isDark: boolean;
+}
+
+function EnrollmentCard({ enrollment, onClick, onContinueLearning, t, isDark }: EnrollmentCardProps) {
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`;
+  };
+
+  const statusLabels: Record<EnrollmentStatus, string> = {
+    PENDING: t.learning.statusPending,
+    APPROVED: t.learning.statusApproved,
+    REJECTED: t.learning.statusRejected,
+    CANCELLED: t.learning.statusCancelled,
+    COMPLETED: t.learning.statusCompleted,
+  };
+
+  return (
+    <Card
+      className={`cursor-pointer transition-all hover:shadow-md ${
+        isDark ? 'bg-white/5 border-white/10 hover:bg-white/10' : 'bg-white border-gray-200'
+      }`}
+      onClick={onClick}
+    >
+      <CardContent className="p-5">
+        {/* Header: Status Badge */}
+        <div className="flex items-center justify-between mb-3">
+          <Badge variant={statusColors[enrollment.status]} className="text-xs flex items-center gap-1">
+            {statusIcons[enrollment.status]}
+            {statusLabels[enrollment.status]}
+          </Badge>
+        </div>
+
+        {/* Program Title */}
+        <h3 className={`font-semibold text-base mb-2 line-clamp-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+          {enrollment.programTitle}
+        </h3>
+
+        {/* Course Time Name */}
+        <p className={`text-sm mb-3 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+          {enrollment.courseTimeName}
+        </p>
+
+        {/* Progress Bar (only for APPROVED status) */}
+        {enrollment.status === 'APPROVED' && enrollment.progress !== undefined && (
+          <div className="mb-3">
+            <div className={`flex items-center justify-between text-xs mb-1 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+              <span>{t.learning.progress}</span>
+              <span className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>{enrollment.progress}%</span>
+            </div>
+            <ProgressBar progress={enrollment.progress} isDark={isDark} />
+          </div>
+        )}
+
+        {/* Date Info */}
+        <div className={`flex items-center gap-2 text-xs ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+          <Clock className="w-3.5 h-3.5" />
+          <span>{formatDate(enrollment.startDate)} ~ {formatDate(enrollment.endDate)}</span>
+        </div>
+
+        {/* Continue Learning Button (only for APPROVED) */}
+        {enrollment.status === 'APPROVED' && (
+          <Button
+            variant="brand"
+            className="w-full mt-4"
+            size="sm"
+            onClick={(e) => {
+              e.stopPropagation();
+              onContinueLearning();
+            }}
+          >
+            <PlayCircle className="w-4 h-4 mr-2" />
+            {t.learning.continueLearning}
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function B2BMyLearningPage() {
+  const { t } = useTranslation();
+  const { theme } = useThemeStore();
+  const isDark = theme === 'dark';
+  const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
+
+  const statusLabels: Record<EnrollmentStatus, string> = {
+    PENDING: t.learning.statusPending,
+    APPROVED: t.learning.statusApproved,
+    REJECTED: t.learning.statusRejected,
+    CANCELLED: t.learning.statusCancelled,
+    COMPLETED: t.learning.statusCompleted,
+  };
+  const [searchQuery, setSearchQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [showFilters, setShowFilters] = useState(false);
+  const [page, setPage] = useState(0);
+
+  // API 파라미터 - "수강 중인 강의" 페이지이므로 APPROVED 상태만 조회
+  // 필터에서 다른 상태를 선택하면 해당 상태로 조회
+  const params: EnrollmentFilterParams = {
+    page,
+    size: 12,
+    status: statusFilter !== 'all' ? statusFilter : 'APPROVED',
+  };
+
+  const { data, isLoading, isError } = useMyEnrollments(params);
+
+  // 검색 필터링 (클라이언트 사이드)
+  const filteredContent = data?.content.filter((enrollment) =>
+    enrollment.programTitle.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    enrollment.courseTimeName.toLowerCase().includes(searchQuery.toLowerCase())
+  ) ?? [];
+
+  const handleEnrollmentClick = (enrollmentId: number) => {
+    navigate(prefixPath(`/tu/b2c/mypage/learning/${enrollmentId}`));
+  };
+
+  const handleContinueLearning = (enrollmentId: number) => {
+    navigate(prefixPath(`/tu/b2c/mypage/learning/${enrollmentId}/player`));
+  };
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    setPage(0);
+  };
+
+  return (
+    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+      <div className="max-w-5xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            {t.learning.enrolledCourses}
+          </h1>
+          <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
+            {t.learning.description}
+          </p>
+        </div>
+
+        {/* Search & Filter Bar */}
+        <div className="flex flex-wrap items-center gap-4 mb-6">
+          {/* Search */}
+          <form onSubmit={handleSearch} className="flex-1 min-w-[280px]">
+            <div className="relative">
+              <Search
+                className={`absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 ${isDark ? 'text-gray-500' : 'text-gray-400'}`}
+              />
+              <Input
+                type="text"
+                placeholder={t.learning.searchPlaceholder}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className={`pl-10 ${isDark ? 'bg-white/5 border-white/10 text-white placeholder:text-gray-500' : ''}`}
+              />
+            </div>
+          </form>
+
+          {/* Filter Toggle */}
+          <Button
+            variant="outline"
+            onClick={() => setShowFilters(!showFilters)}
+            className={`gap-2 ${isDark ? '!bg-transparent border-white/20 text-white hover:!bg-white/10' : ''}`}
+          >
+            <Filter className="w-4 h-4" />
+            {t.learning.filter}
+            <ChevronDown className={`w-4 h-4 transition-transform ${showFilters ? 'rotate-180' : ''}`} />
+          </Button>
+        </div>
+
+        {/* Filter Panel */}
+        {showFilters && (
+          <div className={`p-4 rounded-lg mb-6 border ${isDark ? 'bg-white/5 border-white/10' : 'bg-white border-gray-200'}`}>
+            <div className="flex flex-wrap items-center gap-4">
+              <div>
+                <label className={`block text-sm font-medium mb-2 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  {t.learning.enrollmentStatus}
+                </label>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    variant={statusFilter === 'all' ? 'brand' : 'outline'}
+                    size="sm"
+                    onClick={() => {
+                      setStatusFilter('all');
+                      setPage(0);
+                    }}
+                    className={statusFilter !== 'all' && isDark ? '!bg-transparent border-white/20 text-white hover:!bg-white/10' : ''}
+                  >
+                    {t.landing.all}
+                  </Button>
+                  {(['APPROVED', 'PENDING', 'COMPLETED', 'CANCELLED', 'REJECTED'] as EnrollmentStatus[]).map((status) => (
+                    <Button
+                      key={status}
+                      variant={statusFilter === status ? 'brand' : 'outline'}
+                      size="sm"
+                      onClick={() => {
+                        setStatusFilter(status);
+                        setPage(0);
+                      }}
+                      className={statusFilter !== status && isDark ? '!bg-transparent border-white/20 text-white hover:!bg-white/10' : ''}
+                    >
+                      {statusLabels[status]}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Results Count */}
+        {data && (
+          <p className={`mb-4 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+            {t.learning.totalEnrollments}{' '}
+            <span className={`font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>{filteredContent.length}</span>{' '}
+            {t.learning.enrollments}
+          </p>
+        )}
+
+        {/* Loading State */}
+        {isLoading && (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className={`w-8 h-8 animate-spin ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+          </div>
+        )}
+
+        {/* Error State */}
+        {isError && (
+          <div className="text-center py-20">
+            <p className="text-red-500">
+              {t.learning.loadError}
+            </p>
+          </div>
+        )}
+
+        {/* Empty State */}
+        {data && filteredContent.length === 0 && (
+          <div className="text-center py-20">
+            <BookOpen className={`w-16 h-16 mx-auto mb-4 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
+            <h3 className={`text-lg font-medium mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              {t.learning.noEnrollments}
+            </h3>
+            <p className={`mb-4 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+              {t.learning.noEnrollmentsDesc}
+            </p>
+            <Button variant="brand" onClick={() => navigate(prefixPath('/tu/b2c/courses'))}>
+              {t.learning.browseCourses}
+            </Button>
+          </div>
+        )}
+
+        {/* Enrollment Grid */}
+        {data && filteredContent.length > 0 && (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mb-8">
+              {filteredContent.map((enrollment) => (
+                <EnrollmentCard
+                  key={enrollment.id}
+                  enrollment={enrollment}
+                  onClick={() => handleEnrollmentClick(enrollment.id)}
+                  onContinueLearning={() => handleContinueLearning(enrollment.id)}
+                  t={t}
+                  isDark={isDark}
+                />
+              ))}
+            </div>
+
+            {/* Pagination */}
+            {data.totalPages > 1 && (
+              <Pagination>
+                <PaginationContent>
+                  <PaginationItem>
+                    <PaginationPrevious
+                      onClick={() => setPage(Math.max(0, page - 1))}
+                      className={page === 0 ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
+                    />
+                  </PaginationItem>
+
+                  {Array.from({ length: Math.min(5, data.totalPages) }, (_, i) => {
+                    const pageNum = Math.max(0, Math.min(page - 2, data.totalPages - 5)) + i;
+                    if (pageNum >= data.totalPages) return null;
+                    return (
+                      <PaginationItem key={pageNum}>
+                        <PaginationLink
+                          onClick={() => setPage(pageNum)}
+                          isActive={pageNum === page}
+                          className="cursor-pointer"
+                        >
+                          {pageNum + 1}
+                        </PaginationLink>
+                      </PaginationItem>
+                    );
+                  })}
+
+                  <PaginationItem>
+                    <PaginationNext
+                      onClick={() => setPage(Math.min(data.totalPages - 1, page + 1))}
+                      className={page >= data.totalPages - 1 ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
+                    />
+                  </PaginationItem>
+                </PaginationContent>
+              </Pagination>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/b2b/B2BMyPageHome.tsx
+++ b/src/pages/tu/b2b/B2BMyPageHome.tsx
@@ -1,0 +1,485 @@
+import { useRef, useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSubdomainPath } from '@/hooks/common/useSubdomainPath';
+import {
+  User,
+  BookOpen,
+  Award,
+  ChevronRight,
+  PlayCircle,
+  CheckCircle,
+  Clock,
+  TrendingUp,
+  Calendar,
+  Bell,
+  Shield,
+  Globe,
+  Loader2,
+  Camera,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { useAuth } from '@/hooks/common/auth';
+import { useMyProfile, useUploadProfileImage } from '@/hooks/common';
+import { useMyEnrollments, useMyLearningStats } from '@/hooks/tu';
+import { useThemeStore } from '@/store/common/themeStore';
+import { useTranslation, useLanguageStore } from '@/store/common/languageStore';
+import { Button, Card, CardContent, Badge } from '@/components/common';
+import type { EnrollmentStatus } from '@/services/tu/enrollmentService';
+
+const statusColors: Record<EnrollmentStatus, 'blue' | 'green' | 'red' | 'gray' | 'orange'> = {
+  PENDING: 'orange',
+  APPROVED: 'blue',
+  REJECTED: 'red',
+  CANCELLED: 'gray',
+  COMPLETED: 'green',
+};
+
+interface QuickMenuItemProps {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  onClick: () => void;
+  isDark: boolean;
+}
+
+function QuickMenuItem({ icon, title, description, onClick, isDark }: QuickMenuItemProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full p-4 rounded-xl text-left transition-all hover:scale-[1.02] ${
+        isDark
+          ? 'bg-white/5 hover:bg-white/10 border border-white/10'
+          : 'bg-white hover:bg-gray-50 border border-gray-200 shadow-sm'
+      }`}
+    >
+      <div className="flex items-center gap-4">
+        <div
+          className={`w-12 h-12 rounded-xl flex items-center justify-center ${
+            isDark ? 'bg-gradient-to-r from-[#6778ff] to-[#a855f7]' : 'bg-blue-100'
+          }`}
+        >
+          <div className={isDark ? 'text-white' : 'text-blue-600'}>{icon}</div>
+        </div>
+        <div className="flex-1">
+          <h3 className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>{title}</h3>
+          <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>{description}</p>
+        </div>
+        <ChevronRight className={`w-5 h-5 ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
+      </div>
+    </button>
+  );
+}
+
+export function B2BMyPageHome() {
+  const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
+  const { user } = useAuth();
+  const { data: profile } = useMyProfile();
+  const uploadImageMutation = useUploadProfileImage();
+  const { theme } = useThemeStore();
+  const { language } = useLanguageStore();
+  const { t } = useTranslation();
+  const isDark = theme === 'dark';
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [profileImagePreview, setProfileImagePreview] = useState<string | null>(null);
+
+  // 프로필 이미지 URL 생성
+  const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api').replace('/api', '');
+
+  // 서버에서 받아온 프로필 이미지로 프리뷰 동기화
+  useEffect(() => {
+    if (profile?.profileImageUrl) {
+      const imageUrl = profile.profileImageUrl.startsWith('http')
+        ? profile.profileImageUrl
+        : `${apiBaseUrl}${profile.profileImageUrl}`;
+      setProfileImagePreview(imageUrl);
+    }
+  }, [profile, apiBaseUrl]);
+
+  // 역할 우선순위 (높을수록 상위 역할)
+  const ROLE_PRIORITY: Record<string, number> = {
+    TENANT_ADMIN: 5,
+    OPERATOR: 4,
+    INSTRUCTOR: 3,
+    DESIGNER: 2,
+    USER: 1,
+  };
+
+  // 역할별 뱃지 라벨 및 색상
+  const getRoleBadgeInfo = (role: string) => {
+    switch (role) {
+      case 'USER':
+        return {
+          label: language === 'ko' ? '학습자' : 'Learner',
+          variant: 'gray' as const,
+        };
+      case 'DESIGNER':
+        return {
+          label: language === 'ko' ? '강의 설계자' : 'Course Designer',
+          variant: 'indigo' as const,
+        };
+      case 'INSTRUCTOR':
+        return {
+          label: language === 'ko' ? '강사' : 'Instructor',
+          variant: 'blue' as const,
+        };
+      case 'OPERATOR':
+        return {
+          label: language === 'ko' ? '강의 운영자' : 'Course Operator',
+          variant: 'orange' as const,
+        };
+      case 'TENANT_ADMIN':
+        return {
+          label: language === 'ko' ? '관리자' : 'Administrator',
+          variant: 'red' as const,
+        };
+      default:
+        return {
+          label: language === 'ko' ? '학습자' : 'Learner',
+          variant: 'gray' as const,
+        };
+    }
+  };
+
+  // 가장 높은 우선순위 역할 찾기
+  const getHighestRole = (): string => {
+    const roles = user?.roles || (user?.role ? [user.role] : ['USER']);
+    return roles.reduce((highest, current) => {
+      const currentPriority = ROLE_PRIORITY[current] || 0;
+      const highestPriority = ROLE_PRIORITY[highest] || 0;
+      return currentPriority > highestPriority ? current : highest;
+    }, 'USER');
+  };
+
+  const roleBadgeInfo = getRoleBadgeInfo(getHighestRole());
+
+  // 상태 라벨 (다국어)
+  const statusLabels: Record<EnrollmentStatus, string> = {
+    PENDING: t.mypage.pending,
+    APPROVED: t.mypage.inProgress,
+    REJECTED: language === 'ko' ? '반려됨' : 'Rejected',
+    CANCELLED: language === 'ko' ? '취소됨' : 'Cancelled',
+    COMPLETED: t.mypage.completed,
+  };
+
+  const handleImageUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+      toast.error(language === 'ko' ? '이미지 파일만 업로드 가능합니다.' : 'Only image files can be uploaded.');
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error(language === 'ko' ? '파일 크기는 5MB 이하여야 합니다.' : 'File size must be 5MB or less.');
+      return;
+    }
+
+    // 즉시 프리뷰 표시
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setProfileImagePreview(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+
+    // 서버에 업로드
+    try {
+      await uploadImageMutation.mutateAsync(file);
+      toast.success(language === 'ko' ? '프로필 이미지가 업로드되었습니다.' : 'Profile image uploaded.');
+    } catch {
+      toast.error(language === 'ko' ? '이미지 업로드에 실패했습니다.' : 'Failed to upload image.');
+    }
+  };
+
+  const triggerFileInput = () => {
+    fileInputRef.current?.click();
+  };
+
+  // 학습 통계 API 조회
+  const { data: learningStats, isLoading: isLoadingStats } = useMyLearningStats();
+
+  // 최근 학습을 위한 enrollment 목록 조회 (수강 중인 강의만)
+  const { data: enrollmentData, isLoading: isLoadingEnrollments } = useMyEnrollments({
+    page: 0,
+    size: 3,
+  });
+
+  // 통계 (API에서 가져온 데이터 사용, 없으면 기본값)
+  const stats = {
+    inProgress: learningStats?.overview.inProgress ?? 0,
+    completed: learningStats?.overview.completed ?? 0,
+    dropped: learningStats?.overview.dropped ?? 0,
+    total: learningStats?.overview.totalCourses ?? 0,
+  };
+
+  // 최근 학습 (수강 중인 강의 최대 3개)
+  const recentLearning = enrollmentData?.content
+    .filter((e) => e.status === 'APPROVED')
+    .slice(0, 3) ?? [];
+
+  return (
+    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+      <div className="max-w-5xl mx-auto">
+        {/* 프로필 섹션 */}
+        <section className="mb-8">
+          <div
+            className={`rounded-2xl p-6 sm:p-8 ${
+              isDark
+                ? 'bg-[#1e1e1e] border border-white/10'
+                : 'bg-white shadow-sm border border-gray-200'
+            }`}
+          >
+            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-6">
+              {/* 프로필 아바타 */}
+              <div className="relative">
+                <input
+                  type="file"
+                  ref={fileInputRef}
+                  onChange={handleImageUpload}
+                  accept="image/*"
+                  className="hidden"
+                />
+                <div className="w-24 h-24 rounded-full bg-gradient-to-r from-[#6778ff] to-[#a855f7] flex items-center justify-center flex-shrink-0 overflow-hidden">
+                  {profileImagePreview ? (
+                    <img src={profileImagePreview} alt={t.mypage.profile} className="w-full h-full object-cover" />
+                  ) : (
+                    <User className="w-12 h-12 text-white" />
+                  )}
+                </div>
+                <button
+                  onClick={triggerFileInput}
+                  disabled={uploadImageMutation.isPending}
+                  className="absolute bottom-0 right-0 w-8 h-8 rounded-full bg-white shadow-md flex items-center justify-center hover:scale-110 transition-transform disabled:opacity-50"
+                  title={t.mypage.editProfile}
+                >
+                  {uploadImageMutation.isPending ? (
+                    <Loader2 className="w-4 h-4 text-gray-600 animate-spin" />
+                  ) : (
+                    <Camera className="w-4 h-4 text-gray-600" />
+                  )}
+                </button>
+              </div>
+
+              {/* 프로필 정보 */}
+              <div className="flex-1">
+                <h1 className={`text-2xl font-bold mb-1 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                  {user?.name}{t.mypage.hello}
+                </h1>
+                <p className={`text-sm mb-3 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  {user?.email}
+                </p>
+                <Badge variant={roleBadgeInfo.variant} className="text-xs">
+                  {roleBadgeInfo.label}
+                </Badge>
+              </div>
+
+              {/* 프로필 수정 버튼 */}
+              <Button
+                variant="outline"
+                onClick={() => navigate(prefixPath('/tu/b2c/mypage/profile'))}
+                className={isDark ? 'border-white/30 text-white bg-white/10 hover:bg-white/20' : ''}
+              >
+                {t.mypage.editProfile}
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        {/* 학습 통계 */}
+        <section className="mb-8">
+          <h2 className={`text-lg font-semibold mb-4 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            {t.mypage.learningStatus}
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            {[
+              { label: t.mypage.inProgress, value: stats.inProgress, icon: <PlayCircle className="w-5 h-5" />, color: 'blue' },
+              { label: t.mypage.completed, value: stats.completed, icon: <CheckCircle className="w-5 h-5" />, color: 'green' },
+              { label: t.mypage.dropped, value: stats.dropped, icon: <Clock className="w-5 h-5" />, color: 'orange' },
+              { label: t.mypage.total, value: stats.total, icon: <TrendingUp className="w-5 h-5" />, color: 'purple' },
+            ].map((stat) => (
+              <div
+                key={stat.label}
+                className={`p-4 rounded-xl ${
+                  isDark
+                    ? 'bg-white/5 border border-white/10'
+                    : 'bg-white border border-gray-200 shadow-sm'
+                }`}
+              >
+                <div className="flex items-center gap-3 mb-2">
+                  <div
+                    className={`${
+                      stat.color === 'blue'
+                        ? isDark ? 'text-blue-400' : 'text-blue-600'
+                        : stat.color === 'green'
+                        ? isDark ? 'text-green-400' : 'text-green-600'
+                        : stat.color === 'orange'
+                        ? isDark ? 'text-orange-400' : 'text-orange-600'
+                        : isDark ? 'text-purple-400' : 'text-purple-600'
+                    }`}
+                  >
+                    {stat.icon}
+                  </div>
+                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                    {stat.label}
+                  </span>
+                </div>
+                <p className={`text-2xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                  {isLoadingStats ? '-' : stat.value}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* 최근 학습 */}
+        <section className="mb-8">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className={`text-lg font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              {t.mypage.recentLearning}
+            </h2>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate(prefixPath('/tu/b2c/mypage/learning'))}
+              className={isDark ? 'text-gray-400 hover:text-white' : ''}
+            >
+              {t.mypage.viewAll}
+              <ChevronRight className="w-4 h-4 ml-1" />
+            </Button>
+          </div>
+
+          {isLoadingEnrollments ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className={`w-8 h-8 animate-spin ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
+            </div>
+          ) : recentLearning.length > 0 ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {recentLearning.map((enrollment) => (
+                <Card
+                  key={enrollment.id}
+                  className={`cursor-pointer transition-all hover:scale-[1.02] ${
+                    isDark
+                      ? 'bg-white/5 border-white/10 hover:bg-white/10'
+                      : 'bg-white hover:shadow-md'
+                  }`}
+                  onClick={() => navigate(prefixPath(`/tu/b2c/mypage/learning/${enrollment.id}`))}
+                >
+                  <CardContent className="p-5">
+                    <Badge variant={statusColors[enrollment.status]} className="text-xs mb-3">
+                      {statusLabels[enrollment.status]}
+                    </Badge>
+                    <h3
+                      className={`font-medium mb-2 line-clamp-2 ${
+                        isDark ? 'text-white' : 'text-gray-900'
+                      }`}
+                    >
+                      {enrollment.programTitle}
+                    </h3>
+                    <p className={`text-sm mb-3 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                      {enrollment.courseTimeName}
+                    </p>
+                    {enrollment.progress !== undefined && (
+                      <div className="mb-3">
+                        <div className="flex justify-between text-xs mb-1">
+                          <span className={isDark ? 'text-gray-400' : 'text-gray-600'}>
+                            {language === 'ko' ? '진도율' : 'Progress'}
+                          </span>
+                          <span className={isDark ? 'text-white' : 'text-gray-900'}>
+                            {enrollment.progress}%
+                          </span>
+                        </div>
+                        <div
+                          className={`w-full h-2 rounded-full overflow-hidden ${
+                            isDark ? 'bg-white/10' : 'bg-gray-200'
+                          }`}
+                        >
+                          <div
+                            className="h-full rounded-full bg-gradient-to-r from-[#6778ff] to-[#a855f7]"
+                            style={{ width: `${enrollment.progress}%` }}
+                          />
+                        </div>
+                      </div>
+                    )}
+                    <div className={`flex items-center gap-2 text-xs ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+                      <Calendar className="w-3.5 h-3.5" />
+                      <span>
+                        {new Date(enrollment.startDate).toLocaleDateString()} ~{' '}
+                        {new Date(enrollment.endDate).toLocaleDateString()}
+                      </span>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          ) : (
+            <div
+              className={`text-center py-12 rounded-xl ${
+                isDark ? 'bg-white/5 border border-white/10' : 'bg-white border border-gray-200'
+              }`}
+            >
+              <BookOpen className={`w-12 h-12 mx-auto mb-4 ${isDark ? 'text-gray-600' : 'text-gray-400'}`} />
+              <h3 className={`font-medium mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                {t.mypage.noEnrolledCourses}
+              </h3>
+              <p className={`text-sm mb-4 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                {t.mypage.noEnrolledCoursesDesc}
+              </p>
+              <Button onClick={() => navigate(prefixPath('/tu/b2c/courses'))}>{t.mypage.browseCourses}</Button>
+            </div>
+          )}
+        </section>
+
+        {/* 빠른 메뉴 */}
+        <section>
+          <h2 className={`text-lg font-semibold mb-4 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            {t.mypage.quickMenu}
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <QuickMenuItem
+              icon={<BookOpen className="w-5 h-5" />}
+              title={t.mypage.myLearning}
+              description={t.mypage.myLearningDesc}
+              onClick={() => navigate(prefixPath('/tu/b2c/mypage/learning'))}
+              isDark={isDark}
+            />
+            <QuickMenuItem
+              icon={<Award className="w-5 h-5" />}
+              title={t.mypage.certificates}
+              description={t.mypage.certificatesDesc}
+              onClick={() => navigate(prefixPath('/tu/b2c/mypage/certificates'))}
+              isDark={isDark}
+            />
+            <QuickMenuItem
+              icon={<Shield className="w-5 h-5" />}
+              title={t.mypage.profileAndSecurity}
+              description={t.mypage.profileSecurityDesc}
+              onClick={() => navigate(prefixPath('/tu/b2c/mypage/profile'))}
+              isDark={isDark}
+            />
+            <QuickMenuItem
+              icon={<Bell className="w-5 h-5" />}
+              title={t.mypage.notifications}
+              description={t.mypage.notificationsDesc}
+              onClick={() => navigate(prefixPath('/tu/b2c/mypage/notifications'))}
+              isDark={isDark}
+            />
+            <QuickMenuItem
+              icon={<Globe className="w-5 h-5" />}
+              title={t.mypage.languageRegion}
+              description={t.mypage.languageRegionDesc}
+              onClick={() => navigate(prefixPath('/tu/b2c/mypage/language'))}
+              isDark={isDark}
+            />
+            <QuickMenuItem
+              icon={<TrendingUp className="w-5 h-5" />}
+              title={t.mypage.learningProgress}
+              description={t.mypage.learningProgressDesc}
+              onClick={() => navigate(prefixPath('/tu/b2c/mypage/learning'))}
+              isDark={isDark}
+            />
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/b2b/B2BMyTeachingPage.tsx
+++ b/src/pages/tu/b2b/B2BMyTeachingPage.tsx
@@ -1,0 +1,386 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import {
+  BookOpen,
+  Plus,
+  AlertCircle,
+  Clock,
+  CheckCircle,
+  XCircle,
+  Eye,
+  Edit,
+  MoreHorizontal,
+  Loader2,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { useThemeStore } from '@/store/common/themeStore';
+import { useTranslation } from '@/store/common/languageStore';
+import { useAuth } from '@/hooks/common/auth';
+import { useSubdomainPath } from '@/hooks/common/useSubdomainPath';
+import { userService } from '@/services/common/userService';
+import { authService } from '@/services/common/authService';
+import { useAuthStore } from '@/store/common/authStore';
+import { courseService } from '@/services/common/courseService';
+import {
+  Button,
+  Card,
+  CardContent,
+  Badge,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/common';
+
+const statusIcons = {
+  DRAFT: Edit,
+  PENDING: Clock,
+  APPROVED: CheckCircle,
+  REJECTED: XCircle,
+};
+
+const statusVariants = {
+  DRAFT: 'gray' as const,
+  PENDING: 'orange' as const,
+  APPROVED: 'green' as const,
+  REJECTED: 'red' as const,
+};
+
+export function B2BMyTeachingPage() {
+  const navigate = useNavigate();
+  const { theme } = useThemeStore();
+  const { user } = useAuth();
+  const { t, language } = useTranslation();
+  const { prefixPath } = useSubdomainPath();
+  const isDark = theme === 'dark';
+
+  // 상태 라벨 (다국어)
+  const statusLabels = {
+    DRAFT: t.teaching.draft,
+    PENDING: t.teaching.pendingApproval,
+    APPROVED: t.teaching.approved,
+    REJECTED: t.teaching.rejected,
+  };
+
+  const [showRoleDialog, setShowRoleDialog] = useState(false);
+  const [isGrantingRole, setIsGrantingRole] = useState(false);
+  // USER: 권한 없음, DESIGNER: 강의 개설 권한, OWNER: 강의 소유자
+  const [courseRoleStatus, setCourseRoleStatus] = useState<'USER' | 'DESIGNER' | 'OWNER'>('USER');
+  const [isCheckingRole, setIsCheckingRole] = useState(true);
+
+  // CourseRole API로 역할 확인
+  useEffect(() => {
+    const checkCourseRole = async () => {
+      try {
+        const roles = await userService.getMyCourseRoles();
+        if (Array.isArray(roles) && roles.length > 0) {
+          const hasOwner = roles.some((r: { role: string }) => r.role === 'OWNER');
+          const hasDesigner = roles.some((r: { role: string }) => r.role === 'DESIGNER');
+
+          if (hasOwner) {
+            setCourseRoleStatus('OWNER');
+          } else if (hasDesigner) {
+            setCourseRoleStatus('DESIGNER');
+          }
+        }
+      } catch (error) {
+        console.error('Failed to fetch course roles:', error);
+      } finally {
+        setIsCheckingRole(false);
+      }
+    };
+    checkCourseRole();
+  }, []);
+
+  // 사용자가 DESIGNER 이상의 역할을 가지고 있는지 확인 (시스템 역할 또는 CourseRole)
+  const isDesigner = user?.role === 'OPERATOR' || user?.role === 'TENANT_ADMIN' || courseRoleStatus !== 'USER';
+
+  // 내 강의 목록 조회
+  const { data: coursesData, isLoading: isLoadingCourses } = useQuery({
+    queryKey: ['myCourses'],
+    queryFn: () => courseService.getMyCourses(),
+    enabled: !isCheckingRole && isDesigner,
+  });
+
+  const isLoading = isCheckingRole || isLoadingCourses;
+  const courses = coursesData?.content || [];
+
+  const handleCreateCourse = () => {
+    // DESIGNER 역할 여부와 관계없이 항상 확인 다이얼로그 표시
+    setShowRoleDialog(true);
+  };
+
+  const handleGrantDesignerRole = async () => {
+    // 이미 DESIGNER인 경우 바로 이동
+    if (isDesigner) {
+      setShowRoleDialog(false);
+      navigate(prefixPath('/tu/teaching/courses/create'));
+      return;
+    }
+
+    setIsGrantingRole(true);
+    try {
+      // DESIGNER 역할 부여 API 호출
+      await userService.applyDesignerRole();
+
+      // 토큰 갱신 (CourseRole이 반영된 새 토큰 발급)
+      const refreshToken = useAuthStore.getState().refreshToken;
+      if (refreshToken) {
+        const tokenResponse = await authService.refresh(refreshToken);
+        useAuthStore.getState().setTokens(tokenResponse.accessToken, tokenResponse.refreshToken);
+      }
+
+      // 사용자 정보 다시 조회하여 역할 업데이트
+      const updatedUser = await userService.getMe();
+      useAuthStore.getState().updateUser({ role: updatedUser.role });
+
+      toast.success('강의 개설 권한이 부여되었습니다.');
+      setShowRoleDialog(false);
+
+      // 권한 부여 후 강의 개설 페이지로 이동
+      navigate(prefixPath('/tu/teaching/courses/create'));
+    } catch (error) {
+      // 409 Conflict = 이미 DESIGNER 역할을 가지고 있음
+      const axiosError = error as { response?: { status?: number } };
+      if (axiosError.response?.status === 409) {
+        // 토큰 갱신 (이미 권한이 있어도 토큰에 반영 필요)
+        const refreshToken = useAuthStore.getState().refreshToken;
+        if (refreshToken) {
+          const tokenResponse = await authService.refresh(refreshToken);
+          useAuthStore.getState().setTokens(tokenResponse.accessToken, tokenResponse.refreshToken);
+        }
+
+        // 이미 권한이 있으므로 사용자 정보 업데이트 후 진행
+        const updatedUser = await userService.getMe();
+        useAuthStore.getState().updateUser({ role: updatedUser.role });
+
+        toast.success('이미 강의 개설 권한이 있습니다.');
+        setShowRoleDialog(false);
+        navigate(prefixPath('/tu/teaching/courses/create'));
+      } else {
+        toast.error('권한 부여에 실패했습니다. 다시 시도해주세요.');
+      }
+    } finally {
+      setIsGrantingRole(false);
+    }
+  };
+
+  // 다이얼로그 설명 텍스트
+  const getDialogDescription = () => {
+    if (courseRoleStatus === 'OWNER') {
+      return language === 'ko'
+        ? '이미 강의 소유자입니다. 새 강의를 만드시겠습니까?'
+        : 'You are already a course owner. Would you like to create a new course?';
+    }
+    if (courseRoleStatus === 'DESIGNER') {
+      return language === 'ko'
+        ? '이미 강의 개설 권한이 있습니다. 강의 설계 페이지로 이동하시겠습니까?'
+        : 'You already have course creation permission. Would you like to go to the course design page?';
+    }
+    return t.teaching.grantPermissionDesc;
+  };
+
+  const handleViewCourse = (courseId: string) => {
+    navigate(prefixPath(`/tu/teaching/courses/${courseId}`));
+  };
+
+  const handleEditCourse = (courseId: string) => {
+    navigate(prefixPath(`/tu/teaching/courses/${courseId}/edit`));
+  };
+
+  if (isLoading) {
+    return (
+      <div className={`flex items-center justify-center min-h-full ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+        <Loader2 className={`w-8 h-8 animate-spin ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+      <div className="max-w-5xl mx-auto">
+        {/* 헤더 */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
+          <div>
+            <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              {t.teaching.title}
+            </h1>
+            <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
+              {t.teaching.description}
+            </p>
+          </div>
+          {courses.length > 0 && (
+            <Button onClick={handleCreateCourse} className="gap-2">
+              <Plus className="w-4 h-4" />
+              {t.teaching.newCourse}
+            </Button>
+          )}
+        </div>
+
+        {/* 안내 문구 */}
+        <div
+          className={`rounded-xl p-4 mb-6 flex items-start gap-3 ${
+            isDark
+              ? 'bg-blue-500/10 border border-blue-500/20'
+              : 'bg-blue-50 border border-blue-200'
+          }`}
+        >
+          <AlertCircle className={`w-5 h-5 flex-shrink-0 mt-0.5 ${isDark ? 'text-blue-400' : 'text-blue-600'}`} />
+          <div>
+            <p className={`text-sm font-medium mb-1 ${isDark ? 'text-blue-300' : 'text-blue-800'}`}>
+              {t.teaching.courseNotice}
+            </p>
+            <p className={`text-sm ${isDark ? 'text-blue-400/80' : 'text-blue-700'}`}>
+              {t.teaching.courseNoticeDesc}
+            </p>
+          </div>
+        </div>
+
+        {/* 강의 목록 또는 빈 상태 */}
+        {courses.length === 0 ? (
+          <Card
+            className={`${
+              isDark
+                ? 'bg-white/5 border-white/10'
+                : 'bg-white border-gray-200 shadow-sm'
+            }`}
+          >
+            <CardContent className="py-16">
+              <div className="text-center">
+                <div
+                  className={`w-20 h-20 rounded-full mx-auto mb-6 flex items-center justify-center ${
+                    isDark
+                      ? 'bg-gradient-to-r from-[#6778ff]/20 to-[#a855f7]/20'
+                      : 'bg-blue-100'
+                  }`}
+                >
+                  <BookOpen className={`w-10 h-10 ${isDark ? 'text-[#6778ff]' : 'text-blue-600'}`} />
+                </div>
+                <h3 className={`text-xl font-semibold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                  {t.teaching.noCourses}
+                </h3>
+                <p className={`mb-8 max-w-md mx-auto ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  {t.teaching.noCoursesDesc}
+                </p>
+                <Button onClick={handleCreateCourse} size="lg" className="gap-2">
+                  <Plus className="w-5 h-5" />
+                  {t.teaching.createCourse}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-4">
+            {courses.map((course) => {
+              // Course API에는 status가 없으므로 기본값 DRAFT 사용
+              const courseStatus = 'DRAFT' as const;
+              const StatusIcon = statusIcons[courseStatus];
+
+              return (
+                <Card
+                  key={course.courseId}
+                  className={`transition-all hover:scale-[1.01] ${
+                    isDark
+                      ? 'bg-white/5 border-white/10 hover:bg-white/10'
+                      : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
+                  }`}
+                >
+                  <CardContent className="p-5">
+                    <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+                      {/* 강의 정보 */}
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2 mb-2">
+                          <Badge variant={statusVariants[courseStatus]} className="text-xs">
+                            <StatusIcon className="w-3 h-3 mr-1" />
+                            {statusLabels[courseStatus]}
+                          </Badge>
+                        </div>
+                        <h3
+                          className={`font-medium mb-1 ${isDark ? 'text-white' : 'text-gray-900'}`}
+                        >
+                          {course.title}
+                        </h3>
+                        <div className={`flex items-center gap-4 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                          <span>
+                            {t.teaching.lastModified}: {new Date(course.updatedAt).toLocaleDateString()}
+                          </span>
+                        </div>
+                      </div>
+
+                      {/* 액션 버튼 */}
+                      <div className="flex items-center gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleViewCourse(String(course.courseId))}
+                          className={isDark ? '!bg-transparent !border-white/20 !text-white hover:!bg-white/10' : ''}
+                        >
+                          <Eye className="w-4 h-4 mr-1" />
+                          {t.common.view}
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleEditCourse(String(course.courseId))}
+                          className={isDark ? '!bg-transparent !border-white/20 !text-white hover:!bg-white/10' : ''}
+                        >
+                          <Edit className="w-4 h-4 mr-1" />
+                          {t.common.edit}
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className={isDark ? '!text-gray-400 hover:!text-white hover:!bg-white/10' : ''}
+                        >
+                          <MoreHorizontal className="w-4 h-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* 강의 개설 확인 다이얼로그 */}
+      <AlertDialog open={showRoleDialog} onOpenChange={setShowRoleDialog}>
+        <AlertDialogContent className={isDark ? 'bg-[#2a2a2a] border-white/10' : ''}>
+          <AlertDialogHeader>
+            <AlertDialogTitle className={isDark ? 'text-white' : ''}>{t.teaching.courseDesignTitle}</AlertDialogTitle>
+            <AlertDialogDescription className={isDark ? 'text-gray-300' : ''}>
+              {getDialogDescription()}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              disabled={isGrantingRole}
+              className={isDark ? 'bg-transparent border-white/20 text-gray-200 hover:bg-white/10 hover:text-white' : ''}
+            >
+              {t.common.cancel}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleGrantDesignerRole}
+              disabled={isGrantingRole}
+            >
+              {isGrantingRole ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  {t.teaching.granting}
+                </>
+              ) : (
+                t.teaching.proceed
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/pages/tu/b2b/B2BProfilePage.tsx
+++ b/src/pages/tu/b2b/B2BProfilePage.tsx
@@ -1,0 +1,580 @@
+import { useState, useRef, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { User, Camera, Save, Loader2, Lock, Mail, Calendar, AlertTriangle, CheckCircle, Shield, Info, Building2, Briefcase } from 'lucide-react';
+import { toast } from 'sonner';
+import { useThemeStore } from '@/store/common/themeStore';
+import { useTranslation, useLanguageStore } from '@/store/common/languageStore';
+import {
+  Button,
+  Input,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Badge,
+  Label,
+  Alert,
+  AlertDescription,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/common';
+import {
+  useMyProfile,
+  useUpdateProfile,
+  useChangePassword,
+  useUploadProfileImage,
+  useWithdraw,
+} from '@/hooks/common';
+import { userService } from '@/services/common/userService';
+import type { TenantRole } from '@/types/common/auth.types';
+
+export function B2BProfilePage() {
+  const { theme } = useThemeStore();
+  const { t } = useTranslation();
+  const { language } = useLanguageStore();
+  const isDark = theme === 'dark';
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const location = useLocation();
+
+  // 프로필 미완성 상태로 리다이렉트 된 경우 (단체 계정 생성 사용자)
+  const profileIncomplete = location.state?.profileIncomplete === true;
+
+  // API Hooks
+  const { data: profile, isLoading: isLoadingProfile } = useMyProfile();
+  const updateProfileMutation = useUpdateProfile();
+  const changePasswordMutation = useChangePassword();
+  const uploadImageMutation = useUploadProfileImage();
+  const withdrawMutation = useWithdraw();
+
+  // Local State
+  const [profileData, setProfileData] = useState({ name: '', department: '', position: '' });
+  const [passwordData, setPasswordData] = useState({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: '',
+  });
+  const [profileImagePreview, setProfileImagePreview] = useState<string | null>(null);
+  const [withdrawPassword, setWithdrawPassword] = useState('');
+  const [designAuthStatus, setDesignAuthStatus] = useState<'USER' | 'DESIGNER' | 'OWNER'>('USER');
+  const [isRequestPending, setIsRequestPending] = useState(false);
+
+  // API Base URL
+  const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api').replace('/api', '');
+
+  // Sync profile data from API
+  useEffect(() => {
+    if (profile) {
+      setProfileData({
+        name: profile.name,
+        department: profile.department || '',
+        position: profile.position || '',
+      });
+      if (profile.profileImageUrl) {
+        const imageUrl = profile.profileImageUrl.startsWith('http')
+          ? profile.profileImageUrl
+          : `${apiBaseUrl}${profile.profileImageUrl}`;
+        setProfileImagePreview(imageUrl);
+      }
+    }
+  }, [profile, apiBaseUrl]);
+
+  // 시스템 역할(TenantRole) 기반으로 강의 개설 권한 상태 설정
+  useEffect(() => {
+    if (profile) {
+      // profile.roles (다중 역할) 또는 profile.role (단일 역할) 사용
+      const userRoles: TenantRole[] = profile.roles || [profile.role];
+      console.log('User system roles:', userRoles);
+
+      // DESIGNER 역할이 있으면 강의 개설 권한 있음
+      // TENANT_ADMIN, OPERATOR도 강의 개설 권한 있는 것으로 처리
+      const designerRoles: TenantRole[] = ['DESIGNER', 'TENANT_ADMIN', 'OPERATOR'];
+      const hasDesignerRole = userRoles.some((r) => designerRoles.includes(r));
+
+      if (hasDesignerRole) {
+        setDesignAuthStatus('DESIGNER');
+      } else {
+        setDesignAuthStatus('USER');
+      }
+    }
+  }, [profile]);
+
+  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+      toast.error('이미지 파일만 업로드 가능합니다.');
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error('파일 크기는 5MB 이하여야 합니다.');
+      return;
+    }
+
+    // Show preview immediately
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setProfileImagePreview(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+
+    // Upload to server
+    try {
+      await uploadImageMutation.mutateAsync(file);
+      toast.success('프로필 이미지가 업로드되었습니다.');
+    } catch {
+      toast.error('이미지 업로드에 실패했습니다.');
+    }
+  };
+
+  const handleProfileSave = async () => {
+    if (!profileData.name.trim()) {
+      toast.error('이름을 입력해주세요.');
+      return;
+    }
+
+    try {
+      await updateProfileMutation.mutateAsync({
+        name: profileData.name,
+        department: profileData.department || undefined,
+        position: profileData.position || undefined,
+      });
+      toast.success('프로필 정보가 저장되었습니다.');
+    } catch {
+      toast.error('프로필 저장에 실패했습니다.');
+    }
+  };
+
+  const handlePasswordChange = async () => {
+    if (!passwordData.currentPassword || !passwordData.newPassword || !passwordData.confirmPassword) {
+      toast.error('모든 필드를 입력해주세요.');
+      return;
+    }
+    if (passwordData.newPassword !== passwordData.confirmPassword) {
+      toast.error('새 비밀번호가 일치하지 않습니다.');
+      return;
+    }
+    if (passwordData.newPassword.length < 8) {
+      toast.error('비밀번호는 최소 8자 이상이어야 합니다.');
+      return;
+    }
+
+    try {
+      await changePasswordMutation.mutateAsync({
+        currentPassword: passwordData.currentPassword,
+        newPassword: passwordData.newPassword,
+      });
+      toast.success('비밀번호가 변경되었습니다.');
+      setPasswordData({ currentPassword: '', newPassword: '', confirmPassword: '' });
+    } catch {
+      toast.error('비밀번호 변경에 실패했습니다. 현재 비밀번호를 확인해주세요.');
+    }
+  };
+
+  const handleRequestDesignAuth = async () => {
+    setIsRequestPending(true);
+    try {
+      await userService.applyDesignerRole();
+      setDesignAuthStatus('DESIGNER');
+      toast.success('강의 개설 권한이 부여되었습니다.');
+    } catch (error) {
+      const axiosError = error as { response?: { status?: number } };
+      if (axiosError.response?.status === 409) {
+        // 이미 권한이 있음
+        setDesignAuthStatus('DESIGNER');
+        toast.info('이미 강의 개설 권한이 있습니다.');
+      } else {
+        console.error('Failed to apply designer role:', error);
+        toast.error('권한 신청에 실패했습니다.');
+      }
+    } finally {
+      setIsRequestPending(false);
+    }
+  };
+
+  const handleWithdraw = async () => {
+    if (!withdrawPassword) {
+      toast.error('비밀번호를 입력해주세요.');
+      return;
+    }
+    try {
+      await withdrawMutation.mutateAsync(withdrawPassword);
+      toast.success('회원 탈퇴가 완료되었습니다.');
+      window.location.href = '/';
+    } catch {
+      toast.error('회원 탈퇴에 실패했습니다. 비밀번호를 확인해주세요.');
+    }
+  };
+
+  const formatDate = (dateString?: string) => {
+    if (!dateString) return '-';
+    return new Date(dateString).toLocaleDateString(language === 'ko' ? 'ko-KR' : 'en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  const cardClass = isDark
+    ? 'bg-white/5 border-white/10'
+    : 'bg-white border-gray-200 shadow-sm';
+
+  const inputClass = isDark
+    ? 'bg-white/5 border-white/10 text-white placeholder:text-gray-500'
+    : 'bg-white border-gray-200 text-gray-900';
+
+  const readonlyInputClass = isDark
+    ? 'bg-white/5 border-white/10 text-gray-400'
+    : 'bg-gray-50 border-gray-200 text-gray-500';
+
+  if (isLoadingProfile) {
+    return (
+      <div className={`flex items-center justify-center min-h-full ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+        <Loader2 className={`w-8 h-8 animate-spin ${isDark ? 'text-gray-500' : 'text-gray-400'}`} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+      <div className="max-w-3xl mx-auto">
+        {/* 프로필 미완성 안내 메시지 */}
+        {profileIncomplete && (
+          <Alert className={`mb-6 ${isDark ? 'bg-blue-500/10 border-blue-500/30' : 'bg-blue-50 border-blue-200'}`}>
+            <Info className={`w-5 h-5 ${isDark ? 'text-blue-400' : 'text-blue-600'}`} />
+            <AlertDescription className={isDark ? 'text-blue-400' : 'text-blue-700'}>
+              <span className="font-medium">프로필 정보를 완성해주세요.</span>
+              <br />
+              <span className="text-sm">
+                단체 계정으로 생성된 계정입니다. 원활한 서비스 이용을 위해 이름 등 프로필 정보를 입력해주세요.
+              </span>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            {t.profileSecurity.title}
+          </h1>
+          <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
+            {t.profileSecurity.description}
+          </p>
+        </div>
+
+        {/* Profile Image Card */}
+        <Card className={`mb-6 ${cardClass}`}>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <Shield className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+              <CardTitle className={isDark ? 'text-white' : 'text-gray-900'}>{t.profileSecurity.profileInfo}</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {/* Profile Image */}
+            <div className="mb-6">
+              <Label className={`mb-3 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                {t.profileSecurity.profileImage}
+              </Label>
+              <div className="flex items-center gap-4 mt-3">
+                <div className="relative">
+                  <div className={`w-20 h-20 rounded-full flex items-center justify-center overflow-hidden ${
+                    isDark ? 'bg-gradient-to-r from-[#6778ff] to-[#a855f7]' : 'bg-blue-100'
+                  }`}>
+                    {profileImagePreview ? (
+                      <img src={profileImagePreview} alt="Profile" className="w-full h-full object-cover" />
+                    ) : (
+                      <User className={`w-10 h-10 ${isDark ? 'text-white' : 'text-blue-600'}`} />
+                    )}
+                  </div>
+                  <button
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={uploadImageMutation.isPending}
+                    className="absolute -bottom-1 -right-1 w-8 h-8 rounded-full bg-white shadow-md flex items-center justify-center hover:scale-110 transition-transform"
+                  >
+                    {uploadImageMutation.isPending ? (
+                      <Loader2 className="w-4 h-4 text-gray-600 animate-spin" />
+                    ) : (
+                      <Camera className="w-4 h-4 text-gray-600" />
+                    )}
+                  </button>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    onChange={handleImageUpload}
+                    className="hidden"
+                  />
+                </div>
+                <div>
+                  <p className={`text-sm ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                    {t.profileSecurity.imageGuide}
+                  </p>
+                  <p className={`text-xs mt-1 ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+                    {t.profileSecurity.imageClickGuide}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Name */}
+            <div className="mb-5">
+              <Label className={`mb-2 block text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                {t.profileSecurity.name}
+              </Label>
+              <Input
+                value={profileData.name}
+                onChange={(e) => setProfileData((prev) => ({ ...prev, name: e.target.value }))}
+                className={inputClass}
+              />
+            </div>
+
+            {/* Department & Position */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-5">
+              <div>
+                <Label className={`flex items-center gap-2 mb-2 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  <Building2 className="w-4 h-4" />
+                  부서
+                </Label>
+                <Input
+                  value={profileData.department}
+                  onChange={(e) => setProfileData((prev) => ({ ...prev, department: e.target.value }))}
+                  placeholder="예: 개발팀, 회계팀"
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <Label className={`flex items-center gap-2 mb-2 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  <Briefcase className="w-4 h-4" />
+                  직급
+                </Label>
+                <Input
+                  value={profileData.position}
+                  onChange={(e) => setProfileData((prev) => ({ ...prev, position: e.target.value }))}
+                  placeholder="예: 대리, 과장, 팀장"
+                  className={inputClass}
+                />
+              </div>
+            </div>
+
+            {/* Email (Read-only) */}
+            <div className="mb-5">
+              <Label className={`flex items-center gap-2 mb-2 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                <Mail className="w-4 h-4" />
+                {t.profileSecurity.email}
+              </Label>
+              <input
+                type="email"
+                value={profile?.email || ''}
+                readOnly
+                className={`w-full px-3 py-2.5 rounded-md text-sm cursor-not-allowed border ${readonlyInputClass}`}
+              />
+            </div>
+
+            {/* Join Date (Read-only) */}
+            <div className="mb-6">
+              <Label className={`flex items-center gap-2 mb-2 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                <Calendar className="w-4 h-4" />
+                {t.profileSecurity.joinDate}
+              </Label>
+              <input
+                type="text"
+                value={formatDate(profile?.createdAt)}
+                readOnly
+                className={`w-full px-3 py-2.5 rounded-md text-sm cursor-not-allowed border ${readonlyInputClass}`}
+              />
+            </div>
+
+            <Button onClick={handleProfileSave} disabled={updateProfileMutation.isPending}>
+              {updateProfileMutation.isPending ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  {t.profileSecurity.processing}
+                </>
+              ) : (
+                <>
+                  <Save className="w-4 h-4 mr-2" />
+                  {t.common.save}
+                </>
+              )}
+            </Button>
+          </CardContent>
+        </Card>
+
+        {/* Password Change Card */}
+        <Card className={`mb-6 ${cardClass}`}>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <Lock className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+              <CardTitle className={isDark ? 'text-white' : 'text-gray-900'}>{t.profileSecurity.passwordChange}</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="mb-5">
+              <Label className={`mb-2 block text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                {t.profileSecurity.currentPassword}
+              </Label>
+              <Input
+                type="password"
+                value={passwordData.currentPassword}
+                onChange={(e) => setPasswordData((prev) => ({ ...prev, currentPassword: e.target.value }))}
+                className={inputClass}
+              />
+            </div>
+
+            <div className="mb-5">
+              <Label className={`mb-2 block text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                {t.profileSecurity.newPassword}
+              </Label>
+              <Input
+                type="password"
+                value={passwordData.newPassword}
+                onChange={(e) => setPasswordData((prev) => ({ ...prev, newPassword: e.target.value }))}
+                className={inputClass}
+              />
+              <p className={`text-xs mt-1.5 ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+                {t.profileSecurity.passwordMinLength}
+              </p>
+            </div>
+
+            <div className="mb-6">
+              <Label className={`mb-2 block text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                {t.profileSecurity.confirmPassword}
+              </Label>
+              <Input
+                type="password"
+                value={passwordData.confirmPassword}
+                onChange={(e) => setPasswordData((prev) => ({ ...prev, confirmPassword: e.target.value }))}
+                className={inputClass}
+              />
+            </div>
+
+            <Button onClick={handlePasswordChange} disabled={changePasswordMutation.isPending}>
+              {changePasswordMutation.isPending ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  {t.profileSecurity.processing}
+                </>
+              ) : (
+                t.profileSecurity.changePassword
+              )}
+            </Button>
+          </CardContent>
+        </Card>
+
+        {/* Design Authority Card */}
+        <Card className={`mb-6 ${cardClass}`}>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <CheckCircle className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+              <CardTitle className={isDark ? 'text-white' : 'text-gray-900'}>{t.profileSecurity.coursePermission}</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="mb-5">
+              <Label className={`mb-3 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                {t.profileSecurity.currentPermissionStatus}
+              </Label>
+              <div className="mt-3">
+                <Badge
+                  variant={designAuthStatus === 'USER' ? 'gray' : designAuthStatus === 'DESIGNER' ? 'indigo' : 'orange'}
+                  className="px-4 py-2 text-sm"
+                >
+                  {designAuthStatus === 'USER' ? t.profileSecurity.generalUser : designAuthStatus === 'DESIGNER' ? t.profileSecurity.courseCreationEnabled : t.profileSecurity.fullAccess}
+                </Badge>
+              </div>
+            </div>
+
+            {designAuthStatus === 'USER' && (
+              <div>
+                <p className={`text-sm mb-4 leading-relaxed ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  {t.profileSecurity.permissionRequestDesc}
+                </p>
+                <Button onClick={handleRequestDesignAuth} disabled={isRequestPending}>
+                  {isRequestPending ? (
+                    <>
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      {t.profileSecurity.processing}
+                    </>
+                  ) : (
+                    t.profileSecurity.requestPermission
+                  )}
+                </Button>
+              </div>
+            )}
+
+            {(designAuthStatus === 'DESIGNER' || designAuthStatus === 'OWNER') && (
+              <Alert className={`flex items-center gap-3 ${isDark ? 'bg-green-500/10 border-green-500/30' : 'bg-green-50 border-green-200'}`}>
+                <CheckCircle className={`w-5 h-5 ${isDark ? 'text-green-400' : 'text-green-600'}`} />
+                <AlertDescription className={isDark ? 'text-green-400' : 'text-green-700'}>
+                  {t.profileSecurity.permissionEnabled}
+                </AlertDescription>
+              </Alert>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Account Management Card */}
+        <Card className={cardClass}>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <AlertTriangle className={`w-5 h-5 ${isDark ? 'text-orange-400' : 'text-orange-500'}`} />
+              <CardTitle className={isDark ? 'text-white' : 'text-gray-900'}>{t.profileSecurity.accountManagement}</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Alert className={`mb-4 ${isDark ? 'bg-orange-500/10 border-orange-500/30' : 'bg-orange-50 border-orange-200'}`}>
+              <AlertDescription className={isDark ? 'text-orange-400' : 'text-orange-700'}>
+                {t.profileSecurity.accountDeleteWarning}
+              </AlertDescription>
+            </Alert>
+
+            <AlertDialog onOpenChange={(open) => !open && setWithdrawPassword('')}>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="outline"
+                  className={isDark ? 'text-red-400 border-red-400/50 hover:bg-red-500/10' : 'text-red-600 border-red-300 hover:bg-red-50'}
+                >
+                  {t.profileSecurity.withdraw}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>{t.profileSecurity.withdrawTitle}</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {t.profileSecurity.withdrawDesc}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <div className="py-4">
+                  <Input
+                    type="password"
+                    value={withdrawPassword}
+                    onChange={(e) => setWithdrawPassword(e.target.value)}
+                    placeholder={t.profileSecurity.currentPassword}
+                  />
+                </div>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>{t.common.cancel}</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={handleWithdraw}
+                    className="bg-red-600 hover:bg-red-700 text-white"
+                    disabled={withdrawMutation.isPending || !withdrawPassword}
+                  >
+                    {withdrawMutation.isPending ? t.profileSecurity.processing : t.profileSecurity.withdrawConfirm}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/b2b/B2BSearchPage.tsx
+++ b/src/pages/tu/b2b/B2BSearchPage.tsx
@@ -1,0 +1,473 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  Search,
+  Loader2,
+  BookOpen,
+  X,
+  SlidersHorizontal,
+  ChevronDown,
+} from 'lucide-react';
+import { useThemeStore } from '@/store/common/themeStore';
+import { B2BLandingHeader } from './components/B2BLandingHeader';
+import { LandingFooter } from '@/components/landing/LandingFooter';
+import { B2BCourseCard } from './components/B2BCourseCard';
+import { useCourseTimeCatalog } from '@/hooks/tu';
+import type { CourseTimeCatalogResponse } from '@/types/tu/courseTimeCatalog.types';
+import { DELIVERY_TYPE_LABELS, PROGRAM_LEVEL_LABELS } from '@/types/tu/courseTimeCatalog.types';
+
+// API 사용 여부
+const USE_API = true;
+
+/**
+ * CourseTime API 데이터를 카드 컴포넌트 props로 변환
+ */
+function convertCourseTimeToCardProps(courseTime: CourseTimeCatalogResponse) {
+  const mainInstructor = courseTime.instructors.find((i) => i.role === 'MAIN');
+  const instructorName = mainInstructor?.name || courseTime.instructors[0]?.name || '';
+
+  const tags: string[] = [];
+  if (courseTime.isOnDemand) {
+    tags.push('상시모집');
+  } else if (courseTime.status === 'RECRUITING') {
+    tags.push('모집중');
+  } else if (courseTime.status === 'ONGOING') {
+    tags.push('진행중');
+  }
+
+  const thumbnailUrl =
+    courseTime.program?.thumbnailUrl ||
+    'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=400&h=250&fit=crop';
+
+  return {
+    id: courseTime.id,
+    title: courseTime.title,
+    instructor: instructorName,
+    image: thumbnailUrl,
+    tags,
+    category: courseTime.program?.categoryName ?? '',
+    deliveryType: DELIVERY_TYPE_LABELS[courseTime.deliveryType] || courseTime.deliveryType,
+    level: courseTime.program?.level ? PROGRAM_LEVEL_LABELS[courseTime.program.level] : undefined,
+    studentCount: courseTime.currentEnrollment,
+    classStartDate: courseTime.classStartDate,
+    isOnDemand: courseTime.isOnDemand,
+  };
+}
+
+// 필터 옵션 상수
+const SORT_OPTIONS = [
+  { value: 'relevance', label: '관련도순' },
+  { value: 'latest', label: '최신순' },
+  { value: 'popular', label: '인기순' },
+];
+
+const CATEGORY_OPTIONS = [
+  { value: 'all', label: '전체' },
+  { value: '개발', label: '개발' },
+  { value: 'AI', label: 'AI' },
+  { value: '클라우드', label: '클라우드' },
+  { value: '데이터', label: '데이터' },
+  { value: '디자인', label: '디자인' },
+];
+
+const LEVEL_OPTIONS = [
+  { value: 'all', label: '전체' },
+  { value: 'beginner', label: '입문' },
+  { value: 'intermediate', label: '중급' },
+  { value: 'advanced', label: '고급' },
+];
+
+const STATUS_OPTIONS = [
+  { value: 'all', label: '전체' },
+  { value: 'recruiting', label: '모집중' },
+  { value: 'ongoing', label: '상시모집' },
+];
+
+// 필터 타입
+interface Filters {
+  sort: string;
+  category: string;
+  level: string;
+  status: string;
+}
+
+/**
+ * 필터 드롭다운 컴포넌트
+ */
+function FilterDropdown({
+  label,
+  value,
+  options,
+  onChange,
+  isDark,
+}: {
+  label: string;
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (value: string) => void;
+  isDark: boolean;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const selectedOption = options.find((opt) => opt.value === value);
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-all ${
+          isDark
+            ? 'bg-white/5 border border-white/10 text-gray-300 hover:bg-white/10'
+            : 'bg-white border border-gray-200 text-gray-700 hover:bg-gray-50'
+        } ${value !== 'all' && value !== 'relevance' ? (isDark ? 'border-[#6778ff]/50 text-[#6778ff]' : 'border-[#6778ff] text-[#6778ff]') : ''}`}
+      >
+        <span className={isDark ? 'text-gray-500' : 'text-gray-400'}>{label}:</span>
+        <span>{selectedOption?.label}</span>
+        <ChevronDown className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+      </button>
+      {isOpen && (
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setIsOpen(false)} />
+          <div
+            className={`absolute top-full left-0 mt-1 py-1 rounded-lg shadow-lg z-20 min-w-[140px] ${
+              isDark ? 'bg-[#2a2a2a] border border-white/10' : 'bg-white border border-gray-200'
+            }`}
+          >
+            {options.map((option) => (
+              <button
+                key={option.value}
+                onClick={() => {
+                  onChange(option.value);
+                  setIsOpen(false);
+                }}
+                className={`w-full text-left px-4 py-2 text-sm transition-colors ${
+                  value === option.value
+                    ? 'bg-[#6778ff] text-white'
+                    : isDark
+                      ? 'text-gray-300 hover:bg-white/5'
+                      : 'text-gray-700 hover:bg-gray-50'
+                }`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+const DEFAULT_FILTERS: Filters = {
+  sort: 'relevance',
+  category: 'all',
+  level: 'all',
+  status: 'all',
+};
+
+/**
+ * B2B 과정 검색 페이지
+ */
+export function B2BSearchPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [inputValue, setInputValue] = useState('');
+  const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
+  const [showFilters, setShowFilters] = useState(false);
+  const { theme } = useThemeStore();
+  const isDark = theme === 'dark';
+
+  // 필터 초기화
+  const resetFilters = () => {
+    setFilters(DEFAULT_FILTERS);
+    const params = new URLSearchParams();
+    if (searchQuery) params.set('search', searchQuery);
+    setSearchParams(params);
+  };
+
+  // 활성화된 필터 개수
+  const activeFilterCount = useMemo(() => {
+    let count = 0;
+    if (filters.sort !== 'relevance') count++;
+    if (filters.category !== 'all') count++;
+    if (filters.level !== 'all') count++;
+    if (filters.status !== 'all') count++;
+    return count;
+  }, [filters]);
+
+  // URL에서 검색어 및 필터 가져오기
+  useEffect(() => {
+    const search = searchParams.get('search') || searchParams.get('q') || '';
+    const sort = searchParams.get('sort');
+    const category = searchParams.get('category');
+    const level = searchParams.get('level');
+    const status = searchParams.get('status');
+
+    if (search) {
+      setSearchQuery(search);
+      setInputValue(search);
+    }
+
+    setFilters({
+      sort: sort || 'relevance',
+      category: category || 'all',
+      level: level || 'all',
+      status: status || 'all',
+    });
+  }, [searchParams]);
+
+  // 필터 변경 시 URL 업데이트
+  const updateFilterWithUrl = (key: keyof Filters, value: string) => {
+    const newFilters = { ...filters, [key]: value };
+    setFilters(newFilters);
+
+    const params = new URLSearchParams();
+    if (searchQuery) params.set('search', searchQuery);
+    if (newFilters.sort !== 'relevance') params.set('sort', newFilters.sort);
+    if (newFilters.category !== 'all') params.set('category', newFilters.category);
+    if (newFilters.level !== 'all') params.set('level', newFilters.level);
+    if (newFilters.status !== 'all') params.set('status', newFilters.status);
+
+    setSearchParams(params);
+  };
+
+  // API 데이터
+  const {
+    data: coursesData,
+    isLoading: isCoursesLoading,
+  } = useCourseTimeCatalog(
+    {
+      keyword: searchQuery || undefined,
+      status: ['RECRUITING', 'ONGOING'],
+      size: 20,
+    },
+    USE_API && !!searchQuery
+  );
+
+  const courses = coursesData?.content || [];
+  const totalCourses = coursesData?.totalElements || 0;
+
+  // 검색 실행
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (inputValue.trim()) {
+      setSearchQuery(inputValue.trim());
+      setSearchParams({ search: inputValue.trim() });
+    }
+  };
+
+  // 검색어 초기화
+  const handleClearSearch = () => {
+    setSearchQuery('');
+    setInputValue('');
+    setSearchParams({});
+  };
+
+  return (
+    <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
+      <B2BLandingHeader />
+
+      <main className="w-full px-4 md:px-8 lg:px-16 py-12">
+        {/* 검색 헤더 */}
+        <div className="mb-8">
+          <h1 className={`text-3xl md:text-4xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            과정 검색
+          </h1>
+          <p className={`mb-6 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+            과정명, 강사명으로 검색하세요
+          </p>
+
+          {/* 검색바 */}
+          <form onSubmit={handleSearch} className="relative w-full">
+            <Search
+              className={`absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 ${
+                isDark ? 'text-gray-500' : 'text-gray-400'
+              }`}
+            />
+            <input
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              placeholder="과정명, 강사명으로 검색하세요"
+              className={`w-full rounded-xl pl-12 pr-12 py-3 focus:outline-none focus:ring-2 focus:ring-[#6778ff] focus:border-transparent transition-all ${
+                isDark
+                  ? 'bg-white/5 border border-white/10 text-white placeholder-gray-500'
+                  : 'bg-white border border-gray-200 text-gray-900 placeholder-gray-400'
+              }`}
+            />
+            {inputValue && (
+              <button
+                type="button"
+                onClick={handleClearSearch}
+                className={`absolute right-4 top-1/2 -translate-y-1/2 p-1 rounded-full ${
+                  isDark ? 'text-gray-500 hover:text-white' : 'text-gray-400 hover:text-gray-600'
+                }`}
+              >
+                <X className="w-5 h-5" />
+              </button>
+            )}
+          </form>
+        </div>
+
+        {/* 검색 결과 */}
+        {searchQuery && (
+          <>
+            {/* 필터 영역 */}
+            <div className="mb-6">
+              <button
+                onClick={() => setShowFilters(!showFilters)}
+                className={`md:hidden flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium mb-4 ${
+                  isDark
+                    ? 'bg-white/5 border border-white/10 text-gray-300'
+                    : 'bg-white border border-gray-200 text-gray-700'
+                }`}
+              >
+                <SlidersHorizontal className="w-4 h-4" />
+                필터
+                {activeFilterCount > 0 && (
+                  <span className="px-1.5 py-0.5 rounded-full bg-[#6778ff] text-white text-xs">
+                    {activeFilterCount}
+                  </span>
+                )}
+              </button>
+
+              <div className={`flex flex-wrap gap-2 ${!showFilters ? 'max-md:hidden' : ''}`}>
+                <FilterDropdown
+                  label="정렬"
+                  value={filters.sort}
+                  options={SORT_OPTIONS}
+                  onChange={(value) => updateFilterWithUrl('sort', value)}
+                  isDark={isDark}
+                />
+
+                <FilterDropdown
+                  label="카테고리"
+                  value={filters.category}
+                  options={CATEGORY_OPTIONS}
+                  onChange={(value) => updateFilterWithUrl('category', value)}
+                  isDark={isDark}
+                />
+
+                <FilterDropdown
+                  label="난이도"
+                  value={filters.level}
+                  options={LEVEL_OPTIONS}
+                  onChange={(value) => updateFilterWithUrl('level', value)}
+                  isDark={isDark}
+                />
+
+                <FilterDropdown
+                  label="모집상태"
+                  value={filters.status}
+                  options={STATUS_OPTIONS}
+                  onChange={(value) => updateFilterWithUrl('status', value)}
+                  isDark={isDark}
+                />
+
+                {activeFilterCount > 0 && (
+                  <button
+                    onClick={resetFilters}
+                    className={`flex items-center gap-1 px-3 py-2 rounded-lg text-sm font-medium transition-all ${
+                      isDark
+                        ? 'text-gray-400 hover:text-white hover:bg-white/5'
+                        : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+                    }`}
+                  >
+                    <X className="w-4 h-4" />
+                    초기화
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* 검색 결과 요약 */}
+            <p className={`mb-6 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+              "<span className={`font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>{searchQuery}</span>"
+              검색 결과{' '}
+              <span className={`font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                {totalCourses}
+              </span>
+              건
+            </p>
+
+            {isCoursesLoading ? (
+              <div className="flex items-center justify-center py-20">
+                <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
+                <span className={`ml-3 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  검색 중...
+                </span>
+              </div>
+            ) : totalCourses === 0 ? (
+              <div className="text-center py-20">
+                <Search className={`w-16 h-16 mx-auto mb-4 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
+                <p className={`text-lg ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                  검색 결과가 없습니다
+                </p>
+                <p className={`text-sm mt-2 ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+                  다른 키워드로 검색해 보세요
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-12">
+                {/* 과정 목록 */}
+                <section>
+                  <div className="flex items-center justify-between mb-6">
+                    <h2 className={`text-xl font-bold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                      과정
+                      <span className="ml-2 text-sm font-normal text-[#6778ff]">{totalCourses}</span>
+                    </h2>
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6">
+                    {courses.map((course) => {
+                      const cardProps = convertCourseTimeToCardProps(course);
+                      return <B2BCourseCard key={cardProps.id} {...cardProps} />;
+                    })}
+                  </div>
+                </section>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* 검색어 없을 때 */}
+        {!searchQuery && (
+          <div className="text-center py-16">
+            <Search className={`w-16 h-16 mx-auto mb-4 ${isDark ? 'text-gray-600' : 'text-gray-300'}`} />
+            <h2 className={`text-xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              무엇을 찾으시나요?
+            </h2>
+            <p className={`mb-8 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+              위 검색창에 키워드를 입력해주세요
+            </p>
+
+            <div className="max-w-lg mx-auto">
+              <p className={`text-sm mb-4 ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+                인기 검색어
+              </p>
+              <div className="flex flex-wrap justify-center gap-3">
+                {['React', 'Python', 'AI', '클라우드', 'TypeScript', 'AWS', 'Docker', 'Spring'].map((keyword) => (
+                  <button
+                    key={keyword}
+                    onClick={() => {
+                      setInputValue(keyword);
+                      setSearchQuery(keyword);
+                      setSearchParams({ search: keyword });
+                    }}
+                    className={`px-4 py-2 rounded-full text-sm font-medium transition-all duration-300 ${
+                      isDark
+                        ? 'bg-white/5 text-gray-300 hover:bg-white/10 border border-white/10 hover:text-white'
+                        : 'bg-white text-gray-600 hover:bg-gray-100 border border-gray-200 hover:text-gray-900'
+                    }`}
+                  >
+                    {keyword}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+      </main>
+
+      <LandingFooter />
+    </div>
+  );
+}

--- a/src/pages/tu/b2b/B2BSearchPage.tsx
+++ b/src/pages/tu/b2b/B2BSearchPage.tsx
@@ -3,7 +3,6 @@ import { useSearchParams } from 'react-router-dom';
 import {
   Search,
   Loader2,
-  BookOpen,
   X,
   SlidersHorizontal,
   ChevronDown,

--- a/src/pages/tu/b2b/B2BTeachingStatsPage.tsx
+++ b/src/pages/tu/b2b/B2BTeachingStatsPage.tsx
@@ -1,0 +1,366 @@
+import { BarChart3, Users, BookOpen, GraduationCap, TrendingUp, AlertCircle } from 'lucide-react';
+
+import { useThemeStore } from '@/store/common/themeStore';
+import { useTranslation } from '@/store/common/languageStore';
+import { Card, CardHeader, CardTitle, CardContent, Skeleton, EmptyState } from '@/components/common';
+import { useMyOwnerStats } from '@/hooks/tu';
+import { designTokens } from '@/styles/admin-design-tokens';
+
+export function B2BTeachingStatsPage() {
+  const { theme } = useThemeStore();
+  const { t } = useTranslation();
+  const isDark = theme === 'dark';
+
+  const { data: stats, isLoading, error } = useMyOwnerStats();
+
+  const cardClass = isDark
+    ? 'bg-white/5 border-white/10'
+    : 'bg-white border-gray-200 shadow-sm';
+
+  const statCardClass = isDark
+    ? 'bg-white/5 border border-white/10'
+    : 'bg-white border border-gray-200 shadow-sm';
+
+  // 에러 상태
+  if (error) {
+    return (
+      <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+        <div className="max-w-4xl mx-auto">
+          <div className="mb-8">
+            <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              {t.teaching.stats}
+            </h1>
+            <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
+              {t.teaching.statsDesc}
+            </p>
+          </div>
+          <Card className={cardClass}>
+            <CardContent className="py-12">
+              <div className="flex flex-col items-center justify-center text-center">
+                <AlertCircle className="h-12 w-12 text-red-500 mb-4" />
+                <p className={`text-lg font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                  {t.common.error}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`min-h-full p-6 sm:p-8 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+      <div className="max-w-4xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className={`text-2xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            {t.teaching.stats}
+          </h1>
+          <p className={isDark ? 'text-gray-400' : 'text-gray-600'}>
+            {t.teaching.statsDesc}
+          </p>
+        </div>
+
+        {/* Overview Stats Cards */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+          {isLoading ? (
+            <>
+              <Skeleton className="h-28" />
+              <Skeleton className="h-28" />
+              <Skeleton className="h-28" />
+            </>
+          ) : (
+            <>
+              <div className={`p-4 rounded-xl ${statCardClass}`}>
+                <div className="flex items-center gap-3 mb-2">
+                  <div className={isDark ? 'text-violet-400' : 'text-violet-600'}>
+                    <BookOpen className="w-5 h-5" />
+                  </div>
+                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                    {t.teaching.totalPrograms}
+                  </span>
+                </div>
+                <p className={`text-2xl font-bold tabular-nums ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                  {stats?.overview.totalPrograms ?? 0}
+                </p>
+              </div>
+
+              <div className={`p-4 rounded-xl ${statCardClass}`}>
+                <div className="flex items-center gap-3 mb-2">
+                  <div className={isDark ? 'text-sky-400' : 'text-sky-600'}>
+                    <GraduationCap className="w-5 h-5" />
+                  </div>
+                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                    {t.teaching.totalCourseTimes}
+                  </span>
+                </div>
+                <p className={`text-2xl font-bold tabular-nums ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                  {stats?.overview.totalCourseTimes ?? 0}
+                </p>
+              </div>
+
+              <div className={`p-4 rounded-xl ${statCardClass}`}>
+                <div className="flex items-center gap-3 mb-2">
+                  <div className={isDark ? 'text-emerald-400' : 'text-emerald-600'}>
+                    <Users className="w-5 h-5" />
+                  </div>
+                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                    {t.teaching.totalStudents}
+                  </span>
+                </div>
+                <p className={`text-2xl font-bold tabular-nums ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                  {stats?.overview.totalStudents ?? 0}
+                </p>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Enrollment Stats Card */}
+        <Card className={`${cardClass} mb-6`}>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <TrendingUp className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+              <CardTitle className={isDark ? 'text-white' : 'text-gray-900'}>
+                {t.teaching.enrollmentStats}
+              </CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="space-y-4">
+                <Skeleton className="h-10" />
+                <Skeleton className="h-8" />
+              </div>
+            ) : (
+              <div className="space-y-6">
+                {/* Total Count Header */}
+                <div className="flex items-baseline gap-2">
+                  <span className={`text-3xl font-bold tabular-nums ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                    {stats?.enrollmentStats.totalEnrollments ?? 0}
+                  </span>
+                  <span className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                    {t.teaching.totalEnrollments}
+                  </span>
+                </div>
+
+                {/* Horizontal Stacked Bar */}
+                {(() => {
+                  // Pastel Neon 톤 색상 팔레트 (Dark Mode 최적화)
+                  const colors = {
+                    completed: isDark ? '#34d399' : '#059669',   // Emerald-400 / Emerald-600
+                    inProgress: isDark ? '#a78bfa' : '#7C3AED',  // Violet-400 / Violet-600
+                    dropped: isDark ? '#fb7185' : '#E11D48',     // Rose-400 / Rose-600
+                    failed: isDark ? '#475569' : '#9CA3AF',      // Slate-600 / Gray-400
+                  };
+
+                  const total = stats?.enrollmentStats.totalEnrollments ?? 0;
+                  const items = [
+                    { key: 'completed', label: t.teaching.completed, value: stats?.enrollmentStats.completed ?? 0, color: colors.completed },
+                    { key: 'inProgress', label: t.teaching.inProgress, value: stats?.enrollmentStats.inProgress ?? 0, color: colors.inProgress },
+                    { key: 'dropped', label: t.teaching.dropped, value: stats?.enrollmentStats.dropped ?? 0, color: colors.dropped },
+                    { key: 'failed', label: t.teaching.failed, value: stats?.enrollmentStats.failed ?? 0, color: colors.failed },
+                  ];
+
+                  // 값이 있는 항목만 필터링
+                  const activeItems = items.filter((item) => item.value > 0);
+
+                  // 그라데이션 색상 (다크모드용)
+                  const gradientColors = {
+                    completed: isDark
+                      ? 'bg-gradient-to-r from-emerald-400 to-teal-400'
+                      : 'bg-emerald-600',
+                    inProgress: isDark
+                      ? 'bg-gradient-to-r from-violet-400 to-purple-400'
+                      : 'bg-violet-600',
+                    dropped: isDark
+                      ? 'bg-gradient-to-r from-rose-400 to-pink-400'
+                      : 'bg-rose-600',
+                    failed: isDark
+                      ? 'bg-gradient-to-r from-slate-500 to-slate-600'
+                      : 'bg-gray-400',
+                  };
+
+                  return (
+                    <div className="space-y-4">
+                      {/* Stacked Bar with Gradients - Entrance Animation */}
+                      <div className="flex h-3 w-full gap-1 overflow-hidden">
+                        {activeItems.length > 0 ? (
+                          activeItems.map((item, index) => {
+                            const percentage = total > 0 ? (item.value / total) * 100 : 0;
+                            const gradientClass = gradientColors[item.key as keyof typeof gradientColors];
+
+                            return (
+                              <div
+                                key={item.key}
+                                className={`h-full rounded-full ${gradientClass} animate-[grow-width_0.8s_ease-out_forwards]`}
+                                style={{
+                                  width: `${percentage}%`,
+                                  animationDelay: `${index * 0.1}s`,
+                                  opacity: 0,
+                                  transform: 'scaleX(0)',
+                                  transformOrigin: 'left',
+                                }}
+                              />
+                            );
+                          })
+                        ) : (
+                          <div
+                            className={`h-full w-full rounded-full ${isDark ? 'bg-white/10' : 'bg-gray-200'}`}
+                          />
+                        )}
+                      </div>
+                      {/* Keyframes for entrance animation */}
+                      <style>{`
+                        @keyframes grow-width {
+                          0% {
+                            opacity: 0;
+                            transform: scaleX(0);
+                          }
+                          100% {
+                            opacity: 1;
+                            transform: scaleX(1);
+                          }
+                        }
+                      `}</style>
+
+                      {/* Legend */}
+                      <div className="flex flex-wrap gap-x-6 gap-y-2">
+                        {items.map((item) => {
+                          const dotGradientClass = gradientColors[item.key as keyof typeof gradientColors];
+                          return (
+                            <div key={item.key} className="flex items-center gap-2 leading-none">
+                              <div
+                                className={`w-2.5 h-2.5 rounded-sm flex-shrink-0 ${isDark ? dotGradientClass : ''}`}
+                                style={!isDark ? { backgroundColor: item.color } : undefined}
+                              />
+                              <span className={`text-sm leading-none ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+                                {item.label}
+                              </span>
+                              <span className={`text-sm font-semibold tabular-nums leading-none ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                                {item.value}
+                              </span>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                })()}
+
+                {/* 평균 수료율 */}
+                <div className={`pt-4 border-t ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
+                  <div className="flex items-center justify-between">
+                    <span className={`text-sm font-medium leading-none ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>
+                      {t.teaching.averageCompletionRate}
+                    </span>
+                    <span
+                      className="text-xl font-bold tabular-nums leading-none"
+                      style={{ color: isDark ? '#34d399' : '#059669' }}
+                    >
+                      {stats?.enrollmentStats.averageCompletionRate ?? 0}%
+                    </span>
+                  </div>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Program Stats Card */}
+        <Card className={cardClass}>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <BarChart3 className={`w-5 h-5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} />
+              <CardTitle className={isDark ? 'text-white' : 'text-gray-900'}>
+                {t.teaching.programStats}
+              </CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="space-y-3">
+                <Skeleton className="h-16" />
+                <Skeleton className="h-16" />
+                <Skeleton className="h-16" />
+              </div>
+            ) : !stats?.programStats || stats.programStats.length === 0 ? (
+              <EmptyState
+                icon={BookOpen}
+                title={t.teaching.noProgramStats}
+                description={t.teaching.noProgramStatsDesc}
+                className={`border-2 border-dashed rounded-lg ${isDark ? 'border-white/10' : 'border-gray-200'}`}
+              />
+            ) : (
+              <div className="space-y-3">
+                {stats.programStats.map((program, index) => (
+                  <div
+                    key={program.programId}
+                    className={`p-4 rounded-lg transition-all ${
+                      isDark
+                        ? 'bg-white/5 hover:bg-white/10'
+                        : 'bg-gray-50 hover:bg-gray-100'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between mb-2">
+                      <h4 className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                        {program.programName}
+                      </h4>
+                    </div>
+                    <div className="flex items-center gap-4 text-sm mb-3">
+                      <span className={isDark ? 'text-gray-400' : 'text-gray-600'}>
+                        {t.teaching.courseTimes}: {program.courseTimeCount}
+                      </span>
+                      <span className={isDark ? 'text-gray-400' : 'text-gray-600'}>
+                        {t.teaching.students}: {program.totalStudents}
+                      </span>
+                    </div>
+                    {/* 수료율 Progress Bar with Entrance Animation */}
+                    <div className="space-y-1">
+                      <div className="flex items-center justify-between text-sm">
+                        <span className={isDark ? 'text-gray-400' : 'text-gray-500'}>
+                          {t.teaching.completionRate}
+                        </span>
+                        <span
+                          className="font-semibold"
+                          style={{ color: isDark ? '#34d399' : designTokens.status.success_text }}
+                        >
+                          {program.completionRate}%
+                        </span>
+                      </div>
+                      <div
+                        className={`relative h-2 w-full overflow-hidden rounded-full ${
+                          isDark ? 'bg-white/10' : 'bg-gray-200'
+                        }`}
+                      >
+                        <div
+                          className={`h-full rounded-full animate-[grow-width_0.8s_ease-out_forwards] ${
+                            isDark
+                              ? 'bg-gradient-to-r from-violet-400 to-purple-400'
+                              : ''
+                          }`}
+                          style={{
+                            width: `${program.completionRate}%`,
+                            ...(!isDark && { backgroundColor: designTokens.button.brand_default }),
+                            boxShadow: isDark
+                              ? '0 0 8px rgba(167, 139, 250, 0.4)'
+                              : '0 1px 3px rgba(0, 0, 0, 0.15)',
+                            animationDelay: `${index * 0.15}s`,
+                            opacity: 0,
+                            transform: 'scaleX(0)',
+                            transformOrigin: 'left',
+                          }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/b2b/B2BUserNoticesPage.tsx
+++ b/src/pages/tu/b2b/B2BUserNoticesPage.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react';
+import {
+  Bell,
+  Pin,
+  Eye,
+  ChevronLeft,
+  ChevronRight,
+  Calendar,
+  Inbox,
+} from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Badge } from '@/components/common/Badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/common/Dialog';
+import { useUserNotices, useUserNotice } from '@/hooks/tu/useUserNoticeQueries';
+import type { TenantNotice, TenantNoticeType } from '@/types/ta/tenantNotice.types';
+
+// 공지 타입 설정
+const typeConfig: Record<TenantNoticeType, { label: string; color: string }> = {
+  GENERAL: { label: '일반', color: 'bg-gray-100 text-gray-700' },
+  IMPORTANT: { label: '중요', color: 'bg-blue-100 text-blue-700' },
+  URGENT: { label: '긴급', color: 'bg-red-100 text-red-700' },
+  EVENT: { label: '이벤트', color: 'bg-purple-100 text-purple-700' },
+};
+
+export function B2BUserNoticesPage() {
+  const [page, setPage] = useState(0);
+  const [selectedNoticeId, setSelectedNoticeId] = useState<number | null>(null);
+
+  // API Hooks
+  const { data: noticesData, isLoading } = useUserNotices({ page, size: 10 });
+  const { data: selectedNotice } = useUserNotice(selectedNoticeId || 0);
+
+  const notices = noticesData?.content || [];
+  const totalPages = noticesData?.totalPages || 0;
+  const totalElements = noticesData?.totalElements || 0;
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return '-';
+    return new Date(dateString).toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  const handleViewNotice = (notice: TenantNotice) => {
+    setSelectedNoticeId(notice.id);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+          <div className="h-64 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      {/* Header */}
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold text-text-primary">공지사항</h1>
+        <p className="text-sm text-text-secondary mt-1">
+          관리자가 발송한 공지사항을 확인합니다
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Bell className="h-5 w-5 text-brand-primary" />
+            <div>
+              <CardTitle>공지사항</CardTitle>
+              <CardDescription>전체 {totalElements}개의 공지사항</CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {notices.length === 0 ? (
+            <div className="text-center py-12 text-text-secondary">
+              <Inbox className="h-12 w-12 mx-auto mb-4 opacity-50" />
+              <p>공지사항이 없습니다.</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {notices.map((notice) => {
+                const typeConf = typeConfig[notice.type] || typeConfig.GENERAL;
+
+                return (
+                  <div
+                    key={notice.id}
+                    role="button"
+                    tabIndex={0}
+                    className="p-4 border rounded-lg hover:bg-bg-secondary cursor-pointer transition-colors"
+                    onClick={() => handleViewNotice(notice)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        handleViewNotice(notice);
+                      }
+                    }}
+                  >
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2 mb-1">
+                          {notice.isPinned && (
+                            <Pin className="h-4 w-4 text-yellow-500 flex-shrink-0" />
+                          )}
+                          <h3 className="font-medium">{notice.title}</h3>
+                          <Badge className={typeConf.color}>{typeConf.label}</Badge>
+                        </div>
+                        <p className="text-sm text-text-secondary line-clamp-2">
+                          {notice.content.replace(/<[^>]*>/g, '').substring(0, 150)}...
+                        </p>
+                      </div>
+                      <div className="flex flex-col items-end gap-2 ml-4">
+                        <span className="text-xs text-text-secondary flex items-center gap-1">
+                          <Calendar className="h-3 w-3" />
+                          {formatDate(notice.publishedAt || notice.createdAt)}
+                        </span>
+                        <Button variant="ghost" size="sm">
+                          <Eye className="h-4 w-4 mr-1" />
+                          보기
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 mt-6">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page === 0}
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <span className="text-sm">
+                {page + 1} / {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages - 1}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 상세 Dialog */}
+      <Dialog open={selectedNoticeId !== null} onOpenChange={() => setSelectedNoticeId(null)}>
+        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <div className="flex items-center gap-2">
+              {selectedNotice?.isPinned && <Pin className="h-4 w-4 text-yellow-500" />}
+              <DialogTitle>{selectedNotice?.title}</DialogTitle>
+            </div>
+          </DialogHeader>
+
+          {selectedNotice && (
+            <div className="mt-4">
+              <div className="flex items-center gap-3 mb-4">
+                <Badge className={typeConfig[selectedNotice.type]?.color || typeConfig.GENERAL.color}>
+                  {typeConfig[selectedNotice.type]?.label || '일반'}
+                </Badge>
+                <span className="text-sm text-text-secondary">
+                  {formatDate(selectedNotice.publishedAt || selectedNotice.createdAt)}
+                </span>
+              </div>
+
+              <div className="prose prose-sm max-w-none whitespace-pre-wrap">
+                {selectedNotice.content}
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/tu/b2b/components/B2BLandingHeader.tsx
+++ b/src/pages/tu/b2b/components/B2BLandingHeader.tsx
@@ -236,7 +236,7 @@ export function B2BLandingHeader() {
                 )}
                 {/* 위시리스트 (찜) - B2B에서도 표시 */}
                 <Link
-                  to={prefixPath('/tu/b2b/mypage/wishlist')}
+                  to={prefixPath('/tu/b2b/wishlist')}
                   className={`p-2 rounded-lg transition-colors ${
                     isDark
                       ? 'text-gray-400 hover:text-white hover:bg-white/10'

--- a/src/pages/tu/b2b/index.ts
+++ b/src/pages/tu/b2b/index.ts
@@ -11,10 +11,27 @@
  * HeaderComponent와 showPrice 등의 prop으로 B2B 스타일 적용
  */
 
+// B2B 메인 페이지
 export { B2BLandingPage } from './B2BLandingPage';
 export { B2BCourseDetailPage } from './B2BCourseDetailPage';
+export { B2BSearchPage } from './B2BSearchPage';
+
+// B2B 마이페이지
+export { B2BMyPageHome } from './B2BMyPageHome';
+export { B2BProfilePage } from './B2BProfilePage';
+export { B2BMyLearningPage } from './B2BMyLearningPage';
+export { B2BLearningDetailPage } from './B2BLearningDetailPage';
+export { B2BCompletedCoursesPage } from './B2BCompletedCoursesPage';
+export { B2BCertificationsPage } from './B2BCertificationsPage';
+export { B2BMyTeachingPage } from './B2BMyTeachingPage';
+export { B2BTeachingStatsPage } from './B2BTeachingStatsPage';
+export { B2BUserNoticesPage } from './B2BUserNoticesPage';
+
+// B2B 설정 페이지
 export { B2BSettingsPage } from './B2BSettingsPage';
 export { B2BPreferencesPage } from './B2BPreferencesPage';
+
+// B2B 기타 페이지
 export { B2BMyActivityPage } from './B2BMyActivityPage';
 export { B2BWishlistPage } from './B2BWishlistPage';
 export { B2BLearningPlayerPage } from './B2BLearningPlayerPage';

--- a/src/pages/tu/index.ts
+++ b/src/pages/tu/index.ts
@@ -19,4 +19,4 @@ export { SettingsLanguagePage } from './settings';
 export { LandingPage, CoursesExplorePage, RoadmapExplorePage, RoadmapDetailPage, CommunityPage, CommunityDetailPage, CartPage, WishlistPage, NotificationsPage, NotificationDetailPage, CourseDetailPage, InstructorProfilePage, SearchPage } from './main';
 export { CatalogPage, CatalogDetailPage } from './catalog';
 export { MyLearningPage, LearningDetailPage, LearningPlayerPage } from './learning';
-export { MyPage, MyPageHome, ProfilePage, MyTeachingPage, TeachingStatsPage, CompletedCoursesPage, CertificationsPage, MyPostsPage, MyCommentsPage, UserNoticesPage, B2CSettingsPage, B2CPreferencesPage } from './mypage';
+export { MyPage, MyPageHome, ProfilePage, MyTeachingPage, TeachingStatsPage, CompletedCoursesPage, CertificationsPage, MyPostsPage, MyCommentsPage, UserNoticesPage, SettingsPage, PreferencesPage } from './mypage';

--- a/src/pages/tu/learning/components/PlayerCommunitySection.tsx
+++ b/src/pages/tu/learning/components/PlayerCommunitySection.tsx
@@ -1,0 +1,363 @@
+/**
+ * PlayerCommunitySection (B2C 전용)
+ * 플레이어 페이지 내 커뮤니티 섹션
+ * - 게시글 목록 (질문, 팁, 후기, 토론)
+ * - 검색, 필터, 정렬
+ * - 좋아요 기능
+ *
+ * Note: B2B는 B2BQuestionSection 사용
+ */
+import { useState, useCallback } from 'react';
+import { Search, ThumbsUp, MessageCircle, Send, Loader2 } from 'lucide-react';
+import { Button, Input, Avatar, AvatarFallback, Skeleton } from '@/components/common';
+import {
+  useCourseCommunityPosts,
+  useLikeCourseCommunityPost,
+  useUnlikeCourseCommunityPost,
+  useCreateCourseCommunityPost,
+} from '@/hooks/tu';
+import type { PostType, CourseCommunityFilter } from '@/types/tu/courseCommunity.types';
+
+interface PlayerCommunitySectionProps {
+  timeId: number;
+  isDark: boolean;
+  currentItemName?: string;
+}
+
+type TabType = 'all' | PostType;
+
+const TABS: { value: TabType; labelKey: string }[] = [
+  { value: 'all', labelKey: 'all' },
+  { value: 'question', labelKey: 'question' },
+  { value: 'tip', labelKey: 'tip' },
+  { value: 'review', labelKey: 'review' },
+  { value: 'discussion', labelKey: 'discussion' },
+];
+
+const TAB_LABELS: Record<TabType, string> = {
+  all: '전체',
+  question: '질문',
+  tip: '팁',
+  review: '후기',
+  discussion: '토론',
+  announcement: '공지',
+};
+
+export function PlayerCommunitySection({
+  timeId,
+  isDark,
+  currentItemName,
+}: PlayerCommunitySectionProps) {
+  // 상태
+  const [activeTab, setActiveTab] = useState<TabType>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortBy, setSortBy] = useState<'latest' | 'popular'>('latest');
+  const [isWriting, setIsWriting] = useState(false);
+  const [newPostContent, setNewPostContent] = useState('');
+
+  // 필터 구성
+  const filter: CourseCommunityFilter = {
+    search: searchQuery || undefined,
+    type: activeTab,
+    sortBy,
+    page: 0,
+    pageSize: 20,
+  };
+
+  // API 훅
+  const { data, isLoading, isError } = useCourseCommunityPosts(timeId, filter, !!timeId);
+  const likeMutation = useLikeCourseCommunityPost();
+  const unlikeMutation = useUnlikeCourseCommunityPost();
+  const createPostMutation = useCreateCourseCommunityPost();
+
+  // 좋아요 토글
+  const handleLikeToggle = useCallback((postId: number, isLiked: boolean) => {
+    if (isLiked) {
+      unlikeMutation.mutate({ timeId, postId });
+    } else {
+      likeMutation.mutate({ timeId, postId });
+    }
+  }, [timeId, likeMutation, unlikeMutation]);
+
+  // 게시글 작성
+  const handleCreatePost = useCallback(async () => {
+    if (!newPostContent.trim()) return;
+
+    try {
+      await createPostMutation.mutateAsync({
+        timeId,
+        data: {
+          type: 'question',
+          title: currentItemName ? `[${currentItemName}] 질문` : '질문',
+          content: newPostContent,
+          category: 'general',
+        },
+      });
+      setNewPostContent('');
+      setIsWriting(false);
+    } catch (error) {
+      console.error('Failed to create post:', error);
+    }
+  }, [timeId, newPostContent, currentItemName, createPostMutation]);
+
+  // 검색 핸들러
+  const handleSearch = useCallback((e: React.FormEvent) => {
+    e.preventDefault();
+  }, []);
+
+  // 시간 포맷
+  const formatTime = (dateString: string) => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diff = now.getTime() - date.getTime();
+    const minutes = Math.floor(diff / 60000);
+    const hours = Math.floor(diff / 3600000);
+    const days = Math.floor(diff / 86400000);
+
+    if (minutes < 1) return '방금 전';
+    if (minutes < 60) return `${minutes}분 전`;
+    if (hours < 24) return `${hours}시간 전`;
+    if (days < 7) return `${days}일 전`;
+    return date.toLocaleDateString('ko-KR');
+  };
+
+  return (
+    <div className={`min-h-[400px] p-6 ${isDark ? 'bg-[#1e1e1e]' : 'bg-gray-50'}`}>
+      {/* 섹션 헤더 */}
+      {currentItemName && (
+        <div className="mb-5">
+          <h2 className={`text-lg font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            {currentItemName}
+          </h2>
+        </div>
+      )}
+
+      {/* 검색 및 작성 버튼 */}
+      <div className="flex gap-3 mb-5">
+        <form onSubmit={handleSearch} className="flex-1 relative">
+          <Search
+            className={`absolute left-3 top-1/2 -translate-y-1/2 w-[18px] h-[18px] ${
+              isDark ? 'text-gray-400' : 'text-gray-500'
+            }`}
+          />
+          <Input
+            type="text"
+            placeholder="검색어를 입력하세요"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className={`pl-10 ${
+              isDark
+                ? 'bg-[#252525] border-white/10 text-white placeholder:text-gray-500'
+                : 'bg-white border-gray-200 text-gray-900 placeholder:text-gray-400'
+            }`}
+          />
+        </form>
+        <Button
+          onClick={() => setIsWriting(!isWriting)}
+          className="landing-btn-primary text-white shrink-0"
+        >
+          질문 작성
+        </Button>
+      </div>
+
+      {/* 작성 폼 */}
+      {isWriting && (
+        <div className={`mb-5 p-4 rounded-lg border ${
+          isDark ? 'bg-[#252525] border-white/10' : 'bg-white border-gray-200'
+        }`}>
+          <textarea
+            value={newPostContent}
+            onChange={(e) => setNewPostContent(e.target.value)}
+            placeholder="질문 내용을 입력하세요..."
+            rows={3}
+            className={`w-full p-3 rounded-lg border resize-none ${
+              isDark
+                ? 'bg-[#1e1e1e] border-white/10 text-white placeholder:text-gray-500'
+                : 'bg-gray-50 border-gray-200 text-gray-900 placeholder:text-gray-400'
+            }`}
+          />
+          <div className="flex justify-end gap-2 mt-3">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setIsWriting(false);
+                setNewPostContent('');
+              }}
+              className={isDark ? 'text-gray-400 hover:text-white' : ''}
+            >
+              취소
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleCreatePost}
+              disabled={!newPostContent.trim() || createPostMutation.isPending}
+              className="landing-btn-primary text-white"
+            >
+              {createPostMutation.isPending ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <>
+                  <Send className="w-4 h-4 mr-1" />
+                  등록
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* 탭 및 정렬 */}
+      <div className="flex justify-between items-center mb-5">
+        <div className="flex gap-2">
+          {TABS.map((tab) => (
+            <button
+              key={tab.value}
+              onClick={() => setActiveTab(tab.value)}
+              className={`px-4 py-2 rounded-full text-sm font-medium transition-all ${
+                activeTab === tab.value
+                  ? 'landing-btn-primary text-white'
+                  : isDark
+                    ? 'bg-transparent text-gray-400 hover:bg-white/5 hover:text-white'
+                    : 'bg-transparent text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+              }`}
+            >
+              {TAB_LABELS[tab.value]}
+            </button>
+          ))}
+        </div>
+
+        <select
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value as 'latest' | 'popular')}
+          className={`w-28 px-3 py-2 rounded-lg border text-sm outline-none ${
+            isDark
+              ? 'bg-[#252525] border-white/10 text-white'
+              : 'bg-white border-gray-200 text-gray-900'
+          }`}
+        >
+          <option value="latest">최신순</option>
+          <option value="popular">인기순</option>
+        </select>
+      </div>
+
+      {/* 게시글 목록 */}
+      <div className="flex flex-col gap-4">
+        {isLoading ? (
+          // 로딩 스켈레톤
+          Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className={`p-4 rounded-lg border ${
+                isDark ? 'bg-[#252525] border-white/10' : 'bg-white border-gray-200'
+              }`}
+            >
+              <div className="flex items-center gap-3 mb-3">
+                <Skeleton className="w-10 h-10 rounded-full" />
+                <div className="flex-1">
+                  <Skeleton className="h-4 w-24 mb-1" />
+                  <Skeleton className="h-3 w-16" />
+                </div>
+              </div>
+              <Skeleton className="h-4 w-full mb-2" />
+              <Skeleton className="h-4 w-3/4" />
+            </div>
+          ))
+        ) : isError ? (
+          <div className={`text-center py-8 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+            게시글을 불러오는데 실패했습니다.
+          </div>
+        ) : data?.posts && data.posts.length > 0 ? (
+          data.posts.map((post) => (
+            <div
+              key={post.id}
+              className={`p-4 rounded-lg border transition-colors ${
+                isDark
+                  ? 'bg-[#252525] border-white/10 hover:border-white/20'
+                  : 'bg-white border-gray-200 hover:border-gray-300'
+              }`}
+            >
+              {/* 게시글 헤더 */}
+              <div className="flex items-center gap-3 mb-3">
+                <Avatar className="w-10 h-10">
+                  <AvatarFallback className={isDark ? 'bg-white/10 text-white' : ''}>
+                    {post.author.name.charAt(0)}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className={`text-sm font-medium truncate ${
+                      isDark ? 'text-white' : 'text-gray-900'
+                    }`}>
+                      {post.author.name}
+                    </span>
+                    {post.type !== 'question' && post.type in TAB_LABELS && (
+                      <span className={`px-2 py-0.5 rounded text-xs font-medium ${
+                        isDark
+                          ? 'bg-btn-brand/20 text-purple-300'
+                          : 'bg-btn-brand/10 text-btn-brand'
+                      }`}>
+                        {TAB_LABELS[post.type as TabType]}
+                      </span>
+                    )}
+                  </div>
+                  <div className={`text-xs ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
+                    {formatTime(post.createdAt)}
+                  </div>
+                </div>
+              </div>
+
+              {/* 게시글 제목 */}
+              <h3 className={`text-sm font-medium mb-2 ${
+                isDark ? 'text-white' : 'text-gray-900'
+              }`}>
+                {post.title}
+              </h3>
+
+              {/* 게시글 내용 */}
+              <p className={`text-sm leading-relaxed mb-3 line-clamp-2 ${
+                isDark ? 'text-gray-300' : 'text-gray-600'
+              }`}>
+                {post.excerpt || post.content}
+              </p>
+
+              {/* 게시글 액션 */}
+              <div className="flex gap-4">
+                <button
+                  onClick={() => handleLikeToggle(post.id, post.isLiked || false)}
+                  disabled={likeMutation.isPending || unlikeMutation.isPending}
+                  className={`flex items-center gap-1.5 px-2 py-1 rounded text-sm transition-colors ${
+                    post.isLiked
+                      ? 'text-blue-500'
+                      : isDark
+                        ? 'text-gray-400 hover:text-white'
+                        : 'text-gray-500 hover:text-gray-900'
+                  }`}
+                >
+                  <ThumbsUp className="w-4 h-4" />
+                  <span>{post.likeCount}</span>
+                </button>
+                <button
+                  className={`flex items-center gap-1.5 px-2 py-1 rounded text-sm transition-colors ${
+                    isDark
+                      ? 'text-gray-400 hover:text-white'
+                      : 'text-gray-500 hover:text-gray-900'
+                  }`}
+                >
+                  <MessageCircle className="w-4 h-4" />
+                  <span>{post.commentCount}</span>
+                </button>
+              </div>
+            </div>
+          ))
+        ) : (
+          <div className={`text-center py-12 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+            <MessageCircle className="w-12 h-12 mx-auto mb-3 opacity-50" />
+            <p>아직 게시글이 없습니다.</p>
+            <p className="text-sm mt-1">첫 번째 질문을 남겨보세요!</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tu/main/LandingPage.tsx
+++ b/src/pages/tu/main/LandingPage.tsx
@@ -291,12 +291,16 @@ export function LandingPage() {
               <div className="flex justify-center items-center py-20">
                 <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
               </div>
-            ) : (
+            ) : newCourses.length > 0 ? (
               <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6">
                 {newCourses.map((course) => (
                   <LandingCourseCard key={`new-${course.id}`} {...course} />
                 ))}
               </div>
+            ) : (
+              <p className="col-span-5 text-center landing-text-muted py-10">
+                해당 카테고리에 강의가 없습니다.
+              </p>
             )}
           </div>
         </section>
@@ -319,12 +323,16 @@ export function LandingPage() {
             <div className="flex justify-center items-center py-20">
               <Loader2 className="w-8 h-8 animate-spin text-[#6778ff]" />
             </div>
-          ) : (
+          ) : recommendedCourses.length > 0 ? (
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6">
               {recommendedCourses.map((course) => (
                 <LandingCourseCard key={`rec-${course.id}`} {...course} />
               ))}
             </div>
+          ) : (
+            <p className="col-span-5 text-center landing-text-muted py-10">
+              해당 카테고리에 강의가 없습니다.
+            </p>
           )}
         </section>
 

--- a/src/pages/tu/main/SearchPage.tsx
+++ b/src/pages/tu/main/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, ComponentType } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useSearchParams, Link } from 'react-router-dom';
 import {
   Search,
@@ -16,49 +16,6 @@ import {
 import { useThemeStore } from '@/store/common/themeStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
-
-/** 강의 카드 props 인터페이스 - LandingCourseCard와 B2BCourseCard 공통 */
-interface CourseCardProps {
-  id: number;
-  title: string;
-  instructor: string;
-  image: string;
-  tags: string[];
-  category: string;
-  studentCount: number;
-  // LandingCourseCard 전용 (필수)
-  price: string | null;
-  rating: number;
-  reviewCount: number;
-  courseBasePath?: string;
-  // 공통 옵션
-  deliveryType?: string;
-  level?: string;
-  classStartDate?: string;
-  isOnDemand?: boolean;
-}
-
-/** SearchPage props */
-interface SearchPageProps {
-  /** 커스텀 헤더 컴포넌트 (B2B 등에서 사용) */
-  HeaderComponent?: ComponentType;
-  /** 로드맵/커뮤니티 탭 표시 여부 (B2B에서는 false) */
-  showRoadmapAndCommunity?: boolean;
-  /** 가격 표시 여부 (B2B에서는 false) */
-  showPrice?: boolean;
-  /** 가격 필터 표시 여부 (B2B에서는 false) */
-  showPriceFilter?: boolean;
-  /** 강의 상세 페이지 기본 경로 (B2B: /tu/b2b/courses) */
-  courseBasePath?: string;
-  /** 페이지 제목 (기본: 통합 검색) */
-  pageTitle?: string;
-  /** 페이지 설명 (기본: 강의, 로드맵, 커뮤니티를 한 번에 검색하세요) */
-  pageDescription?: string;
-  /** 검색 입력란 플레이스홀더 */
-  searchPlaceholder?: string;
-  /** 커스텀 강의 카드 컴포넌트 (B2B에서 B2BCourseCard 사용) */
-  CourseCardComponent?: ComponentType<CourseCardProps>;
-}
 import { LandingCourseCard } from '@/components/landing';
 import { useCourseTimeCatalog, useRoadmapExplore, useCommunityPosts } from '@/hooks/tu';
 import { useSubdomainPath } from '@/hooks/common';
@@ -69,13 +26,13 @@ import type { CourseTimeCatalogResponse } from '@/types/tu/courseTimeCatalog.typ
 import { ROADMAP_LEVEL_LABELS } from '@/types/tu/roadmapExplore.types';
 import { DELIVERY_TYPE_LABELS, PROGRAM_LEVEL_LABELS } from '@/types/tu/courseTimeCatalog.types';
 
-// API 사용 여부 (false면 더미 데이터 사용)
+// API 사용 여부
 const USE_API = true;
 
 /**
  * CourseTime API 데이터를 카드 컴포넌트 props로 변환
  */
-function convertCourseTimeToCardProps(courseTime: CourseTimeCatalogResponse): CourseCardProps {
+function convertCourseTimeToCardProps(courseTime: CourseTimeCatalogResponse) {
   const mainInstructor = courseTime.instructors.find((i) => i.role === 'MAIN');
   const instructorName = mainInstructor?.name || courseTime.instructors[0]?.name || '';
 
@@ -104,557 +61,11 @@ function convertCourseTimeToCardProps(courseTime: CourseTimeCatalogResponse): Co
     studentCount: courseTime.currentEnrollment,
     classStartDate: courseTime.classStartDate,
     isOnDemand: courseTime.isOnDemand,
-    // LandingCourseCard 전용 (선택적)
     rating: 0,
     reviewCount: 0,
     price: null,
   };
 }
-
-// 더미 강의 카드 데이터 (LandingCourseCard용)
-interface MockCourseCard {
-  id: number;
-  title: string;
-  instructor: string;
-  price: string;
-  rating: number;
-  reviewCount: number;
-  studentCount: number;
-  image: string;
-  tags: string[];
-  category: string;
-  keywords: string[]; // 검색용 키워드
-}
-
-const MOCK_COURSES: MockCourseCard[] = [
-  {
-    id: 1,
-    title: 'React 완전 정복: 기초부터 고급까지',
-    instructor: '김리액트',
-    price: '₩99,000',
-    rating: 4.8,
-    reviewCount: 45,
-    studentCount: 1234,
-    image: 'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=250&fit=crop',
-    tags: ['상시모집', '인기'],
-    category: '개발',
-    keywords: ['React', '리액트', '프론트엔드', 'JavaScript', 'JS', '강의'],
-  },
-  {
-    id: 2,
-    title: 'TypeScript 마스터클래스',
-    instructor: '박타입',
-    price: '₩79,000',
-    rating: 4.7,
-    reviewCount: 32,
-    studentCount: 856,
-    image: 'https://images.unsplash.com/photo-1587620962725-abab7fe55159?w=400&h=250&fit=crop',
-    tags: ['상시모집'],
-    category: '개발',
-    keywords: ['TypeScript', '타입스크립트', 'TS', '프론트엔드', '강의'],
-  },
-  {
-    id: 3,
-    title: 'Python으로 배우는 AI 기초',
-    instructor: '이파이썬',
-    price: '₩129,000',
-    rating: 4.9,
-    reviewCount: 28,
-    studentCount: 2341,
-    image: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=400&h=250&fit=crop',
-    tags: ['모집중', '신규'],
-    category: 'AI',
-    keywords: ['Python', '파이썬', 'AI', '인공지능', '머신러닝', '강의'],
-  },
-  {
-    id: 4,
-    title: 'AWS 클라우드 실전 가이드',
-    instructor: '최클라우드',
-    price: '무료',
-    rating: 4.6,
-    reviewCount: 156,
-    studentCount: 3456,
-    image: 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=400&h=250&fit=crop',
-    tags: ['상시모집', '무료'],
-    category: '클라우드',
-    keywords: ['AWS', '클라우드', 'Cloud', 'DevOps', '강의'],
-  },
-  {
-    id: 5,
-    title: 'Next.js 14 완벽 가이드',
-    instructor: '정넥스트',
-    price: '₩89,000',
-    rating: 4.8,
-    reviewCount: 41,
-    studentCount: 1567,
-    image: 'https://images.unsplash.com/photo-1555066931-4365d14bab8c?w=400&h=250&fit=crop',
-    tags: ['상시모집', '인기'],
-    category: '개발',
-    keywords: ['Next.js', 'Next', 'React', '프론트엔드', 'SSR', '강의'],
-  },
-  {
-    id: 6,
-    title: 'Vue.js 3 실전 프로젝트',
-    instructor: '한뷰',
-    price: '₩75,000',
-    rating: 4.5,
-    reviewCount: 22,
-    studentCount: 432,
-    image: 'https://images.unsplash.com/photo-1517694712202-14dd9538aa97?w=400&h=250&fit=crop',
-    tags: ['모집중'],
-    category: '개발',
-    keywords: ['Vue', 'Vue.js', '뷰', '프론트엔드', 'JavaScript', '강의'],
-  },
-  {
-    id: 7,
-    title: 'Docker & Kubernetes 완벽 가이드',
-    instructor: '강도커',
-    price: '₩149,000',
-    rating: 4.9,
-    reviewCount: 89,
-    studentCount: 2789,
-    image: 'https://images.unsplash.com/photo-1667372393119-3d4c48d07fc9?w=400&h=250&fit=crop',
-    tags: ['상시모집', '인기'],
-    category: '클라우드',
-    keywords: ['Docker', '도커', 'Kubernetes', '쿠버네티스', 'K8s', 'DevOps', '컨테이너', '강의'],
-  },
-  {
-    id: 8,
-    title: 'Node.js 백엔드 개발 실전',
-    instructor: '노드맨',
-    price: '₩110,000',
-    rating: 4.7,
-    reviewCount: 67,
-    studentCount: 1890,
-    image: 'https://images.unsplash.com/photo-1627398242454-45a1465c2479?w=400&h=250&fit=crop',
-    tags: ['상시모집'],
-    category: '개발',
-    keywords: ['Node.js', '노드', 'Express', '백엔드', 'JavaScript', 'API', '강의'],
-  },
-  {
-    id: 9,
-    title: 'Spring Boot 3.0 실무 프로젝트',
-    instructor: '자바킹',
-    price: '₩139,000',
-    rating: 4.8,
-    reviewCount: 112,
-    studentCount: 3210,
-    image: 'https://images.unsplash.com/photo-1515879218367-8466d910aaa4?w=400&h=250&fit=crop',
-    tags: ['상시모집', '인기'],
-    category: '개발',
-    keywords: ['Spring', 'Spring Boot', '스프링', 'Java', '자바', '백엔드', '강의'],
-  },
-  {
-    id: 10,
-    title: 'Flutter로 만드는 크로스플랫폼 앱',
-    instructor: '플러터박사',
-    price: '₩95,000',
-    rating: 4.6,
-    reviewCount: 54,
-    studentCount: 987,
-    image: 'https://images.unsplash.com/photo-1512941937669-90a1b58e7e9c?w=400&h=250&fit=crop',
-    tags: ['모집중', '신규'],
-    category: '개발',
-    keywords: ['Flutter', '플러터', 'Dart', '다트', '앱개발', '모바일', '강의'],
-  },
-  {
-    id: 11,
-    title: 'SQL과 데이터베이스 기초',
-    instructor: '데이터맨',
-    price: '₩69,000',
-    rating: 4.5,
-    reviewCount: 203,
-    studentCount: 4567,
-    image: 'https://images.unsplash.com/photo-1544383835-bda2bc66a55d?w=400&h=250&fit=crop',
-    tags: ['상시모집', '무료'],
-    category: '데이터',
-    keywords: ['SQL', '데이터베이스', 'MySQL', 'PostgreSQL', 'DB', '강의'],
-  },
-  {
-    id: 12,
-    title: 'Git & GitHub 협업 마스터',
-    instructor: '깃전문가',
-    price: '무료',
-    rating: 4.8,
-    reviewCount: 321,
-    studentCount: 5678,
-    image: 'https://images.unsplash.com/photo-1618401471353-b98afee0b2eb?w=400&h=250&fit=crop',
-    tags: ['상시모집', '무료', '인기'],
-    category: '개발',
-    keywords: ['Git', '깃', 'GitHub', '깃허브', '버전관리', '협업', '강의'],
-  },
-  {
-    id: 13,
-    title: 'ChatGPT API 활용 실전',
-    instructor: 'AI개발자',
-    price: '₩89,000',
-    rating: 4.9,
-    reviewCount: 78,
-    studentCount: 1876,
-    image: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=400&h=250&fit=crop',
-    tags: ['신규', '인기'],
-    category: 'AI',
-    keywords: ['ChatGPT', 'GPT', 'OpenAI', 'AI', 'LLM', 'API', '강의'],
-  },
-  {
-    id: 14,
-    title: 'UI/UX 디자인 실무',
-    instructor: '디자이너K',
-    price: '₩85,000',
-    rating: 4.7,
-    reviewCount: 95,
-    studentCount: 1345,
-    image: 'https://images.unsplash.com/photo-1561070791-2526d30994b5?w=400&h=250&fit=crop',
-    tags: ['상시모집'],
-    category: '디자인',
-    keywords: ['UI', 'UX', '디자인', 'Figma', '피그마', '웹디자인', '강의'],
-  },
-  {
-    id: 15,
-    title: '데이터 분석 with Python',
-    instructor: '분석전문가',
-    price: '₩119,000',
-    rating: 4.8,
-    reviewCount: 134,
-    studentCount: 2987,
-    image: 'https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=400&h=250&fit=crop',
-    tags: ['상시모집', '인기'],
-    category: '데이터',
-    keywords: ['데이터분석', 'Python', '파이썬', 'Pandas', '판다스', 'NumPy', '강의'],
-  },
-];
-
-// 더미 로드맵 데이터
-const MOCK_ROADMAPS: RoadmapExploreItem[] = [
-  {
-    id: 1,
-    title: '프론트엔드 개발자 로드맵',
-    description: 'HTML, CSS부터 React, TypeScript까지 프론트엔드 개발의 모든 것을 배웁니다.',
-    image: 'https://images.unsplash.com/photo-1593720213428-28a5b9e94613?w=400&h=250&fit=crop',
-    author: '김프론트',
-    authorImage: '',
-    level: 'beginner',
-    courseCount: 12,
-    estimatedHours: 120,
-    enrollCount: 2500,
-    rating: 4.8,
-    reviewCount: 320,
-    category: '개발',
-    tags: ['React', 'TypeScript', 'CSS', '프론트엔드', '강의'],
-    isNew: false,
-    isPopular: true,
-  },
-  {
-    id: 2,
-    title: '백엔드 개발자 로드맵',
-    description: 'Node.js, Python, 데이터베이스를 활용한 백엔드 개발 마스터 과정',
-    image: 'https://images.unsplash.com/photo-1627398242454-45a1465c2479?w=400&h=250&fit=crop',
-    author: '박백엔드',
-    authorImage: '',
-    level: 'intermediate',
-    courseCount: 15,
-    estimatedHours: 180,
-    enrollCount: 1800,
-    rating: 4.7,
-    reviewCount: 215,
-    category: '개발',
-    tags: ['Node.js', 'Python', 'Database', '백엔드', '강의'],
-    isNew: false,
-    isPopular: true,
-  },
-  {
-    id: 3,
-    title: 'AI/ML 엔지니어 로드맵',
-    description: '인공지능과 머신러닝의 기초부터 실전 프로젝트까지',
-    image: 'https://images.unsplash.com/photo-1555255707-c07966088b7b?w=400&h=250&fit=crop',
-    author: '이에이아이',
-    authorImage: '',
-    level: 'advanced',
-    courseCount: 20,
-    estimatedHours: 240,
-    enrollCount: 1200,
-    rating: 4.9,
-    reviewCount: 180,
-    category: 'AI',
-    tags: ['Python', 'AI', 'TensorFlow', '머신러닝', '딥러닝', '강의'],
-    isNew: true,
-    isPopular: true,
-  },
-  {
-    id: 4,
-    title: '클라우드 아키텍트 로드맵',
-    description: 'AWS, GCP, Azure를 활용한 클라우드 인프라 설계 및 구축',
-    image: 'https://images.unsplash.com/photo-1544197150-b99a580bb7a8?w=400&h=250&fit=crop',
-    author: '최클라우드',
-    authorImage: '',
-    level: 'intermediate',
-    courseCount: 10,
-    estimatedHours: 100,
-    enrollCount: 900,
-    rating: 4.6,
-    reviewCount: 95,
-    category: '클라우드',
-    tags: ['AWS', '클라우드', 'DevOps', 'GCP', 'Azure', '강의'],
-    isNew: false,
-    isPopular: false,
-  },
-  {
-    id: 5,
-    title: '풀스택 개발자 로드맵',
-    description: '프론트엔드와 백엔드를 모두 아우르는 풀스택 개발자가 되기 위한 종합 과정',
-    image: 'https://images.unsplash.com/photo-1504639725590-34d0984388bd?w=400&h=250&fit=crop',
-    author: '풀스택킹',
-    authorImage: '',
-    level: 'intermediate',
-    courseCount: 25,
-    estimatedHours: 300,
-    enrollCount: 3200,
-    rating: 4.8,
-    reviewCount: 420,
-    category: '개발',
-    tags: ['React', 'Node.js', 'Database', '풀스택', '강의'],
-    isNew: false,
-    isPopular: true,
-  },
-  {
-    id: 6,
-    title: '데이터 사이언티스트 로드맵',
-    description: '데이터 분석부터 머신러닝까지, 데이터 사이언스 전문가 양성 과정',
-    image: 'https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=400&h=250&fit=crop',
-    author: '데이터박사',
-    authorImage: '',
-    level: 'intermediate',
-    courseCount: 18,
-    estimatedHours: 200,
-    enrollCount: 1500,
-    rating: 4.7,
-    reviewCount: 185,
-    category: '데이터',
-    tags: ['Python', 'SQL', '데이터분석', '머신러닝', '강의'],
-    isNew: true,
-    isPopular: false,
-  },
-  {
-    id: 7,
-    title: 'DevOps 엔지니어 로드맵',
-    description: 'CI/CD, 컨테이너, 인프라 자동화를 위한 DevOps 완벽 가이드',
-    image: 'https://images.unsplash.com/photo-1667372393119-3d4c48d07fc9?w=400&h=250&fit=crop',
-    author: '데브옵스마스터',
-    authorImage: '',
-    level: 'advanced',
-    courseCount: 14,
-    estimatedHours: 150,
-    enrollCount: 800,
-    rating: 4.8,
-    reviewCount: 110,
-    category: '클라우드',
-    tags: ['Docker', 'Kubernetes', 'CI/CD', 'DevOps', '강의'],
-    isNew: false,
-    isPopular: true,
-  },
-  {
-    id: 8,
-    title: '모바일 앱 개발자 로드맵',
-    description: 'React Native와 Flutter로 iOS, Android 앱을 동시에 개발하는 방법',
-    image: 'https://images.unsplash.com/photo-1512941937669-90a1b58e7e9c?w=400&h=250&fit=crop',
-    author: '앱개발자',
-    authorImage: '',
-    level: 'beginner',
-    courseCount: 16,
-    estimatedHours: 180,
-    enrollCount: 2100,
-    rating: 4.6,
-    reviewCount: 275,
-    category: '개발',
-    tags: ['React Native', 'Flutter', '모바일', '앱개발', '강의'],
-    isNew: false,
-    isPopular: true,
-  },
-];
-
-// 더미 커뮤니티 데이터
-const MOCK_COMMUNITY: CommunityPost[] = [
-  {
-    id: 1,
-    type: 'tip',
-    title: 'React 18에서 새로 추가된 기능들 정리',
-    content: 'React 18에서 추가된 Concurrent Features, Suspense 개선사항, 자동 배칭 등을 정리해봤습니다.',
-    category: '개발 질문',
-    author: { id: 1, name: '김개발', avatar: '' },
-    viewCount: 342,
-    likeCount: 28,
-    commentCount: 15,
-    tags: ['React', 'JavaScript', '프론트엔드', '강의'],
-    createdAt: '2025-01-05T10:30:00',
-    updatedAt: '2025-01-05T10:30:00',
-    isLiked: false,
-  },
-  {
-    id: 2,
-    type: 'tip',
-    title: 'TypeScript 5.0 새로운 기능 소개',
-    content: 'TypeScript 5.0에서 추가된 데코레이터, const type parameters 등 새로운 기능들을 살펴봅니다.',
-    category: '개발 질문',
-    author: { id: 2, name: '박타입', avatar: '' },
-    viewCount: 256,
-    likeCount: 19,
-    commentCount: 8,
-    tags: ['TypeScript', '프론트엔드', '강의'],
-    createdAt: '2025-01-04T14:20:00',
-    updatedAt: '2025-01-04T14:20:00',
-    isLiked: false,
-  },
-  {
-    id: 3,
-    type: 'discussion',
-    title: 'Python으로 AI 프로젝트 시작하기',
-    content: 'AI 프로젝트를 처음 시작하시는 분들을 위한 가이드입니다. 환경 설정부터 첫 모델 학습까지!',
-    category: '스터디 모집',
-    author: { id: 3, name: '이파이썬', avatar: '' },
-    viewCount: 489,
-    likeCount: 45,
-    commentCount: 23,
-    tags: ['Python', 'AI', '머신러닝', '강의'],
-    createdAt: '2025-01-03T09:15:00',
-    updatedAt: '2025-01-03T09:15:00',
-    isLiked: false,
-  },
-  {
-    id: 4,
-    type: 'discussion',
-    title: 'AWS 자격증 준비 스터디원 모집합니다',
-    content: 'AWS Solutions Architect Associate 자격증 준비 스터디원을 모집합니다. 주 2회 온라인 모임!',
-    category: '스터디 모집',
-    author: { id: 4, name: '최클라우드', avatar: '' },
-    viewCount: 178,
-    likeCount: 12,
-    commentCount: 31,
-    tags: ['AWS', '클라우드', '자격증', '강의'],
-    createdAt: '2025-01-02T16:45:00',
-    updatedAt: '2025-01-02T16:45:00',
-    isLiked: false,
-  },
-  {
-    id: 5,
-    type: 'review',
-    title: 'Next.js 14 App Router 마이그레이션 경험담',
-    content: 'Pages Router에서 App Router로 마이그레이션하면서 겪은 이슈들과 해결 방법을 공유합니다.',
-    category: '경험 공유',
-    author: { id: 5, name: '정넥스트', avatar: '' },
-    viewCount: 623,
-    likeCount: 52,
-    commentCount: 18,
-    tags: ['Next.js', 'React', '마이그레이션', '강의'],
-    createdAt: '2025-01-01T11:00:00',
-    updatedAt: '2025-01-01T11:00:00',
-    isLiked: false,
-  },
-  {
-    id: 6,
-    type: 'tip',
-    title: 'Vue 3 Composition API 실전 팁',
-    content: 'Vue 3 Composition API를 실무에서 효과적으로 사용하는 방법과 팁들을 정리했습니다.',
-    category: '개발 질문',
-    author: { id: 6, name: '한뷰', avatar: '' },
-    viewCount: 198,
-    likeCount: 15,
-    commentCount: 7,
-    tags: ['Vue', 'JavaScript', '프론트엔드', '강의'],
-    createdAt: '2024-12-30T13:30:00',
-    updatedAt: '2024-12-30T13:30:00',
-    isLiked: false,
-  },
-  {
-    id: 7,
-    type: 'question',
-    title: 'Docker 컨테이너 네트워킹 질문드립니다',
-    content: 'Docker Compose로 여러 컨테이너를 연결할 때 네트워크 설정이 헷갈립니다. 도움 부탁드려요!',
-    category: '개발 질문',
-    author: { id: 7, name: '도커초보', avatar: '' },
-    viewCount: 89,
-    likeCount: 5,
-    commentCount: 12,
-    tags: ['Docker', 'DevOps', '네트워크', '강의'],
-    createdAt: '2025-01-05T15:20:00',
-    updatedAt: '2025-01-05T15:20:00',
-    isLiked: false,
-  },
-  {
-    id: 8,
-    type: 'tip',
-    title: 'Spring Boot 3.0 마이그레이션 가이드',
-    content: 'Spring Boot 2.x에서 3.0으로 업그레이드하면서 주의해야 할 점들을 정리했습니다.',
-    category: '경험 공유',
-    author: { id: 8, name: '스프링매니아', avatar: '' },
-    viewCount: 445,
-    likeCount: 38,
-    commentCount: 21,
-    tags: ['Spring', 'Java', '백엔드', '마이그레이션', '강의'],
-    createdAt: '2025-01-04T09:00:00',
-    updatedAt: '2025-01-04T09:00:00',
-    isLiked: false,
-  },
-  {
-    id: 9,
-    type: 'discussion',
-    title: 'Flutter vs React Native 어떤걸 배워야 할까요?',
-    content: '모바일 앱 개발을 시작하려고 합니다. 두 프레임워크 중 어떤 것이 더 좋을까요?',
-    category: '자유 토론',
-    author: { id: 9, name: '모바일러', avatar: '' },
-    viewCount: 567,
-    likeCount: 42,
-    commentCount: 89,
-    tags: ['Flutter', 'React Native', '모바일', '앱개발', '강의'],
-    createdAt: '2025-01-03T18:30:00',
-    updatedAt: '2025-01-03T18:30:00',
-    isLiked: false,
-  },
-  {
-    id: 10,
-    type: 'tip',
-    title: 'Git 브랜치 전략 - GitFlow vs Trunk-based',
-    content: '팀에서 사용할 Git 브랜치 전략을 고민 중이라면 이 글을 참고하세요.',
-    category: '개발 질문',
-    author: { id: 10, name: '깃마스터', avatar: '' },
-    viewCount: 312,
-    likeCount: 29,
-    commentCount: 16,
-    tags: ['Git', 'GitHub', '협업', '버전관리', '강의'],
-    createdAt: '2025-01-02T11:15:00',
-    updatedAt: '2025-01-02T11:15:00',
-    isLiked: false,
-  },
-  {
-    id: 11,
-    type: 'review',
-    title: 'ChatGPT API를 활용한 챗봇 만들기 후기',
-    content: 'OpenAI API를 사용해서 간단한 고객 상담 챗봇을 만들어봤습니다. 생각보다 쉬웠어요!',
-    category: '경험 공유',
-    author: { id: 11, name: 'AI개발자', avatar: '' },
-    viewCount: 892,
-    likeCount: 76,
-    commentCount: 34,
-    tags: ['ChatGPT', 'AI', 'OpenAI', 'API', '강의'],
-    createdAt: '2025-01-01T14:00:00',
-    updatedAt: '2025-01-01T14:00:00',
-    isLiked: false,
-  },
-  {
-    id: 12,
-    type: 'discussion',
-    title: 'Kubernetes 스터디 그룹 모집 (온라인)',
-    content: '쿠버네티스를 함께 공부할 스터디원을 모집합니다. 매주 토요일 오전 진행 예정입니다.',
-    category: '스터디 모집',
-    author: { id: 12, name: 'K8s러버', avatar: '' },
-    viewCount: 234,
-    likeCount: 18,
-    commentCount: 45,
-    tags: ['Kubernetes', 'Docker', 'DevOps', '클라우드', '강의'],
-    createdAt: '2024-12-31T10:00:00',
-    updatedAt: '2024-12-31T10:00:00',
-    isLiked: false,
-  },
-];
 
 // 탭 타입
 type SearchTab = 'all' | 'courses' | 'roadmaps' | 'community';
@@ -734,38 +145,6 @@ const formatRelativeTime = (dateString: string): string => {
   if (diffInSeconds < 604800) return `${Math.floor(diffInSeconds / 86400)}일 전`;
   return date.toLocaleDateString('ko-KR');
 };
-
-// 검색 필터 함수
-function searchCourses(courses: MockCourseCard[], keyword: string): MockCourseCard[] {
-  const lowerKeyword = keyword.toLowerCase();
-  return courses.filter(course =>
-    course.title.toLowerCase().includes(lowerKeyword) ||
-    course.instructor.toLowerCase().includes(lowerKeyword) ||
-    course.category.toLowerCase().includes(lowerKeyword) ||
-    course.keywords.some(k => k.toLowerCase().includes(lowerKeyword)) ||
-    course.tags.some(t => t.toLowerCase().includes(lowerKeyword))
-  );
-}
-
-function searchRoadmaps(roadmaps: RoadmapExploreItem[], keyword: string): RoadmapExploreItem[] {
-  const lowerKeyword = keyword.toLowerCase();
-  return roadmaps.filter(roadmap =>
-    roadmap.title.toLowerCase().includes(lowerKeyword) ||
-    roadmap.description.toLowerCase().includes(lowerKeyword) ||
-    roadmap.category.toLowerCase().includes(lowerKeyword) ||
-    (roadmap.tags || []).some(t => t.toLowerCase().includes(lowerKeyword))
-  );
-}
-
-function searchCommunity(posts: CommunityPost[], keyword: string): CommunityPost[] {
-  const lowerKeyword = keyword.toLowerCase();
-  return posts.filter(post =>
-    post.title.toLowerCase().includes(lowerKeyword) ||
-    post.content.toLowerCase().includes(lowerKeyword) ||
-    post.category.toLowerCase().includes(lowerKeyword) ||
-    (post.tags || []).some(t => t.toLowerCase().includes(lowerKeyword))
-  );
-}
 
 /**
  * 로드맵 카드 컴포넌트
@@ -951,19 +330,10 @@ const DEFAULT_FILTERS: Filters = {
   communityCategory: 'all',
 };
 
-export function SearchPage({
-  HeaderComponent = LandingHeader,
-  showRoadmapAndCommunity = true,
-  showPrice = true,
-  showPriceFilter = true,
-  courseBasePath,
-  pageTitle = '통합 검색',
-  pageDescription = '강의, 로드맵, 커뮤니티를 한 번에 검색하세요',
-  searchPlaceholder = '강의, 로드맵, 커뮤니티 글을 검색하세요',
-  CourseCardComponent,
-}: SearchPageProps = {}) {
-  // 사용할 카드 컴포넌트 결정 (커스텀 또는 기본 LandingCourseCard)
-  const CardComponent = CourseCardComponent || LandingCourseCard;
+/**
+ * B2C 통합 검색 페이지
+ */
+export function SearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [activeTab, setActiveTab] = useState<SearchTab>('all');
   const [searchQuery, setSearchQuery] = useState('');
@@ -980,7 +350,6 @@ export function SearchPage({
   // 필터 초기화
   const resetFilters = () => {
     setFilters(DEFAULT_FILTERS);
-    // URL도 초기화
     const params = new URLSearchParams();
     if (searchQuery) params.set('search', searchQuery);
     if (activeTab !== 'all') params.set('tab', activeTab);
@@ -1020,7 +389,6 @@ export function SearchPage({
       setActiveTab(tab);
     }
 
-    // URL에서 필터 복원
     setFilters({
       sort: sort || 'relevance',
       category: category || 'all',
@@ -1037,7 +405,6 @@ export function SearchPage({
     const newFilters = { ...filters, [key]: value };
     setFilters(newFilters);
 
-    // URL 파라미터 업데이트
     const params = new URLSearchParams();
     if (searchQuery) params.set('search', searchQuery);
     if (activeTab !== 'all') params.set('tab', activeTab);
@@ -1052,7 +419,7 @@ export function SearchPage({
     setSearchParams(params);
   };
 
-  // API 데이터 (USE_API가 true일 때만 사용)
+  // API 데이터
   const {
     data: coursesData,
     isLoading: isCoursesLoading,
@@ -1087,93 +454,16 @@ export function SearchPage({
     USE_API && !!searchQuery
   );
 
-  // 더미 데이터 검색 결과
-  const mockSearchResults = useMemo(() => {
-    if (!searchQuery) return { courses: [], roadmaps: [], community: [] };
-    return {
-      courses: searchCourses(MOCK_COURSES, searchQuery),
-      roadmaps: searchRoadmaps(MOCK_ROADMAPS, searchQuery),
-      community: searchCommunity(MOCK_COMMUNITY, searchQuery),
-    };
-  }, [searchQuery]);
+  const courses = coursesData?.content || [];
+  const roadmaps = roadmapsData?.roadmaps || [];
+  const communityPosts = communityData?.posts || [];
 
-  // 필터링된 결과 (더미 데이터용)
-  const filteredResults = useMemo(() => {
-    let filteredCourses = [...mockSearchResults.courses];
-    let filteredRoadmaps = [...mockSearchResults.roadmaps];
-    let filteredCommunity = [...mockSearchResults.community];
-
-    // 강의 필터링
-    if (filters.category !== 'all') {
-      filteredCourses = filteredCourses.filter((c) => c.category === filters.category);
-    }
-    if (filters.price !== 'all') {
-      filteredCourses = filteredCourses.filter((c) =>
-        filters.price === 'free' ? c.price === '무료' : c.price !== '무료'
-      );
-    }
-    if (filters.status !== 'all') {
-      filteredCourses = filteredCourses.filter((c) =>
-        filters.status === 'recruiting'
-          ? c.tags.some((t) => t.includes('모집'))
-          : c.tags.some((t) => t.includes('상시'))
-      );
-    }
-
-    // 로드맵 필터링
-    if (filters.category !== 'all') {
-      filteredRoadmaps = filteredRoadmaps.filter((r) => r.category === filters.category);
-    }
-    if (filters.level !== 'all') {
-      filteredRoadmaps = filteredRoadmaps.filter((r) => r.level === filters.level);
-    }
-
-    // 커뮤니티 필터링
-    if (filters.postType !== 'all') {
-      filteredCommunity = filteredCommunity.filter((p) => p.type === filters.postType);
-    }
-    if (filters.communityCategory !== 'all') {
-      filteredCommunity = filteredCommunity.filter((p) => p.category === filters.communityCategory);
-    }
-
-    // 정렬
-    const sortFn = (a: { rating?: number; createdAt?: string; viewCount?: number }, b: { rating?: number; createdAt?: string; viewCount?: number }) => {
-      switch (filters.sort) {
-        case 'latest':
-          return new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime();
-        case 'popular':
-          return (b.viewCount || 0) - (a.viewCount || 0);
-        case 'rating':
-          return (b.rating || 0) - (a.rating || 0);
-        default:
-          return 0; // relevance - 기본 순서 유지
-      }
-    };
-
-    if (filters.sort !== 'relevance') {
-      filteredCourses.sort((a, b) => sortFn({ rating: a.rating }, { rating: b.rating }));
-      filteredRoadmaps.sort((a, b) => sortFn({ rating: a.rating, viewCount: a.enrollCount }, { rating: b.rating, viewCount: b.enrollCount }));
-      filteredCommunity.sort(sortFn);
-    }
-
-    return {
-      courses: filteredCourses,
-      roadmaps: filteredRoadmaps,
-      community: filteredCommunity,
-    };
-  }, [mockSearchResults, filters]);
-
-  // 실제 사용할 데이터 결정
-  const courses = USE_API ? (coursesData?.content || []) : filteredResults.courses;
-  const roadmaps = USE_API ? (roadmapsData?.roadmaps || []) : filteredResults.roadmaps;
-  const communityPosts = USE_API ? (communityData?.posts || []) : filteredResults.community;
-
-  const totalCourses = USE_API ? (coursesData?.totalElements || 0) : filteredResults.courses.length;
-  const totalRoadmaps = USE_API ? (roadmapsData?.totalCount || 0) : filteredResults.roadmaps.length;
-  const totalCommunity = USE_API ? (communityData?.totalCount || 0) : filteredResults.community.length;
+  const totalCourses = coursesData?.totalElements || 0;
+  const totalRoadmaps = roadmapsData?.totalCount || 0;
+  const totalCommunity = communityData?.totalCount || 0;
   const totalResults = totalCourses + totalRoadmaps + totalCommunity;
 
-  const isLoading = USE_API && (isCoursesLoading || isRoadmapsLoading || isCommunityLoading);
+  const isLoading = isCoursesLoading || isRoadmapsLoading || isCommunityLoading;
 
   // 검색 실행
   const handleSearch = (e: React.FormEvent) => {
@@ -1199,31 +489,25 @@ export function SearchPage({
     setSearchParams({});
   };
 
-  // 탭 데이터 (B2B에서는 로드맵/커뮤니티 제외)
-  const tabs = showRoadmapAndCommunity
-    ? [
-        { id: 'all' as const, label: '전체', count: totalResults },
-        { id: 'courses' as const, label: '강의', count: totalCourses, icon: BookOpen },
-        { id: 'roadmaps' as const, label: '로드맵', count: totalRoadmaps, icon: Map },
-        { id: 'community' as const, label: '커뮤니티', count: totalCommunity, icon: MessageSquare },
-      ]
-    : [
-        { id: 'all' as const, label: '전체', count: totalCourses },
-        { id: 'courses' as const, label: '강의', count: totalCourses, icon: BookOpen },
-      ];
+  const tabs = [
+    { id: 'all' as const, label: '전체', count: totalResults },
+    { id: 'courses' as const, label: '강의', count: totalCourses, icon: BookOpen },
+    { id: 'roadmaps' as const, label: '로드맵', count: totalRoadmaps, icon: Map },
+    { id: 'community' as const, label: '커뮤니티', count: totalCommunity, icon: MessageSquare },
+  ];
 
   return (
     <div className={`min-h-screen ${isDark ? 'landing-dark bg-[#1e1e1e]' : 'landing-light bg-gray-50'}`}>
-      <HeaderComponent />
+      <LandingHeader />
 
       <main className="w-full px-4 md:px-8 lg:px-16 py-12">
         {/* 검색 헤더 */}
         <div className="mb-8">
           <h1 className={`text-3xl md:text-4xl font-bold mb-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            {pageTitle}
+            통합 검색
           </h1>
           <p className={`mb-6 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-            {pageDescription}
+            강의, 로드맵, 커뮤니티를 한 번에 검색하세요
           </p>
 
           {/* 검색바 */}
@@ -1237,7 +521,7 @@ export function SearchPage({
               type="text"
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
-              placeholder={searchPlaceholder}
+              placeholder="강의, 로드맵, 커뮤니티 글을 검색하세요"
               className={`w-full rounded-xl pl-12 pr-12 py-3 focus:outline-none focus:ring-2 focus:ring-[#6778ff] focus:border-transparent transition-all ${
                 isDark
                   ? 'bg-white/5 border border-white/10 text-white placeholder-gray-500'
@@ -1301,7 +585,6 @@ export function SearchPage({
 
             {/* 필터 영역 */}
             <div className="mb-6">
-              {/* 필터 토글 버튼 (모바일) */}
               <button
                 onClick={() => setShowFilters(!showFilters)}
                 className={`md:hidden flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium mb-4 ${
@@ -1319,9 +602,7 @@ export function SearchPage({
                 )}
               </button>
 
-              {/* 필터 드롭다운들 */}
               <div className={`flex flex-wrap gap-2 ${!showFilters ? 'max-md:hidden' : ''}`}>
-                {/* 공통: 정렬 */}
                 <FilterDropdown
                   label="정렬"
                   value={filters.sort}
@@ -1330,7 +611,6 @@ export function SearchPage({
                   isDark={isDark}
                 />
 
-                {/* 강의/로드맵: 카테고리 */}
                 {(activeTab === 'all' || activeTab === 'courses' || activeTab === 'roadmaps') && (
                   <FilterDropdown
                     label="카테고리"
@@ -1341,7 +621,6 @@ export function SearchPage({
                   />
                 )}
 
-                {/* 강의/로드맵: 난이도 */}
                 {(activeTab === 'courses' || activeTab === 'roadmaps') && (
                   <FilterDropdown
                     label="난이도"
@@ -1352,8 +631,7 @@ export function SearchPage({
                   />
                 )}
 
-                {/* 강의: 가격 (B2B에서는 숨김) */}
-                {showPriceFilter && activeTab === 'courses' && (
+                {activeTab === 'courses' && paidModeEnabled && (
                   <FilterDropdown
                     label="가격"
                     value={filters.price}
@@ -1363,7 +641,6 @@ export function SearchPage({
                   />
                 )}
 
-                {/* 강의: 모집상태 */}
                 {activeTab === 'courses' && (
                   <FilterDropdown
                     label="모집상태"
@@ -1374,29 +651,25 @@ export function SearchPage({
                   />
                 )}
 
-                {/* 커뮤니티: 게시글 유형 */}
                 {activeTab === 'community' && (
-                  <FilterDropdown
-                    label="유형"
-                    value={filters.postType}
-                    options={POST_TYPE_OPTIONS}
-                    onChange={(value) => updateFilterWithUrl('postType', value)}
-                    isDark={isDark}
-                  />
+                  <>
+                    <FilterDropdown
+                      label="유형"
+                      value={filters.postType}
+                      options={POST_TYPE_OPTIONS}
+                      onChange={(value) => updateFilterWithUrl('postType', value)}
+                      isDark={isDark}
+                    />
+                    <FilterDropdown
+                      label="카테고리"
+                      value={filters.communityCategory}
+                      options={COMMUNITY_CATEGORY_OPTIONS}
+                      onChange={(value) => updateFilterWithUrl('communityCategory', value)}
+                      isDark={isDark}
+                    />
+                  </>
                 )}
 
-                {/* 커뮤니티: 카테고리 */}
-                {activeTab === 'community' && (
-                  <FilterDropdown
-                    label="카테고리"
-                    value={filters.communityCategory}
-                    options={COMMUNITY_CATEGORY_OPTIONS}
-                    onChange={(value) => updateFilterWithUrl('communityCategory', value)}
-                    isDark={isDark}
-                  />
-                )}
-
-                {/* 필터 초기화 */}
                 {activeFilterCount > 0 && (
                   <button
                     onClick={resetFilters}
@@ -1462,28 +735,13 @@ export function SearchPage({
                       </div>
                     )}
                     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6">
-                      {(USE_API ? courses : (courses as MockCourseCard[])).map((course) => {
-                        // API 데이터인 경우 변환, 더미 데이터는 그대로 사용
-                        const cardProps = USE_API
-                          ? convertCourseTimeToCardProps(course as CourseTimeCatalogResponse)
-                          : {
-                              id: (course as MockCourseCard).id,
-                              title: (course as MockCourseCard).title,
-                              instructor: (course as MockCourseCard).instructor,
-                              price: showPrice && paidModeEnabled ? (course as MockCourseCard).price : null,
-                              rating: (course as MockCourseCard).rating,
-                              reviewCount: (course as MockCourseCard).reviewCount,
-                              studentCount: (course as MockCourseCard).studentCount,
-                              image: (course as MockCourseCard).image,
-                              tags: (course as MockCourseCard).tags,
-                              category: (course as MockCourseCard).category,
-                            };
-
+                      {courses.map((course) => {
+                        const cardProps = convertCourseTimeToCardProps(course);
                         return (
-                          <CardComponent
+                          <LandingCourseCard
                             key={cardProps.id}
                             {...cardProps}
-                            courseBasePath={courseBasePath}
+                            courseBasePath="/tu/b2c/times"
                           />
                         );
                       })}
@@ -1491,8 +749,8 @@ export function SearchPage({
                   </section>
                 )}
 
-                {/* 로드맵 섹션 (B2B에서는 숨김) */}
-                {showRoadmapAndCommunity && (activeTab === 'all' || activeTab === 'roadmaps') && roadmaps.length > 0 && (
+                {/* 로드맵 섹션 */}
+                {(activeTab === 'all' || activeTab === 'roadmaps') && roadmaps.length > 0 && (
                   <section>
                     {activeTab === 'all' && (
                       <div className="flex items-center justify-between mb-6">
@@ -1518,8 +776,8 @@ export function SearchPage({
                   </section>
                 )}
 
-                {/* 커뮤니티 섹션 (B2B에서는 숨김) */}
-                {showRoadmapAndCommunity && (activeTab === 'all' || activeTab === 'community') && communityPosts.length > 0 && (
+                {/* 커뮤니티 섹션 */}
+                {(activeTab === 'all' || activeTab === 'community') && communityPosts.length > 0 && (
                   <section>
                     {activeTab === 'all' && (
                       <div className="flex items-center justify-between mb-6">
@@ -1560,7 +818,6 @@ export function SearchPage({
               위 검색창에 키워드를 입력해주세요
             </p>
 
-            {/* 인기 검색어 */}
             <div className="max-w-lg mx-auto">
               <p className={`text-sm mb-4 ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
                 인기 검색어

--- a/src/pages/tu/mypage/PreferencesPage.tsx
+++ b/src/pages/tu/mypage/PreferencesPage.tsx
@@ -66,7 +66,7 @@ function ToggleSwitch({ checked, onChange, isDark }: ToggleSwitchProps) {
   );
 }
 
-export function B2CPreferencesPage() {
+export function PreferencesPage() {
   const { theme, toggleTheme } = useThemeStore();
   const { language, toggleLanguage } = useLanguageStore();
   const isDark = theme === 'dark';

--- a/src/pages/tu/mypage/SettingsPage.tsx
+++ b/src/pages/tu/mypage/SettingsPage.tsx
@@ -56,7 +56,7 @@ function SettingsCard({ icon, title, description, onClick, isDark }: SettingsCar
   );
 }
 
-export function B2CSettingsPage() {
+export function SettingsPage() {
   const navigate = useNavigate();
   const { prefixPath } = useSubdomainPath();
   const { theme } = useThemeStore();

--- a/src/pages/tu/mypage/index.ts
+++ b/src/pages/tu/mypage/index.ts
@@ -8,5 +8,5 @@ export { CertificationsPage } from './CertificationsPage';
 export { MyPostsPage } from './MyPostsPage';
 export { MyCommentsPage } from './MyCommentsPage';
 export { UserNoticesPage } from './UserNoticesPage';
-export { B2CSettingsPage } from './B2CSettingsPage';
-export { B2CPreferencesPage } from './B2CPreferencesPage';
+export { SettingsPage } from './SettingsPage';
+export { PreferencesPage } from './PreferencesPage';

--- a/src/routes/tu.b2b.routes.tsx
+++ b/src/routes/tu.b2b.routes.tsx
@@ -3,17 +3,7 @@ import { B2BMyPageLayout } from '@/components/layout';
 import { ProtectedRoute } from '@/components/common/ProtectedRoute';
 import { ProfileRequiredRoute } from '@/components/common/ProfileRequiredRoute';
 import {
-  MyPageHome,
-  ProfilePage,
-  MyLearningPage,
-  LearningDetailPage,
-  MyTeachingPage,
-  TeachingStatsPage,
-  CompletedCoursesPage,
-  CertificationsPage,
-  UserNoticesPage,
-  // B2C 페이지 재사용
-  SearchPage,
+  // B2C 페이지 재사용 (알림, 강사 프로필만)
   NotificationsPage,
   InstructorProfilePage,
 } from '@/pages/tu';
@@ -23,15 +13,29 @@ import {
   SettingsAppearancePage,
 } from '@/pages/common';
 import {
+  // B2B 메인 페이지
   B2BLandingPage,
   B2BCourseDetailPage,
+  B2BSearchPage,
+  // B2B 마이페이지
+  B2BMyPageHome,
+  B2BProfilePage,
+  B2BMyLearningPage,
+  B2BLearningDetailPage,
+  B2BCompletedCoursesPage,
+  B2BCertificationsPage,
+  B2BMyTeachingPage,
+  B2BTeachingStatsPage,
+  B2BUserNoticesPage,
+  // B2B 설정
   B2BSettingsPage,
   B2BPreferencesPage,
+  // B2B 기타
   B2BMyActivityPage,
   B2BWishlistPage,
-  B2BLandingHeader,
-  B2BCourseCard,
   B2BLearningPlayerPage,
+  // B2B 컴포넌트
+  B2BLandingHeader,
 } from '@/pages/tu/b2b';
 
 function B2BMyPageWrapper() {
@@ -56,28 +60,6 @@ function B2BPlayerWrapper() {
   );
 }
 
-/**
- * B2B 검색 페이지 - B2C SearchPage 재사용
- * - B2BLandingHeader 사용
- * - 로드맵/커뮤니티 탭 숨김
- * - 가격 표시/필터 숨김
- * - B2BCourseCard 사용 (랜딩 페이지와 동일한 디자인)
- */
-function B2BSearchPage() {
-  return (
-    <SearchPage
-      HeaderComponent={B2BLandingHeader}
-      showRoadmapAndCommunity={false}
-      showPrice={false}
-      showPriceFilter={false}
-      courseBasePath="/tu/b2b/times"
-      pageTitle="과정 검색"
-      pageDescription="배정된 과정을 검색하세요"
-      searchPlaceholder="과정명, 강사명으로 검색하세요"
-      CourseCardComponent={B2BCourseCard}
-    />
-  );
-}
 
 /**
  * B2B 알림 페이지 - B2C NotificationsPage 재사용
@@ -119,6 +101,7 @@ function B2BInstructorProfilePage() {
  * - 로드맵 없음
  * - 커뮤니티 → 내 활동 (내 댓글만)
  * - 설정 → 카드 형식 (프로필/환경설정)
+ * - 독립적인 B2B SearchPage 사용 (props 기반 커스터마이징 제거)
  */
 export const tuB2bRoutes = (
   <>
@@ -136,18 +119,18 @@ export const tuB2bRoutes = (
 
     {/* 마이페이지 라우트 (subdomain 있음) */}
     <Route path="/:subdomain/tu/b2b/mypage" element={<B2BMyPageWrapper />}>
-      <Route index element={<MyPageHome />} />
-      <Route path="profile" element={<ProfilePage />} />
+      <Route index element={<B2BMyPageHome />} />
+      <Route path="profile" element={<B2BProfilePage />} />
 
       {/* 내 수강 강의 */}
-      <Route path="learning" element={<MyLearningPage />} />
-      <Route path="learning/:enrollmentId" element={<LearningDetailPage />} />
-      <Route path="completed" element={<CompletedCoursesPage />} />
-      <Route path="certificates" element={<CertificationsPage />} />
+      <Route path="learning" element={<B2BMyLearningPage />} />
+      <Route path="learning/:enrollmentId" element={<B2BLearningDetailPage />} />
+      <Route path="completed" element={<B2BCompletedCoursesPage />} />
+      <Route path="certificates" element={<B2BCertificationsPage />} />
 
       {/* 내 강의 관리 */}
-      <Route path="teaching" element={<MyTeachingPage />} />
-      <Route path="teaching/stats" element={<TeachingStatsPage />} />
+      <Route path="teaching" element={<B2BMyTeachingPage />} />
+      <Route path="teaching/stats" element={<B2BTeachingStatsPage />} />
 
       {/* 내 활동 (커뮤니티 → 내 댓글만) */}
       <Route path="comments" element={<B2BMyActivityPage />} />
@@ -156,7 +139,7 @@ export const tuB2bRoutes = (
       <Route path="wishlist" element={<B2BWishlistPage />} />
 
       {/* 공지사항 */}
-      <Route path="notices" element={<UserNoticesPage />} />
+      <Route path="notices" element={<B2BUserNoticesPage />} />
 
       {/* 설정 (B2B 전용 카드 형식) */}
       <Route path="settings" element={<B2BSettingsPage />} />
@@ -168,18 +151,18 @@ export const tuB2bRoutes = (
 
     {/* 마이페이지 라우트 (subdomain 없음) */}
     <Route path="/tu/b2b/mypage" element={<B2BMyPageWrapper />}>
-      <Route index element={<MyPageHome />} />
-      <Route path="profile" element={<ProfilePage />} />
+      <Route index element={<B2BMyPageHome />} />
+      <Route path="profile" element={<B2BProfilePage />} />
 
       {/* 내 수강 강의 */}
-      <Route path="learning" element={<MyLearningPage />} />
-      <Route path="learning/:enrollmentId" element={<LearningDetailPage />} />
-      <Route path="completed" element={<CompletedCoursesPage />} />
-      <Route path="certificates" element={<CertificationsPage />} />
+      <Route path="learning" element={<B2BMyLearningPage />} />
+      <Route path="learning/:enrollmentId" element={<B2BLearningDetailPage />} />
+      <Route path="completed" element={<B2BCompletedCoursesPage />} />
+      <Route path="certificates" element={<B2BCertificationsPage />} />
 
       {/* 내 강의 관리 */}
-      <Route path="teaching" element={<MyTeachingPage />} />
-      <Route path="teaching/stats" element={<TeachingStatsPage />} />
+      <Route path="teaching" element={<B2BMyTeachingPage />} />
+      <Route path="teaching/stats" element={<B2BTeachingStatsPage />} />
 
       {/* 내 활동 (커뮤니티 → 내 댓글만) */}
       <Route path="comments" element={<B2BMyActivityPage />} />
@@ -188,7 +171,7 @@ export const tuB2bRoutes = (
       <Route path="wishlist" element={<B2BWishlistPage />} />
 
       {/* 공지사항 */}
-      <Route path="notices" element={<UserNoticesPage />} />
+      <Route path="notices" element={<B2BUserNoticesPage />} />
 
       {/* 설정 (B2B 전용 카드 형식) */}
       <Route path="settings" element={<B2BSettingsPage />} />

--- a/src/routes/tu.b2b.routes.tsx
+++ b/src/routes/tu.b2b.routes.tsx
@@ -135,9 +135,6 @@ export const tuB2bRoutes = (
       {/* 내 활동 (커뮤니티 → 내 댓글만) */}
       <Route path="comments" element={<B2BMyActivityPage />} />
 
-      {/* 찜 목록 */}
-      <Route path="wishlist" element={<B2BWishlistPage />} />
-
       {/* 공지사항 */}
       <Route path="notices" element={<B2BUserNoticesPage />} />
 
@@ -166,9 +163,6 @@ export const tuB2bRoutes = (
 
       {/* 내 활동 (커뮤니티 → 내 댓글만) */}
       <Route path="comments" element={<B2BMyActivityPage />} />
-
-      {/* 찜 목록 */}
-      <Route path="wishlist" element={<B2BWishlistPage />} />
 
       {/* 공지사항 */}
       <Route path="notices" element={<B2BUserNoticesPage />} />
@@ -206,5 +200,9 @@ export const tuB2bRoutes = (
     {/* 강사 프로필 (B2B - B2C 페이지 재사용) */}
     <Route path="/:subdomain/tu/b2b/instructors/:instructorId" element={<B2BInstructorProfilePage />} />
     <Route path="/tu/b2b/instructors/:instructorId" element={<B2BInstructorProfilePage />} />
+
+    {/* 찜 목록 (독립 페이지 - 헤더/푸터만 있음) */}
+    <Route path="/:subdomain/tu/b2b/wishlist" element={<B2BWishlistPage />} />
+    <Route path="/tu/b2b/wishlist" element={<B2BWishlistPage />} />
   </>
 );

--- a/src/routes/tu.b2c.routes.tsx
+++ b/src/routes/tu.b2c.routes.tsx
@@ -28,6 +28,7 @@ export const tuB2cRoutes = (
     <Route path="/tu/b2c" element={<LandingPage />} />
 
     {/* 통합 검색 */}
+    <Route path="/:subdomain/tu/b2c/search" element={<SearchPage />} />
     <Route path="/tu/b2c/search" element={<SearchPage />} />
 
     {/* 강의 탐색 */}

--- a/src/routes/tu.mypage.routes.tsx
+++ b/src/routes/tu.mypage.routes.tsx
@@ -16,8 +16,8 @@ import {
   MyPostsPage,
   MyCommentsPage,
   UserNoticesPage,
-  B2CSettingsPage,
-  B2CPreferencesPage,
+  SettingsPage,
+  PreferencesPage,
 } from '@/pages/tu';
 import {
   SettingsSecurityPage,
@@ -81,8 +81,8 @@ export const tuMyPageRoutes = (
     <Route path="posts" element={<MyPostsPage />} />
     <Route path="comments" element={<MyCommentsPage />} />
     <Route path="notices" element={<UserNoticesPage />} />
-    <Route path="settings" element={<B2CSettingsPage />} />
-    <Route path="settings/preferences" element={<B2CPreferencesPage />} />
+    <Route path="settings" element={<SettingsPage />} />
+    <Route path="settings/preferences" element={<PreferencesPage />} />
     <Route path="settings/security" element={<SettingsSecurityPage />} />
     <Route path="settings/notifications" element={<SettingsNotificationsPage />} />
     <Route path="settings/language" element={<SettingsLanguagePage />} />
@@ -112,8 +112,8 @@ export const tuMyPageRoutes = (
     <Route path="notices" element={<UserNoticesPage />} />
 
     {/* 설정 (B2C 전용 카드 형식) */}
-    <Route path="settings" element={<B2CSettingsPage />} />
-    <Route path="settings/preferences" element={<B2CPreferencesPage />} />
+    <Route path="settings" element={<SettingsPage />} />
+    <Route path="settings/preferences" element={<PreferencesPage />} />
     <Route path="settings/security" element={<SettingsSecurityPage />} />
     <Route path="settings/notifications" element={<SettingsNotificationsPage />} />
     <Route path="settings/language" element={<SettingsLanguagePage />} />

--- a/src/routes/tu.routes.tsx
+++ b/src/routes/tu.routes.tsx
@@ -12,19 +12,25 @@ import { tuTeachingRoutes } from './tu.teaching.routes';
  * - /tu/b2c/mypage/*  : B2C 마이페이지 (사이드바 있음, 로그인 필요)
  * - /tu/b2b/mypage/*  : B2B 마이페이지 (사이드바 있음, 로그인 필요)
  * - /tu/teaching/*    : 강의 관리 (사이드바 있음, 로그인 필요)
+ *
+ * 라우트 순서 규칙 (React Router v6):
+ * 1. 강의 관리 (가장 구체적 - /tu/teaching/*)
+ * 2. B2B 전체 (구체적 - /tu/b2b/* 및 /:subdomain/tu/b2b/*)
+ * 3. B2C 마이페이지 (구체적 - /tu/b2c/mypage/*)
+ * 4. B2C 메인 (일반적 - /tu/b2c/*)
  */
 export const tuRoutes = (
   <>
-    {/* B2C 마이페이지 (플레이어 포함 - 더 구체적인 경로 먼저) */}
-    {tuMyPageRoutes}
-
-    {/* 강의 관리 */}
+    {/* 1. 강의 관리 (가장 구체적인 경로) */}
     {tuTeachingRoutes}
 
-    {/* B2B 페이지 (기업용 - 마이페이지 포함) */}
+    {/* 2. B2B 전체 (B2B 마이페이지 포함 - B2C보다 먼저) */}
     {tuB2bRoutes}
 
-    {/* B2C 메인 페이지 (개인용 - 가장 일반적인 경로 마지막) */}
+    {/* 3. B2C 마이페이지 (플레이어 포함) */}
+    {tuMyPageRoutes}
+
+    {/* 4. B2C 메인 페이지 (가장 일반적인 경로는 마지막) */}
     {tuB2cRoutes}
   </>
 );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,6 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/test"]
 }


### PR DESCRIPTION
## 📋 Summary
B2B와 B2C 페이지를 명확히 분리하고, 랜딩 페이지의 사용자 경험을 개선합니다.

Closes #459

## 🎯 Changes

### 1. B2B 찜 목록 독립 페이지화
- B2B 찜 목록을 마이페이지에서 분리하여 독립 페이지로 구성
- 헤더/푸터만 표시, 사이드바 제거
- 라우트 변경: `/tu/b2b/mypage/wishlist` → `/tu/b2b/wishlist`
- **파일**: `tu.b2b.routes.tsx`, `B2BLandingHeader.tsx`

### 2. 랜딩 페이지 라이트 모드 UI 개선
- 카테고리 칩 텍스트 가독성 향상
  - 비활성 칩 텍스트 색상: `#666666` → `#424242`
  - 활성 칩 텍스트 색상: 명시적 흰색(`#ffffff`) 적용
- 빈 카테고리 상태 메시지 추가
  - "해당 카테고리에 강의가 없습니다." 표시
  - 필수 강의 및 추천 강의 섹션에 적용
- **파일**: `index.css`, `B2BLandingPage.tsx`, `LandingPage.tsx`

### 3. 히어로 섹션 배경 일관성 개선
- 라이트 모드와 다크 모드의 히어로 섹션 배경 그라데이션 통일
- 기존 연한 색상 → 다크 모드와 동일한 진한 그라데이션 적용
- **파일**: `index.css`

### 4. 모듈 해결 오류 수정
- `useSearchLogic.ts`의 import 경로 수정
- 설정 페이지 export 구조 개선
- **파일**: `useSearchLogic.ts`, `pages/tu/index.ts`

## 🎨 Screenshots
(해당 시 스크린샷 추가)

## 📝 Test Plan
- [ ] B2B 랜딩 페이지에서 하트 아이콘 클릭 시 `/tu/b2b/wishlist`로 이동 확인
- [ ] 라이트 모드에서 카테고리 칩 텍스트 가독성 확인 (선택/비선택 상태 모두)
- [ ] 빈 카테고리 선택 시 "해당 카테고리에 강의가 없습니다." 메시지 표시 확인
- [ ] 히어로 섹션 배경이 라이트/다크 모드에서 일관되게 표시되는지 확인
- [ ] B2C 랜딩 페이지에도 동일한 개선사항 적용 확인
- [ ] 모듈 import 오류 없이 애플리케이션이 정상 로드되는지 확인

## 📂 Modified Files
- `src/routes/tu.b2b.routes.tsx`
- `src/pages/tu/b2b/components/B2BLandingHeader.tsx`
- `src/index.css`
- `src/pages/tu/b2b/B2BLandingPage.tsx`
- `src/pages/tu/main/LandingPage.tsx`
- `src/hooks/tu/useSearchLogic.ts`
- `src/pages/tu/index.ts`

## 🔗 Related
B2B/B2C 페이지 분리 및 사용자 경험 개선 작업의 일환