### PR TITLE
feat: 저장 모달에서 완성도 미충족 시 작성완료 옵션 비활성화

### DIFF
--- a/src/pages/tu/teaching/courses/CourseCreatePage.tsx
+++ b/src/pages/tu/teaching/courses/CourseCreatePage.tsx
@@ -183,6 +183,30 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
 
   const totalSteps = 3;
 
+  // 완성도 체크: 작성완료 상태로 저장하려면 모든 필수 항목이 있어야 함
+  const isComplete =
+    !!formData.title?.trim() &&
+    !!formData.description?.trim() &&
+    !!formData.categoryId &&
+    formData.curriculumItems.length > 0;
+
+  // 누락된 필드 목록 반환
+  const getMissingFields = (): string[] => {
+    const missing: string[] = [];
+    if (!formData.title?.trim()) missing.push('강의명');
+    if (!formData.description?.trim()) missing.push('설명');
+    if (!formData.categoryId) missing.push('카테고리');
+    if (formData.curriculumItems.length === 0) missing.push('차시');
+    return missing;
+  };
+
+  // 완성도 미충족 시 자동으로 임시저장 선택
+  useEffect(() => {
+    if (!isComplete && !saveAsDraft) {
+      setSaveAsDraft(true);
+    }
+  }, [isComplete, saveAsDraft]);
+
   const getText = (key: TranslationKey) =>
     language === 'ko' ? translations[key].ko : translations[key].en;
 
@@ -704,16 +728,19 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
 
               {/* 작성완료 옵션 */}
               <label
-                className="flex items-start gap-3 p-4 rounded-lg border-2 cursor-pointer transition-colors"
+                className={`flex items-start gap-3 p-4 rounded-lg border-2 transition-colors ${
+                  !isComplete ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+                }`}
                 style={{
-                  borderColor: !saveAsDraft ? designTokens.badge.blue.text : designTokens.bg.border,
-                  backgroundColor: !saveAsDraft ? `${designTokens.badge.blue.bg}40` : 'transparent'
+                  borderColor: !saveAsDraft && isComplete ? designTokens.badge.blue.text : designTokens.bg.border,
+                  backgroundColor: !saveAsDraft && isComplete ? `${designTokens.badge.blue.bg}40` : 'transparent'
                 }}
-                onClick={() => setSaveAsDraft(false)}
+                onClick={() => isComplete && setSaveAsDraft(false)}
               >
                 <Checkbox
-                  checked={!saveAsDraft}
-                  onCheckedChange={(checked) => setSaveAsDraft(!checked)}
+                  checked={!saveAsDraft && isComplete}
+                  onCheckedChange={(checked) => isComplete && setSaveAsDraft(!checked)}
+                  disabled={!isComplete}
                 />
                 <div className="flex-1">
                   <div className="flex items-center gap-2 mb-1">
@@ -731,6 +758,11 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
                   <p className="text-sm text-text-secondary">
                     작성을 완료하고 목록에 "작성완료" 상태로 표시됩니다.
                   </p>
+                  {!isComplete && (
+                    <p className="text-xs text-red-500 mt-1">
+                      작성완료하려면 다음 항목이 필요합니다: {getMissingFields().join(', ')}
+                    </p>
+                  )}
                 </div>
               </label>
             </div>


### PR DESCRIPTION
## Summary
- 완성도 기준(제목, 설명, 카테고리, 차시 1개 이상) 미충족 시 "작성완료" 옵션 비활성화
- 누락된 필드를 안내 메시지로 표시하여 사용자에게 안내
- 미충족 상태에서 자동으로 "임시저장" 옵션 선택

## Test plan
- [ ] 과정 설계 페이지에서 제목과 카테고리만 입력 후 저장 버튼 클릭
- [ ] 모달에서 "작성완료" 옵션이 비활성화(회색 처리)되어 있는지 확인
- [ ] 누락 항목 안내 메시지가 표시되는지 확인
- [ ] 모든 필수 항목 입력 후 "작성완료" 옵션이 활성화되는지 확인

Closes #492