### PR TITLE
feat: TA 사용자/공지 관리 개선 및 SA 분석 테넌트 필터링 수정

### DIFF
--- a/src/pages/sa/analytics/UsageContent.tsx
+++ b/src/pages/sa/analytics/UsageContent.tsx
@@ -19,7 +19,7 @@ import {
   SelectValue,
 } from '@/components/common/Select';
 import { Progress } from '@/components/common/Progress';
-import { useSaActivityStats, useSaDashboard } from '@/hooks/sa';
+import { useSaActivityStats, useSaDashboard, useTenantUserStats } from '@/hooks/sa';
 
 interface UsageContentProps {
   tenantId: number | null;
@@ -36,17 +36,26 @@ export function UsageContent({ tenantId }: UsageContentProps) {
     tenantId: tenantId || undefined,
   });
 
-  // Dashboard 데이터 조회 (전체만, tenantId가 없을 때만)
+  // Dashboard 데이터 조회 (전체 통계)
   const { data: dashboard, isLoading: dashboardLoading } = useSaDashboard();
-  const isLoading = activityLoading || (tenantId === null && dashboardLoading);
+
+  // 테넌트별 사용자 수 조회
+  const { data: tenantUserStats, isLoading: tenantUserStatsLoading } = useTenantUserStats();
+
+  const isLoading = activityLoading || dashboardLoading || tenantUserStatsLoading;
 
   const handleViewTenantAnalytics = (tenantIdValue: number) => {
     navigate(`/sa/analytics?tenantId=${tenantIdValue}`);
   };
 
-  // 대시보드에서 통계 추출
-  const totalUsers = dashboard?.userStats?.total || 0;
-  const activeUsers = dashboard?.userStats?.active || 0;
+  // 테넌트가 선택된 경우 해당 테넌트의 사용자 수 조회
+  const selectedTenantUserCount = tenantId
+    ? tenantUserStats?.tenantUserCounts?.find((t) => t.tenantId === tenantId)?.userCount || 0
+    : 0;
+
+  // 대시보드에서 통계 추출 (테넌트 선택 여부에 따라 다른 값 표시)
+  const totalUsers = tenantId ? selectedTenantUserCount : (dashboard?.userStats?.total || 0);
+  const activeUsers = tenantId ? (activityStats?.activeUsers || 0) : (dashboard?.userStats?.active || 0);
   const totalTenants = dashboard?.tenantStats?.total || 0;
   const activeTenants = dashboard?.tenantStats?.active || 0;
 
@@ -86,7 +95,9 @@ export function UsageContent({ tenantId }: UsageContentProps) {
                   </div>
                   <div>
                     <p className="text-2xl font-bold">{totalUsers.toLocaleString()}</p>
-                    <p className="text-sm text-text-secondary">전체 사용자</p>
+                    <p className="text-sm text-text-secondary">
+                      {tenantId ? '테넌트 사용자' : '전체 사용자'}
+                    </p>
                   </div>
                 </div>
                 <div className="mt-2 text-xs text-green-600 flex items-center gap-1">
@@ -95,23 +106,25 @@ export function UsageContent({ tenantId }: UsageContentProps) {
                 </div>
               </CardContent>
             </Card>
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 bg-blue-100 rounded-lg">
-                    <Building2 className="h-5 w-5 text-blue-600" />
+            {!tenantId && (
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-blue-100 rounded-lg">
+                      <Building2 className="h-5 w-5 text-blue-600" />
+                    </div>
+                    <div>
+                      <p className="text-2xl font-bold">{totalTenants}</p>
+                      <p className="text-sm text-text-secondary">전체 테넌트</p>
+                    </div>
                   </div>
-                  <div>
-                    <p className="text-2xl font-bold">{totalTenants}</p>
-                    <p className="text-sm text-text-secondary">전체 테넌트</p>
+                  <div className="mt-2 text-xs text-green-600 flex items-center gap-1">
+                    <TrendingUp className="h-3 w-3" />
+                    활성: {activeTenants}
                   </div>
-                </div>
-                <div className="mt-2 text-xs text-green-600 flex items-center gap-1">
-                  <TrendingUp className="h-3 w-3" />
-                  활성: {activeTenants}
-                </div>
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
+            )}
             <Card>
               <CardContent className="pt-6">
                 <div className="flex items-center gap-3">
@@ -146,89 +159,90 @@ export function UsageContent({ tenantId }: UsageContentProps) {
             </Card>
           </div>
 
-          {/* Tenant Stats by Plan */}
-          <div className="grid grid-cols-2 gap-6 mb-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>테넌트 상태별 현황</CardTitle>
-                <CardDescription>테넌트 상태 분포</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-4">
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm">활성</span>
-                    <div className="flex items-center gap-2">
-                      <Progress
-                        value={totalTenants > 0 ? (activeTenants / totalTenants) * 100 : 0}
-                        className="w-32 h-2"
-                      />
-                      <span className="text-sm font-medium w-8">{activeTenants}</span>
+          {/* Tenant Stats by Plan - 전체 보기일 때만 표시 */}
+          {!tenantId && (
+            <div className="grid grid-cols-2 gap-6 mb-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle>테넌트 상태별 현황</CardTitle>
+                  <CardDescription>테넌트 상태 분포</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm">활성</span>
+                      <div className="flex items-center gap-2">
+                        <Progress
+                          value={totalTenants > 0 ? (activeTenants / totalTenants) * 100 : 0}
+                          className="w-32 h-2"
+                        />
+                        <span className="text-sm font-medium w-8">{activeTenants}</span>
+                      </div>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm">대기</span>
+                      <div className="flex items-center gap-2">
+                        <Progress
+                          value={totalTenants > 0 ? ((dashboard?.tenantStats?.pending || 0) / totalTenants) * 100 : 0}
+                          className="w-32 h-2"
+                        />
+                        <span className="text-sm font-medium w-8">{dashboard?.tenantStats?.pending || 0}</span>
+                      </div>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm">정지</span>
+                      <div className="flex items-center gap-2">
+                        <Progress
+                          value={totalTenants > 0 ? ((dashboard?.tenantStats?.suspended || 0) / totalTenants) * 100 : 0}
+                          className="w-32 h-2"
+                        />
+                        <span className="text-sm font-medium w-8">{dashboard?.tenantStats?.suspended || 0}</span>
+                      </div>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm">종료</span>
+                      <div className="flex items-center gap-2">
+                        <Progress
+                          value={totalTenants > 0 ? ((dashboard?.tenantStats?.terminated || 0) / totalTenants) * 100 : 0}
+                          className="w-32 h-2"
+                        />
+                        <span className="text-sm font-medium w-8">{dashboard?.tenantStats?.terminated || 0}</span>
+                      </div>
                     </div>
                   </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm">대기</span>
-                    <div className="flex items-center gap-2">
-                      <Progress
-                        value={totalTenants > 0 ? ((dashboard?.tenantStats?.pending || 0) / totalTenants) * 100 : 0}
-                        className="w-32 h-2"
-                      />
-                      <span className="text-sm font-medium w-8">{dashboard?.tenantStats?.pending || 0}</span>
-                    </div>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm">정지</span>
-                    <div className="flex items-center gap-2">
-                      <Progress
-                        value={totalTenants > 0 ? ((dashboard?.tenantStats?.suspended || 0) / totalTenants) * 100 : 0}
-                        className="w-32 h-2"
-                      />
-                      <span className="text-sm font-medium w-8">{dashboard?.tenantStats?.suspended || 0}</span>
-                    </div>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm">종료</span>
-                    <div className="flex items-center gap-2">
-                      <Progress
-                        value={totalTenants > 0 ? ((dashboard?.tenantStats?.terminated || 0) / totalTenants) * 100 : 0}
-                        className="w-32 h-2"
-                      />
-                      <span className="text-sm font-medium w-8">{dashboard?.tenantStats?.terminated || 0}</span>
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
 
-            <Card>
-              <CardHeader>
-                <CardTitle>사용자 상태별 분포</CardTitle>
-                <CardDescription>사용자 상태 현황</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-4">
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm">활성</span>
-                    <div className="flex items-center gap-2">
-                      <Progress
-                        value={totalUsers > 0 ? ((dashboard?.userStats?.active || 0) / totalUsers) * 100 : 0}
-                        className="w-32 h-2"
-                      />
-                      <span className="text-sm font-medium w-8">{dashboard?.userStats?.active || 0}</span>
+              <Card>
+                <CardHeader>
+                  <CardTitle>사용자 상태별 분포</CardTitle>
+                  <CardDescription>사용자 상태 현황</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm">활성</span>
+                      <div className="flex items-center gap-2">
+                        <Progress
+                          value={totalUsers > 0 ? ((dashboard?.userStats?.active || 0) / totalUsers) * 100 : 0}
+                          className="w-32 h-2"
+                        />
+                        <span className="text-sm font-medium w-8">{dashboard?.userStats?.active || 0}</span>
+                      </div>
                     </div>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm">정지</span>
-                    <div className="flex items-center gap-2">
-                      <Progress
-                        value={totalUsers > 0 ? ((dashboard?.userStats?.suspended || 0) / totalUsers) * 100 : 0}
-                        className="w-32 h-2"
-                      />
-                      <span className="text-sm font-medium w-8">{dashboard?.userStats?.suspended || 0}</span>
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm">정지</span>
+                      <div className="flex items-center gap-2">
+                        <Progress
+                          value={totalUsers > 0 ? ((dashboard?.userStats?.suspended || 0) / totalUsers) * 100 : 0}
+                          className="w-32 h-2"
+                        />
+                        <span className="text-sm font-medium w-8">{dashboard?.userStats?.suspended || 0}</span>
+                      </div>
                     </div>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm">탈퇴</span>
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm">탈퇴</span>
+                      <div className="flex items-center gap-2">
                       <Progress
                         value={totalUsers > 0 ? ((dashboard?.userStats?.withdrawn || 0) / totalUsers) * 100 : 0}
                         className="w-32 h-2"
@@ -240,8 +254,10 @@ export function UsageContent({ tenantId }: UsageContentProps) {
               </CardContent>
             </Card>
           </div>
+          )}
 
-          {/* Recent Tenants */}
+          {/* Recent Tenants - 전체 보기일 때만 표시 */}
+          {!tenantId && (
           <Card>
             <CardHeader>
               <CardTitle>최근 등록 테넌트</CardTitle>
@@ -298,6 +314,7 @@ export function UsageContent({ tenantId }: UsageContentProps) {
               </div>
             </CardContent>
           </Card>
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary

TA 사용자 관리 페이지의 페이지네이션 및 수정 다이얼로그 개선, TA 공지 관리에 SA 시스템 공지 탭 추가, SA 분석 페이지의 테넌트별 사용자 수 필터링 버그를 수정했습니다.

## Related Issue

- Closes #

## Changes

**TA 사용자 관리 (UsersPage):**
- 서버사이드 페이지네이션 구현 (`manualPagination`, `pageCount`, `pageIndex`)
- 필터/검색/정렬 변경 시 첫 페이지로 이동 처리
- 수정 다이얼로그에서 부서/직급 값이 표시되지 않던 버그 수정
- `useUser` hook으로 사용자 상세 정보 조회 후 폼 반영

**TA 공지 관리 (NoticeAndNotificationPage):**
- SA가 배포한 시스템 공지사항 조회 탭 추가
- `SystemNoticesContent` 컴포넌트 분리

**SA 분석 페이지 (UsageContent):**
- 테넌트 선택 시 해당 테넌트의 사용자 수 표시하도록 수정
- `useTenantUserStats` hook 추가하여 테넌트별 사용자 수 조회
- 테넌트 선택 시 전체 통계 카드 및 글로벌 현황 섹션 숨김 처리

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Screenshots (Optional)

## Additional Notes

- 사용자 목록 API에서 `department`, `position` 필드가 반환되지 않아 `useUser` hook으로 상세 정보를 별도 조회
- SA 분석 페이지에서 기존 `useSaDashboard`는 테넌트 필터링을 지원하지 않아 `useTenantUserStats`를 활용하여 테넌트별 사용자 수 표시
- 시스템 공지사항 탭은 SA가 배포한 공지만 조회 가능 (읽기 전용)