### PR TITLE
feat: 강의 생성 페이지에 예상 학습 시간 입력 필드 추가

### DIFF
--- a/src/pages/tu/teaching/courses/CourseCreatePage.tsx
+++ b/src/pages/tu/teaching/courses/CourseCreatePage.tsx
@@ -172,6 +172,7 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
     tags: [],
     level: '',
     type: '',
+    estimatedHours: null,
     lessons: [], // deprecated
     curriculumItems: [],
     isDraft: false,
@@ -256,6 +257,7 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
           thumbnailUrl: course.thumbnailUrl || undefined,
           level: course.level || '',
           type: course.type || '',
+          estimatedHours: course.estimatedHours,
           categoryId: course.categoryId,
           tags: course.tags || [],
           curriculumItems,
@@ -356,6 +358,7 @@ export function CourseCreatePage({ language = 'ko' }: Readonly<CourseCreatePageP
       thumbnailUrl: formData.thumbnailUrl || undefined,
       level: formData.level || undefined,
       type: formData.type || undefined,
+      estimatedHours: formData.estimatedHours ?? undefined,
       categoryId: formData.categoryId ?? undefined,
       tags: formData.tags.length > 0 ? formData.tags : undefined,
     };

--- a/src/pages/tu/teaching/courses/CourseEditPage.tsx
+++ b/src/pages/tu/teaching/courses/CourseEditPage.tsx
@@ -114,6 +114,7 @@ export function CourseEditPage({ language = 'ko' }: Readonly<CourseEditPageProps
     tags: [],
     level: '',
     type: '',
+    estimatedHours: null,
     lessons: [], // deprecated
     curriculumItems: [],
     isDraft: false,
@@ -152,6 +153,7 @@ export function CourseEditPage({ language = 'ko' }: Readonly<CourseEditPageProps
         tags: courseData.tags || [],
         level: courseData.level || '',
         type: courseData.type || '',
+        estimatedHours: courseData.estimatedHours,
         lessons: [], // deprecated
         curriculumItems: convertHierarchyToCurriculumItems(hierarchyData),
         isDraft: false,

--- a/src/pages/tu/teaching/courses/components/Step1BasicInfo.tsx
+++ b/src/pages/tu/teaching/courses/components/Step1BasicInfo.tsx
@@ -129,6 +129,23 @@ export function Step1BasicInfo({
         />
       </div>
 
+      {/* 예상 학습 시간 */}
+      <div className="space-y-2">
+        <Label htmlFor="estimatedHours">예상 학습시간 (시간)</Label>
+        <Input
+          id="estimatedHours"
+          type="number"
+          value={formData.estimatedHours ?? ''}
+          onChange={(e) =>
+            onFormDataChange({
+              estimatedHours: e.target.value ? Number(e.target.value) : null,
+            })
+          }
+          placeholder="예: 10"
+          min={1}
+        />
+      </div>
+
       {/* 썸네일 URL */}
       <div className="space-y-2">
         <Label htmlFor="thumbnailUrl" className="flex items-center gap-2">

--- a/src/types/co/course.types.ts
+++ b/src/types/co/course.types.ts
@@ -118,6 +118,8 @@ export interface CourseFormData {
   tags: string[];
   level: CourseLevel | '';
   type: CourseType | '';
+  /** 예상 학습 시간 (시간 단위) */
+  estimatedHours: number | null;
   /** @deprecated curriculumItems 사용 권장 */
   lessons: LessonData[];
   /** 커리큘럼 트리 구조 (폴더/콘텐츠 계층) */


### PR DESCRIPTION
## Summary
- 강의 생성 페이지(Step1BasicInfo)에 예상 학습 시간(`estimatedHours`) 입력 필드 추가
- `CourseFormData` 타입에 `estimatedHours` 필드 추가
- 강의 생성/수정 시 API에 `estimatedHours` 값 전달

## Test plan
- [ ] 강의 생성 페이지에서 예상 학습시간 입력 필드가 표시되는지 확인
- [ ] 예상 학습시간 입력 후 저장 시 값이 정상적으로 저장되는지 확인
- [ ] 기존 강의 수정 시 저장된 예상 학습시간이 불러와지는지 확인

Closes #500