### PR TITLE
fix: 수강 중 강의 목록에서 종료일이 NaN으로 표시되는 문제 해결

### DIFF
--- a/src/pages/tu/learning/MyLearningPage.tsx
+++ b/src/pages/tu/learning/MyLearningPage.tsx
@@ -75,7 +75,9 @@ interface EnrollmentCardProps {
 
 function EnrollmentCard({ enrollment, onClick, onContinueLearning, t, isDark }: EnrollmentCardProps) {
   const formatDate = (dateStr: string) => {
+    if (!dateStr) return '-';
     const date = new Date(dateStr);
+    if (isNaN(date.getTime())) return '-';
     return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`;
   };
 

--- a/src/pages/tu/mypage/CompletedCoursesPage.tsx
+++ b/src/pages/tu/mypage/CompletedCoursesPage.tsx
@@ -37,7 +37,9 @@ interface CompletedCourseCardProps {
 
 function CompletedCourseCard({ enrollment, onClick, onViewCertificate, isDark, language }: CompletedCourseCardProps) {
   const formatDate = (dateStr: string) => {
+    if (!dateStr) return '-';
     const date = new Date(dateStr);
+    if (isNaN(date.getTime())) return '-';
     return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`;
   };
 

--- a/src/services/tu/enrollmentService.ts
+++ b/src/services/tu/enrollmentService.ts
@@ -24,6 +24,7 @@ interface BackendEnrollmentResponse {
   progressPercent: number | null;
   score: number | null;
   completedAt: string | null;
+  actualEndDate: string | null;
 }
 
 /**
@@ -127,7 +128,7 @@ const transformEnrollment = (
   completedAt: backend.completedAt ?? undefined,
   progress: backend.progressPercent ?? 0,
   startDate: courseTimeInfo?.classStartDate ?? '',
-  endDate: courseTimeInfo?.classEndDate ?? '',
+  endDate: backend.actualEndDate ?? courseTimeInfo?.classEndDate ?? '',
 });
 
 /**


### PR DESCRIPTION
## Summary
- 백엔드에서 추가된 `actualEndDate` 필드를 사용하여 정확한 종료일 표시
- 유효하지 않은 날짜 처리 로직 추가

## Changes
### API 타입 업데이트
- `BackendEnrollmentResponse`에 `actualEndDate: string | null` 필드 추가
- `transformEnrollment`에서 `actualEndDate` 우선 사용 (fallback: `classEndDate`)

### 날짜 포맷팅 개선
- `formatDate` 함수에 유효성 검사 추가
- 빈 문자열 또는 Invalid Date → `-` 표시
- `MyLearningPage`, `CompletedCoursesPage` 모두 적용

## Test plan
- [x] RELATIVE 타입 차수 생성 (duration_days 설정)
- [x] 수강 신청 후 "수강 중인 강의" 페이지에서 정확한 종료일 표시 확인
- [x] Invalid Date 처리 확인 (빈 문자열 → `-` 표시)

## Related
- 백엔드 PR: #410
- 이슈: #507

Closes #507