### PR TITLE
feat: 수강신청 완료 알림 클릭 시 학습 상세 페이지로 이동

### DIFF
--- a/src/routes/tu.b2b.routes.tsx
+++ b/src/routes/tu.b2b.routes.tsx
@@ -1,4 +1,4 @@
-import { Route, Outlet } from 'react-router-dom';
+import { Route, Outlet, Navigate, useParams } from 'react-router-dom';
 import { B2BMyPageLayout } from '@/components/layout';
 import { ProtectedRoute } from '@/components/common/ProtectedRoute';
 import { ProfileRequiredRoute } from '@/components/common/ProfileRequiredRoute';
@@ -88,6 +88,18 @@ function B2BInstructorProfilePage() {
       roadmapBasePath="/tu/b2b/roadmaps"
     />
   );
+}
+
+/**
+ * 레거시 /my-courses/:id 경로를 B2C 학습 상세 페이지로 리다이렉트
+ * 백엔드에서 보내는 알림 링크 호환성을 위해 추가 (id = enrollmentId)
+ */
+function MyCoursesRedirect() {
+  const { subdomain, id } = useParams<{ subdomain: string; id: string }>();
+  const targetPath = subdomain
+    ? `/${subdomain}/tu/b2c/mypage/learning/${id}`
+    : `/tu/b2c/mypage/learning/${id}`;
+  return <Navigate to={targetPath} replace />;
 }
 
 /**
@@ -204,5 +216,9 @@ export const tuB2bRoutes = (
     {/* 찜 목록 (독립 페이지 - 헤더/푸터만 있음) */}
     <Route path="/:subdomain/tu/b2b/wishlist" element={<B2BWishlistPage />} />
     <Route path="/tu/b2b/wishlist" element={<B2BWishlistPage />} />
+
+    {/* 레거시 경로 리다이렉트 - 백엔드 알림 링크 호환성 */}
+    <Route path="/:subdomain/my-courses/:id" element={<MyCoursesRedirect />} />
+    <Route path="/my-courses/:id" element={<MyCoursesRedirect />} />
   </>
 );

--- a/src/types/tu/notification.types.ts
+++ b/src/types/tu/notification.types.ts
@@ -151,6 +151,11 @@ function getCourseNotificationLink(
   _message?: string,
   metadata?: NotificationMetadata
 ): string | null {
+  // ENROLLMENT 타입이면 학습 상세 페이지로 직접 이동
+  if (referenceType === 'ENROLLMENT') {
+    return `/tu/b2c/mypage/learning/${referenceId}`;
+  }
+
   const courseTimeId = metadata?.courseTimeId;
 
   // courseTimeId가 있으면 해당 강의 페이지로
@@ -158,12 +163,12 @@ function getCourseNotificationLink(
     return `/tu/b2c/times/${courseTimeId}`;
   }
 
-  if (referenceType === 'COURSE') {
+  if (referenceType === 'COURSE' || referenceType === 'COURSE_TIME') {
     return `/tu/b2c/times/${referenceId}`;
   }
 
-  // enrollment의 경우 내 강의 목록으로
-  return '/tu/b2c/my-courses';
+  // 기타의 경우 내 강의 목록으로
+  return '/tu/b2c/mypage/learning';
 }
 
 function getAssignmentNotificationLink(


### PR DESCRIPTION
## Summary

백엔드 알림 링크(`/my-courses/:id`) 호환성을 위한 리다이렉트 라우트 추가 및 알림 딥링크 생성 로직 개선

## Related Issue

- Closes #

## Changes

- `/my-courses/:id` 경로를 `/tu/b2c/mypage/learning/:id`로 리다이렉트하는 라우트 추가
- `ENROLLMENT` referenceType 처리하여 enrollmentId 기반 딥링크 생성
- `COURSE_TIME` referenceType 지원 추가

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes

- 서브도메인 환경에서도 정상 동작 (예: `/company-a/my-courses/14` → `/company-a/tu/b2c/mypage/learning/14`)
- 백엔드에서 `enrollmentId`를 `referenceId`로 전달하도록 수정 필요 (별도 PR)