### PR TITLE
feat: 강의 상세 페이지에 미리보기 버튼 추가

### DIFF
--- a/src/pages/tu/teaching/courses/CourseDetailPage.tsx
+++ b/src/pages/tu/teaching/courses/CourseDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
   ArrowLeft,
-  Edit2,
+  Eye,
   Trash2,
   Loader2,
   AlertCircle,
@@ -25,6 +25,8 @@ import { CourseInfoSection } from './components/CourseInfoSection';
 import { CourseCurriculumSection } from './components/CourseCurriculumSection';
 import type { CourseLevel, CourseType } from '@/types/common/course.types';
 import type { CategoryResponse } from '@/types/common';
+import type { CourseFormData } from '@/types/co/course.types';
+import { convertHierarchyToCurriculumItems } from '@/types/tu/curriculum.types';
 
 // 난이도별 Badge 컬러
 const levelBadgeColor: Record<CourseLevel, BadgeColor> = {
@@ -98,6 +100,37 @@ export function CourseDetailPage() {
       console.error('Delete failed:', err);
       alert('삭제에 실패했습니다.');
     }
+  };
+
+  // 수강생 화면 미리보기 핸들러
+  const handlePreview = () => {
+    // course 데이터를 CourseFormData 형태로 변환
+    const formData: CourseFormData = {
+      title: course?.title || '',
+      description: course?.description || '',
+      thumbnailUrl: course?.thumbnailUrl || undefined,
+      categoryId: course?.categoryId || null,
+      tags: course?.tags || [],
+      level: course?.level || '',
+      type: course?.type || '',
+      estimatedHours: course?.estimatedHours || null,
+      lessons: [],
+      curriculumItems: curriculum ? convertHierarchyToCurriculumItems(curriculum) : [],
+      isDraft: false,
+      multiLanguage: {
+        enabled: false,
+        languages: [],
+      },
+    };
+
+    const previewData = {
+      formData,
+      categories,
+      language: 'ko' as const,
+    };
+
+    sessionStorage.setItem('course-preview-data', JSON.stringify(previewData));
+    window.open(prefixPath('/tu/teaching/courses/preview'), '_blank');
   };
 
   // 콘텐츠 미리보기 핸들러
@@ -193,10 +226,10 @@ export function CourseDetailPage() {
               variant="ghost"
               size="sm"
               className="border border-border"
-              onClick={() => navigate(prefixPath(`/tu/teaching/courses/${id}/edit`))}
+              onClick={handlePreview}
             >
-              <Edit2 size={16} />
-              수정
+              <Eye size={16} />
+              미리보기
             </Button>
             <Button
               variant="destructive"


### PR DESCRIPTION
## Summary
- 강의 상세 페이지(`CourseDetailPage`)에서 수정 버튼을 미리보기 버튼으로 교체
- 수강생이 볼 화면을 새 탭에서 미리볼 수 있는 기능 추가
- 기존 `CoursePreviewPage` 재사용

## 변경 사항
- 버튼 배치: `[과정 등록] [수정] [삭제]` → `[과정 등록] [미리보기] [삭제]`
- `handlePreview` 함수 추가: course 데이터를 CourseFormData로 변환 후 sessionStorage에 저장

## Test plan
- [ ] 강의 상세 페이지에서 미리보기 버튼 클릭 시 새 탭에서 미리보기 페이지 열림 확인
- [ ] 미리보기 페이지에서 강의 정보(제목, 설명, 커리큘럼 등) 정상 표시 확인

Closes #502