### PR TITLE
feat(ta): 사용자 관리 페이지 서버사이드 페이지네이션 구현

### DIFF
--- a/src/pages/ta/users/UsersPage.tsx
+++ b/src/pages/ta/users/UsersPage.tsx
@@ -124,6 +124,7 @@ export function UsersContent() {
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [roleFilter, setRoleFilter] = useState<string>('all');
   const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
   const [sortBy, setSortBy] = useState<string | undefined>(undefined);
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
@@ -143,7 +144,7 @@ export function UsersContent() {
     status: statusFilter !== 'all' ? statusFilter as UserStatus : undefined,
     systemRole: roleFilter !== 'all' ? roleFilter as SystemRole : undefined,
     page,
-    size: 10,
+    size: pageSize,
     sortBy,
     sortDirection,
   });
@@ -630,7 +631,10 @@ export function UsersContent() {
       </div>
 
       {/* 역할별 탭 필터 */}
-      <Tabs value={roleFilter} onValueChange={setRoleFilter} className="mb-6">
+      <Tabs value={roleFilter} onValueChange={(value) => {
+        setRoleFilter(value);
+        setPage(0); // 필터 변경 시 첫 페이지로 이동
+      }} className="mb-6">
         <TabsList>
           <TabsTrigger value="all">
             전체 사용자
@@ -678,11 +682,17 @@ export function UsersContent() {
           <Input
             placeholder="이름 또는 이메일 검색..."
             value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            onChange={(e) => {
+              setSearchQuery(e.target.value);
+              setPage(0); // 검색어 변경 시 첫 페이지로 이동
+            }}
             className="pl-9"
           />
         </div>
-        <Select value={statusFilter} onValueChange={setStatusFilter}>
+        <Select value={statusFilter} onValueChange={(value) => {
+          setStatusFilter(value);
+          setPage(0); // 필터 변경 시 첫 페이지로 이동
+        }}>
           <SelectTrigger className="w-32">
             <SelectValue placeholder="상태" />
           </SelectTrigger>
@@ -716,6 +726,15 @@ export function UsersContent() {
             setSortDirection('desc');
           }
           setPage(0); // 정렬 변경 시 첫 페이지로 이동
+        }}
+        manualPagination={true}
+        pageCount={usersData?.totalPages || 0}
+        pageIndex={page}
+        pageSize={pageSize}
+        onPageChange={(newPage) => setPage(newPage)}
+        onPageSizeChange={(newSize) => {
+          setPageSize(newSize);
+          setPage(0); // 페이지 크기 변경 시 첫 페이지로 이동
         }}
         labels={{
           noResults: '사용자가 없습니다.',


### PR DESCRIPTION
## Summary

TA 사용자 관리 페이지에 서버사이드 페이지네이션을 구현하여 대량의 사용자 데이터를 효율적으로 처리할 수 있도록 개선했습니다.

## Related Issue

- Closes #

## Changes

- `pageSize` 상태 추가 및 DataTable에 서버사이드 페이지네이션 props 연동
- `manualPagination`, `pageCount`, `pageIndex`, `onPageChange`, `onPageSizeChange` 적용
- 역할 필터 변경 시 첫 페이지로 이동 처리
- 검색어 변경 시 첫 페이지로 이동 처리
- 상태 필터 변경 시 첫 페이지로 이동 처리
- 정렬 변경 시 첫 페이지로 이동 처리
- 페이지 크기 변경 시 첫 페이지로 이동 처리

## Type of Change

- [x] Feat: 새로운 기능
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes

- 부서 관리 탭은 트리 구조로 렌더링되어 DataTable을 사용하지 않으므로 페이지네이션 적용 대상이 아닙니다.
- 기존 DataTable 컴포넌트의 서버사이드 페이지네이션 기능을 활용했습니다.