### PR TITLE
Feat : 활동 로그 개선 및 로그아웃 시 서브 도메인 유지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -198,6 +198,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -547,6 +548,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -590,6 +592,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -617,6 +620,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -4152,6 +4156,7 @@
       "resolved": "https://registry.npmjs.org/@svta/cml-xml/-/cml-xml-1.0.1.tgz",
       "integrity": "sha512-11LkJa5kDEcsRMWkVI1ABH3KLCxGoiSVe4kQ293ItVj8ncTTQ7htmCGiJDjS+Cmy35UgF3e/vc0ysJIiWRTx2g==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -4313,8 +4318,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4461,6 +4465,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4471,6 +4476,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4526,6 +4532,7 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -4884,6 +4891,7 @@
       "integrity": "sha512-rkoPH+RqWopVxDnCBE/ysIdfQ2A7j1eDmW8tCxxrR9nnFBa9jKf86VgsSAzxBd1x+ny0GC4JgiD3SNfRHv3pOg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.16",
         "fflate": "^0.8.2",
@@ -4927,6 +4935,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5313,6 +5322,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5970,8 +5980,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5998,7 +6007,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -6175,6 +6185,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7222,6 +7233,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7251,6 +7263,7 @@
       "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.7.2",
         "cssstyle": "^5.3.1",
@@ -7467,7 +7480,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8082,6 +8094,7 @@
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
       "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -8229,6 +8242,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8394,7 +8408,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8410,7 +8423,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8423,8 +8435,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8495,6 +8506,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8525,6 +8537,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8569,7 +8582,8 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
       "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-pdf": {
       "version": "10.3.0",
@@ -8640,6 +8654,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -8871,7 +8886,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -9626,6 +9642,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9763,6 +9780,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9981,6 +9999,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10074,6 +10093,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10087,6 +10107,7 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",

--- a/src/hooks/ta/index.ts
+++ b/src/hooks/ta/index.ts
@@ -49,6 +49,7 @@ export { taDashboardKeys, useTaKpiDashboard } from './useDashboardQueries';
 export {
   analyticsKeys,
   useActivityLogs,
+  useSearchActivityLogs,
   useActivityStats,
   useRecentActivities,
 } from './useAnalyticsQueries';

--- a/src/hooks/ta/useAnalyticsQueries.ts
+++ b/src/hooks/ta/useAnalyticsQueries.ts
@@ -2,12 +2,13 @@
  * TA Analytics React Query Hooks
  */
 import { useQuery } from '@tanstack/react-query';
-import { analyticsService, ActivityLogsParams } from '@/services/ta/analyticsService';
+import { analyticsService, ActivityLogsParams, ActivityLogSearchParams } from '@/services/ta/analyticsService';
 
 // Query Keys
 export const analyticsKeys = {
   all: ['ta-analytics'] as const,
   logs: (params?: ActivityLogsParams) => [...analyticsKeys.all, 'logs', params] as const,
+  search: (params?: ActivityLogSearchParams) => [...analyticsKeys.all, 'search', params] as const,
   stats: (days: number) => [...analyticsKeys.all, 'stats', days] as const,
   recent: () => [...analyticsKeys.all, 'recent'] as const,
 };
@@ -21,6 +22,16 @@ export const useActivityLogs = (params?: ActivityLogsParams) => {
   return useQuery({
     queryKey: analyticsKeys.logs(params),
     queryFn: () => analyticsService.getLogs(params),
+    staleTime: 1000 * 60 * 2, // 2분
+    refetchOnWindowFocus: false,
+  });
+};
+
+/** 활동 로그 검색 (유저별, 유형별, 기간별 필터) */
+export const useSearchActivityLogs = (params?: ActivityLogSearchParams) => {
+  return useQuery({
+    queryKey: analyticsKeys.search(params),
+    queryFn: () => analyticsService.searchLogs(params || {}),
     staleTime: 1000 * 60 * 2, // 2분
     refetchOnWindowFocus: false,
   });

--- a/src/pages/auth/RoleSelectionPage.tsx
+++ b/src/pages/auth/RoleSelectionPage.tsx
@@ -11,32 +11,35 @@ interface CardData {
   description: string;
   image: string;
   icon: React.ReactNode;
-  themeColor: 'blue' | 'purple';
+  themeColor: 'blue' | 'purple' | 'green' | 'orange';
+  delay: number;
   path: string;
   roles: string[]; // 이 카드를 표시할 역할들
 }
 
-// 학습자 모드 / 관리자 모드 2개 카드
+// 전체 카드 설정 데이터 (학습자 / 관리자 2개로 구분)
 const ALL_CARD_DATA: CardData[] = [
   {
-    id: 'learner',
+    id: 'user',
     title: '학습자 모드',
     description: '교육 프로그램에 참여하고, 나의 학습 현황을 확인하세요.',
     image: 'https://images.unsplash.com/photo-1522202176988-66273c2fd55f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=1080',
     icon: <GraduationCap size={32} className="text-blue-400" />,
     themeColor: 'blue',
+    delay: 0.3,
     path: '/tu/b2c',
     roles: ['USER'],
   },
   {
     id: 'admin',
     title: '관리자 모드',
-    description: '테넌트 설정, 사용자 관리, 콘텐츠 운영 기능을 사용하세요.',
+    description: '교육 과정 운영, 강의 제작, 사용자 관리 등 관리 기능을 사용하세요.',
     image: 'https://images.unsplash.com/photo-1553877522-43269d4ea984?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=1080',
     icon: <Shield size={32} className="text-purple-400" />,
     themeColor: 'purple',
+    delay: 0.35,
     path: '/ta/dashboard',
-    roles: ['TENANT_ADMIN', 'SYSTEM_ADMIN', 'OPERATOR', 'DESIGNER', 'INSTRUCTOR'],
+    roles: ['TENANT_ADMIN', 'SYSTEM_ADMIN', 'OPERATOR', 'INSTRUCTOR', 'DESIGNER'],
   },
 ];
 
@@ -48,7 +51,7 @@ interface SelectionCardProps {
   icon: React.ReactNode;
   onClick: () => void;
   delay: number;
-  themeColor: 'blue' | 'purple';
+  themeColor: 'blue' | 'purple' | 'green' | 'orange';
 }
 
 function SelectionCard({
@@ -63,11 +66,15 @@ function SelectionCard({
   const accentClasses = {
     blue: 'group-hover:shadow-blue-500/20 group-hover:border-blue-500/50',
     purple: 'group-hover:shadow-purple-500/20 group-hover:border-purple-500/50',
+    green: 'group-hover:shadow-green-500/20 group-hover:border-green-500/50',
+    orange: 'group-hover:shadow-orange-500/20 group-hover:border-orange-500/50',
   }[themeColor];
 
   const buttonClasses = {
     blue: 'bg-blue-600 hover:bg-blue-500',
     purple: 'bg-purple-600 hover:bg-purple-500',
+    green: 'bg-green-600 hover:bg-green-500',
+    orange: 'bg-orange-600 hover:bg-orange-500',
   }[themeColor];
 
   return (
@@ -186,7 +193,7 @@ export function RoleSelectionPage() {
         </motion.p>
       </div>
 
-      <div className="flex flex-col md:flex-row gap-8 w-full max-w-4xl z-10">
+      <div className="flex flex-col md:flex-row gap-6 w-full max-w-5xl z-10">
         {availableCards.map((card, index) => (
           <SelectionCard
             key={card.id}
@@ -195,7 +202,7 @@ export function RoleSelectionPage() {
             image={card.image}
             icon={card.icon}
             onClick={() => handleSelect(card)}
-            delay={0.3 + index * 0.15}
+            delay={0.3 + index * 0.1}
             themeColor={card.themeColor}
           />
         ))}

--- a/src/pages/common/settings/SettingsPage.tsx
+++ b/src/pages/common/settings/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { SettingsCard, Button } from '@/components/common';
 import { useAuthStore } from '@/store/common/authStore';
 import { authService } from '@/services/common/authService';
 import { toast } from 'sonner';
+import { getLoginPath } from '@/utils/tenantUtils';
 
 type UserRole = 'USER' | 'INSTRUCTOR' | 'DESIGNER' | 'OPERATOR' | 'TENANT_ADMIN' | 'SYSTEM_ADMIN';
 
@@ -105,18 +106,20 @@ export function SettingsPage({ userRole }: SettingsPageProps) {
 
   const handleLogout = async () => {
     if (window.confirm('로그아웃 하시겠습니까?')) {
+      // 로그아웃 전에 현재 서브도메인 경로 저장
+      const loginPath = getLoginPath();
       try {
         if (refreshToken) {
           await authService.logout(refreshToken);
         }
         logout();
-        navigate('/auth/login');
+        navigate(loginPath);
         toast.success('로그아웃되었습니다.');
       } catch (error) {
         console.error('Logout failed:', error);
         // 에러가 나더라도 로컬 상태는 초기화
         logout();
-        navigate('/auth/login');
+        navigate(loginPath);
         toast.error('로그아웃에 실패했습니다.');
       }
     }

--- a/src/pages/ta/analytics/LogsPage.tsx
+++ b/src/pages/ta/analytics/LogsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import {
   Search,
   Download,
@@ -9,6 +9,14 @@ import {
   Calendar,
   User,
   Loader2,
+  Filter,
+  X,
+  LogIn,
+  Users,
+  BookOpen,
+  GraduationCap,
+  FileText,
+  Settings,
 } from 'lucide-react';
 import { AdminPageHeader } from '@/components/domain/admin';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/common/Card';
@@ -22,9 +30,75 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/common/Select';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/common/Tabs';
 import { useActivityLogs, useActivityStats } from '@/hooks/ta';
 import type { ActivityType } from '@/services/ta/analyticsService';
+import { analyticsService } from '@/services/ta/analyticsService';
+import { useUsers } from '@/hooks/ta/useUserQueries';
 import { designTokens } from '@/styles/admin-design-tokens';
+
+// 카테고리 정의
+type CategoryKey = 'all' | 'auth' | 'user' | 'course' | 'enrollment' | 'content' | 'settings';
+
+interface CategoryConfig {
+  key: CategoryKey;
+  label: string;
+  icon: React.ElementType;
+  types: ActivityType[];
+  color: string;
+}
+
+const categories: CategoryConfig[] = [
+  {
+    key: 'all',
+    label: '전체',
+    icon: FileText,
+    types: [],
+    color: 'bg-gray-100 text-gray-700',
+  },
+  {
+    key: 'auth',
+    label: '인증',
+    icon: LogIn,
+    types: ['LOGIN', 'LOGOUT', 'LOGIN_FAILED', 'PASSWORD_CHANGE'],
+    color: 'bg-purple-100 text-purple-700',
+  },
+  {
+    key: 'user',
+    label: '사용자',
+    icon: Users,
+    types: ['USER_CREATE', 'USER_UPDATE', 'USER_DELETE', 'ROLE_CHANGE'],
+    color: 'bg-indigo-100 text-indigo-700',
+  },
+  {
+    key: 'course',
+    label: '강좌',
+    icon: BookOpen,
+    types: ['COURSE_VIEW', 'COURSE_CREATE', 'COURSE_UPDATE', 'COURSE_DELETE'],
+    color: 'bg-cyan-100 text-cyan-700',
+  },
+  {
+    key: 'enrollment',
+    label: '수강',
+    icon: GraduationCap,
+    types: ['ENROLLMENT_CREATE', 'ENROLLMENT_COMPLETE', 'ENROLLMENT_DROP'],
+    color: 'bg-emerald-100 text-emerald-700',
+  },
+  {
+    key: 'content',
+    label: '콘텐츠',
+    icon: FileText,
+    types: ['CONTENT_VIEW', 'CONTENT_COMPLETE', 'PROGRAM_CREATE', 'PROGRAM_UPDATE', 'PROGRAM_APPROVE', 'PROGRAM_REJECT'],
+    color: 'bg-orange-100 text-orange-700',
+  },
+  {
+    key: 'settings',
+    label: '설정',
+    icon: Settings,
+    types: ['SETTINGS_UPDATE', 'TENANT_CREATE', 'TENANT_UPDATE', 'OTHER'],
+    color: 'bg-slate-100 text-slate-700',
+  },
+];
 
 // 활동 타입별 레벨 매핑
 const getLogLevel = (activityType: ActivityType): 'INFO' | 'WARN' | 'ERROR' | 'SUCCESS' => {
@@ -39,15 +113,13 @@ const getLogLevel = (activityType: ActivityType): 'INFO' | 'WARN' | 'ERROR' | 'S
 };
 
 // 활동 타입별 카테고리 매핑
-const getCategory = (activityType: ActivityType): string => {
-  if (['LOGIN', 'LOGOUT', 'LOGIN_FAILED', 'PASSWORD_CHANGE'].includes(activityType)) return '인증';
-  if (['USER_CREATE', 'USER_UPDATE', 'USER_DELETE', 'ROLE_CHANGE'].includes(activityType)) return '사용자';
-  if (['COURSE_VIEW', 'COURSE_CREATE', 'COURSE_UPDATE', 'COURSE_DELETE'].includes(activityType)) return '강좌';
-  if (['PROGRAM_CREATE', 'PROGRAM_UPDATE', 'PROGRAM_APPROVE', 'PROGRAM_REJECT'].includes(activityType)) return '과정';
-  if (['ENROLLMENT_CREATE', 'ENROLLMENT_COMPLETE', 'ENROLLMENT_DROP'].includes(activityType)) return '수강';
-  if (['CONTENT_VIEW', 'CONTENT_COMPLETE'].includes(activityType)) return '콘텐츠';
-  if (['SETTINGS_UPDATE', 'TENANT_CREATE', 'TENANT_UPDATE'].includes(activityType)) return '설정';
-  return '기타';
+const getCategory = (activityType: ActivityType): CategoryConfig => {
+  for (const cat of categories) {
+    if (cat.types.includes(activityType)) {
+      return cat;
+    }
+  }
+  return categories[0]; // 기본: 전체
 };
 
 const levelConfig = {
@@ -77,24 +149,36 @@ const levelConfig = {
   },
 };
 
-const activityTypeOptions: { value: ActivityType; label: string }[] = [
-  { value: 'LOGIN', label: '로그인' },
-  { value: 'LOGOUT', label: '로그아웃' },
-  { value: 'LOGIN_FAILED', label: '로그인 실패' },
-  { value: 'USER_CREATE', label: '사용자 생성' },
-  { value: 'USER_UPDATE', label: '사용자 수정' },
-  { value: 'USER_DELETE', label: '사용자 삭제' },
-  { value: 'COURSE_VIEW', label: '강좌 조회' },
-  { value: 'COURSE_CREATE', label: '강좌 생성' },
-  { value: 'ENROLLMENT_CREATE', label: '수강 신청' },
-  { value: 'ENROLLMENT_COMPLETE', label: '수강 완료' },
+const activityTypeOptions: { value: ActivityType; label: string; category: CategoryKey }[] = [
+  { value: 'LOGIN', label: '로그인', category: 'auth' },
+  { value: 'LOGOUT', label: '로그아웃', category: 'auth' },
+  { value: 'LOGIN_FAILED', label: '로그인 실패', category: 'auth' },
+  { value: 'PASSWORD_CHANGE', label: '비밀번호 변경', category: 'auth' },
+  { value: 'USER_CREATE', label: '사용자 생성', category: 'user' },
+  { value: 'USER_UPDATE', label: '사용자 수정', category: 'user' },
+  { value: 'USER_DELETE', label: '사용자 삭제', category: 'user' },
+  { value: 'ROLE_CHANGE', label: '역할 변경', category: 'user' },
+  { value: 'COURSE_VIEW', label: '강좌 조회', category: 'course' },
+  { value: 'COURSE_CREATE', label: '강좌 생성', category: 'course' },
+  { value: 'COURSE_UPDATE', label: '강좌 수정', category: 'course' },
+  { value: 'COURSE_DELETE', label: '강좌 삭제', category: 'course' },
+  { value: 'ENROLLMENT_CREATE', label: '수강 신청', category: 'enrollment' },
+  { value: 'ENROLLMENT_COMPLETE', label: '수강 완료', category: 'enrollment' },
+  { value: 'ENROLLMENT_DROP', label: '수강 취소', category: 'enrollment' },
+  { value: 'CONTENT_VIEW', label: '콘텐츠 조회', category: 'content' },
+  { value: 'CONTENT_COMPLETE', label: '콘텐츠 완료', category: 'content' },
 ];
 
 export function LogsPage() {
   const [searchKeyword, setSearchKeyword] = useState('');
   const [levelFilter, setLevelFilter] = useState<string>('all');
   const [typeFilter, setTypeFilter] = useState<ActivityType | undefined>(undefined);
+  const [userFilter, setUserFilter] = useState<number | undefined>(undefined);
+  const [startDate, setStartDate] = useState<string>('');
+  const [endDate, setEndDate] = useState<string>('');
   const [page, setPage] = useState(0);
+  const [showFilters, setShowFilters] = useState(false);
+  const [categoryTab, setCategoryTab] = useState<CategoryKey>('all');
 
   const { data: logsData, isLoading, error } = useActivityLogs({
     type: typeFilter,
@@ -102,29 +186,96 @@ export function LogsPage() {
     size: 50,
   });
   const { data: stats } = useActivityStats(30);
+  const { data: usersData } = useUsers({ page: 0, size: 100 });
+
+  // 사용자 목록
+  const users = useMemo(() => usersData?.content || [], [usersData]);
+
+  // 내보내기 핸들러
+  const handleExport = () => {
+    const exportUrl = analyticsService.getExportUrl({
+      userId: userFilter,
+      type: typeFilter,
+      startDate: startDate ? new Date(startDate).toISOString() : undefined,
+      endDate: endDate ? new Date(endDate).toISOString() : undefined,
+    });
+    window.open(exportUrl, '_blank');
+  };
+
+  // 필터 초기화
+  const clearFilters = () => {
+    setSearchKeyword('');
+    setLevelFilter('all');
+    setTypeFilter(undefined);
+    setUserFilter(undefined);
+    setStartDate('');
+    setEndDate('');
+    setPage(0);
+  };
+
+  // 활성 필터 개수
+  const activeFilterCount = [
+    levelFilter !== 'all',
+    typeFilter !== undefined,
+    userFilter !== undefined,
+    startDate !== '',
+    endDate !== '',
+  ].filter(Boolean).length;
 
   const logs = logsData?.content || [];
 
-  // 클라이언트 사이드 필터링 (검색어, 레벨)
-  const filteredLogs = logs.filter((log) => {
-    const matchesSearch = !searchKeyword ||
-      log.description?.toLowerCase().includes(searchKeyword.toLowerCase()) ||
-      log.userName?.toLowerCase().includes(searchKeyword.toLowerCase()) ||
-      log.activityTypeLabel?.toLowerCase().includes(searchKeyword.toLowerCase());
+  // 카테고리별 로그 카운트
+  const categoryCounts = useMemo(() => {
+    const counts: Record<CategoryKey, number> = {
+      all: logs.length,
+      auth: 0,
+      user: 0,
+      course: 0,
+      enrollment: 0,
+      content: 0,
+      settings: 0,
+    };
 
-    const logLevel = getLogLevel(log.activityType);
-    const matchesLevel = levelFilter === 'all' || logLevel === levelFilter;
+    logs.forEach((log) => {
+      const cat = getCategory(log.activityType);
+      if (cat.key !== 'all') {
+        counts[cat.key]++;
+      }
+    });
 
-    return matchesSearch && matchesLevel;
-  });
+    return counts;
+  }, [logs]);
+
+  // 클라이언트 사이드 필터링 (검색어, 레벨, 카테고리)
+  const filteredLogs = useMemo(() => {
+    return logs.filter((log) => {
+      // 카테고리 필터
+      if (categoryTab !== 'all') {
+        const cat = getCategory(log.activityType);
+        if (cat.key !== categoryTab) return false;
+      }
+
+      // 검색어 필터
+      const matchesSearch = !searchKeyword ||
+        log.description?.toLowerCase().includes(searchKeyword.toLowerCase()) ||
+        log.userName?.toLowerCase().includes(searchKeyword.toLowerCase()) ||
+        log.activityTypeLabel?.toLowerCase().includes(searchKeyword.toLowerCase());
+
+      // 레벨 필터
+      const logLevel = getLogLevel(log.activityType);
+      const matchesLevel = levelFilter === 'all' || logLevel === levelFilter;
+
+      return matchesSearch && matchesLevel;
+    });
+  }, [logs, categoryTab, searchKeyword, levelFilter]);
 
   // 레벨별 카운트
-  const levelCounts = {
+  const levelCounts = useMemo(() => ({
     INFO: logs.filter(l => getLogLevel(l.activityType) === 'INFO').length,
     SUCCESS: logs.filter(l => getLogLevel(l.activityType) === 'SUCCESS').length,
     WARN: logs.filter(l => getLogLevel(l.activityType) === 'WARN').length,
     ERROR: logs.filter(l => getLogLevel(l.activityType) === 'ERROR').length,
-  };
+  }), [logs]);
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
@@ -138,18 +289,129 @@ export function LogsPage() {
     });
   };
 
+  // 현재 카테고리에 해당하는 활동 유형 옵션
+  const filteredTypeOptions = useMemo(() => {
+    if (categoryTab === 'all') return activityTypeOptions;
+    return activityTypeOptions.filter(opt => opt.category === categoryTab);
+  }, [categoryTab]);
+
   return (
     <div className="p-6">
       <AdminPageHeader
         title="이력 분석 및 로그 관리"
         description="테넌트 활동 로그를 조회하고 분석합니다"
         actions={
-          <Button variant="outline">
-            <Download className="mr-2 h-4 w-4" />
-            로그 내보내기
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setShowFilters(!showFilters)}
+              className="relative"
+            >
+              <Filter className="mr-2 h-4 w-4" />
+              필터
+              {activeFilterCount > 0 && (
+                <Badge className="ml-2 bg-brand-primary text-white">
+                  {activeFilterCount}
+                </Badge>
+              )}
+            </Button>
+            <Button variant="outline" onClick={handleExport}>
+              <Download className="mr-2 h-4 w-4" />
+              CSV 내보내기
+            </Button>
+          </div>
         }
       />
+
+      {/* 고급 필터 섹션 */}
+      {showFilters && (
+        <Card className="mb-6">
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-base">고급 필터</CardTitle>
+              <Button variant="ghost" size="sm" onClick={clearFilters}>
+                <X className="mr-1 h-4 w-4" />
+                초기화
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              {/* 사용자 필터 */}
+              <div>
+                <label className="text-sm font-medium mb-1 block">사용자</label>
+                <Select
+                  value={userFilter?.toString() || 'all'}
+                  onValueChange={(v) => {
+                    setUserFilter(v === 'all' ? undefined : Number(v));
+                    setPage(0);
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="사용자 선택" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">전체 사용자</SelectItem>
+                    {users.map((user) => (
+                      <SelectItem key={user.id} value={user.id.toString()}>
+                        {user.name} ({user.email})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* 활동 유형 필터 */}
+              <div>
+                <label className="text-sm font-medium mb-1 block">활동 유형</label>
+                <Select
+                  value={typeFilter || 'all'}
+                  onValueChange={(v) => {
+                    setTypeFilter(v === 'all' ? undefined : v as ActivityType);
+                    setPage(0);
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="활동 유형" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">전체</SelectItem>
+                    {filteredTypeOptions.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* 시작일 */}
+              <div>
+                <label className="text-sm font-medium mb-1 block">시작일</label>
+                <Input
+                  type="date"
+                  value={startDate}
+                  onChange={(e) => {
+                    setStartDate(e.target.value);
+                    setPage(0);
+                  }}
+                />
+              </div>
+
+              {/* 종료일 */}
+              <div>
+                <label className="text-sm font-medium mb-1 block">종료일</label>
+                <Input
+                  type="date"
+                  value={endDate}
+                  onChange={(e) => {
+                    setEndDate(e.target.value);
+                    setPage(0);
+                  }}
+                />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Stats Summary */}
       <div className="grid grid-cols-4 gap-4 mb-6">
@@ -161,7 +423,7 @@ export function LogsPage() {
               </div>
               <div>
                 <p className="text-2xl font-bold" style={{ color: designTokens.text.primary }}>
-                  {stats?.totalActivities || levelCounts.INFO}
+                  {stats?.totalActivities || logs.length}
                 </p>
                 <p className="text-sm" style={{ color: designTokens.text.secondary }}>전체 활동</p>
               </div>
@@ -176,7 +438,7 @@ export function LogsPage() {
               </div>
               <div>
                 <p className="text-2xl font-bold" style={{ color: designTokens.text.primary }}>
-                  {stats?.todayActivities || levelCounts.SUCCESS}
+                  {stats?.todayActivities || 0}
                 </p>
                 <p className="text-sm" style={{ color: designTokens.text.secondary }}>오늘 활동</p>
               </div>
@@ -215,172 +477,189 @@ export function LogsPage() {
         </Card>
       </div>
 
-      {/* Logs List */}
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <div>
-              <CardTitle>활동 로그</CardTitle>
-              <CardDescription>테넌트 내 모든 활동 기록입니다</CardDescription>
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="relative">
-                <Search
-                  className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4"
-                  style={{ color: designTokens.text.secondary }}
-                />
-                <Input
-                  placeholder="검색..."
-                  value={searchKeyword}
-                  onChange={(e) => setSearchKeyword(e.target.value)}
-                  className="pl-9 w-64"
-                />
-              </div>
-              <Select value={levelFilter} onValueChange={setLevelFilter}>
-                <SelectTrigger className="w-28">
-                  <SelectValue placeholder="레벨" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">전체</SelectItem>
-                  <SelectItem value="INFO">정보</SelectItem>
-                  <SelectItem value="SUCCESS">성공</SelectItem>
-                  <SelectItem value="WARN">경고</SelectItem>
-                  <SelectItem value="ERROR">오류</SelectItem>
-                </SelectContent>
-              </Select>
-              <Select
-                value={typeFilter || 'all'}
-                onValueChange={(v) => setTypeFilter(v === 'all' ? undefined : v as ActivityType)}
-              >
-                <SelectTrigger className="w-36">
-                  <SelectValue placeholder="활동 유형" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">전체</SelectItem>
-                  {activityTypeOptions.map((opt) => (
-                    <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <div className="flex items-center justify-center py-12">
-              <Loader2 className="h-8 w-8 animate-spin" style={{ color: designTokens.button.brand_default }} />
-            </div>
-          ) : error ? (
-            <div className="text-center py-12" style={{ color: designTokens.status.error_text }}>
-              데이터를 불러오는 중 오류가 발생했습니다.
-            </div>
-          ) : filteredLogs.length === 0 ? (
-            <div className="text-center py-12" style={{ color: designTokens.text.secondary }}>
-              활동 로그가 없습니다.
-            </div>
-          ) : (
-            <div className="space-y-2">
-              {filteredLogs.map((log) => {
-                const level = getLogLevel(log.activityType);
-                const category = getCategory(log.activityType);
-                const config = levelConfig[level];
-                const LevelIcon = config.icon;
+      {/* 카테고리별 탭 */}
+      <Tabs value={categoryTab} onValueChange={(v) => { setCategoryTab(v as CategoryKey); setPage(0); }}>
+        <TabsList className="mb-4 flex-wrap">
+          {categories.map((cat) => {
+            const Icon = cat.icon;
+            return (
+              <TabsTrigger key={cat.key} value={cat.key} className="gap-2">
+                <Icon className="h-4 w-4" />
+                {cat.label}
+                <Badge variant="secondary" className="ml-1 text-xs">
+                  {categoryCounts[cat.key]}
+                </Badge>
+              </TabsTrigger>
+            );
+          })}
+        </TabsList>
 
-                return (
-                  <div
-                    key={log.id}
-                    className="flex items-start gap-3 p-3 rounded-lg transition-colors"
-                    style={{
-                      border: `1px solid ${designTokens.bg.border}`,
-                      backgroundColor: designTokens.bg.default,
-                    }}
-                    onMouseEnter={(e) => {
-                      e.currentTarget.style.backgroundColor = designTokens.bg.secondary;
-                    }}
-                    onMouseLeave={(e) => {
-                      e.currentTarget.style.backgroundColor = designTokens.bg.default;
-                    }}
-                  >
-                    <div
-                      className="shrink-0 px-2 py-1 rounded text-xs font-medium flex items-center gap-1"
-                      style={config.badgeStyle}
-                    >
-                      <LevelIcon className="h-3 w-3" />
-                      {level}
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <Badge variant="outline">{category}</Badge>
-                        <span className="font-medium" style={{ color: designTokens.text.primary }}>
-                          {log.activityTypeLabel}
-                        </span>
-                        {log.userName && (
-                          <span className="text-sm flex items-center gap-1" style={{ color: designTokens.text.secondary }}>
-                            <User className="h-3 w-3" />
-                            {log.userName}
-                          </span>
-                        )}
-                      </div>
-                      <p className="text-sm mt-1" style={{ color: designTokens.text.primary }}>
-                        {log.description}
-                      </p>
-                      {log.targetName && (
-                        <p className="text-xs mt-1" style={{ color: designTokens.text.secondary }}>
-                          대상: {log.targetType} - {log.targetName}
-                        </p>
-                      )}
-                      <div className="flex items-center gap-4 mt-1 text-xs" style={{ color: designTokens.text.secondary }}>
-                        <span className="flex items-center gap-1">
-                          <Calendar className="h-3 w-3" />
-                          {formatDate(log.createdAt)}
-                        </span>
-                        {log.ipAddress && <span>IP: {log.ipAddress}</span>}
-                      </div>
-                    </div>
+        {/* 모든 카테고리에 동일한 콘텐츠 렌더링 */}
+        {categories.map((cat) => (
+          <TabsContent key={cat.key} value={cat.key}>
+            <Card>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <CardTitle className="flex items-center gap-2">
+                      <cat.icon className="h-5 w-5" />
+                      {cat.label} 로그
+                    </CardTitle>
+                    <CardDescription>
+                      {cat.key === 'all' ? '테넌트 내 모든 활동 기록입니다' : `${cat.label} 관련 활동 기록입니다`}
+                    </CardDescription>
                   </div>
-                );
-              })}
-            </div>
-          )}
+                  <div className="flex items-center gap-2">
+                    <div className="relative">
+                      <Search
+                        className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4"
+                        style={{ color: designTokens.text.secondary }}
+                      />
+                      <Input
+                        placeholder="검색..."
+                        value={searchKeyword}
+                        onChange={(e) => setSearchKeyword(e.target.value)}
+                        className="pl-9 w-64"
+                      />
+                    </div>
+                    <Select value={levelFilter} onValueChange={setLevelFilter}>
+                      <SelectTrigger className="w-28">
+                        <SelectValue placeholder="레벨" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">전체</SelectItem>
+                        <SelectItem value="INFO">정보</SelectItem>
+                        <SelectItem value="SUCCESS">성공</SelectItem>
+                        <SelectItem value="WARN">경고</SelectItem>
+                        <SelectItem value="ERROR">오류</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                {isLoading ? (
+                  <div className="flex items-center justify-center py-12">
+                    <Loader2 className="h-8 w-8 animate-spin" style={{ color: designTokens.button.brand_default }} />
+                  </div>
+                ) : error ? (
+                  <div className="text-center py-12" style={{ color: designTokens.status.error_text }}>
+                    데이터를 불러오는 중 오류가 발생했습니다.
+                  </div>
+                ) : filteredLogs.length === 0 ? (
+                  <div className="text-center py-12" style={{ color: designTokens.text.secondary }}>
+                    {cat.key === 'all' ? '활동 로그가 없습니다.' : `${cat.label} 관련 로그가 없습니다.`}
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {filteredLogs.map((log) => {
+                      const level = getLogLevel(log.activityType);
+                      const logCategory = getCategory(log.activityType);
+                      const config = levelConfig[level];
+                      const LevelIcon = config.icon;
+                      const CategoryIcon = logCategory.icon;
 
-          {/* Pagination */}
-          {logsData && logsData.totalPages > 1 && (
-            <div className="flex items-center justify-center gap-2 mt-6">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setPage(p => Math.max(0, p - 1))}
-                disabled={logsData.first}
-                style={logsData.first ? {
-                  backgroundColor: designTokens.status.neutral_disabled_bg,
-                  color: designTokens.status.neutral_disabled_text,
-                  cursor: 'not-allowed',
-                  opacity: 0.6,
-                } : undefined}
-              >
-                이전
-              </Button>
-              <span className="text-sm" style={{ color: designTokens.text.secondary }}>
-                {logsData.number + 1} / {logsData.totalPages}
-              </span>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setPage(p => p + 1)}
-                disabled={logsData.last}
-                style={logsData.last ? {
-                  backgroundColor: designTokens.status.neutral_disabled_bg,
-                  color: designTokens.status.neutral_disabled_text,
-                  cursor: 'not-allowed',
-                  opacity: 0.6,
-                } : undefined}
-              >
-                다음
-              </Button>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+                      return (
+                        <div
+                          key={log.id}
+                          className="flex items-start gap-3 p-3 rounded-lg transition-colors"
+                          style={{
+                            border: `1px solid ${designTokens.bg.border}`,
+                            backgroundColor: designTokens.bg.default,
+                          }}
+                          onMouseEnter={(e) => {
+                            e.currentTarget.style.backgroundColor = designTokens.bg.secondary;
+                          }}
+                          onMouseLeave={(e) => {
+                            e.currentTarget.style.backgroundColor = designTokens.bg.default;
+                          }}
+                        >
+                          <div
+                            className="shrink-0 px-2 py-1 rounded text-xs font-medium flex items-center gap-1"
+                            style={config.badgeStyle}
+                          >
+                            <LevelIcon className="h-3 w-3" />
+                            {level}
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <Badge className={`${logCategory.color} shrink-0`}>
+                                <CategoryIcon className="h-3 w-3 mr-1" />
+                                {logCategory.label}
+                              </Badge>
+                              <span className="font-medium" style={{ color: designTokens.text.primary }}>
+                                {log.activityTypeLabel}
+                              </span>
+                              {log.userName && (
+                                <span className="text-sm flex items-center gap-1" style={{ color: designTokens.text.secondary }}>
+                                  <User className="h-3 w-3" />
+                                  {log.userName}
+                                </span>
+                              )}
+                            </div>
+                            <p className="text-sm mt-1" style={{ color: designTokens.text.primary }}>
+                              {log.description}
+                            </p>
+                            {log.targetName && (
+                              <p className="text-xs mt-1" style={{ color: designTokens.text.secondary }}>
+                                대상: {log.targetType} - {log.targetName}
+                              </p>
+                            )}
+                            <div className="flex items-center gap-4 mt-1 text-xs" style={{ color: designTokens.text.secondary }}>
+                              <span className="flex items-center gap-1">
+                                <Calendar className="h-3 w-3" />
+                                {formatDate(log.createdAt)}
+                              </span>
+                              {log.ipAddress && <span>IP: {log.ipAddress}</span>}
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {/* Pagination */}
+                {logsData && logsData.totalPages > 1 && (
+                  <div className="flex items-center justify-center gap-2 mt-6">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setPage(p => Math.max(0, p - 1))}
+                      disabled={logsData.first}
+                      style={logsData.first ? {
+                        backgroundColor: designTokens.status.neutral_disabled_bg,
+                        color: designTokens.status.neutral_disabled_text,
+                        cursor: 'not-allowed',
+                        opacity: 0.6,
+                      } : undefined}
+                    >
+                      이전
+                    </Button>
+                    <span className="text-sm" style={{ color: designTokens.text.secondary }}>
+                      {logsData.number + 1} / {logsData.totalPages}
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setPage(p => p + 1)}
+                      disabled={logsData.last}
+                      style={logsData.last ? {
+                        backgroundColor: designTokens.status.neutral_disabled_bg,
+                        color: designTokens.status.neutral_disabled_text,
+                        cursor: 'not-allowed',
+                        opacity: 0.6,
+                      } : undefined}
+                    >
+                      다음
+                    </Button>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+        ))}
+      </Tabs>
     </div>
   );
 }

--- a/src/pages/ta/analytics/LogsPage.tsx
+++ b/src/pages/ta/analytics/LogsPage.tsx
@@ -196,14 +196,19 @@ export function LogsPage() {
   const users = useMemo(() => usersData?.content || [], [usersData]);
 
   // 내보내기 핸들러
-  const handleExport = () => {
-    const exportUrl = analyticsService.getExportUrl({
-      userId: userFilter,
-      type: typeFilter,
-      startDate: startDate ? new Date(startDate).toISOString() : undefined,
-      endDate: endDate ? new Date(endDate).toISOString() : undefined,
-    });
-    window.open(exportUrl, '_blank');
+  const handleExport = async () => {
+    try {
+      await analyticsService.exportLogs({
+        userId: userFilter,
+        type: typeFilter,
+        startDate: startDate ? new Date(startDate).toISOString() : undefined,
+        endDate: endDate ? new Date(endDate).toISOString() : undefined,
+      });
+    } catch (error) {
+      console.error('Export failed:', error);
+      const message = error instanceof Error ? error.message : 'CSV 내보내기에 실패했습니다.';
+      alert(message);
+    }
   };
 
   // 필터 초기화

--- a/src/pages/ta/analytics/LogsPage.tsx
+++ b/src/pages/ta/analytics/LogsPage.tsx
@@ -31,7 +31,7 @@ import {
   SelectValue,
 } from '@/components/common/Select';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/common/Tabs';
-import { useActivityLogs, useActivityStats } from '@/hooks/ta';
+import { useSearchActivityLogs, useActivityStats } from '@/hooks/ta';
 import type { ActivityType } from '@/services/ta/analyticsService';
 import { analyticsService } from '@/services/ta/analyticsService';
 import { useUsers } from '@/hooks/ta/useUserQueries';
@@ -180,8 +180,12 @@ export function LogsPage() {
   const [showFilters, setShowFilters] = useState(false);
   const [categoryTab, setCategoryTab] = useState<CategoryKey>('all');
 
-  const { data: logsData, isLoading, error } = useActivityLogs({
+  // 검색 파라미터 - 날짜 미지정 시 undefined로 전달하여 전체 조회
+  const { data: logsData, isLoading, error } = useSearchActivityLogs({
+    userId: userFilter,
     type: typeFilter,
+    startDate: startDate ? new Date(startDate).toISOString() : undefined,
+    endDate: endDate ? new Date(endDate).toISOString() : undefined,
     page,
     size: 50,
   });

--- a/src/services/common/api/axiosInstance.ts
+++ b/src/services/common/api/axiosInstance.ts
@@ -59,6 +59,10 @@ axiosInstance.interceptors.request.use(
 // Response interceptor: ApiResponse wrapper 처리 및 토큰 갱신
 axiosInstance.interceptors.response.use(
   (response) => {
+    // blob 응답은 ApiResponse wrapper 처리를 건너뜀
+    if (response.config.responseType === 'blob') {
+      return response;
+    }
     // ApiResponse wrapper에서 data 추출
     // 서버 응답: { success: boolean, data: T, error?: {...} }
     if (

--- a/src/services/common/api/endpoints.ts
+++ b/src/services/common/api/endpoints.ts
@@ -313,9 +313,11 @@ export const API_ENDPOINTS = {
   // Analytics (TA, SA)
   ANALYTICS: {
     // TA용 (테넌트 단위)
+    TA_BASE: '/admin/analytics',
     TA_LOGS: '/admin/analytics/logs',
     TA_STATS: '/admin/analytics/stats',
     TA_RECENT: '/admin/analytics/recent',
+    TA_TYPES: '/admin/analytics/types',
     // SA용 (전체 시스템)
     SA_LOGS: '/sa/analytics/logs',
     SA_STATS: '/sa/analytics/stats',

--- a/src/services/ta/analyticsService.ts
+++ b/src/services/ta/analyticsService.ts
@@ -160,21 +160,65 @@ export const analyticsService = {
     return data;
   },
 
-  /** 활동 로그 CSV 내보내기 URL 생성 */
-  getExportUrl(params?: {
+  /** 활동 로그 CSV 내보내기 (Blob 다운로드) */
+  async exportLogs(params?: {
     userId?: number;
     type?: ActivityType;
     startDate?: string;
     endDate?: string;
-  }): string {
-    const searchParams = new URLSearchParams();
-    if (params?.userId) searchParams.set('userId', params.userId.toString());
-    if (params?.type) searchParams.set('type', params.type);
-    if (params?.startDate) searchParams.set('startDate', params.startDate);
-    if (params?.endDate) searchParams.set('endDate', params.endDate);
+  }): Promise<void> {
+    try {
+      const response = await axiosInstance.get(
+        `${API_ENDPOINTS.ANALYTICS.TA_LOGS}/export`,
+        {
+          params,
+          responseType: 'blob',
+        }
+      );
 
-    const queryString = searchParams.toString();
-    const baseUrl = `${API_ENDPOINTS.ANALYTICS.TA_LOGS}/export`;
-    return queryString ? `${baseUrl}?${queryString}` : baseUrl;
+      // Content-Type이 JSON이면 에러 응답임
+      const contentType = response.headers['content-type'];
+      if (contentType?.includes('application/json')) {
+        const text = await response.data.text();
+        const errorData = JSON.parse(text);
+        throw new Error(errorData.error?.message || '내보내기에 실패했습니다.');
+      }
+
+      // Blob으로 파일 다운로드
+      const blob = new Blob([response.data], { type: 'text/csv;charset=utf-8' });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', `activity_logs_${Date.now()}.csv`);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (error: unknown) {
+      // axios 에러이고 blob 응답인 경우 에러 내용 읽기
+      if (
+        error &&
+        typeof error === 'object' &&
+        'response' in error &&
+        error.response &&
+        typeof error.response === 'object' &&
+        'data' in error.response &&
+        error.response.data instanceof Blob
+      ) {
+        const text = await error.response.data.text();
+        console.error('Export error response:', text);
+        try {
+          const errorData = JSON.parse(text);
+          throw new Error(errorData.error?.message || errorData.message || '내보내기에 실패했습니다.');
+        } catch {
+          // JSON 파싱 실패시 text 내용 그대로 사용
+          throw new Error(text || '내보내기에 실패했습니다.');
+        }
+      }
+      if (error instanceof Error && error.message) {
+        throw error;
+      }
+      throw new Error('CSV 내보내기에 실패했습니다. 권한을 확인해주세요.');
+    }
   },
 };

--- a/src/services/ta/analyticsService.ts
+++ b/src/services/ta/analyticsService.ts
@@ -90,6 +90,23 @@ export interface ActivityLogsParams {
   size?: number;
 }
 
+// 검색 파라미터
+export interface ActivityLogSearchParams {
+  userId?: number;
+  type?: ActivityType;
+  startDate?: string;
+  endDate?: string;
+  keyword?: string;
+  page?: number;
+  size?: number;
+}
+
+// 활동 유형 정보
+export interface ActivityTypeInfo {
+  type: ActivityType;
+  description: string;
+}
+
 export const analyticsService = {
   /** 활동 로그 목록 조회 */
   async getLogs(params?: ActivityLogsParams): Promise<Page<ActivityLogResponse>> {
@@ -115,5 +132,49 @@ export const analyticsService = {
       API_ENDPOINTS.ANALYTICS.TA_RECENT
     );
     return data;
+  },
+
+  /** 활동 로그 검색 */
+  async searchLogs(params: ActivityLogSearchParams): Promise<Page<ActivityLogResponse>> {
+    const { data } = await axiosInstance.get<Page<ActivityLogResponse>>(
+      `${API_ENDPOINTS.ANALYTICS.TA_LOGS}/search`,
+      { params }
+    );
+    return data;
+  },
+
+  /** 특정 사용자 활동 로그 조회 */
+  async getLogsByUser(userId: number, params?: { page?: number; size?: number }): Promise<Page<ActivityLogResponse>> {
+    const { data } = await axiosInstance.get<Page<ActivityLogResponse>>(
+      `${API_ENDPOINTS.ANALYTICS.TA_LOGS}/users/${userId}`,
+      { params }
+    );
+    return data;
+  },
+
+  /** 활동 유형 목록 조회 */
+  async getActivityTypes(): Promise<ActivityTypeInfo[]> {
+    const { data } = await axiosInstance.get<ActivityTypeInfo[]>(
+      API_ENDPOINTS.ANALYTICS.TA_TYPES
+    );
+    return data;
+  },
+
+  /** 활동 로그 CSV 내보내기 URL 생성 */
+  getExportUrl(params?: {
+    userId?: number;
+    type?: ActivityType;
+    startDate?: string;
+    endDate?: string;
+  }): string {
+    const searchParams = new URLSearchParams();
+    if (params?.userId) searchParams.set('userId', params.userId.toString());
+    if (params?.type) searchParams.set('type', params.type);
+    if (params?.startDate) searchParams.set('startDate', params.startDate);
+    if (params?.endDate) searchParams.set('endDate', params.endDate);
+
+    const queryString = searchParams.toString();
+    const baseUrl = `${API_ENDPOINTS.ANALYTICS.TA_LOGS}/export`;
+    return queryString ? `${baseUrl}?${queryString}` : baseUrl;
   },
 };

--- a/src/types/ta/activityLog.types.ts
+++ b/src/types/ta/activityLog.types.ts
@@ -1,0 +1,86 @@
+/**
+ * 활동 로그 관련 타입 정의
+ */
+
+// 활동 유형
+export type ActivityType =
+  | 'LOGIN'
+  | 'LOGOUT'
+  | 'LOGIN_FAILED'
+  | 'PASSWORD_CHANGE'
+  | 'USER_CREATE'
+  | 'USER_UPDATE'
+  | 'USER_DELETE'
+  | 'ROLE_CHANGE'
+  | 'COURSE_VIEW'
+  | 'COURSE_CREATE'
+  | 'COURSE_UPDATE'
+  | 'COURSE_DELETE'
+  | 'PROGRAM_CREATE'
+  | 'PROGRAM_UPDATE'
+  | 'PROGRAM_APPROVE'
+  | 'PROGRAM_REJECT'
+  | 'ENROLLMENT_CREATE'
+  | 'ENROLLMENT_COMPLETE'
+  | 'ENROLLMENT_DROP'
+  | 'CONTENT_VIEW'
+  | 'CONTENT_COMPLETE'
+  | 'SETTINGS_UPDATE'
+  | 'TENANT_CREATE'
+  | 'TENANT_UPDATE'
+  | 'OTHER';
+
+// 활동 로그 응답
+export interface ActivityLogResponse {
+  id: number;
+  tenantId: number;
+  userId: number | null;
+  userName: string | null;
+  userEmail: string | null;
+  activityType: ActivityType;
+  description: string | null;
+  targetType: string | null;
+  targetId: number | null;
+  targetName: string | null;
+  ipAddress: string | null;
+  userAgent: string | null;
+  metadata: string | null;
+  createdAt: string;
+}
+
+// 활동 유형 정보
+export interface ActivityTypeInfo {
+  type: ActivityType;
+  description: string;
+}
+
+// 활동 통계 응답
+export interface ActivityStatsResponse {
+  totalActivities: number;
+  todayActivities: number;
+  activeUsers: number;
+  byActivityType: Record<string, number>;
+  dailyTrend: DailyActivityCount[];
+  hourlyTrend: HourlyActivityCount[];
+}
+
+export interface DailyActivityCount {
+  date: string;
+  count: number;
+}
+
+export interface HourlyActivityCount {
+  hour: number;
+  count: number;
+}
+
+// 검색 파라미터
+export interface ActivityLogSearchParams {
+  userId?: number;
+  type?: ActivityType;
+  startDate?: string;
+  endDate?: string;
+  keyword?: string;
+  page?: number;
+  size?: number;
+}


### PR DESCRIPTION
## Summary

활동 로그 페이지 UI 개선 및 로그아웃 시 서브도메인 유지 기능을 추가합니다.

## Related Issue

- Closes #494

## Changes

- 활동 로그 페이지에 카테고리별 탭 추가 (전체, 인증, 사용자, 강좌, 수강, 콘텐츠, 설정)
- 고급 필터 패널 추가 (사용자, 활동 유형, 기간)
- CSV 내보내기 버튼 추가
- useSearchActivityLogs 훅 추가 (검색 API 연동)
- SettingsPage 로그아웃 시 getLoginPath() 사용하여 서브도메인 유지

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

- 날짜 필터를 지정하지 않으면 전체 기간 조회됩니다
- 로그아웃 시 `/mzc/ta/settings` → `/mzc/login`으로 서브도메인 유지
