### PR TITLE
feat(tu): 과정 디테일 페이지 버튼 조건부 렌더링 및 DESIGNER 리다이렉션 수정

### DIFF
--- a/src/hooks/common/auth/useAuth.ts
+++ b/src/hooks/common/auth/useAuth.ts
@@ -51,7 +51,7 @@ export const useLogin = () => {
         SYSTEM_ADMIN: '/sa',
         TENANT_ADMIN: '/ta',
         OPERATOR: '/co',
-        DESIGNER: '/tu/teaching',
+        DESIGNER: '/tu/dashboard',
         USER: '/tu/b2c',
       };
       const basePath = roleBasePath[user.role] || '/tu/b2c';

--- a/src/pages/tu/teaching/courses/CourseDetailPage.tsx
+++ b/src/pages/tu/teaching/courses/CourseDetailPage.tsx
@@ -24,7 +24,8 @@ import { categoryService } from '@/services/common';
 import { CourseInfoSection } from './components/CourseInfoSection';
 import { CourseCurriculumSection } from './components/CourseCurriculumSection';
 import { CourseApplyModal } from './components/CourseApplyModal';
-import type { CourseLevel, CourseType } from '@/types/common/course.types';
+import type { CourseLevel, CourseType, CourseStatus } from '@/types/common/course.types';
+import { COURSE_STATUS_LABELS } from '@/types/common/course.types';
 import type { CategoryResponse } from '@/types/common';
 import type { CourseFormData } from '@/types/co/course.types';
 import { convertHierarchyToCurriculumItems } from '@/types/tu/curriculum.types';
@@ -54,6 +55,13 @@ const TYPE_LABELS: Record<CourseType, string> = {
   ONLINE: '온라인',
   OFFLINE: '오프라인',
   BLENDED: '혼합',
+};
+
+// 상태별 Badge 컬러
+const statusBadgeColor: Record<CourseStatus, BadgeColor> = {
+  DRAFT: 'gray',
+  READY: 'blue',
+  REGISTERED: 'green',
 };
 
 export function CourseDetailPage() {
@@ -201,7 +209,12 @@ export function CourseDetailPage() {
         {/* Header Section - 목록 페이지와 동일한 스타일 */}
         <div className="flex items-start justify-between mb-8">
           <div>
-            <h1 className="text-text-primary mb-2">{course.title}</h1>
+            <div className="flex items-center gap-2 mb-2">
+              <Badge variant={statusBadgeColor[course.status]}>
+                {COURSE_STATUS_LABELS[course.status]}
+              </Badge>
+              <h1 className="text-text-primary">{course.title}</h1>
+            </div>
             <div className="flex items-center gap-2">
               {course.level && (
                 <Badge variant={levelBadgeColor[course.level]}>

--- a/src/pages/tu/teaching/courses/CourseDetailPage.tsx
+++ b/src/pages/tu/teaching/courses/CourseDetailPage.tsx
@@ -216,15 +216,19 @@ export function CourseDetailPage() {
             </div>
           </div>
 
-          {/* Action Buttons */}
+          {/* Action Buttons - 상태별 조건부 렌더링 */}
           <div className="flex items-center gap-2">
-            <Button
-              size="sm"
-              onClick={() => setApplyModalOpen(true)}
-            >
-              <Send size={16} />
-              과정 등록
-            </Button>
+            {/* 과정 등록 버튼 - READY 상태에서만 표시 */}
+            {course.status === 'READY' && (
+              <Button
+                size="sm"
+                onClick={() => setApplyModalOpen(true)}
+              >
+                <Send size={16} />
+                과정 등록
+              </Button>
+            )}
+            {/* 미리보기 버튼 - 항상 표시 */}
             <Button
               variant="ghost"
               size="sm"
@@ -234,15 +238,18 @@ export function CourseDetailPage() {
               <Eye size={16} />
               미리보기
             </Button>
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={handleDelete}
-              disabled={deleteCourseMutation.isPending}
-            >
-              <Trash2 size={16} />
-              삭제
-            </Button>
+            {/* 삭제 버튼 - DRAFT, READY 상태에서만 표시 */}
+            {course.status !== 'REGISTERED' && (
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={handleDelete}
+                disabled={deleteCourseMutation.isPending}
+              >
+                <Trash2 size={16} />
+                삭제
+              </Button>
+            )}
           </div>
         </div>
 
@@ -252,14 +259,14 @@ export function CourseDetailPage() {
           <CourseInfoSection
             course={course}
             categories={categories}
-            onEdit={() => navigate(prefixPath(`/tu/teaching/courses/${id}/edit?step=1`))}
+            onEdit={course.status !== 'REGISTERED' ? () => navigate(prefixPath(`/tu/teaching/courses/${id}/edit?step=1`)) : undefined}
           />
 
           {/* 커리큘럼 섹션 */}
           <CourseCurriculumSection
             itemCount={course.itemCount}
             curriculum={curriculum ?? []}
-            onEdit={() => navigate(prefixPath(`/tu/teaching/courses/${id}/edit?step=2`))}
+            onEdit={course.status !== 'REGISTERED' ? () => navigate(prefixPath(`/tu/teaching/courses/${id}/edit?step=2`)) : undefined}
             onPreviewContent={handlePreviewContent}
           />
         </div>


### PR DESCRIPTION
## Summary
- 과정 디테일 페이지에서 상태(DRAFT/READY/REGISTERED)에 따라 버튼을 조건부 렌더링
- DESIGNER 역할 로그인 후 `/tu/dashboard`로 리다이렉션하도록 수정 (기존 `/tu/teaching`은 빈 페이지)

## Changes

### 과정 디테일 페이지 버튼 조건부 렌더링
| 상태 | 헤더 버튼 | 섹션 수정 버튼 |
|------|---------|--------------|
| **DRAFT** | 미리보기, 삭제 | ✅ 표시 |
| **READY** | 과정 등록, 미리보기, 삭제 | ✅ 표시 |
| **REGISTERED** | 미리보기만 | ❌ 숨김 |

### 로그인 리다이렉션 수정
- `DESIGNER`: `/tu/teaching` → `/tu/dashboard`

## Test plan
- [ ] DRAFT 상태 과정 디테일 페이지 진입 → 미리보기, 삭제 버튼만 표시
- [ ] READY 상태 과정 디테일 페이지 진입 → 과정 등록, 미리보기, 삭제 버튼 표시
- [ ] REGISTERED 상태 과정 디테일 페이지 진입 → 미리보기 버튼만 표시, 섹션 수정 버튼 숨김
- [ ] DESIGNER 역할로 로그인 → `/tu/dashboard`로 이동 확인