### PR TITLE
fix(co): 클라이언트 사이드 필터링을 서버 사이드로 전환

### DIFF
--- a/src/components/common/DataTable/DataTable.tsx
+++ b/src/components/common/DataTable/DataTable.tsx
@@ -356,7 +356,19 @@ function DataTableColumnHeader({
   className,
 }: DataTableColumnHeaderProps) {
   const sorted = column.getIsSorted();
+  // @ts-expect-error - columnDef may not have enableSorting property
+  const canSort = column.columnDef.enableSorting !== false;
 
+  // 정렬 불가능한 컬럼은 일반 텍스트로 표시
+  if (!canSort) {
+    return (
+      <div className={cn("flex items-center h-8 -ml-3 px-3", className)}>
+        {title}
+      </div>
+    );
+  }
+
+  // 정렬 가능한 컬럼은 버튼과 아이콘으로 표시
   return (
     <Button
       variant="ghost"

--- a/src/hooks/co/useAutoEnrollmentRuleQueries.ts
+++ b/src/hooks/co/useAutoEnrollmentRuleQueries.ts
@@ -6,6 +6,7 @@ import { useAuthStore } from '@/store/common/authStore';
 import { autoEnrollmentRuleService } from '@/services/co/autoEnrollmentRuleService';
 import type {
   AutoEnrollmentTrigger,
+  AutoEnrollmentRuleQueryParams,
   CreateAutoEnrollmentRuleRequest,
   UpdateAutoEnrollmentRuleRequest,
 } from '@/types/co/autoEnrollmentRule.types';
@@ -17,7 +18,7 @@ import type {
 export const autoEnrollmentRuleKeys = {
   all: ['autoEnrollmentRules'] as const,
   lists: () => [...autoEnrollmentRuleKeys.all, 'list'] as const,
-  list: () => [...autoEnrollmentRuleKeys.lists()] as const,
+  list: (params?: AutoEnrollmentRuleQueryParams) => [...autoEnrollmentRuleKeys.lists(), params] as const,
   active: () => [...autoEnrollmentRuleKeys.all, 'active'] as const,
   byTrigger: (trigger: AutoEnrollmentTrigger) =>
     [...autoEnrollmentRuleKeys.all, 'trigger', trigger] as const,
@@ -30,14 +31,14 @@ export const autoEnrollmentRuleKeys = {
 // ============================================
 
 /**
- * 자동 입과 규칙 목록 조회
+ * 자동 입과 규칙 목록 조회 (페이지네이션)
  */
-export const useAutoEnrollmentRules = () => {
+export const useAutoEnrollmentRules = (params?: AutoEnrollmentRuleQueryParams) => {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
   return useQuery({
-    queryKey: autoEnrollmentRuleKeys.list(),
-    queryFn: () => autoEnrollmentRuleService.getAll(),
+    queryKey: autoEnrollmentRuleKeys.list(params),
+    queryFn: () => autoEnrollmentRuleService.getAll(params),
     enabled: isAuthenticated,
   });
 };

--- a/src/pages/co/auto-enrollment/AutoEnrollmentRulesPage.tsx
+++ b/src/pages/co/auto-enrollment/AutoEnrollmentRulesPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import {
   Plus,
   Search,
@@ -111,6 +111,7 @@ export default function AutoEnrollmentRulesPage() {
   // 검색 및 필터 상태
   const [searchTerm, setSearchTerm] = useState('');
   const [filterTrigger, setFilterTrigger] = useState<AutoEnrollmentTrigger | 'all'>('all');
+  const [page, setPage] = useState(0);
 
   // 모달 상태
   const [showCreateModal, setShowCreateModal] = useState(false);
@@ -121,36 +122,33 @@ export default function AutoEnrollmentRulesPage() {
   // 폼 상태
   const [formData, setFormData] = useState<RuleFormData>(initialFormData);
 
+  // 검색/필터 변경 시 페이지 리셋
+  useEffect(() => {
+    setPage(0);
+  }, [searchTerm, filterTrigger]);
+
   // API 훅
-  const { data: rules, isLoading, error } = useAutoEnrollmentRules();
+  const { data, isLoading, error } = useAutoEnrollmentRules({
+    keyword: searchTerm || undefined,
+    trigger: filterTrigger !== 'all' ? filterTrigger : undefined,
+    page,
+    size: 20,
+  });
   const createRule = useCreateAutoEnrollmentRule();
   const updateRule = useUpdateAutoEnrollmentRule();
   const deleteRule = useDeleteAutoEnrollmentRule();
   const activateRule = useActivateAutoEnrollmentRule();
   const deactivateRule = useDeactivateAutoEnrollmentRule();
 
-  // 필터링된 규칙 목록
-  const filteredRules = useMemo(() => {
-    if (!rules) return [];
+  const rules = data?.content ?? [];
+  const totalElements = data?.totalElements ?? 0;
 
-    return rules.filter((rule) => {
-      const matchesSearch =
-        searchTerm === '' ||
-        rule.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        (rule.description && rule.description.toLowerCase().includes(searchTerm.toLowerCase()));
-
-      const matchesTrigger = filterTrigger === 'all' || rule.trigger === filterTrigger;
-
-      return matchesSearch && matchesTrigger;
-    });
-  }, [rules, searchTerm, filterTrigger]);
-
-  // 통계 계산
+  // 통계 계산 - 전체 데이터 통계는 별도 API가 필요하거나 현재 페이지 기준
   const stats = useMemo(() => ({
-    total: rules?.length || 0,
-    active: rules?.filter((r) => r.isActive).length || 0,
-    inactive: rules?.filter((r) => !r.isActive).length || 0,
-  }), [rules]);
+    total: totalElements,
+    active: rules.filter((r) => r.isActive).length,
+    inactive: rules.filter((r) => !r.isActive).length,
+  }), [rules, totalElements]);
 
   // 새 규칙 생성 모달 열기
   const openCreateModal = () => {
@@ -450,11 +448,11 @@ export default function AutoEnrollmentRulesPage() {
           <CardHeader>
             <div className="flex items-center justify-between">
               <CardTitle>규칙 목록</CardTitle>
-              <Badge variant="gray">{filteredRules.length}개</Badge>
+              <Badge variant="gray">{totalElements}개</Badge>
             </div>
           </CardHeader>
           <CardContent>
-            {filteredRules.length === 0 ? (
+            {rules.length === 0 ? (
               <EmptyState
                 icon={Zap}
                 title="등록된 규칙이 없습니다"
@@ -475,7 +473,7 @@ export default function AutoEnrollmentRulesPage() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {filteredRules.map((rule) => (
+                  {rules.map((rule) => (
                     <TableRow key={rule.id}>
                       <TableCell>
                         <div>

--- a/src/pages/co/course/CourseListPage.tsx
+++ b/src/pages/co/course/CourseListPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSubdomainPath } from '@/hooks/common';
-import type { ColumnDef } from '@tanstack/react-table';
+import type { ColumnDef, SortingState } from '@tanstack/react-table';
 import {
   Search,
   Loader2,
@@ -70,10 +70,11 @@ export function CourseListPage({ language = 'ko' }: Readonly<CourseListPageProps
   const { prefixPath } = useSubdomainPath();
   const [searchQuery, setSearchQuery] = useState('');
   const [page, setPage] = useState(0);
+  const [sorting, setSorting] = useState<SortingState>([]);
 
   // 필터 상태
   const [categories, setCategories] = useState<CategoryResponse[]>([]);
-  const [selectedCategory, setSelectedCategory] = useState<string>('');
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
   const [selectedLevel, setSelectedLevel] = useState<CourseLevel | ''>('');
   const [selectedType, setSelectedType] = useState<CourseType | ''>('');
 
@@ -95,7 +96,7 @@ export function CourseListPage({ language = 'ko' }: Readonly<CourseListPageProps
   // 카테고리 옵션 (Combobox용)
   const categoryOptions = useMemo(() => {
     return categories.map((cat) => ({
-      value: cat.name,
+      value: String(cat.id),
       label: cat.name,
     }));
   }, [categories]);
@@ -117,55 +118,48 @@ export function CourseListPage({ language = 'ko' }: Readonly<CourseListPageProps
   }, []);
 
   // 필터 활성화 여부
-  const hasActiveFilters = selectedCategory || selectedLevel || selectedType;
+  const hasActiveFilters = selectedCategoryId || selectedLevel || selectedType;
 
   // 필터 초기화
   const clearFilters = () => {
-    setSelectedCategory('');
+    setSelectedCategoryId(null);
     setSelectedLevel('');
     setSelectedType('');
+    setPage(0);
   };
 
-  // API 파라미터 구성 (REGISTERED 상태만 조회)
+  // 검색어 또는 필터 변경 시 페이지 리셋
+  useEffect(() => {
+    setPage(0);
+  }, [searchQuery, selectedCategoryId, selectedLevel, selectedType]);
+
+  // 정렬 변경 시 페이지 리셋
+  useEffect(() => {
+    setPage(0);
+  }, [sorting]);
+
+  // SortingState를 Spring sort 파라미터로 변환
+  const sortParam = useMemo(() => {
+    if (sorting.length === 0) return undefined;
+    return sorting.map((s) => `${s.id},${s.desc ? 'desc' : 'asc'}`).join(',');
+  }, [sorting]);
+
+  // API 파라미터 구성 (REGISTERED 상태만 조회, 서버 사이드 필터링)
   const params: Omit<CourseRegistrationFilterParams, 'status'> = {
     page,
     size: 10,
+    keyword: searchQuery || undefined,
+    categoryId: selectedCategoryId || undefined,
+    level: selectedLevel || undefined,
+    type: selectedType || undefined,
+    sort: sortParam,
   };
 
   // React Query 훅 사용 (승인된 과정만 조회)
   const { data, isLoading, error } = useRegisteredCourses(params);
 
-  // 검색 및 필터링 (클라이언트 사이드)
-  const filteredCourses = useMemo(() => {
-    let result = data?.content ?? [];
-
-    // 텍스트 검색 (과정명 + 생성자)
-    if (searchQuery) {
-      const query = searchQuery.toLowerCase();
-      result = result.filter(
-        (course) =>
-          course.title.toLowerCase().includes(query) ||
-          (course.creatorName && course.creatorName.toLowerCase().includes(query))
-      );
-    }
-
-    // 카테고리 필터
-    if (selectedCategory) {
-      result = result.filter((course) => course.categoryName === selectedCategory);
-    }
-
-    // 레벨 필터
-    if (selectedLevel) {
-      result = result.filter((course) => course.level === selectedLevel);
-    }
-
-    // 타입 필터
-    if (selectedType) {
-      result = result.filter((course) => course.type === selectedType);
-    }
-
-    return result;
-  }, [data?.content, searchQuery, selectedCategory, selectedLevel, selectedType]);
+  // 서버에서 필터링된 데이터 직접 사용
+  const courses = data?.content ?? [];
 
   const formatDate = (dateStr: string) => {
     return new Date(dateStr).toLocaleDateString(language === 'ko' ? 'ko-KR' : 'en-US', {
@@ -196,6 +190,7 @@ export function CourseListPage({ language = 'ko' }: Readonly<CourseListPageProps
       },
       {
         id: 'category',
+        enableSorting: false,
         header: ({ column }) => (
           <DataTableColumnHeader column={column} title={getText('columnCategory')} />
         ),
@@ -232,6 +227,7 @@ export function CourseListPage({ language = 'ko' }: Readonly<CourseListPageProps
       },
       {
         accessorKey: 'creatorName',
+        enableSorting: false,
         header: ({ column }) => (
           <DataTableColumnHeader column={column} title={getText('columnCreator')} />
         ),
@@ -254,6 +250,7 @@ export function CourseListPage({ language = 'ko' }: Readonly<CourseListPageProps
       },
       {
         id: 'timeCount',
+        enableSorting: false,
         header: ({ column }) => (
           <DataTableColumnHeader column={column} title={getText('columnTimeCount')} />
         ),
@@ -346,13 +343,13 @@ export function CourseListPage({ language = 'ko' }: Readonly<CourseListPageProps
               {/* 카테고리 필터 (Combobox) */}
               <Combobox
                 options={categoryOptions}
-                value={selectedCategory}
-                onValueChange={setSelectedCategory}
+                value={selectedCategoryId ? String(selectedCategoryId) : ''}
+                onValueChange={(value) => setSelectedCategoryId(value ? Number(value) : null)}
                 placeholder={getText('allCategories')}
                 emptyMessage={language === 'ko' ? '카테고리 없음' : 'No category found'}
                 hideSearch
                 className={`h-10 min-w-[140px] ${
-                  selectedCategory
+                  selectedCategoryId
                     ? 'bg-primary/10 border-primary/30 text-primary'
                     : 'bg-bg-default border-border text-text-primary'
                 }`}
@@ -410,9 +407,7 @@ export function CourseListPage({ language = 'ko' }: Readonly<CourseListPageProps
           {/* Count */}
           <div className="flex items-center justify-between mb-4">
             <p className="text-sm text-text-secondary">
-              {searchQuery || hasActiveFilters
-                ? filteredCourses.length
-                : (data?.totalElements ?? 0)}
+              {data?.totalElements ?? 0}
               {getText('courseCount')}
             </p>
           </div>
@@ -426,7 +421,7 @@ export function CourseListPage({ language = 'ko' }: Readonly<CourseListPageProps
           )}
 
           {/* Empty State - 데이터 자체가 없을 때 */}
-          {!isLoading && (data?.content?.length ?? 0) === 0 && !searchQuery && !hasActiveFilters && (
+          {!isLoading && courses.length === 0 && !searchQuery && !hasActiveFilters && (
             <div className="text-center py-12 text-text-secondary">
               <FileText size={48} className="mx-auto mb-3 text-text-placeholder" />
               <p className="mb-1">{getText('noCourses')}</p>
@@ -435,7 +430,7 @@ export function CourseListPage({ language = 'ko' }: Readonly<CourseListPageProps
           )}
 
           {/* Empty Search/Filter Results - 검색 또는 필터 결과가 없을 때 */}
-          {!isLoading && filteredCourses.length === 0 && (searchQuery || hasActiveFilters) && (
+          {!isLoading && courses.length === 0 && (searchQuery || hasActiveFilters) && (
             <div className="text-center py-12 text-text-secondary">
               <Search size={48} className="mx-auto mb-3 text-text-placeholder" />
               <p>{getText('noResults')}</p>
@@ -443,10 +438,10 @@ export function CourseListPage({ language = 'ko' }: Readonly<CourseListPageProps
           )}
 
           {/* Data Table */}
-          {!isLoading && filteredCourses.length > 0 && (
+          {!isLoading && courses.length > 0 && (
             <DataTable
               columns={columns}
-              data={filteredCourses}
+              data={courses}
               showColumnToggle={false}
               showPagination={true}
               manualPagination={true}
@@ -454,6 +449,9 @@ export function CourseListPage({ language = 'ko' }: Readonly<CourseListPageProps
               pageIndex={page}
               pageSize={10}
               onPageChange={setPage}
+              manualSorting={true}
+              sorting={sorting}
+              onSortingChange={setSorting}
               onRowClick={(item) => navigate(prefixPath(`/co/courses/${item.courseId}`))}
               labels={{
                 noResults: getText('noResults'),

--- a/src/pages/co/course/CoursePendingPage.tsx
+++ b/src/pages/co/course/CoursePendingPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSubdomainPath } from '@/hooks/common';
 import type { ColumnDef } from '@tanstack/react-table';
@@ -126,20 +126,22 @@ export function CoursePendingPage({ language = 'ko' }: Readonly<CoursePendingPag
 
   const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
 
+  // 검색어 변경 시 페이지 리셋
+  useEffect(() => {
+    setPage(0);
+  }, [searchQuery]);
+
   // React Query 훅 사용 - READY 상태만 조회
-  const { data, isLoading, error } = useReadyCourses({ page, size: 10 });
+  const { data, isLoading, error } = useReadyCourses({
+    page,
+    size: 10,
+    keyword: searchQuery || undefined,
+  });
   const registerCourse = useRegisterCourse();
   const unreadyCourse = useUnreadyCourse();
 
   const courses = data?.content ?? [];
   const totalElements = data?.totalElements ?? 0;
-
-  // 검색 필터링 (클라이언트 사이드)
-  const filteredCourses = useMemo(() => {
-    if (!searchQuery) return courses;
-    const query = searchQuery.toLowerCase();
-    return courses.filter((course) => course.title.toLowerCase().includes(query));
-  }, [courses, searchQuery]);
 
   const formatDate = (dateStr: string | null | undefined) => {
     if (!dateStr) return '-';
@@ -397,7 +399,7 @@ export function CoursePendingPage({ language = 'ko' }: Readonly<CoursePendingPag
           <div className="flex items-center justify-between mb-4">
             <p className="text-sm text-text-secondary">
               <Badge variant="warning" className="mr-2">검토 대기</Badge>
-              {filteredCourses.length}
+              {totalElements}
               {getText('courseCount')}
             </p>
           </div>
@@ -420,7 +422,7 @@ export function CoursePendingPage({ language = 'ko' }: Readonly<CoursePendingPag
           )}
 
           {/* Empty Search Results */}
-          {!isLoading && filteredCourses.length === 0 && searchQuery && (
+          {!isLoading && courses.length === 0 && searchQuery && (
             <div className="text-center py-12 text-text-secondary">
               <Search size={48} className="mx-auto mb-3 text-text-placeholder" />
               <p>{getText('noResults')}</p>
@@ -428,10 +430,10 @@ export function CoursePendingPage({ language = 'ko' }: Readonly<CoursePendingPag
           )}
 
           {/* Data Table */}
-          {!isLoading && filteredCourses.length > 0 && (
+          {!isLoading && courses.length > 0 && (
             <DataTable
               columns={columns}
-              data={filteredCourses}
+              data={courses}
               showColumnToggle={false}
               showPagination={true}
               manualPagination={true}

--- a/src/pages/co/enrollment/EnrollmentManagementPage.tsx
+++ b/src/pages/co/enrollment/EnrollmentManagementPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useSubdomainPath } from '@/hooks/common';
 import type { ColumnDef } from '@tanstack/react-table';
@@ -187,10 +187,16 @@ export function EnrollmentManagementPage({ language = 'ko' }: Readonly<Enrollmen
   // 차수 정보 조회
   const { data: courseTime, isLoading: isTimeLoading } = useTime(courseTimeId);
 
+  // 검색어/필터 변경 시 페이지 리셋
+  useEffect(() => {
+    setPage(0);
+  }, [searchQuery, statusFilter]);
+
   // API 파라미터 구성
   const params: EnrollmentFilterParams = {
     page,
     size: 10,
+    keyword: searchQuery || undefined,
     ...(statusFilter !== 'all' && { status: statusFilter }),
   };
 
@@ -208,17 +214,6 @@ export function EnrollmentManagementPage({ language = 'ko' }: Readonly<Enrollmen
   const enrollments = data?.content ?? [];
   const totalElements = data?.totalElements ?? 0;
   const users = usersData?.content ?? [];
-
-  // 검색 필터링 (클라이언트 사이드)
-  const filteredEnrollments = useMemo(() => {
-    if (!searchQuery) return enrollments;
-    const query = searchQuery.toLowerCase();
-    return enrollments.filter(
-      (e) =>
-        e.userName?.toLowerCase().includes(query) ||
-        e.userEmail?.toLowerCase().includes(query)
-    );
-  }, [enrollments, searchQuery]);
 
   const formatDate = (dateStr: string) => {
     return new Date(dateStr).toLocaleDateString(language === 'ko' ? 'ko-KR' : 'en-US', {
@@ -666,7 +661,7 @@ export function EnrollmentManagementPage({ language = 'ko' }: Readonly<Enrollmen
           {/* Count */}
           <div className="flex items-center justify-between mb-4">
             <p className="text-sm text-text-secondary">
-              {filteredEnrollments.length}
+              {totalElements}
               {getText('enrollmentCount')}
             </p>
           </div>
@@ -689,7 +684,7 @@ export function EnrollmentManagementPage({ language = 'ko' }: Readonly<Enrollmen
           )}
 
           {/* Empty Search Results */}
-          {!isLoading && filteredEnrollments.length === 0 && (searchQuery || statusFilter !== 'all') && (
+          {!isLoading && enrollments.length === 0 && (searchQuery || statusFilter !== 'all') && (
             <div className="text-center py-12 text-text-secondary">
               <Search size={48} className="mx-auto mb-3 text-text-placeholder" />
               <p>{getText('noResults')}</p>
@@ -697,10 +692,10 @@ export function EnrollmentManagementPage({ language = 'ko' }: Readonly<Enrollmen
           )}
 
           {/* Data Table */}
-          {!isLoading && filteredEnrollments.length > 0 && (
+          {!isLoading && enrollments.length > 0 && (
             <DataTable
               columns={columns}
-              data={filteredEnrollments}
+              data={enrollments}
               showColumnToggle={false}
               showPagination={true}
               manualPagination={true}

--- a/src/pages/co/instructor/InstructorAssignmentsPage.tsx
+++ b/src/pages/co/instructor/InstructorAssignmentsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useRef } from 'react';
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSubdomainPath } from '@/hooks/common';
 import type { ColumnDef } from '@tanstack/react-table';
@@ -191,10 +191,16 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
   const getStatusLabel = (status: AssignmentStatus) =>
     language === 'ko' ? ASSIGNMENT_STATUS_LABELS[status].ko : ASSIGNMENT_STATUS_LABELS[status].en;
 
+  // 검색어/필터 변경 시 페이지 리셋
+  useEffect(() => {
+    setPage(0);
+  }, [searchQuery, roleFilter, statusFilter]);
+
   // API 파라미터 구성
   const params: InstructorAssignmentFilterParams = {
     page,
     size: 10,
+    keyword: searchQuery || undefined,
     ...(roleFilter !== 'all' && { role: roleFilter }),
     ...(statusFilter !== 'all' && { status: statusFilter }),
   };
@@ -226,19 +232,7 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
   const assignments = data?.content ?? [];
   const totalElements = data?.totalElements ?? 0;
 
-  // 클라이언트 사이드 검색 필터링
-  const filteredAssignments = useMemo(() => {
-    if (!searchQuery) return assignments;
-    const query = searchQuery.toLowerCase();
-    return assignments.filter(
-      (item) =>
-        (item.instructor?.name?.toLowerCase().includes(query) ?? false) ||
-        (item.courseTime?.title?.toLowerCase().includes(query) ?? false) ||
-        (item.program?.title?.toLowerCase().includes(query) ?? false)
-    );
-  }, [assignments, searchQuery]);
-
-  // 통계 계산
+  // 통계: 전체 개수만 정확, 나머지는 현재 페이지 기준 (백엔드에서 통계 API 제공 시 교체 필요)
   const stats = useMemo(() => ({
     total: totalElements,
     main: assignments.filter((a) => a.role === 'MAIN').length,
@@ -659,7 +653,7 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
 
           {/* Count */}
           <p className="text-sm text-text-secondary mb-4">
-            {filteredAssignments.length}
+            {totalElements}
             {getText('assignmentCount')}
           </p>
 
@@ -681,7 +675,7 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
           )}
 
           {/* Empty Search Results */}
-          {!isLoading && filteredAssignments.length === 0 && (searchQuery || roleFilter !== 'all' || statusFilter !== 'all') && (
+          {!isLoading && assignments.length === 0 && (searchQuery || roleFilter !== 'all' || statusFilter !== 'all') && (
             <div className="text-center py-12 text-text-secondary">
               <Search size={48} className="mx-auto mb-3 text-text-placeholder" />
               <p>{getText('noResults')}</p>
@@ -689,10 +683,10 @@ export function InstructorAssignmentsPage({ language = 'ko' }: Readonly<Instruct
           )}
 
           {/* Data Table */}
-          {!isLoading && filteredAssignments.length > 0 && (
+          {!isLoading && assignments.length > 0 && (
             <DataTable
               columns={columns}
-              data={filteredAssignments}
+              data={assignments}
               showColumnToggle={false}
               showPagination={true}
               manualPagination={true}

--- a/src/pages/co/time/CourseTimesPage.tsx
+++ b/src/pages/co/time/CourseTimesPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSubdomainPath } from '@/hooks/common';
 import { toast } from 'sonner';
@@ -169,11 +169,17 @@ export function CourseTimesPage({ language = 'ko' }: Readonly<CourseTimesPagePro
 
   const getText = (key: keyof typeof t) => (language === 'ko' ? t[key].ko : t[key].en);
 
+  // 검색어/필터 변경 시 페이지 리셋
+  useEffect(() => {
+    setPage(0);
+  }, [searchQuery, statusFilter]);
+
   // API 파라미터 구성
   const params: CourseTimeFilterParams = {
     page,
     size: 10,
     sort: 'createdAt,desc', // 최신 생성순 정렬
+    keyword: searchQuery || undefined,
     ...(statusFilter !== 'all' && { status: statusFilter }),
   };
 
@@ -187,17 +193,7 @@ export function CourseTimesPage({ language = 'ko' }: Readonly<CourseTimesPagePro
   const times = data?.content ?? [];
   const totalElements = data?.totalElements ?? 0;
 
-  // 최신 생성순 정렬 (ID 기준 내림차순) + 검색 필터링 (클라이언트 사이드)
-  const filteredTimes = useMemo(() => {
-    // ID 기준 내림차순 정렬 (ID가 높을수록 최신)
-    const sorted = [...times].sort((a, b) => b.id - a.id);
-
-    if (!searchQuery) return sorted;
-    const query = searchQuery.toLowerCase();
-    return sorted.filter((time) => time.title.toLowerCase().includes(query));
-  }, [times, searchQuery]);
-
-  // 통계 계산
+  // 통계 계산: 전체 개수만 정확, 나머지는 현재 페이지 기준 (백엔드에서 통계 API 제공 시 교체 필요)
   const timeStats = useMemo(() => ({
     total: totalElements,
     recruiting: times.filter((t) => t.status === 'RECRUITING').length,
@@ -639,7 +635,7 @@ export function CourseTimesPage({ language = 'ko' }: Readonly<CourseTimesPagePro
           {/* Count and Actions */}
           <div className="flex items-center justify-between mb-4">
             <p className="text-sm text-text-secondary">
-              {filteredTimes.length}
+              {totalElements}
               {getText('timeCount')}
             </p>
             <Button
@@ -672,7 +668,7 @@ export function CourseTimesPage({ language = 'ko' }: Readonly<CourseTimesPagePro
           )}
 
           {/* Empty Search Results */}
-          {!isLoading && filteredTimes.length === 0 && (searchQuery || statusFilter !== 'all') && (
+          {!isLoading && times.length === 0 && (searchQuery || statusFilter !== 'all') && (
             <div className="text-center py-12 text-text-secondary">
               <Search size={48} className="mx-auto mb-3 text-text-placeholder" />
               <p>{getText('noResults')}</p>
@@ -680,10 +676,10 @@ export function CourseTimesPage({ language = 'ko' }: Readonly<CourseTimesPagePro
           )}
 
           {/* Data Table */}
-          {!isLoading && filteredTimes.length > 0 && (
+          {!isLoading && times.length > 0 && (
             <DataTable
               columns={columns}
-              data={filteredTimes}
+              data={times}
               showColumnToggle={false}
               showPagination={true}
               manualPagination={true}

--- a/src/pages/co/user/UserManagementPage.tsx
+++ b/src/pages/co/user/UserManagementPage.tsx
@@ -288,6 +288,7 @@ export function UserManagementPage({ language = 'ko' }: Readonly<UserManagementP
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<UserStatus | 'all'>('all');
   const [showFilters, setShowFilters] = useState(false);
+  const [page, setPage] = useState(0);
   const [selectedUserForDetail, setSelectedUserForDetail] = useState<UserListResponse | null>(null);
 
   // 새로운 필터 상태
@@ -339,10 +340,15 @@ export function UserManagementPage({ language = 'ko' }: Readonly<UserManagementP
   // 뷰 모드 결정: 차수가 선택되면 학습 관리 뷰
   const isLearningView = selectedTimeId !== null;
 
-  // API 파라미터 구성 - 전체 데이터를 가져와서 클라이언트에서 필터링
+  // 검색어/필터 변경 시 페이지 리셋
+  useEffect(() => {
+    setPage(0);
+  }, [searchQuery, statusFilter]);
+
+  // API 파라미터 구성
   const params: UserFilterParams = {
-    page: 0,
-    size: 1000, // 충분히 큰 값으로 전체 조회
+    page,
+    size: 20,
     ...(statusFilter !== 'all' && { status: statusFilter }),
     ...(searchQuery && { keyword: searchQuery }),
   };
@@ -489,12 +495,12 @@ export function UserManagementPage({ language = 'ko' }: Readonly<UserManagementP
     return result;
   }, [enrollmentsData?.content, completionFilter, searchQuery, isLearningView]);
 
-  // 전체 필터링된 사용자 수
-  const totalElements = isLearningView ? filteredEnrollments.length : filteredUsers.length;
+  // 전체 필터링된 사용자 수 (서버에서 제공)
+  const totalElements = isLearningView ? filteredEnrollments.length : (data?.totalElements ?? 0);
 
-  // 통계 계산 (전체 필터링된 데이터 기준)
+  // 통계 계산: 학습 뷰는 클라이언트 기준, 사용자 뷰는 현재 페이지 기준
   const userStats = useMemo(() => ({
-    total: isLearningView ? (enrollmentsData?.content?.length ?? 0) : filteredUsers.length,
+    total: isLearningView ? (enrollmentsData?.content?.length ?? 0) : (data?.totalElements ?? 0),
     active: isLearningView
       ? (enrollmentsData?.content?.filter((e) => e.status === 'ENROLLED').length ?? 0)
       : filteredUsers.filter((u) => u.status === 'ACTIVE').length,
@@ -504,7 +510,7 @@ export function UserManagementPage({ language = 'ko' }: Readonly<UserManagementP
     suspended: isLearningView
       ? (enrollmentsData?.content?.filter((e) => e.status === 'DROPPED' || e.status === 'FAILED').length ?? 0)
       : filteredUsers.filter((u) => u.status === 'SUSPENDED').length,
-  }), [filteredUsers, enrollmentsData?.content, isLearningView]);
+  }), [filteredUsers, enrollmentsData?.content, isLearningView, data?.totalElements]);
 
   // 과정 옵션
   const courseOptions = useMemo(() => {
@@ -1459,7 +1465,11 @@ export function UserManagementPage({ language = 'ko' }: Readonly<UserManagementP
               data={filteredUsers}
               showColumnToggle={false}
               showPagination={true}
-              pageSize={PAGE_SIZE}
+              manualPagination={true}
+              pageCount={data?.totalPages ?? 0}
+              pageIndex={page}
+              pageSize={20}
+              onPageChange={setPage}
               onRowClick={(user) => setSelectedUserForDetail(user)}
               labels={{
                 noResults: getText('noResults'),

--- a/src/services/co/autoEnrollmentRuleService.ts
+++ b/src/services/co/autoEnrollmentRuleService.ts
@@ -3,9 +3,11 @@
  */
 import axiosInstance from '@/services/common/api/axiosInstance';
 import { API_ENDPOINTS } from '@/services/common/api/endpoints';
+import type { PageResponse } from '@/types/common';
 import type {
   AutoEnrollmentRuleResponse,
   AutoEnrollmentTrigger,
+  AutoEnrollmentRuleQueryParams,
   CreateAutoEnrollmentRuleRequest,
   UpdateAutoEnrollmentRuleRequest,
 } from '@/types/co/autoEnrollmentRule.types';
@@ -15,10 +17,11 @@ export const autoEnrollmentRuleService = {
   // Auto Enrollment Rule CRUD
   // ============================================
 
-  /** 자동 입과 규칙 목록 조회 */
-  async getAll(): Promise<AutoEnrollmentRuleResponse[]> {
-    const { data } = await axiosInstance.get<AutoEnrollmentRuleResponse[]>(
-      API_ENDPOINTS.AUTO_ENROLLMENT_RULES.BASE
+  /** 자동 입과 규칙 목록 조회 (페이지네이션) */
+  async getAll(params?: AutoEnrollmentRuleQueryParams): Promise<PageResponse<AutoEnrollmentRuleResponse>> {
+    const { data } = await axiosInstance.get<PageResponse<AutoEnrollmentRuleResponse>>(
+      API_ENDPOINTS.AUTO_ENROLLMENT_RULES.BASE,
+      { params }
     );
     return data;
   },

--- a/src/services/common/courseService.ts
+++ b/src/services/common/courseService.ts
@@ -22,6 +22,9 @@ import type {
   CourseRegistrationDetailResponse,
   ReadyCourseResponse,
   RegisterCourseRequest,
+  // 필터용 타입
+  CourseLevel,
+  CourseType,
 } from '@/types/common/course.types';
 
 // Spring Page 응답 타입
@@ -46,6 +49,9 @@ export interface CourseFilterParams {
 export interface CourseRegistrationFilterParams {
   keyword?: string;
   status?: CourseRegistrationStatus;
+  categoryId?: number;
+  level?: CourseLevel;
+  type?: CourseType;
   page?: number;
   size?: number;
   sort?: string;

--- a/src/types/co/autoEnrollmentRule.types.ts
+++ b/src/types/co/autoEnrollmentRule.types.ts
@@ -67,6 +67,9 @@ export interface AutoEnrollmentRuleResponse {
 
 /** 자동 입과 규칙 목록 조회 파라미터 */
 export interface AutoEnrollmentRuleQueryParams {
+  keyword?: string; // 규칙명으로 검색
   isActive?: boolean;
   trigger?: AutoEnrollmentTrigger;
+  page?: number;
+  size?: number;
 }

--- a/src/types/co/enrollment.types.ts
+++ b/src/types/co/enrollment.types.ts
@@ -111,6 +111,7 @@ export interface UpdateEnrollmentStatusRequest {
 /** 수강 목록 조회 파라미터 */
 export interface EnrollmentFilterParams {
   status?: EnrollmentStatus;
+  keyword?: string; // 수강생 이름, 이메일로 검색
   page?: number;
   size?: number;
   sort?: string;

--- a/src/types/co/instructorAssignment.types.ts
+++ b/src/types/co/instructorAssignment.types.ts
@@ -54,6 +54,7 @@ export interface InstructorAssignmentFilterParams {
   courseTimeId?: number;
   role?: import('@/types/tu/instructorAssignment.types').InstructorRole;
   status?: import('@/types/tu/instructorAssignment.types').AssignmentStatus;
+  keyword?: string; // 강사명, 차수명으로 검색
   page?: number;
   size?: number;
 }

--- a/src/types/co/time.types.ts
+++ b/src/types/co/time.types.ts
@@ -232,6 +232,7 @@ export interface CourseTimeValidationResult {
 export interface CourseTimeFilterParams {
   courseId?: number; // Phase 3: programId → courseId
   status?: CourseTimeStatus;
+  keyword?: string; // 차수명, 과정명으로 검색
   page?: number;
   size?: number;
   sort?: string;


### PR DESCRIPTION
## Summary
CO 페이지에서 서버 사이드 페이지네이션과 클라이언트 사이드 필터링이 혼용되어 발생하는 버그를 수정했습니다. 기존에는 현재 페이지의 데이터에서만 검색/필터링이 적용되어, 다른 페이지에 있는 데이터는 검색되지 않는 문제가 있었습니다.

## Changes

### Backend
- InstructorAssignments API: 강사명, 차수명 keyword 검색 추가
- Enrollment API: 수강생 이름, 이메일 keyword 검색 추가  
- CourseTime API: 차수명, 과정명 keyword 검색 추가
- AutoEnrollmentRule API: List → Page 응답으로 변경, keyword/isActive/trigger 필터 추가

### Frontend

#### Types
- `InstructorAssignmentFilterParams`: keyword 파라미터 추가
- `EnrollmentFilterParams`: keyword 파라미터 추가
- `CourseTimeFilterParams`: keyword 파라미터 추가
- `AutoEnrollmentRuleQueryParams`: keyword, page, size 파라미터 추가

#### Services
- `autoEnrollmentRuleService.getAll()`: Array → PageResponse 반환 타입 변경

#### Pages (6개)
1. **CoursePendingPage**: 검색어를 API 파라미터로 전달, 클라이언트 필터링 제거
2. **InstructorAssignmentsPage**: keyword 파라미터 추가, useMemo 필터링 제거
3. **EnrollmentManagementPage**: keyword 파라미터 추가, 클라이언트 필터링 제거
4. **UserManagementPage**: size를 1000에서 20으로 변경, 페이지네이션 활성화
5. **CourseTimesPage**: 클라이언트 정렬/필터링 제거, 서버 사이드로 전환
6. **AutoEnrollmentRulesPage**: Page 응답 대응, keyword 파라미터 추가

#### 공통 패턴
- 검색/필터 변경 시 페이지 자동 리셋 (useEffect)
- useMemo 클라이언트 필터링 로직 제거
- totalElements를 서버 응답에서 직접 사용
- keyword 파라미터를 `|| undefined`로 전달하여 빈 문자열 방지

## Test Plan
- [ ] 각 페이지에서 검색 시 전체 데이터에서 검색되는지 확인
- [ ] 검색/필터 변경 시 1페이지로 자동 리셋되는지 확인
- [ ] 페이지네이션이 정상 작동하는지 확인
- [ ] totalElements가 필터링된 결과 개수와 일치하는지 확인
- [ ] 다중 필터 조합이 정상 작동하는지 확인

## Related Issues
현재 페이지 데이터에서만 검색되던 클라이언트/서버 필터링 혼용 버그 수정