### PR TITLE
[Feat] CourseDetailPage UI 개선 - 수정 버튼 및 콘텐츠 미리보기 기능 추가 (#471)

### DIFF
--- a/src/pages/tu/teaching/courses/CourseDetailPage.tsx
+++ b/src/pages/tu/teaching/courses/CourseDetailPage.tsx
@@ -14,7 +14,11 @@ import {
   useCourse,
   useCourseItemsHierarchy,
   useDeleteCourse,
+  useLearningObject,
 } from '@/hooks/tu';
+import { ContentPreviewModal } from '@/components/domain/tu/content/ContentPreviewModal';
+import type { ContentType } from '@/types/tu';
+import type { CourseItemHierarchyResponse } from '@/types/common/course.types';
 import { useSubdomainPath } from '@/hooks/common/useSubdomainPath';
 import { categoryService } from '@/services/common';
 import { CourseInfoSection } from './components/CourseInfoSection';
@@ -62,6 +66,13 @@ export function CourseDetailPage() {
   const { data: curriculum } = useCourseItemsHierarchy(id);
   const deleteCourseMutation = useDeleteCourse();
 
+  // 콘텐츠 미리보기 상태
+  const [previewModalOpen, setPreviewModalOpen] = useState(false);
+  const [selectedItem, setSelectedItem] = useState<CourseItemHierarchyResponse | null>(null);
+
+  // LO 조회 (selectedItem이 있을 때만)
+  const { data: learningObject } = useLearningObject(selectedItem?.learningObjectId ?? 0);
+
   // 카테고리 목록 조회
   useEffect(() => {
     const fetchCategories = async () => {
@@ -87,6 +98,17 @@ export function CourseDetailPage() {
       console.error('Delete failed:', err);
       alert('삭제에 실패했습니다.');
     }
+  };
+
+  // 콘텐츠 미리보기 핸들러
+  const handlePreviewContent = (item: CourseItemHierarchyResponse) => {
+    setSelectedItem(item);
+    setPreviewModalOpen(true);
+  };
+
+  const handleClosePreview = () => {
+    setPreviewModalOpen(false);
+    setSelectedItem(null);
   };
 
   // 로딩 상태
@@ -165,7 +187,7 @@ export function CourseDetailPage() {
               onClick={() => navigate(prefixPath(`/tu/teaching/courses/${id}/apply`))}
             >
               <Send size={16} />
-              과정 신청
+              과정 등록
             </Button>
             <Button
               variant="ghost"
@@ -191,15 +213,32 @@ export function CourseDetailPage() {
         {/* Content */}
         <div className="space-y-6">
           {/* 기본 정보 섹션 */}
-          <CourseInfoSection course={course} categories={categories} />
+          <CourseInfoSection
+            course={course}
+            categories={categories}
+            onEdit={() => navigate(prefixPath(`/tu/teaching/courses/${id}/edit?step=1`))}
+          />
 
           {/* 커리큘럼 섹션 */}
           <CourseCurriculumSection
             itemCount={course.itemCount}
             curriculum={curriculum ?? []}
+            onEdit={() => navigate(prefixPath(`/tu/teaching/courses/${id}/edit?step=2`))}
+            onPreviewContent={handlePreviewContent}
           />
         </div>
       </div>
+
+      {/* 콘텐츠 미리보기 모달 */}
+      {selectedItem && learningObject && (
+        <ContentPreviewModal
+          isOpen={previewModalOpen}
+          onClose={handleClosePreview}
+          contentId={learningObject.contentId}
+          contentType={learningObject.contentType as ContentType}
+          fileName={selectedItem.displayName || selectedItem.itemName}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/tu/teaching/courses/CourseEditPage.tsx
+++ b/src/pages/tu/teaching/courses/CourseEditPage.tsx
@@ -6,7 +6,7 @@
  * CourseCreatePage와 동일한 Step 구조 사용
  */
 import { useState, useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { ArrowLeft, ArrowRight, Save, Upload, Loader2 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button } from '@/components/common';
@@ -97,6 +97,7 @@ export function CourseEditPage({ language = 'ko' }: Readonly<CourseEditPageProps
   const navigate = useNavigate();
   const { prefixPath } = useSubdomainPath();
   const { courseId } = useParams<{ courseId: string }>();
+  const [searchParams] = useSearchParams();
   const courseIdNum = Number(courseId);
 
   const { data: courseData, isLoading, isError } = useCourse(courseIdNum);
@@ -164,8 +165,17 @@ export function CourseEditPage({ language = 'ko' }: Readonly<CourseEditPageProps
         },
       });
       setIsInitialized(true);
+
+      // URL에서 step 파라미터 확인하여 초기 step 설정
+      const stepParam = searchParams.get('step');
+      if (stepParam) {
+        const step = parseInt(stepParam, 10);
+        if (step >= 1 && step <= 3) {
+          setCurrentStep(step);
+        }
+      }
     }
-  }, [courseData, hierarchyData, isInitialized]);
+  }, [courseData, hierarchyData, isInitialized, searchParams]);
 
   // 네비게이션 핸들러
   const handleNext = () => currentStep < totalSteps && setCurrentStep(currentStep + 1);

--- a/src/pages/tu/teaching/courses/components/CourseCurriculumSection.tsx
+++ b/src/pages/tu/teaching/courses/components/CourseCurriculumSection.tsx
@@ -1,19 +1,24 @@
 import { useState } from 'react';
-import { BookOpen, Folder, FileText, ChevronRight, ChevronDown } from 'lucide-react';
+import { BookOpen, Folder, FileText, ChevronRight, ChevronDown, Pencil, Eye } from 'lucide-react';
+import { Button } from '@/components/common';
 import type { CourseItemHierarchyResponse } from '@/types/common/course.types';
 
 interface CourseCurriculumSectionProps {
   itemCount: number;
   curriculum: CourseItemHierarchyResponse[];
+  onEdit?: () => void;
+  onPreviewContent?: (item: CourseItemHierarchyResponse) => void;
 }
 
 // 재귀적으로 트리 아이템 렌더링
 function CurriculumTreeItem({
   item,
   depth = 0,
+  onPreviewContent,
 }: {
   item: CourseItemHierarchyResponse;
   depth?: number;
+  onPreviewContent?: (item: CourseItemHierarchyResponse) => void;
 }) {
   const [isOpen, setIsOpen] = useState(true);
   const paddingLeft = depth * 24;
@@ -58,11 +63,30 @@ function CurriculumTreeItem({
             </span>
           )}
         </div>
+        {/* 콘텐츠(폴더가 아닌 경우)에 미리보기 버튼 */}
+        {!item.isFolder && item.learningObjectId && onPreviewContent && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="ml-auto shrink-0 h-6 px-2"
+            onClick={(e) => {
+              e.stopPropagation();
+              onPreviewContent(item);
+            }}
+          >
+            <Eye size={14} />
+          </Button>
+        )}
       </div>
       {hasChildren && isOpen && (
         <div>
           {item.children.map((child) => (
-            <CurriculumTreeItem key={child.itemId} item={child} depth={depth + 1} />
+            <CurriculumTreeItem
+              key={child.itemId}
+              item={child}
+              depth={depth + 1}
+              onPreviewContent={onPreviewContent}
+            />
           ))}
         </div>
       )}
@@ -73,6 +97,8 @@ function CurriculumTreeItem({
 export function CourseCurriculumSection({
   itemCount,
   curriculum,
+  onEdit,
+  onPreviewContent,
 }: Readonly<CourseCurriculumSectionProps>) {
   return (
     <div className="bg-bg-default border border-border rounded-lg p-6">
@@ -82,13 +108,23 @@ export function CourseCurriculumSection({
           커리큘럼
           <span className="text-text-secondary font-normal">({itemCount}차시)</span>
         </h2>
+        {onEdit && (
+          <Button variant="ghost" size="sm" onClick={onEdit} className="border border-border">
+            <Pencil size={14} />
+            수정
+          </Button>
+        )}
       </div>
 
       {curriculum.length > 0 ? (
         <div className="border border-border rounded-lg overflow-hidden">
           <div className="max-h-96 overflow-auto">
             {curriculum.map((item) => (
-              <CurriculumTreeItem key={item.itemId} item={item} />
+              <CurriculumTreeItem
+                key={item.itemId}
+                item={item}
+                onPreviewContent={onPreviewContent}
+              />
             ))}
           </div>
         </div>

--- a/src/pages/tu/teaching/courses/components/CourseInfoSection.tsx
+++ b/src/pages/tu/teaching/courses/components/CourseInfoSection.tsx
@@ -1,10 +1,12 @@
-import { FileText, Calendar, Clock, Tag, ImageIcon } from 'lucide-react';
+import { FileText, Calendar, Clock, Tag, ImageIcon, Pencil } from 'lucide-react';
+import { Button } from '@/components/common';
 import type { CourseDetailResponse } from '@/types/common/course.types';
 import type { CategoryResponse } from '@/types/common';
 
 interface CourseInfoSectionProps {
   course: CourseDetailResponse;
   categories: CategoryResponse[];
+  onEdit?: () => void;
 }
 
 // 날짜 포맷팅
@@ -31,7 +33,7 @@ const TYPE_LABELS: Record<string, string> = {
   BLENDED: '블렌디드',
 };
 
-export function CourseInfoSection({ course, categories }: Readonly<CourseInfoSectionProps>) {
+export function CourseInfoSection({ course, categories, onEdit }: Readonly<CourseInfoSectionProps>) {
   // categoryId로 카테고리 이름 찾기
   const getCategoryName = (categoryId: number | null): string => {
     if (!categoryId) return '-';
@@ -40,10 +42,18 @@ export function CourseInfoSection({ course, categories }: Readonly<CourseInfoSec
   };
   return (
     <div className="bg-bg-default border border-border rounded-lg p-6">
-      <h2 className="text-text-primary text-lg font-medium flex items-center gap-2 mb-4">
-        <FileText size={20} />
-        기본 정보
-      </h2>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-text-primary text-lg font-medium flex items-center gap-2">
+          <FileText size={20} />
+          기본 정보
+        </h2>
+        {onEdit && (
+          <Button variant="ghost" size="sm" onClick={onEdit} className="border border-border">
+            <Pencil size={14} />
+            수정
+          </Button>
+        )}
+      </div>
 
       <div className="space-y-6">
         {/* 썸네일 */}


### PR DESCRIPTION
## Summary
- "과정 신청" 버튼을 "과정 등록"으로 표기 변경
- 기본 정보/커리큘럼 박스 우상단에 수정 버튼 추가 (해당 step으로 즉시 이동)
- 커리큘럼 콘텐츠 미리보기 버튼 및 기능 추가

## 변경 내용

### 1. 버튼 텍스트 변경
- `CourseDetailPage.tsx`: "과정 신청" → "과정 등록"

### 2. 수정 버튼 추가
- `CourseInfoSection.tsx`: 기본 정보 박스에 수정 버튼 (→ Step 1)
- `CourseCurriculumSection.tsx`: 커리큘럼 박스에 수정 버튼 (→ Step 2)
- `CourseEditPage.tsx`: URL query param `?step=N` 지원

### 3. 콘텐츠 미리보기 기능
- `CourseCurriculumSection.tsx`: 콘텐츠 항목에 Eye 버튼 추가
- `CourseDetailPage.tsx`: `ContentPreviewModal` 통합, `useLearningObject` hook 사용

## Test plan
- [ ] 강의 상세 페이지에서 "과정 등록" 버튼 표시 확인
- [ ] 기본 정보 수정 버튼 클릭 → `/edit?step=1`로 이동 후 Step 1 표시 확인
- [ ] 커리큘럼 수정 버튼 클릭 → `/edit?step=2`로 이동 후 Step 2 표시 확인
- [ ] 커리큘럼 콘텐츠 Eye 버튼 클릭 → 미리보기 모달에서 콘텐츠 표시 확인

Closes #471