### PR TITLE
refactor: 역할 선택 페이지 카드 2개로 단순화

### DIFF
--- a/src/pages/auth/RoleSelectionPage.tsx
+++ b/src/pages/auth/RoleSelectionPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { motion } from 'framer-motion';
-import { ArrowRight, GraduationCap, Shield, Sparkles, Settings, Pencil } from 'lucide-react';
+import { ArrowRight, GraduationCap, Shield, Sparkles } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAuthStore } from '@/store/common/authStore';
 
@@ -11,13 +11,12 @@ interface CardData {
   description: string;
   image: string;
   icon: React.ReactNode;
-  themeColor: 'blue' | 'purple' | 'green' | 'orange';
-  delay: number;
+  themeColor: 'blue' | 'purple';
   path: string;
   roles: string[]; // 이 카드를 표시할 역할들
 }
 
-// 전체 카드 설정 데이터
+// 학습자 모드 / 관리자 모드 2개 카드
 const ALL_CARD_DATA: CardData[] = [
   {
     id: 'learner',
@@ -26,42 +25,18 @@ const ALL_CARD_DATA: CardData[] = [
     image: 'https://images.unsplash.com/photo-1522202176988-66273c2fd55f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=1080',
     icon: <GraduationCap size={32} className="text-blue-400" />,
     themeColor: 'blue',
-    delay: 0.3,
     path: '/tu/b2c',
     roles: ['USER'],
   },
   {
-    id: 'teaching',
-    title: '강사/디자이너 모드',
-    description: '강의를 제작하고, 교육 콘텐츠를 관리하세요.',
-    image: 'https://images.unsplash.com/photo-1524178232363-1fb2b075b655?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=1080',
-    icon: <Pencil size={32} className="text-green-400" />,
-    themeColor: 'green',
-    delay: 0.35,
-    path: '/tu/teaching',
-    roles: ['INSTRUCTOR', 'DESIGNER'],
-  },
-  {
-    id: 'operator',
-    title: '운영자 모드',
-    description: '교육 과정을 운영하고, 수강생을 관리하세요.',
-    image: 'https://images.unsplash.com/photo-1460925895917-afdab827c52f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=1080',
-    icon: <Settings size={32} className="text-orange-400" />,
-    themeColor: 'orange',
-    delay: 0.4,
-    path: '/co/dashboard',
-    roles: ['OPERATOR'],
-  },
-  {
     id: 'admin',
     title: '관리자 모드',
-    description: '테넌트 설정, 사용자 관리, 시스템 관리 기능을 사용하세요.',
+    description: '테넌트 설정, 사용자 관리, 콘텐츠 운영 기능을 사용하세요.',
     image: 'https://images.unsplash.com/photo-1553877522-43269d4ea984?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=1080',
     icon: <Shield size={32} className="text-purple-400" />,
     themeColor: 'purple',
-    delay: 0.45,
     path: '/ta/dashboard',
-    roles: ['TENANT_ADMIN', 'SYSTEM_ADMIN'],
+    roles: ['TENANT_ADMIN', 'SYSTEM_ADMIN', 'OPERATOR', 'DESIGNER', 'INSTRUCTOR'],
   },
 ];
 
@@ -73,7 +48,7 @@ interface SelectionCardProps {
   icon: React.ReactNode;
   onClick: () => void;
   delay: number;
-  themeColor: 'blue' | 'purple' | 'green' | 'orange';
+  themeColor: 'blue' | 'purple';
 }
 
 function SelectionCard({
@@ -88,15 +63,11 @@ function SelectionCard({
   const accentClasses = {
     blue: 'group-hover:shadow-blue-500/20 group-hover:border-blue-500/50',
     purple: 'group-hover:shadow-purple-500/20 group-hover:border-purple-500/50',
-    green: 'group-hover:shadow-green-500/20 group-hover:border-green-500/50',
-    orange: 'group-hover:shadow-orange-500/20 group-hover:border-orange-500/50',
   }[themeColor];
 
   const buttonClasses = {
     blue: 'bg-blue-600 hover:bg-blue-500',
     purple: 'bg-purple-600 hover:bg-purple-500',
-    green: 'bg-green-600 hover:bg-green-500',
-    orange: 'bg-orange-600 hover:bg-orange-500',
   }[themeColor];
 
   return (
@@ -215,7 +186,7 @@ export function RoleSelectionPage() {
         </motion.p>
       </div>
 
-      <div className="flex flex-col md:flex-row gap-6 w-full max-w-5xl z-10">
+      <div className="flex flex-col md:flex-row gap-8 w-full max-w-4xl z-10">
         {availableCards.map((card, index) => (
           <SelectionCard
             key={card.id}
@@ -224,7 +195,7 @@ export function RoleSelectionPage() {
             image={card.image}
             icon={card.icon}
             onClick={() => handleSelect(card)}
-            delay={0.3 + index * 0.1}
+            delay={0.3 + index * 0.15}
             themeColor={card.themeColor}
           />
         ))}


### PR DESCRIPTION
## Summary
- 역할 선택 페이지 카드를 4개에서 2개(학습자 모드/관리자 모드)로 단순화
- 관리자 모드에 TENANT_ADMIN, SYSTEM_ADMIN, OPERATOR, DESIGNER, INSTRUCTOR 역할 통합
- 불필요한 아이콘 import 제거 (Settings, Pencil)
- 카드 레이아웃 조정 (max-w-4xl, gap-8)

## Test plan
- [ ] /select-role 페이지에서 학습자 모드/관리자 모드 2개 카드만 표시되는지 확인
- [ ] 각 카드 클릭 시 해당 경로로 정상 이동하는지 확인

Closes #490