### PR TITLE
feat: 관리자 페이지 반응형 그리드 개선 및 배너 배경 수정

### DIFF
--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -99,13 +99,13 @@ export function HeroSection() {
     return null;
   }
 
-  // 브랜딩 배너(이미지/코드)가 있는지 확인
-  const hasBrandingBanner = brandingBannerItems.length > 0;
+  // 브랜딩 배너 중 이미지 타입이 있는지 확인 (코드 타입만 있으면 배경 표시)
+  const hasImageBanner = brandingBannerItems.some(item => item.type === 'image' && item.imageUrl);
 
   return (
     <div className="w-full overflow-hidden relative">
-      {/* 브랜딩 배너가 없을 때만 기본 배경 표시 */}
-      {!hasBrandingBanner && (
+      {/* 이미지 배너가 없을 때 기본 배경 표시 (코드 타입이거나 배너가 없는 경우) */}
+      {!hasImageBanner && (
         <>
           <div className="absolute inset-0 animated-bg" />
           {/* Background decorative elements */}

--- a/src/pages/co/auto-enrollment/AutoEnrollmentRulesPage.tsx
+++ b/src/pages/co/auto-enrollment/AutoEnrollmentRulesPage.tsx
@@ -315,7 +315,7 @@ export default function AutoEnrollmentRulesPage() {
         </div>
 
         {/* 통계 카드 */}
-        <div className="grid grid-cols-4 gap-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
           <Card>
             <CardContent className="p-4">
               <div className="flex items-center justify-between">

--- a/src/pages/co/member-pool/MemberPoolListPage.tsx
+++ b/src/pages/co/member-pool/MemberPoolListPage.tsx
@@ -339,7 +339,7 @@ export default function MemberPoolListPage() {
         </div>
 
         {/* 통계 카드 */}
-        <div className="grid grid-cols-4 gap-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
           <Card>
             <CardContent className="p-4">
               <div className="flex items-center justify-between">

--- a/src/pages/sa/analytics/ActivityContent.tsx
+++ b/src/pages/sa/analytics/ActivityContent.tsx
@@ -114,7 +114,7 @@ export function ActivityContent({ tenantId }: ActivityContentProps) {
       ) : (
         <>
           {/* Activity Stats */}
-          <div className="grid grid-cols-4 gap-4 mb-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
             <Card>
               <CardContent className="pt-6">
                 <div className="flex items-center gap-3">

--- a/src/pages/sa/analytics/AnalyticsPage.tsx
+++ b/src/pages/sa/analytics/AnalyticsPage.tsx
@@ -51,7 +51,7 @@ export function AnalyticsPage() {
         </div>
 
         {!tenantsLoading && (
-          <div className="grid grid-cols-6 gap-3">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
             {/* 전체 보기 카드 */}
             <Card
               className={`cursor-pointer transition-all hover:shadow-md ${

--- a/src/pages/sa/analytics/LogsContent.tsx
+++ b/src/pages/sa/analytics/LogsContent.tsx
@@ -202,7 +202,7 @@ export function LogsContent({ tenantId }: LogsContentProps) {
       </div>
 
       {/* Stats Summary */}
-      <div className="grid grid-cols-4 gap-4 mb-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center gap-3">

--- a/src/pages/sa/analytics/UsageContent.tsx
+++ b/src/pages/sa/analytics/UsageContent.tsx
@@ -77,7 +77,7 @@ export function UsageContent({ tenantId }: UsageContentProps) {
       ) : (
         <>
           {/* Overview Stats */}
-          <div className="grid grid-cols-4 gap-4 mb-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
             <Card>
               <CardContent className="pt-6">
                 <div className="flex items-center gap-3">

--- a/src/pages/sa/notices/NoticeDistributionContent.tsx
+++ b/src/pages/sa/notices/NoticeDistributionContent.tsx
@@ -65,7 +65,7 @@ export function NoticeDistributionContent() {
   if (isLoading) {
     return (
       <div className="animate-pulse space-y-4">
-        <div className="grid grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           {[1, 2, 3, 4].map((i) => (
             <div key={i} className="h-24 bg-gray-200 rounded"></div>
           ))}
@@ -78,7 +78,7 @@ export function NoticeDistributionContent() {
   return (
     <div>
       {/* Stats Summary */}
-      <div className="grid grid-cols-4 gap-4 mb-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center gap-3">

--- a/src/pages/sa/notices/NoticeDistributionPage.tsx
+++ b/src/pages/sa/notices/NoticeDistributionPage.tsx
@@ -68,7 +68,7 @@ export function NoticeDistributionPage() {
       <div className="p-6">
         <div className="animate-pulse space-y-4">
           <div className="h-8 bg-gray-200 rounded w-1/4"></div>
-          <div className="grid grid-cols-4 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             {[1, 2, 3, 4].map((i) => (
               <div key={i} className="h-24 bg-gray-200 rounded"></div>
             ))}
@@ -87,7 +87,7 @@ export function NoticeDistributionPage() {
       />
 
       {/* Stats Summary */}
-      <div className="grid grid-cols-4 gap-4 mb-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center gap-3">

--- a/src/pages/ta/analytics/DataAnalyticsPage.tsx
+++ b/src/pages/ta/analytics/DataAnalyticsPage.tsx
@@ -204,7 +204,7 @@ function RealtimeTab() {
         </div>
       ) : (
         <>
-          <div className="grid grid-cols-4 gap-4 mb-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
             <Card>
               <CardContent className="pt-6">
                 <div className="flex items-center gap-3">
@@ -543,7 +543,7 @@ function LogsTab() {
       )}
 
       {/* 통계 요약 */}
-      <div className="grid grid-cols-4 gap-4 mb-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center gap-3">

--- a/src/pages/ta/analytics/LogsPage.tsx
+++ b/src/pages/ta/analytics/LogsPage.tsx
@@ -423,7 +423,7 @@ export function LogsPage() {
       )}
 
       {/* Stats Summary */}
-      <div className="grid grid-cols-4 gap-4 mb-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center gap-3">

--- a/src/pages/ta/analytics/RealtimePage.tsx
+++ b/src/pages/ta/analytics/RealtimePage.tsx
@@ -99,7 +99,7 @@ export function RealtimePage() {
       ) : (
         <>
           {/* Realtime Stats */}
-          <div className="grid grid-cols-4 gap-4 mb-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
             <Card>
               <CardContent className="pt-6">
                 <div className="flex items-center gap-3">

--- a/src/pages/ta/automation/AutoEnrollmentRulesPage.tsx
+++ b/src/pages/ta/automation/AutoEnrollmentRulesPage.tsx
@@ -166,7 +166,7 @@ export const AutoEnrollmentRulesPage = () => {
         </div>
 
         {/* 통계 카드 */}
-        <div className="grid grid-cols-4 gap-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
           <Card>
             <CardContent className="p-4">
               <div className="flex items-center justify-between">

--- a/src/pages/ta/automation/MemberPoolPage.tsx
+++ b/src/pages/ta/automation/MemberPoolPage.tsx
@@ -154,7 +154,7 @@ export const MemberPoolPage = () => {
         </div>
 
         {/* 통계 카드 */}
-        <div className="grid grid-cols-4 gap-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
           <Card>
             <CardContent className="p-4">
               <div className="flex items-center justify-between">

--- a/src/pages/ta/notices/NoticeDistributionPage.tsx
+++ b/src/pages/ta/notices/NoticeDistributionPage.tsx
@@ -75,7 +75,7 @@ export function DistributionContent() {
   if (isLoading) {
     return (
       <div className="animate-pulse space-y-4">
-        <div className="grid grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           {[1, 2, 3, 4].map((i) => (
             <div key={i} className="h-24 bg-gray-200 rounded"></div>
           ))}
@@ -89,7 +89,7 @@ export function DistributionContent() {
     <div>
 
       {/* Stats Summary */}
-      <div className="grid grid-cols-4 gap-4 mb-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center gap-3">

--- a/src/pages/ta/users/BulkAccountCreationPage.tsx
+++ b/src/pages/ta/users/BulkAccountCreationPage.tsx
@@ -376,7 +376,7 @@ export const BulkAccountCreationPage = () => {
         ) : (
           <>
             {/* 업로드 결과 */}
-            <div className="grid grid-cols-4 gap-4 mb-6">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
               <Card>
                 <CardContent className="p-4">
                   <div className="flex items-center justify-between">

--- a/src/pages/ta/users/EmployeeListPage.tsx
+++ b/src/pages/ta/users/EmployeeListPage.tsx
@@ -297,7 +297,7 @@ export const EmployeeListPage = () => {
         </div>
 
         {/* 통계 카드 */}
-        <div className="grid grid-cols-5 gap-4 mb-6">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 mb-6">
           <Card>
             <CardContent className="p-4">
               <div className="flex items-center justify-between">

--- a/src/pages/ta/users/UserDetailPage.tsx
+++ b/src/pages/ta/users/UserDetailPage.tsx
@@ -171,7 +171,7 @@ function UserDetailSkeleton() {
           </div>
         </CardContent>
       </Card>
-      <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 mb-6">
         {[1, 2, 3, 4, 5].map((i) => (
           <Card key={i}>
             <CardContent className="pt-6 text-center">
@@ -395,7 +395,7 @@ export function UserDetailPage() {
       </Card>
 
       {/* 학습 통계 카드 */}
-      <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 mb-6">
         <Card>
           <CardContent className="pt-6 text-center">
             <p className="text-3xl font-bold text-brand-primary">{formState.stats.totalCourses}</p>


### PR DESCRIPTION
## Summary
- 관리자 페이지(SA/TA/CO)의 통계 카드 그리드를 반응형으로 개선
- 코드 타입 배너일 때 기본 배경이 표시되도록 수정

Closes #530

## Changes

### 1. 반응형 그리드 개선 (17개 파일)
- `grid-cols-4` → `grid-cols-1 sm:grid-cols-2 lg:grid-cols-4`
- `grid-cols-5` → `grid-cols-2 sm:grid-cols-3 lg:grid-cols-5`
- `grid-cols-6` → `grid-cols-2 sm:grid-cols-3 lg:grid-cols-6`

### 2. 배너 배경 수정 (HeroSection.tsx)
- 이미지 배너가 없을 때만 기본 배경 숨김
- 코드 타입 배너는 배경과 함께 표시

## Affected Pages
- SA: AnalyticsPage, LogsContent, ActivityContent, UsageContent
- TA: DataAnalyticsPage, RealtimePage, LogsPage, EmployeeListPage, UserDetailPage, MemberPoolPage, BulkAccountCreationPage, NoticeDistributionPage
- CO: AutoEnrollmentRulesPage, MemberPoolListPage
- Landing: HeroSection

## Test Plan
- [ ] 모바일(< 640px)에서 1열 그리드 확인
- [ ] 태블릿(640px-1024px)에서 2-3열 그리드 확인
- [ ] 데스크톱(> 1024px)에서 4-6열 그리드 확인
- [ ] 코드 타입 배너에서 기본 배경 표시 확인