### PR TITLE
fix: TA 설정 페이지에서 하위 설정 클릭 시 SA 경로로 이동하는 버그 수정

### DIFF
--- a/src/pages/common/settings/SettingsPage.tsx
+++ b/src/pages/common/settings/SettingsPage.tsx
@@ -66,23 +66,17 @@ const getRoleFromPath = (pathname: string): UserRole => {
 
 // 역할별 base path (subdomain 지원)
 const getBasePath = (pathname: string): string => {
-  // /sa 또는 /:subdomain/sa
-  const saMatch = pathname.match(/^(\/[^/]+)?\/sa/);
-  if (saMatch) return saMatch[0];
+  // 경로를 세그먼트로 분리
+  const segments = pathname.split('/').filter(Boolean);
 
-  // /ta 또는 /:subdomain/ta
-  const taMatch = pathname.match(/^(\/[^/]+)?\/ta/);
-  if (taMatch) return taMatch[0];
+  // 역할 세그먼트 찾기 (sa, ta, co, tu)
+  const roleSegments = ['sa', 'ta', 'co', 'tu'];
+  const roleIndex = segments.findIndex(s => roleSegments.includes(s));
 
-  // /co 또는 /:subdomain/co
-  const coMatch = pathname.match(/^(\/[^/]+)?\/co/);
-  if (coMatch) return coMatch[0];
+  if (roleIndex === -1) return '/tu';
 
-  // /tu 또는 /:subdomain/tu
-  const tuMatch = pathname.match(/^(\/[^/]+)?\/tu/);
-  if (tuMatch) return tuMatch[0];
-
-  return '/tu';
+  // 역할까지의 경로 구성 (서브도메인 포함)
+  return '/' + segments.slice(0, roleIndex + 1).join('/');
 };
 
 export function SettingsPage({ userRole }: SettingsPageProps) {


### PR DESCRIPTION
## Summary

TA(Tenant Admin) 설정 페이지에서 "계정 및 보안" 등 하위 설정을 클릭할 때 `/sa/settings/security`로 잘못 이동하는 버그를 수정했습니다.

## Related Issue

- N/A

## Changes

- `getBasePath` 함수를 정규식 기반에서 세그먼트 기반으로 변경
- URL 경로에서 역할 세그먼트(sa, ta, co, tu)를 정확히 찾아 base path 구성

## Type of Change

- [x] Fix: 버그 수정

## Checklist

- [x] 코드가 컨벤션을 따르고 있습니다
- [x] Self-review를 완료했습니다
- [ ] 테스트를 추가/수정했습니다
- [x] 로컬에서 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요시)

## Additional Notes

**수정 전:**
- `/ta/settings`에서 "계정 및 보안" 클릭 시 → `/sa/settings/security`로 이동 (버그)

**수정 후:**
- `/ta/settings`에서 "계정 및 보안" 클릭 시 → `/ta/settings/security`로 정상 이동