### PR TITLE
feat(ta): 사용자 관리 페이지 페이지네이션 및 수정 다이얼로그 개선

### DIFF
--- a/src/pages/ta/users/UsersPage.tsx
+++ b/src/pages/ta/users/UsersPage.tsx
@@ -55,6 +55,7 @@ import { Checkbox } from '@/components/common/Checkbox';
 import { designTokens } from '@/styles/admin-design-tokens';
 import {
   useUsers,
+  useUser,
   useUpdateUser,
   useUpdateUserRoles,
   useDeleteUser,
@@ -157,6 +158,9 @@ export function UsersContent() {
   // 선택한 사용자의 역할 조회 (다이얼로그 열릴 때)
   const { data: selectedUserRoles, refetch: refetchUserRoles } = useUserRoles(selectedUser?.id || 0);
 
+  // 선택한 사용자의 상세 정보 조회 (부서, 직급 등)
+  const { data: selectedUserDetail } = useUser(selectedUser?.id || 0);
+
   const { register, handleSubmit, reset, setValue, watch } = useForm<UserFormData>({
     defaultValues: {
       systemRole: 'USER',
@@ -188,6 +192,14 @@ export function UsersContent() {
       setValue('systemRoles', selectedUserRoles);
     }
   }, [selectedUserRoles, isEditDialogOpen, setValue]);
+
+  // 사용자 상세 정보가 로드되면 부서/직급 form에 반영
+  useEffect(() => {
+    if (selectedUserDetail && isEditDialogOpen) {
+      setValue('department', selectedUserDetail.department || '');
+      setValue('position', selectedUserDetail.position || '');
+    }
+  }, [selectedUserDetail, isEditDialogOpen, setValue]);
 
   const columns: ColumnDef<AdminUser>[] = [
     {
@@ -299,6 +311,8 @@ export function UsersContent() {
     setSelectedUser(user);
     setValue('name', user.name);
     setValue('email', user.email);
+    setValue('department', user.department || '');
+    setValue('position', user.position || '');
     setValue('systemRole', user.systemRole);
     // 사용자의 roles 배열이 있으면 그것을 사용, 없으면 systemRole 하나로 초기화
     const initialRoles = user.roles && user.roles.length > 0 ? user.roles : [user.systemRole];


### PR DESCRIPTION
## Summary

TA 사용자 관리 페이지의 서버사이드 페이지네이션 구현 및 수정 다이얼로그에서 부서/직급 값이 표시되지 않던 버그를 수정했습니다.

## Related Issue

- Closes #

## Changes

- 서버사이드 페이지네이션 구현 (`manualPagination`, `pageCount`, `pageIndex`, `onPageChange`, `onPageSizeChange`)
- 필터/검색/정렬 변경 시 첫 페이지로 자동 이동 처리
- 수정 다이얼로그에서 부서/직급 값이 표시되지 않던 문제 수정
- `useUser` hook을 통해 사용자 상세 정보 조회 후 폼에 반영

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes

- 부서 관리 탭은 트리 구조로 렌더링되어 DataTable을 사용하지 않으므로 페이지네이션 적용 대상이 아닙니다.
- 사용자 목록 API에서 `department`, `position` 필드가 반환되지 않아 `useUser` hook으로 상세 정보를 별도 조회하여 해결했습니다.
