### PR TITLE
fix(tu): B2B 페이지 내 잘못된 B2C 경로 참조 수정

### DIFF
--- a/src/pages/tu/b2b/B2BCertificationsPage.tsx
+++ b/src/pages/tu/b2b/B2BCertificationsPage.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Award, Loader2 } from 'lucide-react';
 import { useThemeStore } from '@/store/common/themeStore';
+import { useSubdomainPath } from '@/hooks/common/useSubdomainPath';
 import { useTranslation, useLanguageStore } from '@/store/common/languageStore';
 import { useAuthStore } from '@/store/common/authStore';
 import { useMyCertificates, useDownloadCertificate } from '@/hooks/tu';
@@ -17,6 +19,8 @@ import { CertificateCard, CertificatePreviewModal } from '@/components/domain/tu
 import type { CertificateResponse } from '@/types/tu';
 
 export function B2BCertificationsPage() {
+  const navigate = useNavigate();
+  const { prefixPath } = useSubdomainPath();
   const { theme } = useThemeStore();
   const { language } = useLanguageStore();
   const { t } = useTranslation();
@@ -159,7 +163,7 @@ export function B2BCertificationsPage() {
                 ? '강의를 수료하면 수료증이 여기에 표시됩니다.'
                 : 'Certificates will appear here when you complete courses.'}
             </p>
-            <Button variant="brand" onClick={() => window.location.href = '/tu/b2c/mypage/learning'}>
+            <Button variant="brand" onClick={() => navigate(prefixPath('/tu/b2b/mypage/learning'))}>
               {language === 'ko' ? '학습 중인 강의 보기' : 'View Current Courses'}
             </Button>
           </div>

--- a/src/pages/tu/b2b/B2BCompletedCoursesPage.tsx
+++ b/src/pages/tu/b2b/B2BCompletedCoursesPage.tsx
@@ -173,7 +173,7 @@ export function B2BCompletedCoursesPage() {
   const issueMutation = useIssueCertificate();
 
   const handleCourseClick = (enrollmentId: number) => {
-    navigate(prefixPath(`/tu/b2c/mypage/learning/${enrollmentId}`));
+    navigate(prefixPath(`/tu/b2b/mypage/learning/${enrollmentId}`));
   };
 
   const handleViewCertificate = (enrollmentId: number) => {
@@ -284,7 +284,7 @@ export function B2BCompletedCoursesPage() {
                 ? '강의를 완료하면 여기에 표시됩니다.'
                 : 'Completed courses will appear here.'}
             </p>
-            <Button variant="brand" onClick={() => navigate(prefixPath('/tu/b2c/mypage/learning'))}>
+            <Button variant="brand" onClick={() => navigate(prefixPath('/tu/b2b/mypage/learning'))}>
               {language === 'ko' ? '학습 중인 강의 보기' : 'View Current Courses'}
             </Button>
           </div>

--- a/src/pages/tu/b2b/B2BCourseDetailPage.tsx
+++ b/src/pages/tu/b2b/B2BCourseDetailPage.tsx
@@ -140,7 +140,7 @@ export function B2BCourseDetailPage() {
     enrollMutation.mutate(courseTimeId, {
       onSuccess: () => {
         toast.success('수강 신청이 완료되었습니다.');
-        navigate(prefixPath('/tu/b2c/mypage/learning'));
+        navigate(prefixPath('/tu/b2b/mypage/learning'));
       },
       onError: (error: Error & { response?: { data?: { error?: { message?: string } } } }) => {
         const message = error.response?.data?.error?.message || '수강 신청에 실패했습니다.';

--- a/src/pages/tu/b2b/B2BMyLearningPage.tsx
+++ b/src/pages/tu/b2b/B2BMyLearningPage.tsx
@@ -318,7 +318,7 @@ export function B2BMyLearningPage() {
             <p className={`mb-4 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
               {t.learning.noEnrollmentsDesc}
             </p>
-            <Button variant="brand" onClick={() => navigate(prefixPath('/tu/b2c/courses'))}>
+            <Button variant="brand" onClick={() => navigate(prefixPath('/tu/b2b'))}>
               {t.learning.browseCourses}
             </Button>
           </div>

--- a/src/pages/tu/b2b/B2BMyPageHome.tsx
+++ b/src/pages/tu/b2b/B2BMyPageHome.tsx
@@ -378,7 +378,7 @@ export function B2BMyPageHome() {
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => navigate(prefixPath('/tu/b2c/mypage/learning'))}
+              onClick={() => navigate(prefixPath('/tu/b2b/mypage/learning'))}
               className={isDark ? 'text-gray-400 hover:text-white' : ''}
             >
               {t.mypage.viewAll}
@@ -400,7 +400,7 @@ export function B2BMyPageHome() {
                       ? 'bg-white/5 border-white/10 hover:bg-white/10'
                       : 'bg-white hover:shadow-md'
                   }`}
-                  onClick={() => navigate(prefixPath(`/tu/b2c/mypage/learning/${enrollment.id}`))}
+                  onClick={() => navigate(prefixPath(`/tu/b2b/mypage/learning/${enrollment.id}`))}
                 >
                   <CardContent className="p-5">
                     <Badge variant={statusColors[enrollment.status]} className="text-xs mb-3">
@@ -462,7 +462,7 @@ export function B2BMyPageHome() {
               <p className={`text-sm mb-4 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
                 {t.mypage.noEnrolledCoursesDesc}
               </p>
-              <Button onClick={() => navigate(prefixPath('/tu/b2c/courses'))}>{t.mypage.browseCourses}</Button>
+              <Button onClick={() => navigate(prefixPath('/tu/b2b'))}>{t.mypage.browseCourses}</Button>
             </div>
           )}
         </section>
@@ -477,42 +477,42 @@ export function B2BMyPageHome() {
               icon={<BookOpen className="w-5 h-5" />}
               title={t.mypage.myLearning}
               description={t.mypage.myLearningDesc}
-              onClick={() => navigate(prefixPath('/tu/b2c/mypage/learning'))}
+              onClick={() => navigate(prefixPath('/tu/b2b/mypage/learning'))}
               isDark={isDark}
             />
             <QuickMenuItem
               icon={<Award className="w-5 h-5" />}
               title={t.mypage.certificates}
               description={t.mypage.certificatesDesc}
-              onClick={() => navigate(prefixPath('/tu/b2c/mypage/certificates'))}
+              onClick={() => navigate(prefixPath('/tu/b2b/mypage/certificates'))}
               isDark={isDark}
             />
             <QuickMenuItem
               icon={<Shield className="w-5 h-5" />}
               title={t.mypage.profileAndSecurity}
               description={t.mypage.profileSecurityDesc}
-              onClick={() => navigate(prefixPath('/tu/b2c/mypage/profile'))}
+              onClick={() => navigate(prefixPath('/tu/b2b/mypage/profile'))}
               isDark={isDark}
             />
             <QuickMenuItem
               icon={<Bell className="w-5 h-5" />}
               title={t.mypage.notifications}
               description={t.mypage.notificationsDesc}
-              onClick={() => navigate(prefixPath('/tu/b2c/mypage/notifications'))}
+              onClick={() => navigate(prefixPath('/tu/b2b/notifications'))}
               isDark={isDark}
             />
             <QuickMenuItem
               icon={<Globe className="w-5 h-5" />}
               title={t.mypage.languageRegion}
               description={t.mypage.languageRegionDesc}
-              onClick={() => navigate(prefixPath('/tu/b2c/mypage/language'))}
+              onClick={() => navigate(prefixPath('/tu/b2b/mypage/settings'))}
               isDark={isDark}
             />
             <QuickMenuItem
               icon={<TrendingUp className="w-5 h-5" />}
               title={t.mypage.learningProgress}
               description={t.mypage.learningProgressDesc}
-              onClick={() => navigate(prefixPath('/tu/b2c/mypage/learning'))}
+              onClick={() => navigate(prefixPath('/tu/b2b/mypage/learning'))}
               isDark={isDark}
             />
           </div>


### PR DESCRIPTION
## Summary

B2B 페이지 내에서 B2C 경로로 잘못 연결되어 있던 라우팅을 B2B 경로로 수정했습니다.

## Related Issue

- Closes #539

## Changes

- B2BCompletedCoursesPage: 완료된 강의 클릭 시 B2B 학습 상세로 이동하도록 수정
- B2BCompletedCoursesPage: 빈 상태 버튼 B2B 학습 목록으로 이동하도록 수정
- B2BCertificationsPage: 빈 상태 버튼 B2B 학습 목록으로 이동하도록 수정

## Type of Change

- [x] Fix: 버그 수정

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [x] 로컬에서 테스트가 통과합니다

## Additional Notes

### 레거시 `/my-courses/:id` 경로 관련

백엔드에서 알림 발송 시 `/my-courses/:id` 링크를 B2B/B2C 구분 없이 보내고, 프론트엔드에서 이를 B2C로만 리다이렉트합니다. B2B 사용자는 알림 클릭 시 B2C 페이지로 이동되므로, 향후 백엔드에서 테넌트 타입별 경로를 직접 생성하거나 프론트엔드에서 동적 분기하도록 개선이 필요합니다.