### PR TITLE
feat: 다중 역할 로그인 시 역할 선택 페이지 리다이렉트

### DIFF
--- a/src/components/landing/LandingCourseCard.tsx
+++ b/src/components/landing/LandingCourseCard.tsx
@@ -5,6 +5,7 @@ import { useSubdomainPath } from '@/hooks/common';
 import { useCheckWishlistStatus, useToggleWishlist } from '@/hooks/tu';
 import { useTenantFeatures } from '@/contexts/TenantFeaturesContext';
 import { toast } from 'sonner';
+import { getLoginPath } from '@/utils/tenantUtils';
 
 interface LandingCourseCardProps {
   id: number;
@@ -71,7 +72,7 @@ export function LandingCourseCard({
 
     if (!isAuthenticated) {
       toast.error('로그인이 필요합니다.');
-      navigate('/login', { state: { from: prefixPath(`/tu/b2c/courses/${id}`) } });
+      navigate(getLoginPath(), { state: { from: prefixPath(`/tu/b2c/courses/${id}`) } });
       return;
     }
 

--- a/src/components/layout/common/GlobalRoleSwitcher/GlobalRoleSwitcher.tsx
+++ b/src/components/layout/common/GlobalRoleSwitcher/GlobalRoleSwitcher.tsx
@@ -54,7 +54,9 @@ export function GlobalRoleSwitcher({
 
   // 사용자의 역할 가져오기 (현재는 단일 role, 향후 roles 배열로 확장 가능)
   const userRole = useAuthStore((state) => state.user?.role);
-  const userRoles = useAuthStore((state) => state.user?.roles) as string[] | undefined;
+  const userRolesRaw = useAuthStore((state) => state.user?.roles);
+  // Set이나 배열 모두 처리 가능하도록 Array.from 사용
+  const userRoles = userRolesRaw ? Array.from(userRolesRaw) as string[] : undefined;
 
   // 외부 클릭 시 드롭다운 닫기
   useEffect(() => {
@@ -70,34 +72,28 @@ export function GlobalRoleSwitcher({
 
   // 사용자가 가진 역할만 표시 (순서: 학습자 → 강사 → 교육 운영자 → 관리자)
   const availableRoles: GlobalRole[] = (() => {
-    // roles 배열이 있으면 사용 (1:N 관계 지원)
-    if (userRoles && userRoles.length > 0) {
-      const roles: GlobalRole[] = [];
-      // 사용자에게 부여된 역할에 따라 표시
-      if (userRoles.includes('USER')) {
-        roles.push('USER');
-      }
-      if (userRoles.includes('INSTRUCTOR') || userRoles.includes('DESIGNER')) {
-        roles.push('TU');
-      }
-      if (userRoles.includes('OPERATOR')) {
-        roles.push('CO');
-      }
-      if (userRoles.includes('TENANT_ADMIN')) {
-        roles.push('TA');
-      }
-      return roles;
+    const roles: GlobalRole[] = [];
+
+    // roles 배열 또는 단일 role을 기반으로 체크할 역할 목록 결정
+    const rolesToCheck = userRoles && userRoles.length > 0
+      ? userRoles
+      : (userRole ? [userRole] : []);
+
+    // 부여받은 역할만 표시 (USER 역할도 부여받은 경우에만)
+    if (rolesToCheck.includes('USER')) {
+      roles.push('USER');
+    }
+    if (rolesToCheck.includes('INSTRUCTOR') || rolesToCheck.includes('DESIGNER')) {
+      roles.push('TU');
+    }
+    if (rolesToCheck.includes('OPERATOR')) {
+      roles.push('CO');
+    }
+    if (rolesToCheck.includes('TENANT_ADMIN')) {
+      roles.push('TA');
     }
 
-    // 단일 role 기반 (기존 호환)
-    if (userRole === 'TENANT_ADMIN') {
-      return ['USER', 'TU', 'CO', 'TA'];
-    } else if (userRole === 'OPERATOR') {
-      return ['USER', 'TU', 'CO'];
-    } else {
-      // 기본: 현재 역할만 표시
-      return [currentRole];
-    }
+    return roles;
   })();
 
   const CurrentIcon = roleIcons[currentRole];

--- a/src/hooks/common/auth/useAuth.ts
+++ b/src/hooks/common/auth/useAuth.ts
@@ -38,6 +38,7 @@ export const useLogin = () => {
         email: userDetail.email,
         name: userDetail.name,
         role: userDetail.role,
+        roles: userDetail.roles,
         tenantId: userDetail.tenantId,
         tenantSubdomain: userDetail.tenantSubdomain,
       };
@@ -139,6 +140,7 @@ export const useMe = () => {
         email: userDetail.email,
         name: userDetail.name,
         role: userDetail.role,
+        roles: userDetail.roles,  // 다중 역할 (1:N) 동기화
         tenantId: userDetail.tenantId,
       });
       return userDetail;

--- a/src/hooks/common/useAuthQueries.ts
+++ b/src/hooks/common/useAuthQueries.ts
@@ -7,7 +7,6 @@ import { useAuthStore } from '@/store/common/authStore';
 import { authService } from '@/services/common/authService';
 import { userService } from '@/services/common/userService';
 import type { LoginRequest, RegisterRequest } from '@/types/common/auth.types';
-import { getLoginPath } from '@/utils/tenantUtils';
 
 // Query Keys
 export const authKeys = {
@@ -124,7 +123,18 @@ export const useLogout = () => {
   const queryClient = useQueryClient();
   const logout = useAuthStore((state) => state.logout);
   const refreshToken = useAuthStore((state) => state.refreshToken);
+  const user = useAuthStore((state) => state.user);
   const navigate = useNavigate();
+
+  // 로그아웃 전에 서브도메인 저장 (로그아웃 후에는 user 정보가 없어짐)
+  const getLogoutRedirectPath = () => {
+    const subdomain = user?.tenantSubdomain;
+    const isDefaultSubdomain = !subdomain || subdomain === 'default' || subdomain === 'www';
+    if (isDefaultSubdomain) {
+      return '/login';
+    }
+    return `/${subdomain}/login`;
+  };
 
   return useMutation({
     mutationFn: () => {
@@ -134,15 +144,17 @@ export const useLogout = () => {
       return authService.logout(refreshToken);
     },
     onSuccess: () => {
+      const redirectPath = getLogoutRedirectPath();
       logout();
       queryClient.clear();
-      navigate(getLoginPath());
+      navigate(redirectPath);
     },
     onError: () => {
       // 서버 에러가 나더라도 로컬 상태는 초기화
+      const redirectPath = getLogoutRedirectPath();
       logout();
       queryClient.clear();
-      navigate(getLoginPath());
+      navigate(redirectPath);
     },
   });
 };

--- a/src/hooks/common/useAuthQueries.ts
+++ b/src/hooks/common/useAuthQueries.ts
@@ -80,9 +80,13 @@ export const useLogin = () => {
         return;
       }
 
-      // 다중 역할을 가진 사용자는 역할 선택 페이지로 리다이렉트
+      // 다중 역할 체크: 관리자 역할 + USER 역할을 동시에 가진 경우 역할 선택 페이지로 리다이렉트
       const roles = userDetail.roles || [];
-      if (roles.length > 1) {
+      const adminLikeRoles = ['SYSTEM_ADMIN', 'TENANT_ADMIN', 'OPERATOR', 'DESIGNER', 'INSTRUCTOR'];
+      const hasAdminLikeRole = roles.some(role => adminLikeRoles.includes(role));
+      const hasUserRole = roles.includes('USER');
+
+      if (hasAdminLikeRole && hasUserRole) {
         const selectRolePath = `${subdomainPrefix}/select-role`;
         navigate(selectRolePath);
         return;

--- a/src/hooks/ta/useTenantNoticeQueries.ts
+++ b/src/hooks/ta/useTenantNoticeQueries.ts
@@ -176,3 +176,38 @@ export const useVisibleTenantNoticeCount = () => {
     queryFn: () => tenantNoticeService.countVisibleNotices(),
   });
 };
+
+// ============================================
+// 배포 통계 훅
+// ============================================
+
+/**
+ * 배포 통계 목록 조회
+ */
+export const useTenantNoticeDistributionStats = (params?: { page?: number; size?: number }) => {
+  return useQuery({
+    queryKey: [...tenantNoticeKeys.all, 'distribution-stats', params] as const,
+    queryFn: () => tenantNoticeService.getDistributionStats(params),
+  });
+};
+
+/**
+ * 배포 통계 요약 조회
+ */
+export const useTenantNoticeDistributionSummary = () => {
+  return useQuery({
+    queryKey: [...tenantNoticeKeys.all, 'distribution-summary'] as const,
+    queryFn: () => tenantNoticeService.getDistributionSummary(),
+  });
+};
+
+/**
+ * 특정 공지사항의 배포 상세 현황 조회
+ */
+export const useTenantNoticeDistributionDetail = (noticeId: number) => {
+  return useQuery({
+    queryKey: [...tenantNoticeKeys.all, 'distribution-detail', noticeId] as const,
+    queryFn: () => tenantNoticeService.getDistributionDetail(noticeId),
+    enabled: !!noticeId,
+  });
+};

--- a/src/hooks/ta/useUserQueries.ts
+++ b/src/hooks/ta/useUserQueries.ts
@@ -3,6 +3,8 @@
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { userService } from '@/services/ta';
+import { useAuthStore } from '@/store/common/authStore';
+import { authKeys } from '@/hooks/common/auth/useAuth';
 import type {
   UserListParams,
   UpdateUserDetailRequest,
@@ -104,6 +106,13 @@ export const useUpdateUserRoles = () => {
       queryClient.invalidateQueries({ queryKey: userKeys.detail(variables.id) });
       queryClient.invalidateQueries({ queryKey: userKeys.roles(variables.id) });
       queryClient.invalidateQueries({ queryKey: userKeys.lists() });
+
+      // 현재 로그인한 사용자의 역할이 변경된 경우 store 직접 업데이트
+      const currentUserId = useAuthStore.getState().user?.id;
+      if (currentUserId === variables.id) {
+        queryClient.invalidateQueries({ queryKey: authKeys.me() });
+        useAuthStore.getState().updateUser({ roles: variables.request.roles });
+      }
     },
   });
 };
@@ -119,6 +128,16 @@ export const useAddUserRole = () => {
       queryClient.invalidateQueries({ queryKey: userKeys.detail(variables.id) });
       queryClient.invalidateQueries({ queryKey: userKeys.roles(variables.id) });
       queryClient.invalidateQueries({ queryKey: userKeys.lists() });
+
+      // 현재 로그인한 사용자의 역할이 변경된 경우 store 직접 업데이트
+      const authState = useAuthStore.getState();
+      if (authState.user?.id === variables.id) {
+        queryClient.invalidateQueries({ queryKey: authKeys.me() });
+        const currentRoles = authState.user?.roles || [];
+        if (!currentRoles.includes(variables.role)) {
+          authState.updateUser({ roles: [...currentRoles, variables.role] });
+        }
+      }
     },
   });
 };
@@ -134,6 +153,14 @@ export const useRemoveUserRole = () => {
       queryClient.invalidateQueries({ queryKey: userKeys.detail(variables.id) });
       queryClient.invalidateQueries({ queryKey: userKeys.roles(variables.id) });
       queryClient.invalidateQueries({ queryKey: userKeys.lists() });
+
+      // 현재 로그인한 사용자의 역할이 변경된 경우 store 직접 업데이트
+      const authState = useAuthStore.getState();
+      if (authState.user?.id === variables.id) {
+        queryClient.invalidateQueries({ queryKey: authKeys.me() });
+        const currentRoles = authState.user?.roles || [];
+        authState.updateUser({ roles: currentRoles.filter(r => r !== variables.role) });
+      }
     },
   });
 };

--- a/src/pages/auth/RoleSelectionPage.tsx
+++ b/src/pages/auth/RoleSelectionPage.tsx
@@ -1,41 +1,67 @@
+import { useMemo } from 'react';
 import { motion } from 'framer-motion';
-import { ArrowRight, GraduationCap, Shield, Sparkles } from 'lucide-react';
+import { ArrowRight, GraduationCap, Shield, Sparkles, Settings, Pencil } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAuthStore } from '@/store/common/authStore';
 
 // 카드 데이터 타입
 interface CardData {
-  id: 'learner' | 'admin';
+  id: string;
   title: string;
   description: string;
   image: string;
   icon: React.ReactNode;
-  themeColor: 'blue' | 'purple';
+  themeColor: 'blue' | 'purple' | 'green' | 'orange';
   delay: number;
   path: string;
+  roles: string[]; // 이 카드를 표시할 역할들
 }
 
-// 카드 설정 데이터
-const CARD_DATA: CardData[] = [
+// 전체 카드 설정 데이터
+const ALL_CARD_DATA: CardData[] = [
   {
     id: 'learner',
     title: '학습자 모드',
-    description: '기업 교육 프로그램에 참여하고, 나의 학습 현황을 확인하세요.',
+    description: '교육 프로그램에 참여하고, 나의 학습 현황을 확인하세요.',
     image: 'https://images.unsplash.com/photo-1522202176988-66273c2fd55f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=1080',
     icon: <GraduationCap size={32} className="text-blue-400" />,
     themeColor: 'blue',
     delay: 0.3,
-    path: '/tu/b2b/mypage',
+    path: '/tu/b2c',
+    roles: ['USER'],
+  },
+  {
+    id: 'teaching',
+    title: '강사/디자이너 모드',
+    description: '강의를 제작하고, 교육 콘텐츠를 관리하세요.',
+    image: 'https://images.unsplash.com/photo-1524178232363-1fb2b075b655?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=1080',
+    icon: <Pencil size={32} className="text-green-400" />,
+    themeColor: 'green',
+    delay: 0.35,
+    path: '/tu/teaching',
+    roles: ['INSTRUCTOR', 'DESIGNER'],
+  },
+  {
+    id: 'operator',
+    title: '운영자 모드',
+    description: '교육 과정을 운영하고, 수강생을 관리하세요.',
+    image: 'https://images.unsplash.com/photo-1460925895917-afdab827c52f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=1080',
+    icon: <Settings size={32} className="text-orange-400" />,
+    themeColor: 'orange',
+    delay: 0.4,
+    path: '/co/dashboard',
+    roles: ['OPERATOR'],
   },
   {
     id: 'admin',
     title: '관리자 모드',
-    description: '테넌트 관리, 사용자 관리, 교육 과정 운영 등 관리 기능을 사용하세요.',
+    description: '테넌트 설정, 사용자 관리, 시스템 관리 기능을 사용하세요.',
     image: 'https://images.unsplash.com/photo-1553877522-43269d4ea984?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=1080',
     icon: <Shield size={32} className="text-purple-400" />,
     themeColor: 'purple',
-    delay: 0.4,
+    delay: 0.45,
     path: '/ta/dashboard',
+    roles: ['TENANT_ADMIN', 'SYSTEM_ADMIN'],
   },
 ];
 
@@ -47,7 +73,7 @@ interface SelectionCardProps {
   icon: React.ReactNode;
   onClick: () => void;
   delay: number;
-  themeColor: 'blue' | 'purple';
+  themeColor: 'blue' | 'purple' | 'green' | 'orange';
 }
 
 function SelectionCard({
@@ -62,11 +88,15 @@ function SelectionCard({
   const accentClasses = {
     blue: 'group-hover:shadow-blue-500/20 group-hover:border-blue-500/50',
     purple: 'group-hover:shadow-purple-500/20 group-hover:border-purple-500/50',
+    green: 'group-hover:shadow-green-500/20 group-hover:border-green-500/50',
+    orange: 'group-hover:shadow-orange-500/20 group-hover:border-orange-500/50',
   }[themeColor];
 
   const buttonClasses = {
     blue: 'bg-blue-600 hover:bg-blue-500',
     purple: 'bg-purple-600 hover:bg-purple-500',
+    green: 'bg-green-600 hover:bg-green-500',
+    orange: 'bg-orange-600 hover:bg-orange-500',
   }[themeColor];
 
   return (
@@ -133,6 +163,14 @@ export function RoleSelectionPage() {
     return path;
   };
 
+  // 사용자 역할에 맞는 카드만 필터링
+  const availableCards = useMemo(() => {
+    const userRoles = user?.roles || [];
+    return ALL_CARD_DATA.filter(card =>
+      card.roles.some(role => userRoles.includes(role as typeof userRoles[number]))
+    );
+  }, [user?.roles]);
+
   const handleSelect = (card: CardData) => {
     navigate(prefixPath(card.path));
   };
@@ -178,7 +216,7 @@ export function RoleSelectionPage() {
       </div>
 
       <div className="flex flex-col md:flex-row gap-6 w-full max-w-5xl z-10">
-        {CARD_DATA.map((card) => (
+        {availableCards.map((card, index) => (
           <SelectionCard
             key={card.id}
             title={card.title}
@@ -186,7 +224,7 @@ export function RoleSelectionPage() {
             image={card.image}
             icon={card.icon}
             onClick={() => handleSelect(card)}
-            delay={card.delay}
+            delay={0.3 + index * 0.1}
             themeColor={card.themeColor}
           />
         ))}

--- a/src/pages/ta/index.ts
+++ b/src/pages/ta/index.ts
@@ -18,4 +18,4 @@ export { TenantSettingsPage, UserManagementSettingsPage } from './settings';
 export { FeatureSettingsPage, TenantCategoryPage } from './features';
 
 // Notices
-export { TenantNoticesPage, SystemNoticesPage, NoticeInboxPage } from './notices';
+export { TenantNoticesPage, SystemNoticesPage, NoticeInboxPage, NoticeDistributionPage } from './notices';

--- a/src/pages/ta/notices/NoticeDistributionPage.tsx
+++ b/src/pages/ta/notices/NoticeDistributionPage.tsx
@@ -1,0 +1,341 @@
+import { useState } from 'react';
+import {
+  Send,
+  Users,
+  CheckCircle,
+  Eye,
+  Search,
+  ChevronLeft,
+  ChevronRight,
+  Pin,
+} from 'lucide-react';
+import { AdminPageHeader } from '@/components/domain/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Badge } from '@/components/common/Badge';
+import { Progress } from '@/components/common/Progress';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/common/Dialog';
+import {
+  useTenantNoticeDistributionStats,
+  useTenantNoticeDistributionSummary,
+  useTenantNoticeDistributionDetail,
+} from '@/hooks/ta/useTenantNoticeQueries';
+import type { TenantNoticeType, NoticeTargetAudience, UserDistributionInfo } from '@/types/ta/tenantNotice.types';
+
+const typeConfig: Record<TenantNoticeType, { label: string; color: string }> = {
+  GENERAL: { label: '일반', color: 'bg-gray-100 text-gray-700' },
+  IMPORTANT: { label: '중요', color: 'bg-blue-100 text-blue-700' },
+  URGENT: { label: '긴급', color: 'bg-red-100 text-red-700' },
+  EVENT: { label: '이벤트', color: 'bg-purple-100 text-purple-700' },
+};
+
+const audienceConfig: Record<NoticeTargetAudience, string> = {
+  ALL: '전체',
+  OPERATOR: '운영자',
+  USER: '사용자',
+  DESIGNER: '설계자',
+  INSTRUCTOR: '강사',
+};
+
+export function NoticeDistributionPage() {
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [page, setPage] = useState(0);
+  const [selectedNotice, setSelectedNotice] = useState<number | null>(null);
+
+  const { data: statsData, isLoading } = useTenantNoticeDistributionStats({ page, size: 10 });
+  const { data: summary } = useTenantNoticeDistributionSummary();
+  const { data: noticeDetail } = useTenantNoticeDistributionDetail(selectedNotice || 0);
+
+  const distributions = statsData?.content || [];
+  const totalPages = statsData?.totalPages || 0;
+
+  const filteredDistributions = distributions.filter((dist) =>
+    dist.noticeTitle.toLowerCase().includes(searchKeyword.toLowerCase())
+  );
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return '-';
+    return new Date(dateString).toLocaleString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+          <div className="grid grid-cols-4 gap-4">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="h-24 bg-gray-200 rounded"></div>
+            ))}
+          </div>
+          <div className="h-64 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="공지사항 배포 관리"
+        description="공지사항의 사용자별 배포 현황을 관리합니다"
+      />
+
+      {/* Stats Summary */}
+      <div className="grid grid-cols-4 gap-4 mb-6">
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-brand-primary/10 rounded-lg">
+                <Send className="h-5 w-5 text-brand-primary" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{summary?.totalDistributions || 0}</p>
+                <p className="text-sm text-text-secondary">전체 배포</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-green-100 rounded-lg">
+                <CheckCircle className="h-5 w-5 text-green-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{summary?.completedCount || 0}</p>
+                <p className="text-sm text-text-secondary">발행 완료</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-blue-100 rounded-lg">
+                <Eye className="h-5 w-5 text-blue-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{summary?.totalReadCount || 0}</p>
+                <p className="text-sm text-text-secondary">총 열람</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-yellow-100 rounded-lg">
+                <Users className="h-5 w-5 text-yellow-600" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{summary?.totalTargetUsers || 0}</p>
+                <p className="text-sm text-text-secondary">대상 사용자</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Average Read Rate */}
+      {summary && summary.averageReadRate > 0 && (
+        <Card className="mb-6">
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm font-medium">평균 열람율</span>
+              <span className="text-sm font-bold">{summary.averageReadRate.toFixed(1)}%</span>
+            </div>
+            <Progress value={summary.averageReadRate} className="h-2" />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Distribution List */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>배포 현황</CardTitle>
+              <CardDescription>공지사항별 배포 및 열람 현황입니다</CardDescription>
+            </div>
+            <div className="relative w-64">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-secondary" />
+              <Input
+                placeholder="공지 검색..."
+                value={searchKeyword}
+                onChange={(e) => setSearchKeyword(e.target.value)}
+                className="pl-9"
+              />
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {filteredDistributions.length === 0 ? (
+            <div className="text-center py-12 text-text-secondary">
+              <Send className="h-12 w-12 mx-auto mb-4 opacity-50" />
+              <p>배포된 공지사항이 없습니다.</p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {filteredDistributions.map((dist) => {
+                const typeConf = typeConfig[dist.noticeType] || typeConfig.GENERAL;
+                const sentPercent = dist.totalUsers > 0 ? (dist.sentCount / dist.totalUsers) * 100 : 0;
+                const readPercent = dist.sentCount > 0 ? (dist.readCount / dist.sentCount) * 100 : 0;
+
+                return (
+                  <div key={dist.noticeId} className="p-4 border rounded-lg hover:bg-bg-secondary">
+                    <div className="flex items-center justify-between mb-3">
+                      <div className="flex items-center gap-2">
+                        {dist.isPinned && <Pin className="h-4 w-4 text-yellow-500" />}
+                        <h3 className="font-medium">{dist.noticeTitle}</h3>
+                        <Badge className={typeConf.color}>{typeConf.label}</Badge>
+                        <Badge variant="outline">{audienceConfig[dist.targetAudience]}</Badge>
+                      </div>
+                      <span className="text-sm text-text-secondary">
+                        {formatDate(dist.publishedAt)}
+                      </span>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <div className="flex justify-between text-sm mb-1">
+                          <span className="text-text-secondary">발송 현황</span>
+                          <span>{dist.sentCount} / {dist.totalUsers} 명</span>
+                        </div>
+                        <Progress value={sentPercent} className="h-2" />
+                      </div>
+                      <div>
+                        <div className="flex justify-between text-sm mb-1">
+                          <span className="text-text-secondary">열람율</span>
+                          <span>{dist.readCount} / {dist.sentCount} ({readPercent.toFixed(0)}%)</span>
+                        </div>
+                        <Progress value={readPercent} className="h-2" />
+                      </div>
+                    </div>
+
+                    <div className="flex justify-end mt-3">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setSelectedNotice(dist.noticeId)}
+                      >
+                        <Eye className="h-4 w-4 mr-1" />
+                        상세 보기
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 mt-6">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page === 0}
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <span className="text-sm">
+                {page + 1} / {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages - 1}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Detail Dialog */}
+      <Dialog open={selectedNotice !== null} onOpenChange={() => setSelectedNotice(null)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>배포 상세 현황</DialogTitle>
+            <DialogDescription>
+              {noticeDetail?.noticeTitle}
+            </DialogDescription>
+          </DialogHeader>
+
+          {noticeDetail && (
+            <div className="space-y-4">
+              {/* Summary */}
+              <div className="grid grid-cols-3 gap-4">
+                <div className="p-3 bg-bg-secondary rounded-lg text-center">
+                  <p className="text-2xl font-bold">{noticeDetail.sentCount}</p>
+                  <p className="text-sm text-text-secondary">배포됨</p>
+                </div>
+                <div className="p-3 bg-bg-secondary rounded-lg text-center">
+                  <p className="text-2xl font-bold">{noticeDetail.readCount}</p>
+                  <p className="text-sm text-text-secondary">열람</p>
+                </div>
+                <div className="p-3 bg-bg-secondary rounded-lg text-center">
+                  <p className="text-2xl font-bold">
+                    {noticeDetail.sentCount > 0
+                      ? ((noticeDetail.readCount / noticeDetail.sentCount) * 100).toFixed(0)
+                      : 0}%
+                  </p>
+                  <p className="text-sm text-text-secondary">열람율</p>
+                </div>
+              </div>
+
+              {/* User List */}
+              <div className="border rounded-lg max-h-80 overflow-y-auto">
+                <table className="w-full">
+                  <thead className="bg-bg-secondary sticky top-0">
+                    <tr>
+                      <th className="px-4 py-2 text-left text-sm font-medium">사용자</th>
+                      <th className="px-4 py-2 text-left text-sm font-medium">이메일</th>
+                      <th className="px-4 py-2 text-left text-sm font-medium">역할</th>
+                      <th className="px-4 py-2 text-center text-sm font-medium">상태</th>
+                      <th className="px-4 py-2 text-left text-sm font-medium">열람일시</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {noticeDetail.userDistributions.map((user: UserDistributionInfo) => (
+                      <tr key={user.userId} className="border-t">
+                        <td className="px-4 py-2 text-sm">{user.userName}</td>
+                        <td className="px-4 py-2 text-sm text-text-secondary">{user.userEmail}</td>
+                        <td className="px-4 py-2 text-sm">{user.userRole}</td>
+                        <td className="px-4 py-2 text-center">
+                          {user.isRead ? (
+                            <Badge className="bg-green-100 text-green-700">읽음</Badge>
+                          ) : (
+                            <Badge className="bg-gray-100 text-gray-600">미읽음</Badge>
+                          )}
+                        </td>
+                        <td className="px-4 py-2 text-sm">{formatDate(user.readAt)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/ta/notices/index.ts
+++ b/src/pages/ta/notices/index.ts
@@ -1,3 +1,4 @@
 export { TenantNoticesPage } from './TenantNoticesPage';
 export { SystemNoticesPage } from './SystemNoticesPage';
 export { NoticeInboxPage } from './NoticeInboxPage';
+export { NoticeDistributionPage } from './NoticeDistributionPage';

--- a/src/pages/tu/b2b/components/B2BCourseCard.tsx
+++ b/src/pages/tu/b2b/components/B2BCourseCard.tsx
@@ -4,6 +4,7 @@ import { useSubdomainPath } from '@/hooks/common';
 import { useAuthStore } from '@/store/common/authStore';
 import { useCheckWishlistStatus, useToggleWishlist } from '@/hooks/tu';
 import { toast } from 'sonner';
+import { getLoginPath } from '@/utils/tenantUtils';
 
 interface B2BCourseCardProps {
   id: number;
@@ -64,7 +65,7 @@ export function B2BCourseCard({
 
     if (!isAuthenticated) {
       toast.error('로그인이 필요합니다.');
-      navigate('/login', { state: { from: prefixPath(`/tu/b2b/times/${id}`) } });
+      navigate(getLoginPath(), { state: { from: prefixPath(`/tu/b2b/times/${id}`) } });
       return;
     }
 

--- a/src/pages/tu/main/CoursesExplorePage.tsx
+++ b/src/pages/tu/main/CoursesExplorePage.tsx
@@ -8,6 +8,7 @@ import { useCourseTimeCatalog, useCheckWishlistStatus, useToggleWishlist } from 
 import { useAuthStore } from '@/store/common/authStore';
 import { useSubdomainPath } from '@/hooks/common';
 import { toast } from 'sonner';
+import { getLoginPath } from '@/utils/tenantUtils';
 import type {
   CourseTimeCatalogResponse,
   CourseTimeCatalogParams,
@@ -93,7 +94,7 @@ function CourseTimeCard({ courseTime, isDark }: CourseTimeCardProps) {
 
     if (!isAuthenticated) {
       toast.error('로그인이 필요합니다.');
-      navigate('/login', { state: { from: prefixPath(`/tu/b2c/times/${courseTime.id}`) } });
+      navigate(getLoginPath(), { state: { from: prefixPath(`/tu/b2c/times/${courseTime.id}`) } });
       return;
     }
 

--- a/src/pages/tu/main/NotificationsPage.tsx
+++ b/src/pages/tu/main/NotificationsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, ComponentType } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useSubdomainPath } from '@/hooks/common';
-import { Bell, CheckCheck, Trash2, Settings, Heart, MessageSquare, BookOpen, Megaphone, Loader2, FileText, AlertCircle, ChevronRight } from 'lucide-react';
+import { Bell, CheckCheck, Trash2, Settings, Heart, MessageSquare, BookOpen, Megaphone, Loader2, FileText, AlertCircle, ChevronRight, Zap } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
 import { LandingHeader } from '@/components/landing/LandingHeader';
 import { LandingFooter } from '@/components/landing/LandingFooter';
@@ -15,16 +15,17 @@ interface NotificationsPageProps {
 }
 import { useNotifications, useMarkAsRead, useMarkAllAsRead, useDeleteNotification, useDeleteReadNotifications, useUserNotice } from '@/hooks/tu';
 import type { NotificationType, NotificationItem } from '@/types/tu';
-import { getNotificationDeepLink } from '@/types/tu';
+import { getNotificationDeepLink, getDisplayNotificationType } from '@/types/tu';
 import { useAuthStore } from '@/store/common/authStore';
 
-// 알림 타입별 필터 옵션
+// 알림 타입별 필터 옵션 (NOTICE: 공지사항, SYSTEM: 시스템 알림 트리거)
 const notificationTypes: { id: NotificationType | 'all'; label: string }[] = [
   { id: 'all', label: '전체' },
   { id: 'COMMENT', label: '댓글' },
   { id: 'LIKE', label: '좋아요' },
   { id: 'COURSE', label: '강의' },
-  { id: 'SYSTEM', label: '공지사항' },
+  { id: 'NOTICE', label: '공지사항' },
+  { id: 'SYSTEM', label: '시스템' },
   { id: 'ASSIGNMENT', label: '과제' },
 ];
 
@@ -34,7 +35,8 @@ const getNotificationIcon = (type: NotificationType) => {
     case 'COMMENT': return MessageSquare;
     case 'LIKE': return Heart;
     case 'COURSE': return BookOpen;
-    case 'SYSTEM': return Megaphone;
+    case 'NOTICE': return Megaphone;  // 공지사항은 메가폰
+    case 'SYSTEM': return Zap;        // 시스템 알림은 번개
     case 'ASSIGNMENT': return FileText;
     default: return AlertCircle;
   }
@@ -46,7 +48,8 @@ const getIconColor = (type: NotificationType) => {
     case 'COMMENT': return 'text-[#10b981] bg-[#10b981]/20';
     case 'LIKE': return 'text-[#f43f5e] bg-[#f43f5e]/20';
     case 'COURSE': return 'text-[#6778ff] bg-[#6778ff]/20';
-    case 'SYSTEM': return 'text-[#f59e0b] bg-[#f59e0b]/20';
+    case 'NOTICE': return 'text-[#f59e0b] bg-[#f59e0b]/20';  // 공지사항은 amber
+    case 'SYSTEM': return 'text-[#64748b] bg-[#64748b]/20';  // 시스템은 slate
     case 'ASSIGNMENT': return 'text-[#8b5cf6] bg-[#8b5cf6]/20';
     default: return 'text-gray-400 bg-gray-400/20';
   }
@@ -131,16 +134,18 @@ export function NotificationsPage({
   const [activeType, setActiveType] = useState<NotificationType | 'all'>('all');
   const { isAuthenticated } = useAuthStore();
 
-  // URL 쿼리 파라미터로 탭 설정 (예: ?tab=SYSTEM)
+  // URL 쿼리 파라미터로 탭 설정 (예: ?tab=NOTICE)
   useEffect(() => {
-    if (tabParam && ['COMMENT', 'LIKE', 'COURSE', 'SYSTEM', 'ASSIGNMENT'].includes(tabParam)) {
+    if (tabParam && ['COMMENT', 'LIKE', 'COURSE', 'NOTICE', 'SYSTEM', 'ASSIGNMENT'].includes(tabParam)) {
       setActiveType(tabParam as NotificationType);
     }
   }, [tabParam]);
 
-  // React Query 훅
-  const filter = activeType === 'all' ? undefined : { type: activeType };
-  const { data: apiNotificationData, isLoading, error } = useNotifications(filter);
+  // React Query 훅 - NOTICE/SYSTEM 필터는 프론트에서 처리 (백엔드는 SYSTEM 타입만 있음)
+  const backendFilter = activeType === 'all' ? undefined
+    : activeType === 'NOTICE' || activeType === 'SYSTEM' ? { type: 'SYSTEM' as NotificationType }
+    : { type: activeType };
+  const { data: apiNotificationData, isLoading, error } = useNotifications(backendFilter);
   const markAsReadMutation = useMarkAsRead();
   const markAllAsReadMutation = useMarkAllAsRead();
   const deleteNotificationMutation = useDeleteNotification();
@@ -149,10 +154,10 @@ export function NotificationsPage({
   // 실제 사용할 데이터 결정
   const allNotifications = apiNotificationData?.notifications || [];
 
-  // 필터링 적용
+  // 필터링 적용 (getDisplayNotificationType으로 NOTICE/SYSTEM 구분)
   const filteredNotifications = activeType === 'all'
     ? allNotifications
-    : allNotifications.filter(n => n.type === activeType);
+    : allNotifications.filter(n => getDisplayNotificationType(n) === activeType);
 
   const unreadCount = allNotifications.filter(n => !n.isRead).length;
 
@@ -333,7 +338,8 @@ export function NotificationsPage({
         ) : (
           <div className="space-y-3">
             {filteredNotifications.map((notification) => {
-              const IconComponent = getNotificationIcon(notification.type);
+              const displayType = getDisplayNotificationType(notification);
+              const IconComponent = getNotificationIcon(displayType);
               const deepLink = getNotificationDeepLink(notification);
               return (
                 <div
@@ -350,13 +356,13 @@ export function NotificationsPage({
                       : 'bg-white border-gray-200 hover:bg-gray-50'
                   } ${!notification.isRead ? 'border-l-4 border-l-[#6778ff]' : ''}`}
                 >
-                  <div className={`w-12 h-12 rounded-full flex items-center justify-center ${getIconColor(notification.type)}`}>
+                  <div className={`w-12 h-12 rounded-full flex items-center justify-center ${getIconColor(displayType)}`}>
                     <IconComponent className="w-6 h-6" />
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-start justify-between gap-4">
-                      {/* SYSTEM 알림이고 NOTICE 참조인 경우 실제 공지 데이터 표시 */}
-                      {notification.type === 'SYSTEM' ? (
+                      {/* NOTICE 타입 (공지사항)인 경우 실제 공지 데이터 표시 */}
+                      {displayType === 'NOTICE' ? (
                         <SystemNotificationContent notification={notification} isDark={isDark} />
                       ) : (
                         <div>

--- a/src/pages/tu/mypage/MyPage.tsx
+++ b/src/pages/tu/mypage/MyPage.tsx
@@ -22,6 +22,7 @@ import { useThemeStore } from '@/store/common/themeStore';
 import { useSubdomainPath } from '@/hooks/common/useSubdomainPath';
 import { Button, Card, CardContent, Badge } from '@/components/common';
 import type { EnrollmentStatus } from '@/services/tu/enrollmentService';
+import { getLoginPath } from '@/utils/tenantUtils';
 
 const statusLabels: Record<EnrollmentStatus, string> = {
   PENDING: '승인 대기',
@@ -115,7 +116,7 @@ export function MyPage() {
             <p className={`mb-6 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
               마이페이지를 이용하시려면 로그인해주세요
             </p>
-            <Button onClick={() => navigate('/login')}>로그인하기</Button>
+            <Button onClick={() => navigate(getLoginPath())}>로그인하기</Button>
           </div>
         </div>
         <LandingFooter />

--- a/src/pages/tu/mypage/MyPageHome.tsx
+++ b/src/pages/tu/mypage/MyPageHome.tsx
@@ -16,6 +16,7 @@ import {
   Globe,
   Loader2,
   Camera,
+  AlertTriangle,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/common/auth';
@@ -284,6 +285,41 @@ export function MyPageHome() {
             </div>
           </div>
         </section>
+
+        {/* 부서/직급 미입력 안내 배너 */}
+        {profile && (!profile.department || !profile.position) && (
+          <section className="mb-8">
+            <button
+              onClick={() => navigate(prefixPath('/tu/b2c/mypage/profile'))}
+              className={`w-full p-4 rounded-xl flex items-center gap-4 transition-all hover:scale-[1.01] ${
+                isDark
+                  ? 'bg-amber-500/10 border border-amber-500/30 hover:bg-amber-500/20'
+                  : 'bg-amber-50 border border-amber-200 hover:bg-amber-100'
+              }`}
+            >
+              <div
+                className={`w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 ${
+                  isDark ? 'bg-amber-500/20' : 'bg-amber-100'
+                }`}
+              >
+                <AlertTriangle className={`w-5 h-5 ${isDark ? 'text-amber-400' : 'text-amber-600'}`} />
+              </div>
+              <div className="flex-1 text-left">
+                <p className={`font-medium ${isDark ? 'text-amber-300' : 'text-amber-800'}`}>
+                  {language === 'ko'
+                    ? '부서와 직급 정보를 입력해 주세요'
+                    : 'Please enter your department and position'}
+                </p>
+                <p className={`text-sm ${isDark ? 'text-amber-400/70' : 'text-amber-600'}`}>
+                  {language === 'ko'
+                    ? '프로필 정보를 완성하면 더 나은 학습 경험을 제공받을 수 있습니다.'
+                    : 'Complete your profile for a better learning experience.'}
+                </p>
+              </div>
+              <ChevronRight className={`w-5 h-5 flex-shrink-0 ${isDark ? 'text-amber-400' : 'text-amber-600'}`} />
+            </button>
+          </section>
+        )}
 
         {/* 학습 통계 */}
         <section className="mb-8">

--- a/src/routes/ta.routes.tsx
+++ b/src/routes/ta.routes.tsx
@@ -23,6 +23,7 @@ import {
   TenantNoticesPage,
   SystemNoticesPage,
   NoticeInboxPage,
+  NoticeDistributionPage,
 } from '@/pages/ta';
 import { EmployeeListPage } from '@/pages/ta/users/EmployeeListPage';
 import { AutoEnrollmentRulesPage } from '@/pages/ta/automation/AutoEnrollmentRulesPage';
@@ -67,6 +68,7 @@ const taChildRoutes = (
     {/* 공지사항 관리 */}
     <Route path="notices" element={<NoticeInboxPage />} />
     <Route path="notices/manage" element={<TenantNoticesPage />} />
+    <Route path="notices/distribution" element={<NoticeDistributionPage />} />
     <Route path="notices/system" element={<SystemNoticesPage />} />
     {/* 설정 */}
     <Route path="settings" element={<SettingsPage />} />

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -411,6 +411,10 @@ export const API_ENDPOINTS = {
     BY_ID: (id: number) => `/tenant/notices/${id}`,
     PUBLISH: (id: number) => `/tenant/notices/${id}/publish`,
     ARCHIVE: (id: number) => `/tenant/notices/${id}/archive`,
+    // 배포 통계
+    DISTRIBUTION_STATS: '/tenant/notices/distribution/stats',
+    DISTRIBUTION_SUMMARY: '/tenant/notices/distribution/summary',
+    DISTRIBUTION_BY_ID: (id: number) => `/tenant/notices/${id}/distribution`,
     // TU/TO 조회용
     TU_BASE: '/tu/notices',
     TU_BY_ID: (id: number) => `/tu/notices/${id}`,

--- a/src/services/ta/tenantNoticeService.ts
+++ b/src/services/ta/tenantNoticeService.ts
@@ -10,6 +10,9 @@ import type {
   TenantNoticeSearchParams,
   CreateTenantNoticeRequest,
   UpdateTenantNoticeRequest,
+  TenantNoticeDistributionStatsResponse,
+  TenantNoticeDistributionSummary,
+  TenantNoticeDistributionDetail,
 } from '@/types/ta/tenantNotice.types';
 
 /**
@@ -146,6 +149,41 @@ export const tenantNoticeService = {
   async countVisibleNotices(): Promise<number> {
     const { data } = await axiosInstance.get<number>(
       API_ENDPOINTS.TENANT_NOTICES.TU_COUNT
+    );
+    return data;
+  },
+
+  // ============================================
+  // 배포 통계 API
+  // ============================================
+
+  /**
+   * 배포 통계 목록 조회
+   */
+  async getDistributionStats(params?: { page?: number; size?: number }): Promise<TenantNoticeDistributionStatsResponse> {
+    const { data } = await axiosInstance.get<TenantNoticeDistributionStatsResponse>(
+      API_ENDPOINTS.TENANT_NOTICES.DISTRIBUTION_STATS,
+      { params }
+    );
+    return data;
+  },
+
+  /**
+   * 배포 통계 요약 조회
+   */
+  async getDistributionSummary(): Promise<TenantNoticeDistributionSummary> {
+    const { data } = await axiosInstance.get<TenantNoticeDistributionSummary>(
+      API_ENDPOINTS.TENANT_NOTICES.DISTRIBUTION_SUMMARY
+    );
+    return data;
+  },
+
+  /**
+   * 특정 공지사항의 배포 상세 현황 조회
+   */
+  async getDistributionDetail(noticeId: number): Promise<TenantNoticeDistributionDetail> {
+    const { data } = await axiosInstance.get<TenantNoticeDistributionDetail>(
+      API_ENDPOINTS.TENANT_NOTICES.DISTRIBUTION_BY_ID(noticeId)
     );
     return data;
   },

--- a/src/types/ta/tenantNotice.types.ts
+++ b/src/types/ta/tenantNotice.types.ts
@@ -63,3 +63,61 @@ export interface UpdateTenantNoticeRequest {
   isPinned?: boolean;
   expiredAt?: string;
 }
+
+// ============================================
+// 배포 통계 관련 타입
+// ============================================
+
+/** 사용자별 배포 정보 */
+export interface UserDistributionInfo {
+  userId: number;
+  userName: string;
+  userEmail: string;
+  userRole: string;
+  isRead: boolean;
+  distributedAt: string;
+  readAt: string | null;
+}
+
+/** 공지사항별 배포 통계 */
+export interface TenantNoticeDistributionStats {
+  noticeId: number;
+  noticeTitle: string;
+  noticeType: TenantNoticeType;
+  targetAudience: NoticeTargetAudience;
+  isPinned: boolean;
+  publishedAt: string | null;
+  totalUsers: number;    // 대상 사용자 수
+  sentCount: number;     // 발송된 수
+  readCount: number;     // 열람한 수
+}
+
+/** 배포 통계 목록 응답 */
+export interface TenantNoticeDistributionStatsResponse {
+  content: TenantNoticeDistributionStats[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+}
+
+/** 배포 통계 요약 */
+export interface TenantNoticeDistributionSummary {
+  totalDistributions: number;  // 총 배포 건수
+  completedCount: number;      // 발행 완료 건수
+  totalReadCount: number;      // 총 열람 수
+  totalTargetUsers: number;    // 총 대상 사용자 수
+  averageReadRate: number;     // 평균 열람율 (%)
+}
+
+/** 특정 공지사항의 상세 배포 현황 */
+export interface TenantNoticeDistributionDetail {
+  noticeId: number;
+  noticeTitle: string;
+  noticeType: TenantNoticeType;
+  targetAudience: NoticeTargetAudience;
+  publishedAt: string | null;
+  sentCount: number;
+  readCount: number;
+  userDistributions: UserDistributionInfo[];
+}

--- a/src/types/tu/index.ts
+++ b/src/types/tu/index.ts
@@ -137,6 +137,7 @@ export {
   NOTIFICATION_TYPE_LABELS,
   NOTIFICATION_TYPE_COLORS,
   getNotificationDeepLink,
+  getDisplayNotificationType,
 } from './notification.types';
 
 // Course Explore (강의 탐색)

--- a/src/types/tu/notification.types.ts
+++ b/src/types/tu/notification.types.ts
@@ -7,8 +7,21 @@ export type NotificationType =
   | 'COMMENT'     // 댓글 알림
   | 'LIKE'        // 좋아요 알림
   | 'COURSE'      // 강의 관련 알림
-  | 'SYSTEM'      // 시스템 알림
+  | 'SYSTEM'      // 시스템 알림 (트리거 - 웰컴, 수강완료 등)
+  | 'NOTICE'      // 공지사항 알림
   | 'ASSIGNMENT'; // 과제 알림
+
+/**
+ * 백엔드 SYSTEM 타입 알림을 공지사항/시스템으로 분류
+ * - referenceType이 'NOTICE'면 공지사항
+ * - 그 외는 시스템 트리거 (웰컴 메시지, 수강완료 등)
+ */
+export function getDisplayNotificationType(notification: NotificationItem): NotificationType {
+  if (notification.type === 'SYSTEM' && notification.referenceType === 'NOTICE') {
+    return 'NOTICE';
+  }
+  return notification.type;
+}
 
 // 알림 메타데이터 (타입별 추가 정보)
 export interface NotificationMetadata {
@@ -77,7 +90,8 @@ export const NOTIFICATION_TYPE_LABELS: Record<NotificationType, string> = {
   COMMENT: '댓글',
   LIKE: '좋아요',
   COURSE: '강의',
-  SYSTEM: '공지사항',
+  SYSTEM: '시스템',
+  NOTICE: '공지사항',
   ASSIGNMENT: '과제',
 };
 
@@ -86,7 +100,8 @@ export const NOTIFICATION_TYPE_COLORS: Record<NotificationType, string> = {
   COMMENT: 'emerald',
   LIKE: 'rose',
   COURSE: 'blue',
-  SYSTEM: 'amber',
+  SYSTEM: 'slate',      // 시스템 알림은 회색 계열
+  NOTICE: 'amber',      // 공지사항은 amber (기존 SYSTEM 색상)
   ASSIGNMENT: 'purple',
 };
 
@@ -136,6 +151,7 @@ export function getNotificationDeepLink(notification: NotificationItem): string 
     case 'ASSIGNMENT':
       return getAssignmentNotificationLink(referenceType, referenceId, message);
     case 'SYSTEM':
+    case 'NOTICE':
       return getSystemNotificationLink(referenceType, referenceId);
     case 'COMMENT':
     case 'LIKE':

--- a/src/utils/tenantUtils.ts
+++ b/src/utils/tenantUtils.ts
@@ -22,12 +22,13 @@ export interface TenantIdentifier {
  * /mzc/login → 'mzc'
  * /mzc/register → 'mzc'
  * /mzc/admin/login → 'mzc'
+ * /mzc/select-role → 'mzc'
  */
 export function extractSubdomainFromPath(): string | null {
   const pathname = window.location.pathname;
 
-  // 경로 기반 서브도메인 패턴: /{subdomain}/(tu|ta|co|admin)/... 또는 /{subdomain}/(login|register)
-  const regex = /^\/([^/]+)\/(tu|ta|co|admin|login|register)(\/|$)/;
+  // 경로 기반 서브도메인 패턴: /{subdomain}/(tu|ta|co|admin|login|register|select-role)/...
+  const regex = /^\/([^/]+)\/(tu|ta|co|admin|login|register|select-role)(\/|$)/;
   const match = regex.exec(pathname);
   const subdomain = match?.[1];
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  optimizeDeps: {
+    force: true,
+  },
   server: {
     port: 3000,
     proxy: {


### PR DESCRIPTION
## Summary

관리자 역할(SA, TA, CO, DESIGNER, INSTRUCTOR)과 USER 역할을 동시에 가진 사용자가 로그인할 때 역할 선택 페이지로 리다이렉트하여 진입할 모드를 선택할 수 있도록 합니다.

## Related Issue

- Closes #479

## Changes

- 로그인 시 다중 역할(관리자 + USER) 체크 로직 추가
- RoleSelectionPage 4가지 모드 카드 추가 (학습자, 강사/디자이너, 운영자, 관리자)
- 사용자 역할에 따른 카드 필터링 기능 구현
- 로그아웃 시 서브도메인 유지하도록 수정
- extractSubdomainFromPath에 select-role 경로 패턴 추가
- GlobalRoleSwitcher 다중 역할 지원 개선

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

N/A

## Additional Notes

- 백엔드 PR과 함께 머지 필요