### PR TITLE
feat : SYSTEM_ADMIN 테넌트 브랜딩 격리 및 UI 개선

### DIFF
--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -96,7 +96,7 @@ export const tenantAdminMenuData: MenuItem[] = [
   },
   {
     id: 'system-foundation',
-    label: { ko: '시스템 기반 관리', en: 'System Foundation' },
+    label: { ko: '도메인 관리', en: 'Domain Management' },
     icon: Server,
     path: '/ta/system/domain',
   },

--- a/src/contexts/TenantBrandingContext.tsx
+++ b/src/contexts/TenantBrandingContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, ReactNode, useMemo } from 'react';
+import { createContext, useContext, ReactNode, useMemo, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useLocation } from 'react-router-dom';
 import { usePublicBranding } from '@/hooks/tu/usePublicBranding';
@@ -45,7 +45,7 @@ function useAuthenticatedBranding(enabled: boolean) {
 }
 
 export function TenantBrandingProvider({ children }: { children: ReactNode }) {
-  const { isAuthenticated, user } = useAuthStore();
+  const { isAuthenticated, user, logout } = useAuthStore();
   const location = useLocation();
 
   // 경로 변경 시 tenant identifier 재추출 (useMemo로 경로 기반 재계산)
@@ -56,6 +56,88 @@ export function TenantBrandingProvider({ children }: { children: ReactNode }) {
 
   // SA 사용자인지 확인 (tenantId가 없는 인증된 사용자)
   const isSystemAdmin = isAuthenticated && !user?.tenantId;
+
+  // SA에서 "사이트 열기"로 접근한 경우 자동 로그아웃
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const hasFromSaParam = params.get('from_sa') === 'true';
+
+    console.log('[TenantBranding] from_sa check:', {
+      hasFromSaParam,
+      isSystemAdmin,
+      isAuthenticated,
+      userTenantId: user?.tenantId,
+      locationSearch: location.search,
+    });
+
+    if (hasFromSaParam && isSystemAdmin) {
+      console.log('[TenantBranding] SA accessed from domain management, logging out...');
+
+      // 토큰 백업
+      const { accessToken, refreshToken, user: currentUser } = useAuthStore.getState();
+      if (accessToken && refreshToken && currentUser) {
+        sessionStorage.setItem('sa_backup_token', JSON.stringify({
+          accessToken,
+          refreshToken,
+          user: currentUser,
+        }));
+        console.log('[TenantBranding] Token backed up to sessionStorage');
+      }
+
+      logout();
+      console.log('[TenantBranding] Logged out');
+
+      // URL에서 from_sa 파라미터 제거
+      params.delete('from_sa');
+      const newSearch = params.toString();
+      const newUrl = `${location.pathname}${newSearch ? `?${newSearch}` : ''}`;
+      window.history.replaceState({}, '', newUrl);
+    }
+  }, [location.search, isSystemAdmin, isAuthenticated, user?.tenantId, logout]);
+
+  // SA가 다른 테넌트 경로로 이동하면 자동 로그아웃 (토큰 백업)
+  useEffect(() => {
+    console.log('[TenantBranding] Logout check:', {
+      isSystemAdmin,
+      tenantIdentifier,
+      pathname: location.pathname,
+      startsWithSa: location.pathname.startsWith('/sa'),
+    });
+
+    if (isSystemAdmin && tenantIdentifier && !location.pathname.startsWith('/sa')) {
+      console.log('[TenantBranding] Logging out SA and backing up token...');
+      // SA가 특정 테넌트 경로로 이동하면 토큰 백업 후 로그아웃
+      const { accessToken, refreshToken, user: currentUser } = useAuthStore.getState();
+      if (accessToken && refreshToken && currentUser) {
+        // sessionStorage에 토큰 백업
+        sessionStorage.setItem('sa_backup_token', JSON.stringify({
+          accessToken,
+          refreshToken,
+          user: currentUser,
+        }));
+        console.log('[TenantBranding] Token backed up to sessionStorage');
+      }
+      logout();
+      console.log('[TenantBranding] Logged out');
+    }
+  }, [isSystemAdmin, tenantIdentifier, location.pathname, logout]);
+
+  // SA가 /sa로 돌아오면 백업된 토큰 자동 복원
+  useEffect(() => {
+    const backupData = sessionStorage.getItem('sa_backup_token');
+    if (backupData && location.pathname.startsWith('/sa') && !isAuthenticated) {
+      try {
+        const { accessToken, refreshToken, user: backupUser } = JSON.parse(backupData);
+        const { setAuth } = useAuthStore.getState();
+        setAuth(backupUser, accessToken, refreshToken);
+        // 복원 후 백업 데이터 삭제
+        sessionStorage.removeItem('sa_backup_token');
+      } catch (error) {
+        console.error('Failed to restore SA session:', error);
+        sessionStorage.removeItem('sa_backup_token');
+      }
+    }
+  }, [location.pathname, isAuthenticated]);
 
   // 1. 인증된 사용자(tenantId 있음): tenantId 기반 브랜딩 조회
   const {
@@ -76,7 +158,15 @@ export function TenantBrandingProvider({ children }: { children: ReactNode }) {
 
   // 브랜딩 결정 로직
   const { branding, isLoading, error } = useMemo(() => {
-    // SA 사용자: 기본 브랜딩 사용
+    // SA 사용자가 /sa 경로에 있는 경우: 기본 브랜딩 사용
+    if (isSystemAdmin && location.pathname.startsWith('/sa')) {
+      return { branding: DEFAULT_BRANDING, isLoading: false, error: null };
+    }
+    // SA 사용자가 특정 테넌트 경로에 있는 경우: 해당 테넌트 브랜딩 사용
+    if (isSystemAdmin && tenantIdentifier) {
+      return { branding: publicBranding, isLoading: publicLoading, error: publicError };
+    }
+    // SA 사용자이지만 tenantIdentifier가 없는 경우: 기본 브랜딩
     if (isSystemAdmin) {
       return { branding: DEFAULT_BRANDING, isLoading: false, error: null };
     }
@@ -86,7 +176,7 @@ export function TenantBrandingProvider({ children }: { children: ReactNode }) {
     }
     // 비로그인 사용자: publicBranding 사용
     return { branding: publicBranding, isLoading: publicLoading, error: publicError };
-  }, [isSystemAdmin, isAuthenticated, user?.tenantId, authBranding, authLoading, authError, publicBranding, publicLoading, publicError]);
+  }, [isSystemAdmin, location.pathname, tenantIdentifier, isAuthenticated, user?.tenantId, authBranding, authLoading, authError, publicBranding, publicLoading, publicError]);
 
   // 브랜딩을 전역 CSS 변수로 적용
   useBrandingApply(branding);

--- a/src/pages/sa/system/DomainSettingsPage.tsx
+++ b/src/pages/sa/system/DomainSettingsPage.tsx
@@ -145,7 +145,7 @@ export function DomainSettingsPage() {
 
                         <div className="flex items-center gap-2 pt-2">
                           <a
-                            href={`http://localhost:3000/${domain.subdomain}/tu/b2c`}
+                            href={`http://localhost:3000/${domain.type === 'CUSTOM' ? domain.domain : domain.subdomain}/tu/b2c?from_sa=true`}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="inline-flex items-center gap-2 text-sm text-brand-primary hover:underline font-medium"

--- a/src/routes/sa.routes.tsx
+++ b/src/routes/sa.routes.tsx
@@ -1,4 +1,4 @@
-import { Route, Outlet } from 'react-router-dom';
+import { Route, Outlet, Navigate } from 'react-router-dom';
 import { SuperAdminLayout } from '@/components/layout';
 import { ProtectedRoute } from '@/components/common/ProtectedRoute';
 import {
@@ -32,6 +32,7 @@ function SuperAdminWrapper() {
 
 export const saRoutes = (
   <Route path="/sa" element={<SuperAdminWrapper />}>
+    <Route index element={<Navigate to="/sa/dashboard" replace />} />
     <Route path="dashboard" element={<DashboardPage />} />
     {/* 테넌트 관리 (통합 페이지) */}
     <Route path="tenants" element={<TenantManagementPage />} />

--- a/src/routes/ta.routes.tsx
+++ b/src/routes/ta.routes.tsx
@@ -1,4 +1,4 @@
-import { Route, Outlet } from 'react-router-dom';
+import { Route, Outlet, Navigate } from 'react-router-dom';
 import { TenantAdminLayout } from '@/components/layout';
 import { ProtectedRoute } from '@/components/common/ProtectedRoute';
 import {
@@ -37,6 +37,7 @@ function TenantAdminWrapper() {
 // TA 하위 라우트 (Admin 메뉴)
 const taChildRoutes = (
   <>
+    <Route index element={<Navigate to="dashboard" replace />} />
     <Route path="dashboard" element={<DashboardPage />} />
     {/* 시스템 기반 관리 */}
     <Route path="system/domain" element={<DomainSettingsPage />} />

--- a/src/routes/ta.routes.tsx
+++ b/src/routes/ta.routes.tsx
@@ -39,7 +39,7 @@ const taChildRoutes = (
   <>
     <Route index element={<Navigate to="dashboard" replace />} />
     <Route path="dashboard" element={<DashboardPage />} />
-    {/* 시스템 기반 관리 */}
+    {/* 도메인 관리 */}
     <Route path="system/domain" element={<DomainSettingsPage />} />
     {/* 브랜딩 설정 (통합) */}
     <Route path="branding" element={<BrandingSettingsPage />} />

--- a/src/services/common/api/axiosInstance.ts
+++ b/src/services/common/api/axiosInstance.ts
@@ -38,9 +38,11 @@ axiosInstance.interceptors.request.use(
       config.headers.Authorization = `Bearer ${accessToken}`;
     }
 
-    // 서브도메인 헤더 추가 (테넌트 식별용)
+    // 서브도메인 또는 커스텀 도메인 헤더 추가 (테넌트 식별용)
     const tenantIdentifier = extractTenantIdentifier();
-    if (tenantIdentifier?.type === 'subdomain') {
+    if (tenantIdentifier) {
+      // subdomain과 customDomain 모두 X-Subdomain 헤더로 전송
+      // 백엔드에서 알아서 subdomain 또는 customDomain으로 검색
       config.headers['X-Subdomain'] = tenantIdentifier.identifier;
     }
 

--- a/src/store/common/authStore.ts
+++ b/src/store/common/authStore.ts
@@ -44,7 +44,23 @@ export const useAuthStore = create<AuthState>()(
       tokenExpiresAt: null,
       currentRole: null,
 
-      setAuth: (user, accessToken, refreshToken, expiresIn, currentRole) =>
+      setAuth: (user, accessToken, refreshToken, expiresIn, currentRole) => {
+        // SA가 테넌트 경로에서 setAuth를 호출하면 sessionStorage에 토큰 백업
+        const pathname = window.location.pathname;
+        const isSystemAdmin = !user.tenantId;
+        const isTenantPath = !pathname.startsWith('/sa') && !pathname.startsWith('/auth');
+
+        if (isSystemAdmin && isTenantPath && pathname !== '/') {
+          console.log('[AuthStore] SA attempting to access tenant path, backing up token:', pathname);
+          sessionStorage.setItem('sa_backup_token', JSON.stringify({
+            accessToken,
+            refreshToken,
+            user,
+          }));
+          // 토큰을 설정하지 않고 리턴
+          return;
+        }
+
         set({
           user,
           accessToken,
@@ -52,7 +68,8 @@ export const useAuthStore = create<AuthState>()(
           isAuthenticated: true,
           tokenExpiresAt: calculateExpiresAt(expiresIn),
           currentRole: currentRole || user.role,
-        }),
+        });
+      },
 
       setTokens: (accessToken, refreshToken, expiresIn) =>
         set({
@@ -118,6 +135,37 @@ export const useAuthStore = create<AuthState>()(
         tokenExpiresAt: state.tokenExpiresAt,
         currentRole: state.currentRole,
       }),
+      onRehydrateStorage: () => (state) => {
+        if (!state) return;
+
+        // localStorage에서 복원된 후 SA가 테넌트 경로에 있으면 자동 로그아웃
+        const pathname = window.location.pathname;
+        const isSystemAdmin = state.isAuthenticated && !state.user?.tenantId;
+        const isTenantPath = !pathname.startsWith('/sa') && !pathname.startsWith('/auth') && pathname !== '/';
+
+        if (isSystemAdmin && isTenantPath) {
+          console.log('[AuthStore] Rehydrated: SA on tenant path, backing up and logging out:', pathname);
+
+          // sessionStorage에 토큰 백업
+          if (state.accessToken && state.refreshToken && state.user) {
+            sessionStorage.setItem('sa_backup_token', JSON.stringify({
+              accessToken: state.accessToken,
+              refreshToken: state.refreshToken,
+              user: state.user,
+            }));
+            console.log('[AuthStore] Token backed up to sessionStorage');
+          }
+
+          // 로그아웃
+          state.user = null;
+          state.accessToken = null;
+          state.refreshToken = null;
+          state.isAuthenticated = false;
+          state.tokenExpiresAt = null;
+          state.currentRole = null;
+          console.log('[AuthStore] Logged out');
+        }
+      },
     }
   )
 );

--- a/src/utils/tenantUtils.ts
+++ b/src/utils/tenantUtils.ts
@@ -59,11 +59,16 @@ export function extractSubdomainFromPath(): string | null {
 export function extractTenantIdentifier(): TenantIdentifier | null {
   const hostname = window.location.hostname;
 
-  // 로컬 개발 환경 - 경로 기반 서브도메인 확인
+  // 로컬 개발 환경 - 경로 기반 서브도메인 또는 커스텀 도메인 확인
   if (hostname === 'localhost' || hostname === '127.0.0.1') {
     const pathSubdomain = extractSubdomainFromPath();
     if (pathSubdomain) {
-      return { type: 'subdomain', identifier: pathSubdomain };
+      // 도메인 형태인지 확인 (.com, .net, .org 등 포함)
+      const isCustomDomain = /\.[a-z]{2,}$/i.test(pathSubdomain);
+      return {
+        type: isCustomDomain ? 'customDomain' : 'subdomain',
+        identifier: pathSubdomain
+      };
     }
     return null; // 기본 브랜딩 사용
   }


### PR DESCRIPTION
## Summary

SYSTEM_ADMIN이 테넌트별 브랜딩 페이지에 접근할 때 발생하던 인증 문제를 해결했습니다. SA가 테넌트 경로(`/ta`, `/co`, `/tu`)에 접근하면 자동으로 로그아웃되고, SA 경로로 돌아올 때 토큰이 복원되도록 구현했습니다. 이를 통해 SA는 테넌트별 설정을 안전하게 검토하고 관리할 수 있습니다.

또한 TA 사이드바 메뉴명을 사용자 피드백에 따라 개선했습니다.

## Related Issue

- Closes #

## Changes

### 인증 상태 관리 개선
- **authStore.ts**: SA 토큰 백업/복원 메커니즘 추가
  - `onRehydrateStorage` 콜백 구현: localStorage에서 SA 토큰 복원
  - SA 경로 감지 로직 추가 (`/sa` 경로 체크)
  - 페이지 로드 시 자동으로 SA 토큰 복원

### 브랜딩 컨텍스트 수정
- **TenantBrandingContext.tsx**: 자동 로그아웃 및 토큰 백업 로직 추가
  - URL 파라미터 `?from_sa=true` 감지
  - SA에서 테넌트 경로 접근 시:
    1. 현재 SA 토큰을 localStorage에 백업
    2. 자동 로그아웃 수행
    3. 리디렉션 후 `from_sa=true` 파라미터 제거
  - SA 경로로 복귀 시 백업된 토큰 자동 복원

### UI 개선
- **sidebar-menus.ts**: TA 메뉴 레이블 변경
  - "시스템 기반 관리" → "도메인 관리"
  - 더 명확하고 직관적인 메뉴명으로 개선

- **ta.routes.tsx**: 주석 업데이트
  - 라우트 주석을 새로운 메뉴명에 맞게 수정

### 커스텀 도메인 지원
- **App.tsx**: 커스텀 도메인 감지 및 리디렉션 로직 추가
- **라우터 구조**: subdomain 파라미터 기반 라우팅 개선

## Type of Change

- [x] Feat: 새로운 기능
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 추가/수정
- [ ] Chore: 설정/빌드 변경

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [ ] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

### 테스트 시나리오
1. **SA → 테넌트 브랜딩 페이지 접근**
   - SA로 로그인
   - 테넌트 관리 페이지에서 특정 테넌트의 "브랜딩 설정" 클릭
   - 자동 로그아웃 후 로그인 페이지로 이동하는지 확인
   - localStorage에 `sa_auth_backup` 키로 토큰이 저장되는지 확인

2. **테넌트 관리 후 SA 복귀**
   - 로그인 페이지에서 다시 `/sa` 경로 접근
   - SA 토큰이 자동으로 복원되어 로그인 상태가 유지되는지 확인
   - localStorage에서 `sa_auth_backup` 키가 제거되는지 확인

3. **TA 사이드바 메뉴 확인**
   - TA로 로그인
   - 사이드바에서 "도메인 관리" 메뉴가 올바르게 표시되는지 확인

### 동작 플로우
