### PR TITLE
fix(tu): 과정 상세페이지 등록 API를 register로 변경

### DIFF
--- a/src/hooks/tu/index.ts
+++ b/src/hooks/tu/index.ts
@@ -88,6 +88,7 @@ export {
   useUpdateCourse,
   useDeleteCourse,
   useReadyCourse,
+  useRegisterCourse,
 } from './useCourseQueries';
 
 // Course Detail Hooks

--- a/src/pages/tu/teaching/courses/CourseDetailPage.tsx
+++ b/src/pages/tu/teaching/courses/CourseDetailPage.tsx
@@ -14,7 +14,7 @@ import {
   useCourseItemsHierarchy,
   useDeleteCourse,
   useLearningObject,
-  useReadyCourse,
+  useRegisterCourse,
 } from '@/hooks/tu';
 import { ContentPreviewModal } from '@/components/domain/tu/content/ContentPreviewModal';
 import type { ContentType } from '@/types/tu';
@@ -68,7 +68,7 @@ export function CourseDetailPage() {
   const { data: course, isLoading, error } = useCourse(id);
   const { data: curriculum } = useCourseItemsHierarchy(id);
   const deleteCourseMutation = useDeleteCourse();
-  const readyCourseMutation = useReadyCourse();
+  const registerCourseMutation = useRegisterCourse();
 
   // 콘텐츠 미리보기 상태
   const [previewModalOpen, setPreviewModalOpen] = useState(false);
@@ -152,9 +152,9 @@ export function CourseDetailPage() {
   // 과정 등록 핸들러
   const handleApply = async () => {
     try {
-      await readyCourseMutation.mutateAsync(id);
+      await registerCourseMutation.mutateAsync({ id });
       setApplyModalOpen(false);
-      alert('과정이 등록되었습니다. 운영자 검토 후 승인됩니다.');
+      alert('과정이 등록되었습니다. 운영자가 차수를 개설할 수 있습니다.');
       navigate(prefixPath('/tu/teaching/courses'));
     } catch (err) {
       console.error('Apply failed:', err);
@@ -284,7 +284,7 @@ export function CourseDetailPage() {
         curriculum={curriculum ?? []}
         categories={categories}
         onApply={handleApply}
-        isApplying={readyCourseMutation.isPending}
+        isApplying={registerCourseMutation.isPending}
       />
     </div>
   );

--- a/src/pages/tu/teaching/courses/components/CourseApplyModal.tsx
+++ b/src/pages/tu/teaching/courses/components/CourseApplyModal.tsx
@@ -380,10 +380,7 @@ export function CourseApplyModal({
             <AlertDialogTitle>과정을 등록하시겠습니까?</AlertDialogTitle>
             <AlertDialogDescription className="space-y-2">
               <p>
-                등록하면 과정 상태가 <strong>DRAFT → READY</strong>로 변경됩니다.
-              </p>
-              <p className="text-text-secondary">
-                등록된 과정은 운영자(CO)의 검토 후 승인됩니다.
+                등록된 과정은 운영자가 차수를 개설할 수 있습니다.
               </p>
             </AlertDialogDescription>
           </AlertDialogHeader>


### PR DESCRIPTION
## Summary
- CourseDetailPage에서 `ready()` 대신 `register()` API 호출하도록 수정
- `useRegisterCourse` 훅 export 추가
- CourseApplyModal에서 백엔드 용어(`DRAFT → READY`) 제거

## 문제 상황
상세페이지에서 "과정 등록" 버튼 클릭 시 `ready()` API만 호출되어 READY 상태로만 변경되고, REGISTERED로 변경되지 않는 문제

| 페이지 | 기존 API | 상태 변화 |
|--------|---------|----------|
| 목록 | `register()` | READY → REGISTERED ✅ |
| 생성 | `ready()` + `register()` | DRAFT → READY → REGISTERED ✅ |
| **상세** | `ready()` 만 | DRAFT → READY ❌ |

## 수정 내용
- 상세페이지에서 `register()` API 호출하도록 변경
- 모달 확인 메시지에서 백엔드 용어 제거

## Test plan
- [ ] 상세페이지에서 "과정 등록" 버튼 클릭 후 REGISTERED 상태로 변경되는지 확인
- [ ] 등록 확인 모달에서 백엔드 용어가 표시되지 않는지 확인