### PR TITLE
[Fix] 과정 등록 에러 시 커리큘럼 데이터 손실 방지

### DIFF
--- a/src/pages/tu/teaching/courses/CourseCreatePage.tsx
+++ b/src/pages/tu/teaching/courses/CourseCreatePage.tsx
@@ -336,8 +336,18 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
       const targetCourseId = await saveCourse();
       if (!targetCourseId) throw new Error('저장 실패');
 
+      // 저장 성공 후 최신 데이터 재조회하여 동기화
+      const hierarchyData = await courseService.getItemsHierarchy(targetCourseId);
+      const curriculumItems = convertHierarchyToCurriculumItems(hierarchyData);
+      setFormData((prev) => ({
+        ...prev,
+        curriculumItems,
+        lastSaved: new Date().toISOString(),
+      }));
+
       // 작성완료 API 호출 (DRAFT → READY)
       await courseService.ready(targetCourseId);
+      setCourseStatus('READY');
 
       alert(getText('completeSuccess'));
       navigate(prefixPath('/tu/teaching/courses'));
@@ -367,23 +377,51 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
 
       // DRAFT 상태이면 먼저 저장
       if (courseStatus === 'DRAFT') {
-        targetCourseId = await saveCourse();
-        if (!targetCourseId) throw new Error('저장 실패');
+        try {
+          targetCourseId = await saveCourse();
+          if (!targetCourseId) throw new Error('저장 실패');
 
-        // DRAFT → READY
-        await courseService.ready(targetCourseId);
+          // 저장 성공 후 최신 데이터 재조회하여 동기화
+          const hierarchyData = await courseService.getItemsHierarchy(targetCourseId);
+          const curriculumItems = convertHierarchyToCurriculumItems(hierarchyData);
+          setFormData((prev) => ({
+            ...prev,
+            curriculumItems,
+            lastSaved: new Date().toISOString(),
+          }));
+
+          // DRAFT → READY
+          await courseService.ready(targetCourseId);
+          setCourseStatus('READY');
+        } catch (error) {
+          console.error('저장 또는 작성완료 실패:', error);
+          // 어느 단계에서 실패했는지에 따라 다른 메시지
+          if (!targetCourseId) {
+            alert('저장에 실패했습니다. 다시 시도해주세요.');
+          } else {
+            alert('작성완료 처리에 실패했습니다. 저장은 완료되었습니다.');
+          }
+          setIsRegistering(false);
+          return; // 등록 단계로 진행하지 않음
+        }
       }
 
       // READY → REGISTERED (DRAFT였어도 이제 READY 상태)
       if (targetCourseId) {
-        await courseService.register(targetCourseId);
+        try {
+          await courseService.register(targetCourseId);
+          alert(getText('registerSuccess'));
+          navigate(prefixPath('/tu/teaching/courses'));
+        } catch (error: any) {
+          console.error('등록 실패:', error);
+          // 403 에러는 권한 부족으로 명확히 표시
+          if (error.response?.status === 403) {
+            alert('등록 권한이 없습니다. OPERATOR 역할이 필요합니다.\n\n저장 및 작성완료는 성공했으므로 과정 목록에서 확인할 수 있습니다.');
+          } else {
+            alert('등록에 실패했습니다. 저장은 완료되었으므로 나중에 다시 시도해주세요.');
+          }
+        }
       }
-
-      alert(getText('registerSuccess'));
-      navigate(prefixPath('/tu/teaching/courses'));
-    } catch (error) {
-      console.error('등록 실패:', error);
-      alert(getText('registerError'));
     } finally {
       setIsRegistering(false);
     }


### PR DESCRIPTION
## Summary

과정 등록 중 에러 발생 시 커리큘럼 데이터가 손실되는 문제를 해결했습니다.

### 변경 사항

#### 1. `handleRegister()` 함수 개선
- **데이터 동기화**: `saveCourse()` 성공 후 서버에서 최신 데이터 재조회하여 `curriculumItems`의 itemId 동기화
- **상태 동기화**: `courseService.ready()` 성공 시 `courseStatus`를 'READY'로 업데이트
- **에러 핸들링 개선**: 각 단계별 에러를 구분하여 처리
  - 저장 실패: "저장에 실패했습니다"
  - 작성완료 실패: "작성완료 처리에 실패했습니다. 저장은 완료되었습니다"
  - 등록 실패 (403): "등록 권한이 없습니다. OPERATOR 역할이 필요합니다. 저장 및 작성완료는 성공했으므로 과정 목록에서 확인할 수 있습니다"
  - 등록 실패 (기타): "등록에 실패했습니다. 저장은 완료되었으므로 나중에 다시 시도해주세요"

#### 2. `handleComplete()` 함수 개선
- `handleRegister()`와 동일한 패턴으로 데이터 재조회 및 상태 동기화 추가

### 해결된 문제

이제 에러가 발생해도:
- ✅ 저장된 데이터는 DB에 안전하게 보관됨
- ✅ 커리큘럼 데이터가 서버와 동기화되어 손실 없음
- ✅ 사용자는 어느 단계에서 실패했는지 명확히 알 수 있음
- ✅ Step2로 돌아가도 itemId가 동기화되어 중복 생성 방지
- ✅ 403 권한 에러 시 명확한 안내 메시지 제공

## Test plan

- [ ] DRAFT 상태에서 등록 버튼 클릭 시 정상 동작 확인
- [ ] 등록 중 403 에러 발생 시 명확한 메시지 표시 확인
- [ ] 에러 후 Step2로 돌아갔을 때 커리큘럼 데이터 유지 확인
- [ ] 에러 후 과정 목록에서 저장된 과정 확인 가능
- [ ] 작성완료 버튼 클릭 시 데이터 동기화 확인
- [ ] READY 상태로 전환 후 courseStatus 업데이트 확인

Closes #457