### PR TITLE
[Feat] 역할 전환 API 연동 및 currentRole 기반 권한 체크

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
         "embla-carousel-react": "^8.6.0",
+        "framer-motion": "^12.26.2",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.487.0",
         "motion": "^12.26.2",
@@ -198,7 +199,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -548,7 +548,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -592,7 +591,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -620,7 +618,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -4156,7 +4153,6 @@
       "resolved": "https://registry.npmjs.org/@svta/cml-xml/-/cml-xml-1.0.1.tgz",
       "integrity": "sha512-11LkJa5kDEcsRMWkVI1ABH3KLCxGoiSVe4kQ293ItVj8ncTTQ7htmCGiJDjS+Cmy35UgF3e/vc0ysJIiWRTx2g==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -4318,7 +4314,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4465,7 +4462,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4476,7 +4472,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4532,7 +4527,6 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -4891,7 +4885,6 @@
       "integrity": "sha512-rkoPH+RqWopVxDnCBE/ysIdfQ2A7j1eDmW8tCxxrR9nnFBa9jKf86VgsSAzxBd1x+ny0GC4JgiD3SNfRHv3pOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.16",
         "fflate": "^0.8.2",
@@ -4935,7 +4928,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5322,7 +5314,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5980,7 +5971,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6007,8 +5999,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -6185,7 +6176,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7233,7 +7223,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7263,7 +7252,6 @@
       "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.7.2",
         "cssstyle": "^5.3.1",
@@ -7480,6 +7468,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8120,7 +8109,6 @@
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
       "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -8268,7 +8256,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8434,6 +8421,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8449,6 +8437,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8461,7 +8450,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8532,7 +8522,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8563,7 +8552,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8608,8 +8596,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
       "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-pdf": {
       "version": "10.3.0",
@@ -8680,7 +8667,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -8912,8 +8898,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -9668,7 +9653,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9806,7 +9790,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10025,7 +10008,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10119,7 +10101,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10133,7 +10114,6 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.6.0",
+    "framer-motion": "^12.26.2",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.487.0",
     "motion": "^12.26.2",

--- a/src/components/common/ProtectedRoute/ProtectedRoute.tsx
+++ b/src/components/common/ProtectedRoute/ProtectedRoute.tsx
@@ -24,7 +24,7 @@ export function ProtectedRoute({
   redirectTo = '/login',
 }: ProtectedRouteProps) {
   const location = useLocation();
-  const { isAuthenticated, user } = useAuthStore();
+  const { isAuthenticated, user, currentRole } = useAuthStore();
 
   // 개발 모드에서 인증 우회
   if (DEV_BYPASS_AUTH) {
@@ -38,7 +38,17 @@ export function ProtectedRoute({
 
   // 역할 제한이 있고, 사용자 역할이 허용되지 않은 경우
   if (allowedRoles && allowedRoles.length > 0 && user) {
-    if (!allowedRoles.includes(user.role)) {
+    // currentRole이 있으면 현재 선택된 역할로 체크
+    // 없으면 roles 배열 또는 기본 role로 체크
+    const activeRole = currentRole || user.role;
+    const userRoles = user.roles || [user.role];
+
+    // 현재 역할이 허용된 역할 목록에 있는지 확인
+    const hasPermission = currentRole
+      ? allowedRoles.includes(activeRole)
+      : allowedRoles.some(role => userRoles.includes(role));
+
+    if (!hasPermission) {
       // 권한이 없으면 403 또는 홈으로 리다이렉트
       return <Navigate to="/unauthorized" replace />;
     }

--- a/src/components/layout/co/CourseOperatorSidebar/CourseOperatorSidebar.tsx
+++ b/src/components/layout/co/CourseOperatorSidebar/CourseOperatorSidebar.tsx
@@ -36,7 +36,8 @@ export function CourseOperatorSidebar(props: CourseOperatorSidebarProps) {
 
     let count = 0;
     if (userRoles.includes('USER')) count++;
-    if (userRoles.includes('INSTRUCTOR') || userRoles.includes('DESIGNER')) count++;
+    if (userRoles.includes('DESIGNER')) count++;
+    if (userRoles.includes('INSTRUCTOR')) count++;
     if (userRoles.includes('OPERATOR')) count++;
     if (userRoles.includes('TENANT_ADMIN')) count++;
     return count;

--- a/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
+++ b/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
@@ -14,6 +14,8 @@ import { cn } from '@/utils/cn';
 import { useTenantBranding } from '@/contexts/TenantBrandingContext';
 import { GlobalRoleSwitcher, type GlobalRole } from '../GlobalRoleSwitcher';
 import { useSubdomainPath } from '@/hooks/common';
+import { useAuthStore } from '@/store/common/authStore';
+import type { TenantRole } from '@/types/common/auth.types';
 
 // 역할 타입
 type RoleType = 'sa' | 'ta' | 'co' | 'tu';
@@ -100,14 +102,34 @@ export function BaseSidebar({
   // 테넌트 브랜딩 (SA 제외)
   const { branding } = useTenantBranding();
 
-  // 글로벌 역할 타입 매핑
+  // authStore에서 현재 역할 가져오기
+  const storeCurrentRole = useAuthStore((state) => state.currentRole);
+  const userRole = useAuthStore((state) => state.user?.role);
+
+  // TenantRole → GlobalRole 매핑
+  const tenantRoleToGlobalRole: Record<TenantRole, GlobalRole> = {
+    SYSTEM_ADMIN: 'TA',
+    TENANT_ADMIN: 'TA',
+    OPERATOR: 'CO',
+    DESIGNER: 'DS',
+    INSTRUCTOR: 'TU',
+    USER: 'USER',
+  };
+
+  // 글로벌 역할 타입 매핑 (fallback용)
   const globalRoleMap: Record<RoleType, GlobalRole> = {
-    sa: 'TA', // SA는 TA로 매핑 (SA에서는 글로벌 스위처 안 씀)
+    sa: 'TA',
     ta: 'TA',
     co: 'CO',
     tu: 'TU',
   };
-  const currentGlobalRole = globalRoleMap[roleType];
+
+  // 현재 역할 결정: authStore의 currentRole > user.role > roleType 기반 fallback
+  const currentGlobalRole = storeCurrentRole
+    ? tenantRoleToGlobalRole[storeCurrentRole]
+    : userRole
+      ? tenantRoleToGlobalRole[userRole]
+      : globalRoleMap[roleType];
 
   // SA는 플랫폼 기본 로고, 나머지는 테넌트 브랜딩
   const isSuperAdmin = roleType === 'sa';

--- a/src/components/layout/common/GlobalRoleSwitcher/GlobalRoleSwitcher.tsx
+++ b/src/components/layout/common/GlobalRoleSwitcher/GlobalRoleSwitcher.tsx
@@ -1,10 +1,12 @@
 import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ChevronDown, Shield, Briefcase, BookOpen, GraduationCap } from 'lucide-react';
+import { ChevronDown, Shield, Briefcase, BookOpen, GraduationCap, Loader2 } from 'lucide-react';
 import type { SidebarColors } from '@/types';
+import type { TenantRole } from '@/types/common/auth.types';
 import { cn } from '@/utils/cn';
 import { useSubdomainPath } from '@/hooks/common';
 import { useAuthStore } from '@/store/common/authStore';
+import { authService } from '@/services/common/authService';
 
 // 글로벌 역할 타입 (TA, CO, TU, USER)
 export type GlobalRole = 'TA' | 'CO' | 'TU' | 'USER';
@@ -40,6 +42,14 @@ const roleDefaultPaths: Record<Exclude<GlobalRole, 'USER'>, string> = {
   TU: '/tu/dashboard',
 };
 
+// GlobalRole → TenantRole 매핑
+const globalRoleToTenantRole: Record<GlobalRole, TenantRole> = {
+  TA: 'TENANT_ADMIN',
+  CO: 'OPERATOR',
+  TU: 'INSTRUCTOR',
+  USER: 'USER',
+};
+
 export function GlobalRoleSwitcher({
   currentRole,
   isExpanded,
@@ -50,11 +60,14 @@ export function GlobalRoleSwitcher({
   const navigate = useNavigate();
   const { prefixPath } = useSubdomainPath();
   const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // 사용자의 역할 가져오기 (현재는 단일 role, 향후 roles 배열로 확장 가능)
+  // 사용자의 역할 가져오기
   const userRole = useAuthStore((state) => state.user?.role);
   const userRolesRaw = useAuthStore((state) => state.user?.roles);
+  const setTokens = useAuthStore((state) => state.setTokens);
+  const setCurrentRole = useAuthStore((state) => state.setCurrentRole);
   // Set이나 배열 모두 처리 가능하도록 Array.from 사용
   const userRoles = userRolesRaw ? Array.from(userRolesRaw) as string[] : undefined;
 
@@ -103,16 +116,35 @@ export function GlobalRoleSwitcher({
     return null;
   }
 
-  const handleRoleChange = (role: GlobalRole) => {
-    if (role !== currentRole) {
+  const handleRoleChange = async (role: GlobalRole) => {
+    if (role === currentRole) {
+      setIsOpen(false);
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      // 역할 전환 API 호출
+      const targetRole = globalRoleToTenantRole[role];
+      const response = await authService.switchRole({ targetRole });
+
+      // 새 토큰 저장
+      setTokens(response.accessToken, response.refreshToken, response.expiresIn);
+      setCurrentRole(targetRole);
+
+      // 페이지 이동
       if (role === 'USER') {
-        // TODO: 테넌트 설정(siteMode)에 따라 B2B/B2C 경로 결정 (현재는 B2C 기본)
         navigate(prefixPath('/tu/b2c/mypage'));
       } else {
         navigate(prefixPath(roleDefaultPaths[role]));
       }
+    } catch (error) {
+      console.error('Role switch failed:', error);
+      // TODO: 에러 토스트 표시
+    } finally {
+      setIsLoading(false);
+      setIsOpen(false);
     }
-    setIsOpen(false);
   };
 
   // 접힌 상태 - 아이콘만 표시
@@ -120,15 +152,17 @@ export function GlobalRoleSwitcher({
     return (
       <div ref={dropdownRef} className="relative">
         <button
-          onClick={() => setIsOpen(!isOpen)}
+          onClick={() => !isLoading && setIsOpen(!isOpen)}
+          disabled={isLoading}
           className="w-11 h-11 rounded-xl flex items-center justify-center transition-all duration-200"
           style={{
             backgroundColor: isDarkMode ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.05)',
             color: colors.textPrimary,
+            opacity: isLoading ? 0.7 : 1,
           }}
           title={roleLabels[currentRole][language]}
         >
-          <CurrentIcon className="w-5 h-5" />
+          {isLoading ? <Loader2 className="w-5 h-5 animate-spin" /> : <CurrentIcon className="w-5 h-5" />}
         </button>
 
         {/* 드롭다운 메뉴 (접힌 상태) */}
@@ -188,7 +222,8 @@ export function GlobalRoleSwitcher({
   return (
     <div ref={dropdownRef} className="relative">
       <button
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => !isLoading && setIsOpen(!isOpen)}
+        disabled={isLoading}
         className={cn(
           'w-full flex items-center gap-3 px-4 py-3 rounded-xl transition-all duration-200',
           'border'
@@ -197,11 +232,16 @@ export function GlobalRoleSwitcher({
           backgroundColor: isDarkMode ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.03)',
           borderColor: isDarkMode ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.08)',
           color: colors.textPrimary,
+          opacity: isLoading ? 0.7 : 1,
         }}
       >
-        <CurrentIcon className="w-5 h-5" style={{ color: colors.textSecondary }} />
+        {isLoading ? (
+          <Loader2 className="w-5 h-5 animate-spin" style={{ color: colors.textSecondary }} />
+        ) : (
+          <CurrentIcon className="w-5 h-5" style={{ color: colors.textSecondary }} />
+        )}
         <span className="flex-1 text-left text-sm font-medium">
-          {roleLabels[currentRole][language]}
+          {isLoading ? (language === 'ko' ? '전환 중...' : 'Switching...') : roleLabels[currentRole][language]}
         </span>
         <ChevronDown
           className={cn('w-4 h-4 transition-transform duration-200', isOpen && 'rotate-180')}

--- a/src/components/layout/common/GlobalRoleSwitcher/GlobalRoleSwitcher.tsx
+++ b/src/components/layout/common/GlobalRoleSwitcher/GlobalRoleSwitcher.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ChevronDown, Shield, Briefcase, BookOpen, GraduationCap, Loader2 } from 'lucide-react';
+import { ChevronDown, Shield, Briefcase, BookOpen, GraduationCap, Loader2, Pencil } from 'lucide-react';
 import type { SidebarColors } from '@/types';
 import type { TenantRole } from '@/types/common/auth.types';
 import { cn } from '@/utils/cn';
@@ -8,8 +8,8 @@ import { useSubdomainPath } from '@/hooks/common';
 import { useAuthStore } from '@/store/common/authStore';
 import { authService } from '@/services/common/authService';
 
-// 글로벌 역할 타입 (TA, CO, TU, USER)
-export type GlobalRole = 'TA' | 'CO' | 'TU' | 'USER';
+// 글로벌 역할 타입 (TA, CO, TU, DS, USER)
+export type GlobalRole = 'TA' | 'CO' | 'TU' | 'DS' | 'USER';
 
 interface GlobalRoleSwitcherProps {
   currentRole: GlobalRole;
@@ -24,6 +24,7 @@ const roleIcons: Record<GlobalRole, typeof Shield> = {
   TA: Shield,
   CO: Briefcase,
   TU: BookOpen,
+  DS: Pencil,
   USER: GraduationCap,
 };
 
@@ -32,6 +33,7 @@ const roleLabels: Record<GlobalRole, { ko: string; en: string }> = {
   TA: { ko: '관리자', en: 'Admin' },
   CO: { ko: '교육 운영자', en: 'Course Operator' },
   TU: { ko: '강사', en: 'Instructor' },
+  DS: { ko: '설계자', en: 'Designer' },
   USER: { ko: '학습자', en: 'Learner' },
 };
 
@@ -40,6 +42,7 @@ const roleDefaultPaths: Record<Exclude<GlobalRole, 'USER'>, string> = {
   TA: '/ta/dashboard',
   CO: '/co/dashboard',
   TU: '/tu/dashboard',
+  DS: '/tu/dashboard',
 };
 
 // GlobalRole → TenantRole 매핑
@@ -47,6 +50,7 @@ const globalRoleToTenantRole: Record<GlobalRole, TenantRole> = {
   TA: 'TENANT_ADMIN',
   CO: 'OPERATOR',
   TU: 'INSTRUCTOR',
+  DS: 'DESIGNER',
   USER: 'USER',
 };
 
@@ -83,7 +87,7 @@ export function GlobalRoleSwitcher({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  // 사용자가 가진 역할만 표시 (순서: 학습자 → 강사 → 교육 운영자 → 관리자)
+  // 사용자가 가진 역할만 표시 (순서: 학습자 → 설계자 → 강사 → 교육 운영자 → 관리자)
   const availableRoles: GlobalRole[] = (() => {
     const roles: GlobalRole[] = [];
 
@@ -96,7 +100,10 @@ export function GlobalRoleSwitcher({
     if (rolesToCheck.includes('USER')) {
       roles.push('USER');
     }
-    if (rolesToCheck.includes('INSTRUCTOR') || rolesToCheck.includes('DESIGNER')) {
+    if (rolesToCheck.includes('DESIGNER')) {
+      roles.push('DS');
+    }
+    if (rolesToCheck.includes('INSTRUCTOR')) {
       roles.push('TU');
     }
     if (rolesToCheck.includes('OPERATOR')) {

--- a/src/components/layout/mypage/B2BMyPageSidebar.tsx
+++ b/src/components/layout/mypage/B2BMyPageSidebar.tsx
@@ -97,7 +97,8 @@ export function B2BMyPageSidebar({ onMenuItemClick }: B2BMyPageSidebarProps) {
 
     let count = 0;
     if (userRoles.includes('USER')) count++;
-    if (userRoles.includes('INSTRUCTOR') || userRoles.includes('DESIGNER')) count++;
+    if (userRoles.includes('DESIGNER')) count++;
+    if (userRoles.includes('INSTRUCTOR')) count++;
     if (userRoles.includes('OPERATOR')) count++;
     if (userRoles.includes('TENANT_ADMIN')) count++;
     return count;

--- a/src/components/layout/mypage/MyPageSidebar.tsx
+++ b/src/components/layout/mypage/MyPageSidebar.tsx
@@ -115,7 +115,8 @@ export function MyPageSidebar({ onMenuItemClick, menuData: externalMenuData }: M
 
     let count = 0;
     if (userRoles.includes('USER')) count++;
-    if (userRoles.includes('INSTRUCTOR') || userRoles.includes('DESIGNER')) count++;
+    if (userRoles.includes('DESIGNER')) count++;
+    if (userRoles.includes('INSTRUCTOR')) count++;
     if (userRoles.includes('OPERATOR')) count++;
     if (userRoles.includes('TENANT_ADMIN')) count++;
     return count;

--- a/src/components/layout/ta/TenantAdminSidebar/TenantAdminSidebar.tsx
+++ b/src/components/layout/ta/TenantAdminSidebar/TenantAdminSidebar.tsx
@@ -20,7 +20,8 @@ export function TenantAdminSidebar(props: TenantAdminSidebarProps) {
 
     let count = 0;
     if (userRoles.includes('USER')) count++;
-    if (userRoles.includes('INSTRUCTOR') || userRoles.includes('DESIGNER')) count++;
+    if (userRoles.includes('DESIGNER')) count++;
+    if (userRoles.includes('INSTRUCTOR')) count++;
     if (userRoles.includes('OPERATOR')) count++;
     if (userRoles.includes('TENANT_ADMIN')) count++;
     return count;

--- a/src/components/layout/tu/TenantUserSidebar/TenantUserSidebar.tsx
+++ b/src/components/layout/tu/TenantUserSidebar/TenantUserSidebar.tsx
@@ -42,7 +42,8 @@ export function TenantUserSidebar(props: TenantUserSidebarProps) {
 
     let count = 0;
     if (userRoles.includes('USER')) count++;
-    if (userRoles.includes('INSTRUCTOR') || userRoles.includes('DESIGNER')) count++;
+    if (userRoles.includes('DESIGNER')) count++;
+    if (userRoles.includes('INSTRUCTOR')) count++;
     if (userRoles.includes('OPERATOR')) count++;
     if (userRoles.includes('TENANT_ADMIN')) count++;
     return count;

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -8,6 +8,7 @@ export const API_ENDPOINTS = {
     LOGIN: '/auth/login',
     LOGOUT: '/auth/logout',
     REFRESH: '/auth/refresh',
+    SWITCH_ROLE: '/auth/switch-role',
   },
 
   // Users

--- a/src/services/common/authService.ts
+++ b/src/services/common/authService.ts
@@ -4,6 +4,7 @@ import type {
   LoginRequest,
   RegisterRequest,
   RefreshTokenRequest,
+  SwitchRoleRequest,
   TokenResponse,
   UserResponse,
 } from '@/types/common/auth.types';
@@ -51,5 +52,16 @@ export const authService = {
   logout: async (refreshToken: string): Promise<void> => {
     const request: RefreshTokenRequest = { refreshToken };
     await axiosInstance.post(API_ENDPOINTS.AUTH.LOGOUT, request);
+  },
+
+  /**
+   * 역할 전환
+   */
+  switchRole: async (request: SwitchRoleRequest): Promise<TokenResponse> => {
+    const response = await axiosInstance.post<TokenResponse>(
+      API_ENDPOINTS.AUTH.SWITCH_ROLE,
+      request
+    );
+    return response.data;
   },
 };

--- a/src/store/common/authStore.ts
+++ b/src/store/common/authStore.ts
@@ -8,10 +8,12 @@ interface AuthState {
   refreshToken: string | null;
   isAuthenticated: boolean;
   tokenExpiresAt: number | null; // 토큰 만료 시간 (timestamp)
+  currentRole: TenantRole | null; // 현재 선택된 역할
 
   // Actions
-  setAuth: (user: AuthUser, accessToken: string, refreshToken: string, expiresIn?: number) => void;
+  setAuth: (user: AuthUser, accessToken: string, refreshToken: string, expiresIn?: number, currentRole?: TenantRole) => void;
   setTokens: (accessToken: string, refreshToken: string, expiresIn?: number) => void;
+  setCurrentRole: (role: TenantRole) => void;
   updateUser: (user: Partial<AuthUser>) => void;
   logout: () => void;
 
@@ -22,6 +24,7 @@ interface AuthState {
   // Selectors
   hasRole: (role: TenantRole) => boolean;
   hasAnyRole: (roles: TenantRole[]) => boolean;
+  getCurrentRole: () => TenantRole | null;
 }
 
 // 토큰 만료 시간 계산 (expiresIn: 초 단위)
@@ -39,14 +42,16 @@ export const useAuthStore = create<AuthState>()(
       refreshToken: null,
       isAuthenticated: false,
       tokenExpiresAt: null,
+      currentRole: null,
 
-      setAuth: (user, accessToken, refreshToken, expiresIn) =>
+      setAuth: (user, accessToken, refreshToken, expiresIn, currentRole) =>
         set({
           user,
           accessToken,
           refreshToken,
           isAuthenticated: true,
           tokenExpiresAt: calculateExpiresAt(expiresIn),
+          currentRole: currentRole || user.role,
         }),
 
       setTokens: (accessToken, refreshToken, expiresIn) =>
@@ -54,6 +59,11 @@ export const useAuthStore = create<AuthState>()(
           accessToken,
           refreshToken,
           tokenExpiresAt: calculateExpiresAt(expiresIn),
+        }),
+
+      setCurrentRole: (role) =>
+        set({
+          currentRole: role,
         }),
 
       updateUser: (userData) =>
@@ -68,6 +78,7 @@ export const useAuthStore = create<AuthState>()(
           refreshToken: null,
           isAuthenticated: false,
           tokenExpiresAt: null,
+          currentRole: null,
         }),
 
       isTokenExpired: () => {
@@ -91,6 +102,11 @@ export const useAuthStore = create<AuthState>()(
         const userRole = get().user?.role;
         return userRole ? roles.includes(userRole) : false;
       },
+
+      getCurrentRole: () => {
+        const { currentRole, user } = get();
+        return currentRole || user?.role || null;
+      },
     }),
     {
       name: 'auth-storage',
@@ -100,6 +116,7 @@ export const useAuthStore = create<AuthState>()(
         refreshToken: state.refreshToken,
         isAuthenticated: state.isAuthenticated,
         tokenExpiresAt: state.tokenExpiresAt,
+        currentRole: state.currentRole,
       }),
     }
   )

--- a/src/types/common/auth.types.ts
+++ b/src/types/common/auth.types.ts
@@ -31,6 +31,10 @@ export interface ChangePasswordRequest {
   newPassword: string;
 }
 
+export interface SwitchRoleRequest {
+  targetRole: TenantRole;
+}
+
 export interface UpdateProfileRequest {
   name?: string;
   phone?: string;
@@ -83,7 +87,8 @@ export interface AuthUser {
   email: string;
   name: string;
   role: TenantRole;
-  roles?: TenantRole[];  // 1:N 역할 지원 (향후 확장용)
+  roles?: TenantRole[];  // 1:N 역할 지원
+  currentRole?: TenantRole;  // 현재 선택된 역할
   tenantId?: number;
   tenantSubdomain?: string;
 }


### PR DESCRIPTION
## Summary

백엔드 역할 전환 API와 연동하여 프론트엔드에서 역할 전환 시 서버 검증을 거치도록 개선합니다.

## Related Issue

- Closes #482

## Changes

- authStore에 currentRole 상태 및 setCurrentRole 액션 추가
- authService에 switchRole API 함수 추가
- endpoints.ts에 SWITCH_ROLE 엔드포인트 추가
- auth.types.ts에 SwitchRoleRequest 타입 추가
- GlobalRoleSwitcher에서 역할 전환 API 호출 및 로딩 상태 처리
- ProtectedRoute에서 currentRole 기반 권한 체크 로직 개선

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 백엔드 PR과 함께 배포 필요: mzcATU/mzc-lp-backend#400