### PR TITLE
fix: SA 로그인, 브랜딩 제거, INSTRUCTOR 라우팅 및 로그아웃 버튼 추가

### DIFF
--- a/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
+++ b/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
@@ -7,6 +7,7 @@ import {
   PanelLeft,
   GraduationCap,
   ArrowLeft,
+  LogOut,
 } from 'lucide-react';
 import type { BaseSidebarProps, SidebarColors } from '@/types';
 import { designTokens } from '@/styles/admin-design-tokens';
@@ -15,6 +16,7 @@ import { useTenantBranding } from '@/contexts/TenantBrandingContext';
 import { GlobalRoleSwitcher, type GlobalRole } from '../GlobalRoleSwitcher';
 import { useSubdomainPath } from '@/hooks/common';
 import { useAuthStore } from '@/store/common/authStore';
+import { authService } from '@/services/common/authService';
 import type { TenantRole } from '@/types/common/auth.types';
 
 // 역할 타입
@@ -105,6 +107,27 @@ export function BaseSidebar({
   // authStore에서 현재 역할 가져오기
   const storeCurrentRole = useAuthStore((state) => state.currentRole);
   const userRole = useAuthStore((state) => state.user?.role);
+  const logout = useAuthStore((state) => state.logout);
+  const refreshToken = useAuthStore((state) => state.refreshToken);
+  const userSubdomain = useAuthStore((state) => state.user?.tenantSubdomain);
+
+  // 로그아웃 처리
+  const handleLogout = async () => {
+    if (window.confirm(language === 'ko' ? '로그아웃 하시겠습니까?' : 'Are you sure you want to logout?')) {
+      try {
+        if (refreshToken) {
+          await authService.logout(refreshToken);
+        }
+      } catch (error) {
+        console.error('Logout API failed:', error);
+      }
+      logout();
+      // 로그인 페이지로 이동
+      const isDefaultSubdomain = !userSubdomain || userSubdomain === 'default' || userSubdomain === 'www';
+      const loginPath = isDefaultSubdomain ? '/login' : `/${userSubdomain}/login`;
+      navigate(loginPath);
+    }
+  };
 
   // TenantRole → GlobalRole 매핑
   const tenantRoleToGlobalRole: Record<TenantRole, GlobalRole> = {
@@ -531,6 +554,39 @@ export function BaseSidebar({
               )}
             </button>
           )}
+
+          {/* Logout Button */}
+          <button
+            onClick={handleLogout}
+            className="flex items-center rounded-xl transition-all duration-300 overflow-hidden"
+            style={{
+              width: isExpanded ? '100%' : '44px',
+              height: '44px',
+              padding: isExpanded ? '0 16px' : '0',
+              justifyContent: 'center',
+              color: colors.textPrimary,
+              margin: isExpanded ? '0' : '0 auto',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.backgroundColor = isDarkMode ? 'rgba(239, 68, 68, 0.2)' : 'rgba(239, 68, 68, 0.1)';
+              e.currentTarget.style.color = '#EF4444';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = 'transparent';
+              e.currentTarget.style.color = colors.textPrimary;
+            }}
+            title={language === 'ko' ? '로그아웃' : 'Logout'}
+          >
+            <LogOut
+              className="w-5 h-5 flex-shrink-0"
+              style={{ color: colors.textSecondary }}
+            />
+            {isExpanded && (
+              <span className="flex-1 text-left text-sm font-medium whitespace-nowrap ml-3">
+                {language === 'ko' ? '로그아웃' : 'Logout'}
+              </span>
+            )}
+          </button>
 
           {/* Collapse Toggle */}
           <button

--- a/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
+++ b/src/components/layout/common/BaseSidebar/BaseSidebar.tsx
@@ -18,6 +18,41 @@ import { useSubdomainPath } from '@/hooks/common';
 import { useAuthStore } from '@/store/common/authStore';
 import { authService } from '@/services/common/authService';
 import type { TenantRole } from '@/types/common/auth.types';
+import { useVisibleTenantNotices } from '@/hooks/ta/useTenantNoticeQueries';
+import { useSystemNotices } from '@/hooks/ta/useSystemNoticeQueries';
+
+// localStorage 키
+const TENANT_NOTICE_STORAGE_KEY = 'tenant-notice-dismissed';
+const SYSTEM_NOTICE_STORAGE_KEY = 'dismissed_system_notices';
+
+// 안읽은 공지 수를 계산하기 위한 유틸리티 함수
+function getTenantDismissedIds(): number[] {
+  try {
+    const stored = localStorage.getItem(TENANT_NOTICE_STORAGE_KEY);
+    if (stored) {
+      const data = JSON.parse(stored);
+      if (data.dismissedUntil && data.dismissedUntil < Date.now()) {
+        return [];
+      }
+      return data.noticeIds || [];
+    }
+  } catch {
+    // ignore
+  }
+  return [];
+}
+
+function getSystemDismissedIds(): number[] {
+  try {
+    const stored = localStorage.getItem(SYSTEM_NOTICE_STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored) as number[];
+    }
+  } catch {
+    // ignore
+  }
+  return [];
+}
 
 // 역할 타입
 type RoleType = 'sa' | 'ta' | 'co' | 'tu';
@@ -110,6 +145,35 @@ export function BaseSidebar({
   const logout = useAuthStore((state) => state.logout);
   const refreshToken = useAuthStore((state) => state.refreshToken);
   const userSubdomain = useAuthStore((state) => state.user?.tenantSubdomain);
+
+  // 안읽은 공지 수 계산을 위한 데이터 조회
+  const { data: systemNoticesData } = useSystemNotices(
+    roleType === 'ta' ? { size: 100 } : undefined
+  );
+  const { data: tenantNoticesData } = useVisibleTenantNotices(
+    (roleType === 'co' || roleType === 'tu') ? { size: 100 } : undefined
+  );
+
+  // 안읽은 공지 수 계산
+  const unreadNoticeCount = useMemo(() => {
+    if (roleType === 'ta') {
+      if (!systemNoticesData?.content) return 0;
+      const dismissedIds = getSystemDismissedIds();
+      return systemNoticesData.content.filter(
+        (notice) => !dismissedIds.includes(notice.id)
+      ).length;
+    } else if (roleType === 'co' || roleType === 'tu') {
+      if (!tenantNoticesData?.content) return 0;
+      const dismissedIds = getTenantDismissedIds();
+      return tenantNoticesData.content.filter(
+        (notice) => !dismissedIds.includes(notice.id)
+      ).length;
+    }
+    return 0;
+  }, [roleType, systemNoticesData, tenantNoticesData]);
+
+  // 공지 메뉴 ID (역할별로 다름)
+  const noticeMenuIds = ['notice-management', 'global-notice'];
 
   // 로그아웃 처리
   const handleLogout = async () => {
@@ -321,6 +385,8 @@ export function BaseSidebar({
             const hasSubItems = item.subItems && item.subItems.length > 0;
             const isExpandedItem = expandedItems.includes(item.id);
             const isActive = activeItem === item.id;
+            const isNoticeMenu = noticeMenuIds.includes(item.id);
+            const showBadge = isNoticeMenu && unreadNoticeCount > 0;
 
             return (
               <div key={item.id} className="mb-1">
@@ -353,19 +419,33 @@ export function BaseSidebar({
                   }}
                   title={!isExpanded ? item.label[language] : ''}
                 >
-                  <Icon
-                    className="w-5 h-5 flex-shrink-0"
-                    style={{
-                      color:
-                        isActive && !hasSubItems
-                          ? colors.activeText
-                          : colors.textSecondary,
-                    }}
-                  />
+                  <div className="relative">
+                    <Icon
+                      className="w-5 h-5 flex-shrink-0"
+                      style={{
+                        color:
+                          isActive && !hasSubItems
+                            ? colors.activeText
+                            : colors.textSecondary,
+                      }}
+                    />
+                    {/* 접힌 상태에서 안읽은 공지 배지 */}
+                    {!isExpanded && showBadge && (
+                      <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-[16px] flex items-center justify-center rounded-full text-[10px] font-medium bg-red-500 text-white px-0.5">
+                        {unreadNoticeCount > 99 ? '99+' : unreadNoticeCount}
+                      </span>
+                    )}
+                  </div>
                   {isExpanded && (
                     <>
                       <span className="flex-1 text-left text-sm font-medium whitespace-nowrap ml-3">
                         {item.label[language]}
+                        {/* 펼친 상태에서 안읽은 공지 수 */}
+                        {showBadge && (
+                          <span className="ml-2 text-red-500 font-semibold">
+                            ({unreadNoticeCount})
+                          </span>
+                        )}
                       </span>
                       {hasSubItems && (
                         <span style={{ color: colors.textSecondary }}>

--- a/src/components/tu/TenantNoticePopup/TenantNoticePopup.tsx
+++ b/src/components/tu/TenantNoticePopup/TenantNoticePopup.tsx
@@ -69,9 +69,9 @@ export function TenantNoticePopup() {
 
     const dismissedData = getDismissedData();
 
-    // 사용자에게 보여줄 공지 필터링 (USER 대상만, 이미 본 공지 제외)
+    // 사용자에게 보여줄 공지 필터링 (이미 본 공지 제외)
+    // 백엔드에서 이미 사용자 역할에 맞는 공지만 반환하므로 별도 필터링 불필요
     const userNotices = noticesData.content
-      .filter((notice) => notice.targetAudience === 'USER')
       .filter((notice) => !dismissedData.noticeIds.includes(notice.id));
 
     // 고정된 공지 먼저, 그 다음 최신순

--- a/src/config/sidebar-menus.ts
+++ b/src/config/sidebar-menus.ts
@@ -61,7 +61,6 @@ export const superAdminMenuData: MenuItem[] = [
     subItems: [
       { id: 'domain-management', label: { ko: '도메인 관리', en: 'Domain Management' }, icon: Globe, path: '/sa/system/domain' },
       { id: 'operator-mgmt', label: { ko: '운영자 관리', en: 'Operator Management' }, icon: UserCog, path: '/sa/system/operators' },
-      { id: 'global-branding', label: { ko: '브랜딩 설정', en: 'Branding Settings' }, icon: Palette, path: '/sa/system/branding' },
     ],
   },
   {

--- a/src/hooks/common/useAuthQueries.ts
+++ b/src/hooks/common/useAuthQueries.ts
@@ -97,6 +97,7 @@ export const useLogin = () => {
         TENANT_ADMIN: '/ta',
         OPERATOR: '/co',
         DESIGNER: '/tu/teaching',
+        INSTRUCTOR: '/tu/teaching',
         USER: '/tu/b2c',
       };
       const basePath = roleBasePath[user.role] || '/tu/b2c';

--- a/src/routes/sa.routes.tsx
+++ b/src/routes/sa.routes.tsx
@@ -13,7 +13,6 @@ import {
   TenantDetailPage,
   DomainSettingsPage,
   OperatorsPage,
-  BrandingSettingsPage,
   NoticesPage,
   AnalyticsPage,
   SystemSettingsPage,
@@ -40,7 +39,6 @@ export const saRoutes = (
     {/* 시스템 환경 관리 */}
     <Route path="system/domain" element={<DomainSettingsPage />} />
     <Route path="system/operators" element={<OperatorsPage />} />
-    <Route path="system/branding" element={<BrandingSettingsPage />} />
     {/* 글로벌 공지 관리 */}
     <Route path="notices" element={<NoticesPage />} />
     {/* 데이터 및 로그 분석 */}

--- a/src/routes/tu.teaching.routes.tsx
+++ b/src/routes/tu.teaching.routes.tsx
@@ -1,4 +1,4 @@
-import { Route, Outlet } from 'react-router-dom';
+import { Route, Outlet, Navigate } from 'react-router-dom';
 import { TenantUserLayout } from '@/components/layout';
 import { ProtectedRoute } from '@/components/common/ProtectedRoute';
 import { ProfileRequiredRoute } from '@/components/common/ProfileRequiredRoute';
@@ -58,6 +58,7 @@ export const tuTeachingRoutes = (
 
   <Route path="/:subdomain/tu" element={<TenantUserWrapper />}>
     <Route path="dashboard" element={<TUDashboardPage />} />
+    <Route path="teaching" element={<Navigate to="courses" replace />} />
     <Route path="teaching/courses" element={<MyCoursesPage />} />
     <Route path="teaching/courses/create" element={<CourseCreatePage />} />
     <Route path="teaching/courses/:courseId" element={<TeachingCourseDetailPage />} />
@@ -76,6 +77,9 @@ export const tuTeachingRoutes = (
   </Route>
   <Route path="/tu" element={<TenantUserWrapper />}>
     <Route path="dashboard" element={<TUDashboardPage />} />
+
+    {/* Teaching 인덱스 - courses로 리다이렉트 */}
+    <Route path="teaching" element={<Navigate to="courses" replace />} />
 
     {/* 내 강의계획 */}
     <Route path="teaching/courses" element={<MyCoursesPage />} />


### PR DESCRIPTION
## Summary

SA/TA/INSTRUCTOR 관련 버그 수정 및 사이드바 로그아웃 버튼 추가

## Related Issue

- N/A

## Changes

- SA 브랜딩 메뉴 제거 (사이드바 및 라우트)
- INSTRUCTOR 로그인 시 `/tu/teaching`으로 리다이렉트
- `/tu/teaching` 인덱스 라우트 추가 (courses로 리다이렉트)
- 모든 사이드바(SA, TA, CO, TU)에 로그아웃 버튼 추가

## Type of Change

- [x] Fix: 버그 수정

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

백엔드 PR과 함께 머지해야 합니다.