### PR TITLE
fix: 사이드바 메뉴 활성 상태 표시 개선

### DIFF
--- a/src/components/layout/co/CourseOperatorSidebar/CourseOperatorSidebar.tsx
+++ b/src/components/layout/co/CourseOperatorSidebar/CourseOperatorSidebar.tsx
@@ -27,11 +27,11 @@ export function CourseOperatorSidebar(props: CourseOperatorSidebarProps) {
   const { data: layoutData } = usePublicLayout();
   const sidebarSettings = layoutData?.sidebarCOSettings as { enabled?: boolean; items?: BrandingSidebarItem[] } | undefined;
 
-  // 사용자 역할 가져오기
-  const userRole = useAuthStore((state) => state.user?.role);
+  // 사용자 역할 가져오기 (다중 역할 지원)
+  const userRoles = useAuthStore((state) => state.user?.roles);
 
-  // TENANT_ADMIN만 글로벌 역할 스위처 표시
-  const showGlobalRoleSwitcher = userRole === 'TENANT_ADMIN';
+  // 부여된 역할이 2개 이상이면 글로벌 역할 스위처 표시
+  const showGlobalRoleSwitcher = (userRoles?.length ?? 0) >= 2;
 
   // 브랜딩 설정을 기반으로 메뉴 필터링
   const filteredMenuData = useMemo((): MenuItem[] => {

--- a/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
+++ b/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
@@ -88,12 +88,13 @@ export function BaseSidebar({
 
   // URL 변경 시 활성 상태 동기화
   useEffect(() => {
-    setActiveItem(findActiveMenuItem.itemId);
+    const { itemId, parentId } = findActiveMenuItem;
+    setActiveItem(itemId);
 
-    if (findActiveMenuItem.parentId && !expandedItems.includes(findActiveMenuItem.parentId)) {
-      setExpandedItems(prev => [...prev, findActiveMenuItem.parentId!]);
+    if (parentId && !expandedItems.includes(parentId)) {
+      setExpandedItems(prev => [...prev, parentId]);
     }
-  }, [findActiveMenuItem]);
+  }, [location.pathname, menuData]);
 
   // 인증 스토어
   const { refreshToken, logout } = useAuthStore();

--- a/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
+++ b/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
@@ -50,19 +50,36 @@ export function BaseSidebar({
   const findActiveMenuItem = useMemo(() => {
     const { pathname } = location;
 
+    // 가장 긴 경로부터 매칭하기 위해 모든 경로를 수집하고 정렬
+    const allPaths: { path: string; itemId: string; parentId: string | null }[] = [];
+
     for (const item of menuData) {
-      // 2단계 서브메뉴 먼저 확인 (더 구체적인 경로 우선)
       if (item.subItems) {
         for (const subItem of item.subItems) {
-          if (subItem.path && pathname.startsWith(subItem.path)) {
-            return { itemId: subItem.id, parentId: item.id };
+          if (subItem.path) {
+            allPaths.push({ path: subItem.path, itemId: subItem.id, parentId: item.id });
           }
         }
       }
 
-      // 1단계 메뉴 확인
-      if (item.path && pathname.startsWith(item.path)) {
-        return { itemId: item.id, parentId: null };
+      if (item.path) {
+        allPaths.push({ path: item.path, itemId: item.id, parentId: null });
+      }
+    }
+
+    // 경로 길이 내림차순 정렬 (더 구체적인 경로 먼저 매칭)
+    allPaths.sort((a, b) => b.path.length - a.path.length);
+
+    for (const { path, itemId, parentId } of allPaths) {
+      if (pathname === path || pathname.startsWith(path + '/')) {
+        return { itemId, parentId };
+      }
+    }
+
+    // 정확한 매칭이 없으면 startsWith로 다시 시도
+    for (const { path, itemId, parentId } of allPaths) {
+      if (pathname.startsWith(path)) {
+        return { itemId, parentId };
       }
     }
 

--- a/src/components/layout/common/GlobalRoleSwitcher/GlobalRoleSwitcher.tsx
+++ b/src/components/layout/common/GlobalRoleSwitcher/GlobalRoleSwitcher.tsx
@@ -52,7 +52,7 @@ export function GlobalRoleSwitcher({
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // 사용자의 역할 가져오기 (현재는 단일 role, 향후 roles 배열로 확장 가능)
+  // 사용자의 역할 가져오기 (roles 배열 우선 사용)
   const userRole = useAuthStore((state) => state.user?.role);
   const userRoles = useAuthStore((state) => state.user?.roles) as string[] | undefined;
 
@@ -70,34 +70,26 @@ export function GlobalRoleSwitcher({
 
   // 사용자가 가진 역할만 표시 (순서: 학습자 → 강사 → 교육 운영자 → 관리자)
   const availableRoles: GlobalRole[] = (() => {
+    const roles: GlobalRole[] = [];
+
     // roles 배열이 있으면 사용 (1:N 관계 지원)
-    if (userRoles && userRoles.length > 0) {
-      const roles: GlobalRole[] = [];
-      // 사용자에게 부여된 역할에 따라 표시
-      if (userRoles.includes('USER')) {
-        roles.push('USER');
-      }
-      if (userRoles.includes('INSTRUCTOR') || userRoles.includes('DESIGNER')) {
-        roles.push('TU');
-      }
-      if (userRoles.includes('OPERATOR')) {
-        roles.push('CO');
-      }
-      if (userRoles.includes('TENANT_ADMIN')) {
-        roles.push('TA');
-      }
-      return roles;
+    const rolesToCheck = userRoles && userRoles.length > 0 ? userRoles : (userRole ? [userRole] : []);
+
+    // 부여받은 역할만 표시 (USER 역할도 부여받은 경우에만)
+    if (rolesToCheck.includes('USER')) {
+      roles.push('USER');
+    }
+    if (rolesToCheck.includes('INSTRUCTOR') || rolesToCheck.includes('DESIGNER')) {
+      roles.push('TU');
+    }
+    if (rolesToCheck.includes('OPERATOR')) {
+      roles.push('CO');
+    }
+    if (rolesToCheck.includes('TENANT_ADMIN')) {
+      roles.push('TA');
     }
 
-    // 단일 role 기반 (기존 호환)
-    if (userRole === 'TENANT_ADMIN') {
-      return ['USER', 'TU', 'CO', 'TA'];
-    } else if (userRole === 'OPERATOR') {
-      return ['USER', 'TU', 'CO'];
-    } else {
-      // 기본: 현재 역할만 표시
-      return [currentRole];
-    }
+    return roles;
   })();
 
   const CurrentIcon = roleIcons[currentRole];

--- a/src/components/layout/ta/TenantAdminSidebar/TenantAdminSidebar.tsx
+++ b/src/components/layout/ta/TenantAdminSidebar/TenantAdminSidebar.tsx
@@ -90,12 +90,13 @@ export function TenantAdminSidebar({
 
   // URL 변경 시 활성 상태 동기화
   useEffect(() => {
-    setActiveItem(findActiveMenuItem.itemId);
+    const { itemId, parentId } = findActiveMenuItem;
+    setActiveItem(itemId);
 
-    if (findActiveMenuItem.parentId && !expandedItems.includes(findActiveMenuItem.parentId)) {
-      setExpandedItems(prev => [...prev, findActiveMenuItem.parentId!]);
+    if (parentId && !expandedItems.includes(parentId)) {
+      setExpandedItems(prev => [...prev, parentId]);
     }
-  }, [findActiveMenuItem]);
+  }, [location.pathname]);
 
   // 로그아웃 핸들러
   const handleLogout = async () => {

--- a/src/components/layout/ta/TenantAdminSidebar/TenantAdminSidebar.tsx
+++ b/src/components/layout/ta/TenantAdminSidebar/TenantAdminSidebar.tsx
@@ -52,6 +52,11 @@ export function TenantAdminSidebar({
   const findActiveMenuItem = useMemo(() => {
     const { pathname } = location;
 
+    // 서브도메인 제거: /{subdomain}/ta/... -> /ta/...
+    // pathname에서 /ta/ 부분을 찾아서 그 이후부터 매칭
+    const taIndex = pathname.indexOf('/ta/');
+    const normalizedPath = taIndex !== -1 ? pathname.substring(taIndex) : pathname;
+
     // 가장 긴 경로부터 매칭하기 위해 모든 경로를 수집하고 정렬
     const allPaths: { path: string; itemId: string; parentId: string | null }[] = [];
 
@@ -73,14 +78,14 @@ export function TenantAdminSidebar({
     allPaths.sort((a, b) => b.path.length - a.path.length);
 
     for (const { path, itemId, parentId } of allPaths) {
-      if (pathname === path || pathname.startsWith(path + '/')) {
+      if (normalizedPath === path || normalizedPath.startsWith(path + '/')) {
         return { itemId, parentId };
       }
     }
 
     // 정확한 매칭이 없으면 startsWith로 다시 시도
     for (const { path, itemId, parentId } of allPaths) {
-      if (pathname.startsWith(path)) {
+      if (normalizedPath.startsWith(path)) {
         return { itemId, parentId };
       }
     }

--- a/src/components/layout/ta/TenantAdminSidebar/TenantAdminSidebar.tsx
+++ b/src/components/layout/ta/TenantAdminSidebar/TenantAdminSidebar.tsx
@@ -52,17 +52,36 @@ export function TenantAdminSidebar({
   const findActiveMenuItem = useMemo(() => {
     const { pathname } = location;
 
+    // 가장 긴 경로부터 매칭하기 위해 모든 경로를 수집하고 정렬
+    const allPaths: { path: string; itemId: string; parentId: string | null }[] = [];
+
     for (const item of tenantAdminMenuData) {
       if (item.subItems) {
         for (const subItem of item.subItems) {
-          if (subItem.path && pathname.startsWith(subItem.path)) {
-            return { itemId: subItem.id, parentId: item.id };
+          if (subItem.path) {
+            allPaths.push({ path: subItem.path, itemId: subItem.id, parentId: item.id });
           }
         }
       }
 
-      if (item.path && pathname.startsWith(item.path)) {
-        return { itemId: item.id, parentId: null };
+      if (item.path) {
+        allPaths.push({ path: item.path, itemId: item.id, parentId: null });
+      }
+    }
+
+    // 경로 길이 내림차순 정렬 (더 구체적인 경로 먼저 매칭)
+    allPaths.sort((a, b) => b.path.length - a.path.length);
+
+    for (const { path, itemId, parentId } of allPaths) {
+      if (pathname === path || pathname.startsWith(path + '/')) {
+        return { itemId, parentId };
+      }
+    }
+
+    // 정확한 매칭이 없으면 startsWith로 다시 시도
+    for (const { path, itemId, parentId } of allPaths) {
+      if (pathname.startsWith(path)) {
+        return { itemId, parentId };
       }
     }
 

--- a/src/components/layout/tu/TenantUserSidebar/TenantUserSidebar.tsx
+++ b/src/components/layout/tu/TenantUserSidebar/TenantUserSidebar.tsx
@@ -28,15 +28,16 @@ export function TenantUserSidebar(props: TenantUserSidebarProps) {
   const { data: layoutData } = usePublicLayout();
   const sidebarSettings = layoutData?.sidebarTUSettings as { enabled?: boolean; items?: BrandingSidebarItem[] } | undefined;
 
-  // 사용자 역할 가져오기
+  // 사용자 역할 가져오기 (다중 역할 지원)
   const userRole = useAuthStore((state) => state.user?.role);
+  const userRoles = useAuthStore((state) => state.user?.roles);
 
   // 기능 설정 가져오기
   const { isFeatureEnabled } = useTenantFeatures();
   const instructorTabEnabled = isFeatureEnabled('instructorTabEnabled');
 
-  // 글로벌 역할 스위처 표시 여부 (강사 탭이 활성화된 경우)
-  const showGlobalRoleSwitcher = instructorTabEnabled;
+  // 글로벌 역할 스위처 표시 여부 (부여된 역할이 2개 이상인 경우)
+  const showGlobalRoleSwitcher = instructorTabEnabled && (userRoles?.length ?? 0) >= 2;
 
   // 브랜딩 설정 + 역할 기반 메뉴 필터링
   const filteredMenuData = useMemo((): MenuItem[] => {

--- a/src/hooks/common/auth/useAuth.ts
+++ b/src/hooks/common/auth/useAuth.ts
@@ -38,6 +38,7 @@ export const useLogin = () => {
         email: userDetail.email,
         name: userDetail.name,
         role: userDetail.role,
+        roles: userDetail.roles,  // 다중 역할 (1:N) 지원
         tenantId: userDetail.tenantId,
         tenantSubdomain: userDetail.tenantSubdomain,
       };
@@ -139,6 +140,7 @@ export const useMe = () => {
         email: userDetail.email,
         name: userDetail.name,
         role: userDetail.role,
+        roles: userDetail.roles,  // 다중 역할 (1:N) 동기화
         tenantId: userDetail.tenantId,
       });
       return userDetail;

--- a/src/hooks/ta/useUserQueries.ts
+++ b/src/hooks/ta/useUserQueries.ts
@@ -3,6 +3,8 @@
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { userService } from '@/services/ta';
+import { useAuthStore } from '@/store/common/authStore';
+import { authKeys } from '@/hooks/common/auth/useAuth';
 import type {
   UserListParams,
   UpdateUserDetailRequest,
@@ -100,10 +102,18 @@ export const useUpdateUserRoles = () => {
   return useMutation({
     mutationFn: ({ id, request }: { id: number; request: UpdateUserRolesRequest }) =>
       userService.updateUserRoles(id, request),
-    onSuccess: (_, variables) => {
+    onSuccess: async (_, variables) => {
       queryClient.invalidateQueries({ queryKey: userKeys.detail(variables.id) });
       queryClient.invalidateQueries({ queryKey: userKeys.roles(variables.id) });
       queryClient.invalidateQueries({ queryKey: userKeys.lists() });
+
+      // 현재 로그인한 사용자의 역할이 변경된 경우 store 직접 업데이트
+      const currentUserId = useAuthStore.getState().user?.id;
+      if (currentUserId === variables.id) {
+        queryClient.invalidateQueries({ queryKey: authKeys.me() });
+        // store에 새 roles 직접 업데이트
+        useAuthStore.getState().updateUser({ roles: variables.request.roles });
+      }
     },
   });
 };
@@ -119,6 +129,16 @@ export const useAddUserRole = () => {
       queryClient.invalidateQueries({ queryKey: userKeys.detail(variables.id) });
       queryClient.invalidateQueries({ queryKey: userKeys.roles(variables.id) });
       queryClient.invalidateQueries({ queryKey: userKeys.lists() });
+
+      // 현재 로그인한 사용자의 역할이 변경된 경우 store 직접 업데이트
+      const authState = useAuthStore.getState();
+      if (authState.user?.id === variables.id) {
+        queryClient.invalidateQueries({ queryKey: authKeys.me() });
+        const currentRoles = authState.user?.roles || [];
+        if (!currentRoles.includes(variables.role)) {
+          authState.updateUser({ roles: [...currentRoles, variables.role] });
+        }
+      }
     },
   });
 };
@@ -134,6 +154,14 @@ export const useRemoveUserRole = () => {
       queryClient.invalidateQueries({ queryKey: userKeys.detail(variables.id) });
       queryClient.invalidateQueries({ queryKey: userKeys.roles(variables.id) });
       queryClient.invalidateQueries({ queryKey: userKeys.lists() });
+
+      // 현재 로그인한 사용자의 역할이 변경된 경우 store 직접 업데이트
+      const authState = useAuthStore.getState();
+      if (authState.user?.id === variables.id) {
+        queryClient.invalidateQueries({ queryKey: authKeys.me() });
+        const currentRoles = authState.user?.roles || [];
+        authState.updateUser({ roles: currentRoles.filter(r => r !== variables.role) });
+      }
     },
   });
 };


### PR DESCRIPTION
## Summary

사이드바 메뉴에서 현재 페이지에 맞는 활성 상태가 올바르게 표시되지 않는 문제를 수정했습니다. 다른 메뉴를 클릭해도 대시보드에만 활성 표시가 남아있던 버그를 해결했습니다.

## Related Issue

- Closes #

## Changes

### 사이드바 활성 상태 로직 개선
- `findActiveMenuItem` 로직 개선: 경로 길이 내림차순 정렬로 더 구체적인 경로 먼저 매칭
- 정확한 경로 매칭(`pathname === path`) 우선, `startsWith` 매칭은 후순위로 적용
- `BaseSidebar.tsx`, `TenantAdminSidebar.tsx` 모두 동일한 로직 적용

### GlobalRoleSwitcher 개선
- roles 배열 우선 사용하도록 변경
- 부여받은 역할만 드롭다운에 표시되도록 수정

### 기타
- `CourseOperatorSidebar`, `TenantUserSidebar` 관련 수정
- `useUserQueries` 훅 개선

## Type of Change

- [ ] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### 수정된 파일
- `TenantAdminSidebar.tsx` - TA 사이드바 활성 상태 로직
- `BaseSidebar.tsx` - 공용 사이드바 활성 상태 로직
- `GlobalRoleSwitcher.tsx` - 역할 전환 드롭다운 로직
- `CourseOperatorSidebar.tsx`, `TenantUserSidebar.tsx` - 기타 사이드바
- `useUserQueries.ts` - 유저 쿼리 훅

### 테스트 시나리오
1. TA 로그인 후 사용자 관리 > 부서 관리 클릭 시 해당 메뉴가 활성화되는지 확인
2. 대시보드 외 다른 메뉴 클릭 시 대시보드 활성 표시가 사라지는지 확인
3. 하위 메뉴 클릭 시 상위 메뉴가 펼쳐지고 하위 메뉴가 활성화되는지 확인
