### PR TITLE
feat(ta): 사용자 관리 개선 및 시스템 공지 탭 추가

### DIFF
--- a/src/pages/ta/notices/NoticeAndNotificationPage.tsx
+++ b/src/pages/ta/notices/NoticeAndNotificationPage.tsx
@@ -1,13 +1,15 @@
 import { AdminPageHeader } from '@/components/domain/admin';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/common/Tabs';
-import { Megaphone, Send, Bell } from 'lucide-react';
+import { Megaphone, Send, Bell, Globe } from 'lucide-react';
 import { NoticesContent } from './TenantNoticesPage';
 import { DistributionContent } from './NoticeDistributionPage';
+import { SystemNoticesContent } from './SystemNoticesPage';
 import { NotificationTemplatesContent } from '../system/NotificationTemplatesPage';
 
 /**
  * 공지 및 알림 관리 통합 페이지
  * - 공지사항 탭: 공지사항 작성/관리
+ * - 시스템 공지 탭: SA가 배포한 시스템 공지사항 조회
  * - 배포 관리 탭: 공지 배포 현황
  * - 알림 템플릿 탭: 시스템 알림 템플릿 관리
  */
@@ -25,6 +27,10 @@ export function NoticeAndNotificationPage() {
             <Megaphone className="h-4 w-4" />
             공지사항
           </TabsTrigger>
+          <TabsTrigger value="system-notices" className="gap-2">
+            <Globe className="h-4 w-4" />
+            시스템 공지
+          </TabsTrigger>
           <TabsTrigger value="distribution" className="gap-2">
             <Send className="h-4 w-4" />
             배포 관리
@@ -37,6 +43,10 @@ export function NoticeAndNotificationPage() {
 
         <TabsContent value="notices" className="mt-6">
           <NoticesContent />
+        </TabsContent>
+
+        <TabsContent value="system-notices" className="mt-6">
+          <SystemNoticesContent />
         </TabsContent>
 
         <TabsContent value="distribution" className="mt-6">

--- a/src/pages/ta/notices/SystemNoticesPage.tsx
+++ b/src/pages/ta/notices/SystemNoticesPage.tsx
@@ -34,7 +34,8 @@ const typeConfig: Record<string, { label: string; color: string }> = {
   EVENT: { label: '이벤트', color: 'bg-purple-100 text-purple-700' },
 };
 
-export function SystemNoticesPage() {
+// 탭용 콘텐츠 컴포넌트 (NoticeAndNotificationPage에서 사용)
+export function SystemNoticesContent() {
   const [page, setPage] = useState(0);
   const [selectedNoticeId, setSelectedNoticeId] = useState<number | null>(null);
 
@@ -63,21 +64,15 @@ export function SystemNoticesPage() {
 
   if (isLoading) {
     return (
-      <div className="p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
-          <div className="h-64 bg-gray-200 rounded"></div>
-        </div>
+      <div className="animate-pulse space-y-4">
+        <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+        <div className="h-64 bg-gray-200 rounded"></div>
       </div>
     );
   }
 
   return (
-    <div className="p-6">
-      <AdminPageHeader
-        title="시스템 공지사항"
-        description="시스템 관리자가 배포한 공지사항입니다"
-      />
+    <>
 
       <Card>
         <CardHeader>
@@ -217,6 +212,21 @@ export function SystemNoticesPage() {
           )}
         </DialogContent>
       </Dialog>
+    </>
+  );
+}
+
+// 독립 페이지 컴포넌트
+export function SystemNoticesPage() {
+  return (
+    <div className="p-6">
+      <AdminPageHeader
+        title="시스템 공지사항"
+        description="시스템 관리자가 배포한 공지사항입니다"
+      />
+      <div className="mt-6">
+        <SystemNoticesContent />
+      </div>
     </div>
   );
 }

--- a/src/pages/ta/notices/index.ts
+++ b/src/pages/ta/notices/index.ts
@@ -1,5 +1,5 @@
 export { TenantNoticesPage, NoticesContent } from './TenantNoticesPage';
-export { SystemNoticesPage } from './SystemNoticesPage';
+export { SystemNoticesPage, SystemNoticesContent } from './SystemNoticesPage';
 export { NoticeInboxPage } from './NoticeInboxPage';
 export { NoticeDistributionPage, DistributionContent } from './NoticeDistributionPage';
 export { NoticeAndNotificationPage } from './NoticeAndNotificationPage';


### PR DESCRIPTION
## Summary

TA 사용자 관리 페이지의 서버사이드 페이지네이션 구현, 수정 다이얼로그 버그 수정 및 공지 관리 페이지에 SA 시스템 공지사항 탭을 추가했습니다.

## Related Issue

- Closes #

## Changes

**사용자 관리 페이지:**
- 서버사이드 페이지네이션 구현 (`manualPagination`, `pageCount`, `pageIndex`)
- 필터/검색/정렬 변경 시 첫 페이지로 이동 처리
- 수정 다이얼로그에서 부서/직급 값이 표시되지 않던 버그 수정
- `useUser` hook으로 사용자 상세 정보 조회 후 폼 반영

**공지 및 알림 관리 페이지:**
- SA가 배포한 시스템 공지사항 조회 탭 추가
- `SystemNoticesContent` 컴포넌트 분리

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes

- 사용자 목록 API에서 `department`, `position` 필드가 반환되지 않아 `useUser` hook으로 상세 정보를 별도 조회하여 해결
- 시스템 공지사항 탭은 SA가 배포한 공지만 조회 가능 (읽기 전용)